### PR TITLE
Make the example error free

### DIFF
--- a/docs/primitives/symmetric-encryption.rst
+++ b/docs/primitives/symmetric-encryption.rst
@@ -14,7 +14,7 @@ where the encrypter and decrypter both use the same key.
 
         >>> from cryptography.primitives.block import BlockCipher, ciphers, modes
         >>> cipher = BlockCipher(ciphers.AES(key), modes.CBC(iv))
-        >>> cipher.encrypt("my secret message") + cipher.finalize()
+        >>> cipher.encrypt(b"a secret message") + cipher.finalize()
         # The ciphertext
         [...]
 


### PR DESCRIPTION
Without padding b"my secret message" is not divisible by AES's block size and thus would throw an error.
