### PR TITLE
Removing padding from the encryption API

### DIFF
--- a/docs/primitives/symmetric-encryption.rst
+++ b/docs/primitives/symmetric-encryption.rst
@@ -61,9 +61,3 @@ Modes
                                         ``block_size`` of the cipher. Do not
                                         reuse an ``initialization_vector`` with
                                         a given ``key``.
-    :param padding: One of the paddings described below.
-
-Paddings
-~~~~~~~~
-
-.. class:: cryptography.primitives.block.padding.PKCS7()


### PR DESCRIPTION
- Padding is fundamentally an operation that occurs prior to encryption to make plaintext suitable.
- Even though wether it's regarded is dependent on the mode, it can be used safely regardless.
- Moving it out of this API makes the API's simpler and more composable.
- Moving it out of this API makes it simpler for backends that don't work exactly like OpenSSL's EVP.
- Move it out of this API makes it simpler to include padding that OpenSSL's EVP API doesn't expose.
