### PR TITLE
Make key_sizes a frozenset, since these are/should be immutable

### DIFF
--- a/cryptography/primitives/block/ciphers.py
+++ b/cryptography/primitives/block/ciphers.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function
 class AES(object):
     name = "AES"
     block_size = 128
-    key_sizes = set([128, 192, 256])
+    key_sizes = frozenset([128, 192, 256])
 
     def __init__(self, key):
         super(AES, self).__init__()


### PR DESCRIPTION
The `key_sizes` attribute on `AES` should be an immutable type. This pull request changes the `key_sizes` type from `set` to `frozenset`.

All tests pass.
