### PR TITLE
rand bindings for openssl (refs #77)

### DIFF
--- a/cryptography/bindings/openssl/api.py
+++ b/cryptography/bindings/openssl/api.py
@@ -30,6 +30,7 @@ class API(object):
         "dh",
         "dsa",
         "evp",
+        "rand",
         "rsa",
         "opensslv",
     ]

--- a/cryptography/bindings/openssl/rand.py
+++ b/cryptography/bindings/openssl/rand.py
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INCLUDES = """
+#include <openssl/rand.h>
+"""
+
+TYPES = """
+"""
+
+FUNCTIONS = """
+void RAND_seed(const void *, int);
+void RAND_add(const void *, int, double);
+int RAND_status();
+int RAND_egd(const char *);
+int RAND_egd_bytes(const char *, int);
+int RAND_query_egd_bytes(const char *, unsigned char *, int);
+const char *RAND_file_name(char *, size_t);
+int RAND_load_file(const char *, long);
+int RAND_write_file(const char *);
+void RAND_cleanup();
+int RAND_bytes(unsigned char *, int);
+int RAND_pseudo_bytes(unsigned char *, int);
+"""
+
+MACROS = """
+"""


### PR DESCRIPTION
These bindings should be used with care as there are many opportunities to shoot yourself in the foot. Take special care to re-seed on process fork and for the love of god don't use DUAL_EC_DRBG. Or just wait until we wrap a higher level interface on it :)
