### PR TITLE
Hash Saga Part 5 (RIPEMD160 support)

### DIFF
--- a/cryptography/primitives/hashes.py
+++ b/cryptography/primitives/hashes.py
@@ -70,3 +70,9 @@ class SHA512(BaseHash):
     name = "sha512"
     digest_size = 64
     block_size = 128
+
+
+class RIPEMD160(BaseHash):
+    name = "ripemd160"
+    digest_size = 20
+    block_size = 64

--- a/tests/primitives/test_hash_vectors.py
+++ b/tests/primitives/test_hash_vectors.py
@@ -17,7 +17,7 @@ import os
 
 from cryptography.primitives import hashes
 
-from .utils import generate_hash_test
+from .utils import generate_hash_test, generate_long_string_hash_test
 from ..utils import load_hash_vectors_from_file
 
 
@@ -88,4 +88,24 @@ class TestSHA512(object):
         hashes.SHA512,
         only_if=lambda api: api.supports_hash(hashes.SHA512),
         skip_message="Does not support SHA512",
+    )
+
+
+class TestRIPEMD160(object):
+    test_RIPEMD160 = generate_hash_test(
+        load_hash_vectors_from_file,
+        os.path.join("ISO", "ripemd160"),
+        [
+            "ripevectors.txt",
+        ],
+        hashes.RIPEMD160,
+        only_if=lambda api: api.supports_hash(hashes.RIPEMD160),
+        skip_message="Does not support RIPEMD160",
+    )
+
+    test_RIPEMD160_long_string = generate_long_string_hash_test(
+        hashes.RIPEMD160,
+        "52783243c1697bdbe16d37f97f68f08325dc1528",
+        only_if=lambda api: api.supports_hash(hashes.RIPEMD160),
+        skip_message="Does not support RIPEMD160",
     )

--- a/tests/primitives/test_hashes.py
+++ b/tests/primitives/test_hashes.py
@@ -66,3 +66,13 @@ class TestSHA512(object):
         only_if=lambda api: api.supports_hash(hashes.SHA512),
         skip_message="Does not support SHA512",
     )
+
+
+class TestRIPEMD160(object):
+    test_RIPEMD160 = generate_base_hash_test(
+        hashes.RIPEMD160,
+        digest_size=20,
+        block_size=64,
+        only_if=lambda api: api.supports_hash(hashes.RIPEMD160),
+        skip_message="Does not support RIPEMD160",
+    )

--- a/tests/primitives/test_utils.py
+++ b/tests/primitives/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
-from .utils import encrypt_test, hash_test, base_hash_test
+from .utils import (base_hash_test, encrypt_test, hash_test,
+    long_string_hash_test)
 
 
 class TestEncryptTest(object):
@@ -30,6 +31,17 @@ class TestBaseHashTest(object):
         with pytest.raises(pytest.skip.Exception) as exc_info:
             base_hash_test(
                 None, None, None, None,
+                only_if=lambda api: False,
+                skip_message="message!"
+            )
+        assert exc_info.value.args[0] == "message!"
+
+
+class TestLongHashTest(object):
+    def test_skips_if_only_if_returns_false(self):
+        with pytest.raises(pytest.skip.Exception) as exc_info:
+            long_string_hash_test(
+                None, None, None,
                 only_if=lambda api: False,
                 skip_message="message!"
             )

--- a/tests/primitives/utils.py
+++ b/tests/primitives/utils.py
@@ -95,3 +95,26 @@ def base_hash_test(api, hash_cls, digest_size, block_size, only_if,
     m_copy = m.copy()
     assert m != m_copy
     assert m._ctx != m_copy._ctx
+
+
+def generate_long_string_hash_test(hash_factory, md, only_if=lambda api: True,
+                                   skip_message=None):
+    def test_long_string_hash(self):
+        for api in _ALL_APIS:
+            yield(
+                long_string_hash_test,
+                api,
+                hash_factory,
+                md,
+                only_if,
+                skip_message
+            )
+    return test_long_string_hash
+
+
+def long_string_hash_test(api, hash_factory, md, only_if, skip_message):
+    if not only_if(api):
+        pytest.skip(skip_message)
+    m = hash_factory(api)
+    m.update(b"a" * 1000000)
+    assert m.hexdigest() == md.lower()


### PR DESCRIPTION
Dependent on #121, #123, #124

Adds RIPEMD160 + a long string test generator.

Note that the long string hash test for RIPEMD160 adds a vector in the test. You can verify this vector (for b"a" \* 1000000) on the RIPE homepage: http://homes.esat.kuleuven.be/~bosselae/ripemd160.html
