### PR TITLE
Changes to parameterize_encrypt_test to support other NIST vectors

### DIFF
--- a/tests/primitives/test_nist.py
+++ b/tests/primitives/test_nist.py
@@ -28,13 +28,13 @@ from cryptography.primitives.block import BlockCipher, ciphers, modes
 from ..utils import load_nist_vectors_from_file
 
 
-def parameterize_encrypt_test(cipher, vector_type, fnames):
-    return pytest.mark.parametrize(("key", "iv", "plaintext", "ciphertext"),
+def parameterize_encrypt_test(cipher, vector_type, params, fnames):
+    return pytest.mark.parametrize(params,
         list(itertools.chain.from_iterable(
             load_nist_vectors_from_file(
                 os.path.join(cipher, vector_type, fname),
                 "ENCRYPT",
-                ["key", "iv", "plaintext", "ciphertext"],
+                params
             )
             for fname in fnames
         ))
@@ -42,20 +42,24 @@ def parameterize_encrypt_test(cipher, vector_type, fnames):
 
 
 class TestAES_CBC(object):
-    @parameterize_encrypt_test("AES", "KAT", [
-        "CBCGFSbox128.rsp",
-        "CBCGFSbox192.rsp",
-        "CBCGFSbox256.rsp",
-        "CBCKeySbox128.rsp",
-        "CBCKeySbox192.rsp",
-        "CBCKeySbox256.rsp",
-        "CBCVarKey128.rsp",
-        "CBCVarKey192.rsp",
-        "CBCVarKey256.rsp",
-        "CBCVarTxt128.rsp",
-        "CBCVarTxt192.rsp",
-        "CBCVarTxt256.rsp",
-    ])
+    @parameterize_encrypt_test(
+        "AES", "KAT",
+        ("key", "iv", "plaintext", "ciphertext"),
+        [
+            "CBCGFSbox128.rsp",
+            "CBCGFSbox192.rsp",
+            "CBCGFSbox256.rsp",
+            "CBCKeySbox128.rsp",
+            "CBCKeySbox192.rsp",
+            "CBCKeySbox256.rsp",
+            "CBCVarKey128.rsp",
+            "CBCVarKey192.rsp",
+            "CBCVarKey256.rsp",
+            "CBCVarTxt128.rsp",
+            "CBCVarTxt192.rsp",
+            "CBCVarTxt256.rsp",
+        ]
+    )
     def test_KAT(self, key, iv, plaintext, ciphertext):
         cipher = BlockCipher(
             ciphers.AES(binascii.unhexlify(key)),
@@ -65,11 +69,15 @@ class TestAES_CBC(object):
         actual_ciphertext += cipher.finalize()
         assert binascii.hexlify(actual_ciphertext) == ciphertext
 
-    @parameterize_encrypt_test("AES", "MMT", [
-        "CBCMMT128.rsp",
-        "CBCMMT192.rsp",
-        "CBCMMT256.rsp",
-    ])
+    @parameterize_encrypt_test(
+        "AES", "MMT",
+        ("key", "iv", "plaintext", "ciphertext"),
+        [
+            "CBCMMT128.rsp",
+            "CBCMMT192.rsp",
+            "CBCMMT256.rsp",
+        ]
+    )
     def test_MMT(self, key, iv, plaintext, ciphertext):
         cipher = BlockCipher(
             ciphers.AES(binascii.unhexlify(key)),


### PR DESCRIPTION
- ECB has no IV so we need to be able to pass params rather than have
  them hardcoded in the method
