### PR TITLE
Don't test coverage on PyPy - Do Not Merge

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ commands =
     coverage run --source=cryptography/,tests/ -m pytest
     coverage report -m --fail-under 100
 
+[testenv:pypy]
+commands = py.test
+
 [testenv:docs]
 deps = sphinx
 basepython = python2.7


### PR DESCRIPTION
Theoretically speeds up PyPy by not running coverage which is really slow. Testing the speedup.
