### PR TITLE
Hash Saga Part 6 (Whirlpool support)

### DIFF
--- a/cryptography/primitives/hashes.py
+++ b/cryptography/primitives/hashes.py
@@ -76,3 +76,9 @@ class RIPEMD160(BaseHash):
     name = "ripemd160"
     digest_size = 20
     block_size = 64
+
+
+class Whirlpool(BaseHash):
+    name = "whirlpool"
+    digest_size = 64
+    block_size = 64

--- a/tests/primitives/test_hash_vectors.py
+++ b/tests/primitives/test_hash_vectors.py
@@ -109,3 +109,25 @@ class TestRIPEMD160(object):
         only_if=lambda api: api.supports_hash(hashes.RIPEMD160),
         skip_message="Does not support RIPEMD160",
     )
+
+
+class TestWhirlpool(object):
+    test_whirlpool = generate_hash_test(
+        load_hash_vectors_from_file,
+        os.path.join("ISO", "whirlpool"),
+        [
+            "iso-test-vectors.txt",
+        ],
+        hashes.Whirlpool,
+        only_if=lambda api: api.supports_hash(hashes.Whirlpool),
+        skip_message="Does not support Whirlpool",
+    )
+
+    test_whirlpool_long_string = generate_long_string_hash_test(
+        hashes.Whirlpool,
+        ("0c99005beb57eff50a7cf005560ddf5d29057fd86b2"
+         "0bfd62deca0f1ccea4af51fc15490eddc47af32bb2b"
+         "66c34ff9ad8c6008ad677f77126953b226e4ed8b01"),
+        only_if=lambda api: api.supports_hash(hashes.Whirlpool),
+        skip_message="Does not support Whirlpool",
+    )

--- a/tests/primitives/test_hashes.py
+++ b/tests/primitives/test_hashes.py
@@ -76,3 +76,13 @@ class TestRIPEMD160(object):
         only_if=lambda api: api.supports_hash(hashes.RIPEMD160),
         skip_message="Does not support RIPEMD160",
     )
+
+
+class TestWhirlpool(object):
+    test_Whirlpool = generate_base_hash_test(
+        hashes.Whirlpool,
+        digest_size=64,
+        block_size=64,
+        only_if=lambda api: api.supports_hash(hashes.Whirlpool),
+        skip_message="Does not support Whirlpool",
+    )


### PR DESCRIPTION
Dependent on #121, #123, #124, and #125

Whirlpool, like RIPEMD160, adds a long string (b"a" \* 1000000) vector. You can validate it by going to http://www.larc.usp.br/~pbarreto/WhirlpoolPage.html, downloading the documentation package, and looking at the ISO test vectors.
