### PR TITLE
Use _new and _free methods on EVP_CIPHER_CTX

### DIFF
--- a/cryptography/bindings/openssl/api.py
+++ b/cryptography/bindings/openssl/api.py
@@ -99,10 +99,8 @@ class API(object):
                 self.lib.EVP_get_cipherbyname(ciphername.encode("ascii")))
 
     def create_block_cipher_context(self, cipher, mode):
-        ctx = self.ffi.new("EVP_CIPHER_CTX *")
-        res = self.lib.EVP_CIPHER_CTX_init(ctx)
-        assert res != 0
-        ctx = self.ffi.gc(ctx, self.lib.EVP_CIPHER_CTX_cleanup)
+        ctx = self.lib.EVP_CIPHER_CTX_new()
+        ctx = self.ffi.gc(ctx, self.lib.EVP_CIPHER_CTX_free)
         # TODO: compute name using a better algorithm
         ciphername = "{0}-{1}-{2}".format(
             cipher.name, cipher.key_size, mode.name

--- a/cryptography/bindings/openssl/evp.py
+++ b/cryptography/bindings/openssl/evp.py
@@ -45,6 +45,8 @@ int EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *);
 const EVP_CIPHER *EVP_CIPHER_CTX_cipher(const EVP_CIPHER_CTX *);
 int EVP_CIPHER_block_size(const EVP_CIPHER *);
 void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *);
+EVP_CIPHER_CTX *EVP_CIPHER_CTX_new();
+void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *);
 
 EVP_MD_CTX *EVP_MD_CTX_create();
 int EVP_MD_CTX_copy_ex(EVP_MD_CTX *, const EVP_MD_CTX *);


### PR DESCRIPTION
This is more consistent (to the extent consistency is even a thing in OpenSSL) with our EVP_MD_CTX behaviors.
