### PR TITLE
Explicitly add ssl.h as dependency

### DIFF
--- a/cryptography/bindings/openssl/api.py
+++ b/cryptography/bindings/openssl/api.py
@@ -26,17 +26,18 @@ class API(object):
     """
     _modules = [
         "bignum",
-        "conf",
         "bio",
+        "conf",
         "crypto",
         "dh",
         "dsa",
         "engine",
         "err",
         "evp",
+        "opensslv",
         "rand",
         "rsa",
-        "opensslv",
+        "ssl",
     ]
 
     def __init__(self):
@@ -71,7 +72,7 @@ class API(object):
         #   int foo(short);
         self.lib = self.ffi.verify(
             source="\n".join(includes + functions),
-            libraries=["crypto"],
+            libraries=["crypto", "ssl"],
         )
 
         self.lib.OpenSSL_add_all_algorithms()

--- a/cryptography/bindings/openssl/err.py
+++ b/cryptography/bindings/openssl/err.py
@@ -24,7 +24,6 @@ typedef struct ERR_string_data_st ERR_STRING_DATA;
 """
 
 FUNCTIONS = """
-void SSL_load_error_strings();
 void ERR_load_crypto_strings();
 void ERR_free_strings();
 char* ERR_error_string(unsigned long, char *);

--- a/cryptography/bindings/openssl/ssl.py
+++ b/cryptography/bindings/openssl/ssl.py
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INCLUDES = """
+#include <openssl/ssl.h>
+"""
+
+TYPES = """
+"""
+
+FUNCTIONS = """
+void SSL_load_error_strings();
+"""
+
+MACROS = """
+"""


### PR DESCRIPTION
Add ssl as a linked library, this is at least necessary
on ArchLinux

Otherwise I receive `undefined symbol: SSL_load_error_strings`

See http://pastie.org/pastes/8407159/text
