### PR TITLE
Added a EVP_CIPHER_CTX_init() call

### DIFF
--- a/cryptography/bindings/openssl/api.py
+++ b/cryptography/bindings/openssl/api.py
@@ -56,6 +56,8 @@ class API(object):
 
     def create_block_cipher_context(self, cipher, mode):
         ctx = self.ffi.new("EVP_CIPHER_CTX *")
+        res = self.lib.EVP_CIPHER_CTX_init(ctx)
+        assert res != 0
         ctx = self.ffi.gc(ctx, self.lib.EVP_CIPHER_CTX_cleanup)
         # TODO: compute name using a better algorithm
         ciphername = "{0}-{1}-{2}".format(

--- a/cryptography/bindings/openssl/evp.py
+++ b/cryptography/bindings/openssl/evp.py
@@ -35,4 +35,5 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *, unsigned char *, int *);
 int EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *);
 const EVP_CIPHER *EVP_CIPHER_CTX_cipher(const EVP_CIPHER_CTX *);
 int EVP_CIPHER_block_size(const EVP_CIPHER *);
+void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *);
 """


### PR DESCRIPTION
- In OpenSSL when you alloc an EVP_CIPHER_CTX you must then init it
  (which just zeroes the allocated memory). If you do not then it is
  possible for things to kerplode when passing the uninitialized context
  to EVP_EncryptInit_ex(). This patch fixes that.
