### PR TITLE
Use the Sphinx doctest builder

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@
 # extensions  coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,9 @@ commands = py.test --cov=cryptography/ --cov=tests/
 [testenv:docs]
 deps = sphinx
 basepython = python2.7
-changedir = docs
-commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . _build/html
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
+    sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
Currently we are testing if our documentation builds. However this doesn't prevent incorrect examples inside of our documentation (such as was a problem in https://github.com/alex/cryptography/pull/40). This adds the ability to use doc tests inside of Sphinx in order to also test our examples. Currently there are zero documentation tests however an example one could be added to https://github.com/alex/cryptography/pull/28 with this diff:

``` diff
diff --git a/docs/primitives/symmetric-encryption.rst b/docs/primitives/symmetric-encryption.rst
index 9986d89..52eb0c3 100644
--- a/docs/primitives/symmetric-encryption.rst
+++ b/docs/primitives/symmetric-encryption.rst
@@ -1,6 +1,13 @@
 Symmetric Encryption
 ====================

+.. testsetup::
+
+    import binascii
+    key = binascii.unhexlify(b"0" * 32)
+    iv = binascii.unhexlify(b"0" * 32)
+
+
 Symmetric encryption is a way to encrypt (hide the plaintext value) material
 where the encrypter and decrypter both use the same key.

@@ -10,13 +17,12 @@ where the encrypter and decrypter both use the same key.
     They combine an underlying algorithm (such as AES), with a mode (such as
     CBC, CTR, or GCM). A simple example of encrypting content with AES is:

-    .. code-block:: pycon
+    .. doctest::

         >>> from cryptography.primitives.block import BlockCipher, ciphers, modes
         >>> cipher = BlockCipher(ciphers.AES(key), modes.CBC(iv))
         >>> cipher.encrypt(b"a secret message") + cipher.finalize()
-        # The ciphertext
-        [...]
+        '...'

     :param cipher: One of the ciphers described below.
     :param mode: One of the modes described below.
```
