### PR TITLE
Add PKCS7 padding

### DIFF
--- a/cryptography/primitives/interfaces.py
+++ b/cryptography/primitives/interfaces.py
@@ -20,3 +20,7 @@ import six
 
 class ModeWithInitializationVector(six.with_metaclass(abc.ABCMeta)):
     pass
+
+
+class Padding(six.with_metaclass(abc.ABCMeta)):
+    pass

--- a/cryptography/primitives/padding.py
+++ b/cryptography/primitives/padding.py
@@ -1,0 +1,98 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function
+
+import six
+
+from cryptography.primitives import interfaces
+
+
+def bytes_normalize(inp):
+    # We have a single integer, convert it to a bytes
+    if isinstance(inp, six.integer_types):
+        return six.int2byte(inp)
+    elif isinstance(inp, six.binary_type):
+        return inp
+
+
+class PKCS7(object):
+
+    def __init__(self, block_size):
+        self.block_size = block_size
+        self.byte_size = block_size // 8
+
+        if self.byte_size >= 256:
+            raise ValueError("Invalid block size, too large")
+
+        if self.block_size % 8:
+            raise ValueError("Invalid block size, must be multiple of 8")
+
+    def iter_pad(self, data):
+        # Iterate over the data yielding it in chunks the size of our blocks
+        # until theres not enough data to fill another full block
+        buf = b""
+        for chunk in data:
+            # Add our chunk into our buffer
+            buf += bytes_normalize(chunk)
+
+            # If we have enough data stored in the buffer then remove it from
+            # the buffer and yield it
+            while len(buf) >= self.byte_size:
+                next_chunk, buf = buf[:self.byte_size], buf[self.byte_size:]
+                yield next_chunk
+
+        # Determine how big our padding needs to be
+        pad_size = self.byte_size - len(buf)
+
+        yield buf + (six.int2byte(pad_size) * pad_size)
+
+    def pad(self, data):
+        return b"".join(self.iter_pad(data))
+
+    def iter_unpad(self, data):
+        # Iterate over the data yielding chunks the size of our block size
+        # keeping one block staged at all times so we can unpad the final block
+        last = None
+        buf = b""
+        for chunk in data:
+            # Add our chunk into our buffer
+            buf += bytes_normalize(chunk)
+
+            # If we have enough data stored in the buffer, remove it from the
+            # buffer and do the staging + yield dance
+            while len(buf) >= self.byte_size:
+                next_chunk, buf = buf[:self.byte_size], buf[self.byte_size:]
+                last, next_chunk = next_chunk, last
+                if next_chunk:
+                    yield next_chunk
+
+        if not last:
+            raise ValueError("Invalid padding bytes")
+
+        # Determine how big our padding is
+        pad_size = six.indexbytes(last, -1)
+
+        if pad_size > self.byte_size:
+            raise ValueError("Invalid padding bytes")
+
+        # Ensure the padding characters are correct
+        if set(six.iterbytes(last[-pad_size:])) != set([pad_size]):
+            raise ValueError("Invalid padding bytes")
+
+        yield last[:-pad_size]
+
+    def unpad(self, data):
+        return b"".join(self.iter_unpad(data))
+
+
+interfaces.Padding.register(PKCS7)

--- a/docs/primitives/index.rst
+++ b/docs/primitives/index.rst
@@ -5,3 +5,4 @@ Primitives
     :maxdepth: 1
 
     symmetric-encryption
+    padding

--- a/docs/primitives/padding.rst
+++ b/docs/primitives/padding.rst
@@ -1,0 +1,48 @@
+Padding
+=======
+
+Padding is a way to take data that may or may not be be a multiple of the block
+size for a cipher and extend it out so that it is. This is required for many
+block cipher modes as they require the data to be encrypted to be an exact
+multiple of the block size.
+
+
+.. class:: cryptography.primitives.padding.PKCS7(block_size)
+
+    PKCS7 padding works by appending ``N`` bytes with the value of ``chr(N)``,
+    where ``N`` is the number of bytes required to make the final block of data
+    the same size as the cipher's block size. A Simple example of padding is:
+
+    .. doctest::
+
+        >>> from cryptography.primitives import padding
+        >>> padder = padding.PKCS7(128)
+        >>> padder.pad(b"1111111111")
+        '1111111111\x06\x06\x06\x06\x06\x06'
+
+    :param block_size: The size of the block in bits that the data is being
+                       padded to.
+
+    .. method:: pad(data)
+
+        :param data: The data that should be padded, can be any iterable of
+                     bytes.
+        :rtype bytes: The padded data.
+
+    .. method:: iter_pad(data):
+
+        :param data: The data that should be padded, can be any iterable of
+                     bytes.
+        :rtype generator: A generator that yields blocks of padded data.
+
+    .. method:: unpad(data)
+
+        :param data: The data that should be unpadded, can be any iterable of
+                     bytes.
+        :rtype bytes: The unpadded data.
+
+    .. method:: iter_unpad(data):
+
+        :param data: The data that should be unpadded, can be any iterable of
+                     bytes.
+        :rtype generator: A generator that yields blocks of unpadded data.

--- a/tests/primitives/test_padding.py
+++ b/tests/primitives/test_padding.py
@@ -1,0 +1,131 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function
+
+import types
+
+import pytest
+
+from cryptography.primitives import padding
+
+
+class TestPKCS7:
+
+    @pytest.mark.parametrize(("size",), [(127,), (4096,)])
+    def test_invalid_block_size(self, size):
+        with pytest.raises(ValueError):
+            padding.PKCS7(size)
+
+    @pytest.mark.parametrize(("size", "padded"), [
+        (128, b"1111"),
+        (128, b"1111111111111111"),
+        (128, b"111111111111111\x06"),
+    ])
+    def test_invalid_padding(self, size, padded):
+        padder = padding.PKCS7(size)
+
+        with pytest.raises(ValueError):
+            padder.unpad(padded)
+
+        with pytest.raises(ValueError):
+            b"".join(padder.iter_unpad(padded))
+
+    @pytest.mark.parametrize(("size", "unpadded", "padded"), [
+        (
+            128,
+            b"1111111111",
+            b"1111111111\x06\x06\x06\x06\x06\x06",
+        ),
+        (
+            128,
+            b"111111111111111122222222222222",
+            b"111111111111111122222222222222\x02\x02",
+        ),
+        (
+            128,
+            iter(b"111111111111111122222222222222"),
+            b"111111111111111122222222222222\x02\x02",
+        ),
+        (
+            128,
+            [b"1111", b"1111", b"1111", b"1111", b"2222", b"2222222222"],
+            b"111111111111111122222222222222\x02\x02",
+        ),
+    ])
+    def test_pad(self, size, unpadded, padded):
+        padder = padding.PKCS7(size)
+        assert padder.pad(unpadded) == padded
+
+    @pytest.mark.parametrize(("size", "unpadded", "padded"), [
+        (
+            128,
+            b"1111111111",
+            b"1111111111\x06\x06\x06\x06\x06\x06",
+        ),
+        (
+            128,
+            b"111111111111111122222222222222",
+            b"111111111111111122222222222222\x02\x02",
+        ),
+    ])
+    def test_iter_pad(self, size, unpadded, padded):
+        padder = padding.PKCS7(size)
+        ipadded = padder.iter_pad(iter(unpadded))
+
+        assert isinstance(ipadded, types.GeneratorType)
+        assert b"".join(ipadded) == padded
+
+    @pytest.mark.parametrize(("size", "unpadded", "padded"), [
+        (
+            128,
+            b"1111111111",
+            b"1111111111\x06\x06\x06\x06\x06\x06",
+        ),
+        (
+            128,
+            b"111111111111111122222222222222",
+            b"111111111111111122222222222222\x02\x02",
+        ),
+        (
+            128,
+            b"111111111111111122222222222222",
+            iter(b"111111111111111122222222222222\x02\x02"),
+        ),
+        (
+            128,
+            b"111111111111111122222222222222",
+            [b"1111", b"1111", b"1111", b"1111", b"22222222222222\x02\x02"],
+        ),
+    ])
+    def test_unpad(self, size, unpadded, padded):
+        padder = padding.PKCS7(size)
+        assert padder.unpad(padded) == unpadded
+
+    @pytest.mark.parametrize(("size", "unpadded", "padded"), [
+        (
+            128,
+            b"1111111111",
+            b"1111111111\x06\x06\x06\x06\x06\x06",
+        ),
+        (
+            128,
+            b"111111111111111122222222222222",
+            b"111111111111111122222222222222\x02\x02",
+        ),
+    ])
+    def test_iter_unpad(self, size, unpadded, padded):
+        padder = padding.PKCS7(size)
+        iunpadded = padder.iter_unpad(iter(padded))
+
+        assert isinstance(iunpadded, types.GeneratorType)
+        assert b"".join(iunpadded) == unpadded


### PR DESCRIPTION
- [x] Handle error case when byte_size > 256
- [x] Tests
- [x] Documentation
#### Normal Operation

``` python
from cryptography.primitives import padding
padder = padding.PKCS7(128)

def datamaker():
    for c in b"11111111111111112222222222":
        yield c

def datamaker2():
    for c in [b"1111", b"1111", b"1111", b"1111", b"2222", b"2222", b"22"]:
        yield c

def datamaker3():
    for c in b"11111111111111112222222222\x06\x06\x06\x06\x06\x06":
        yield c

def datamaker4():
    for c in ['1111', '1111', '1111', '1111', '2222', '2222', '22\x06\x06', '\x06\x06\x06\x06']:
        yield c

padded1 = padder.pad(b"1111")            # '1111\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c'
padded2 = padder.pad(datamaker())        # '11111111111111112222222222\x06\x06\x06\x06\x06\x06'
padded3 = padder.iter_pad(datamaker2())  # <generator object iter_pad at 0x103ea4d70>

padded3 = b"".join(padded3)              # '11111111111111112222222222\x06\x06\x06\x06\x06\x06'

unpadded1 = padder.unpad(padded1) # '1111'
unpadded2 = padder.unpad(datamaker3()) # '11111111111111112222222222'
unpadded3 = padder.iter_unpad(datamaker4())  # <generator object iter_unpad at 0x103ea4d70>

unpadded3 = b"".join(unpadded3) # '11111111111111112222222222'
```
#### Error Conditions

``` pycon
>>> from cryptography.primitives import padding
>>> padder = padding.PKCS7(128)
>>>
>>> padder.unpad(b"1111")  # Too Few Bytes
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cryptography/primitives/padding.py", line 75, in unpad
    return b"".join(self.iter_unpad(data))
  File "cryptography/primitives/padding.py", line 60, in iter_unpad
    raise ValueError("Invalid padding bytes")
ValueError: Invalid padding bytes
>>>
>>> padder.unpad(b"1111111111111111")  # No padding characters at all
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cryptography/primitives/padding.py", line 75, in unpad
    return b"".join(self.iter_unpad(data))
  File "cryptography/primitives/padding.py", line 66, in iter_unpad
    raise ValueError("Invalid padding bytes")
ValueError: Invalid padding bytes
>>>
>>> padder.unpad(b"111111111111111\x06")  # Padding character but Invalid bytes
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cryptography/primitives/padding.py", line 75, in unpad
    return b"".join(self.iter_unpad(data))
  File "cryptography/primitives/padding.py", line 70, in iter_unpad
    raise ValueError("Invalid padding bytes")
ValueError: Invalid padding bytes
```
