### PR TITLE
Return proper string type from hexdigest in py2/3

### DIFF
--- a/cryptography/primitives/hashes.py
+++ b/cryptography/primitives/hashes.py
@@ -44,7 +44,7 @@ class BaseHash(six.with_metaclass(abc.ABCMeta)):
                                                self.digest_size)
 
     def hexdigest(self):
-        return binascii.hexlify(self.digest()).decode("ascii")
+        return str(binascii.hexlify(self.digest()).decode("ascii"))
 
     def _copy_ctx(self):
         return self._api.copy_hash_context(self._ctx)

--- a/tests/primitives/test_hashes.py
+++ b/tests/primitives/test_hashes.py
@@ -28,6 +28,10 @@ class TestBaseHash(object):
         with pytest.raises(TypeError):
             m.update(six.u("\u00FC"))
 
+    def test_base_hash_hexdigest_string_type(self, api):
+        m = hashes.SHA1(api=api, data=b"")
+        assert isinstance(m.hexdigest(), str)
+
 
 class TestSHA1(object):
     test_SHA1 = generate_base_hash_test(


### PR DESCRIPTION
fixes #148 + test case
