### PR TITLE
Load types from all cffi modules before declaring functions or macros

### DIFF
--- a/cryptography/bindings/openssl/api.py
+++ b/cryptography/bindings/openssl/api.py
@@ -17,8 +17,6 @@ import sys
 
 import cffi
 
-import six
-
 from cryptography.primitives import interfaces
 
 
@@ -56,8 +54,9 @@ class API(object):
         # loop over the functions & macros after declaring all the types
         # so we can set interdependent types in different files and still
         # have them all defined before we parse the funcs & macros
-        for func, macro in six.moves.zip(functions, macros):
+        for func in functions:
             self.ffi.cdef(func)
+        for macro in macros:
             self.ffi.cdef(macro)
 
         # We include functions here so that if we got any of their definitions


### PR DESCRIPTION
This change loads all the types via cdef & then loops over the macros
& functions and cdefs them. The advantage of this approach is that you
can define the types in the right modules without worrying about
import order. For example, if you need the BIO typedef in the asn1
module but it is defined in the bio module you can still import
the modules alphabetically and expect that BIO will be properly
declared.
