### PR TITLE
[WIP] Simplify Cipher Encryption/Decryption Interfaces in OpenSSL

### DIFF
--- a/cryptography/bindings/openssl/evp.py
+++ b/cryptography/bindings/openssl/evp.py
@@ -49,6 +49,11 @@ int EVP_DecryptInit_ex(EVP_CIPHER_CTX *, const EVP_CIPHER *, ENGINE *,
 int EVP_DecryptUpdate(EVP_CIPHER_CTX *, unsigned char *, int *,
                       const unsigned char *, int);
 int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *, unsigned char *, int *);
+int EVP_CipherInit_ex(EVP_CIPHER_CTX *, const EVP_CIPHER *, ENGINE *,
+                      const unsigned char *, const unsigned char *, int);
+int EVP_CipherUpdate(EVP_CIPHER_CTX *, unsigned char *, int *,
+                     const unsigned char *, int);
+int EVP_CipherFinal_ex(EVP_CIPHER_CTX *, unsigned char *, int *);
 int EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *);
 const EVP_CIPHER *EVP_CIPHER_CTX_cipher(const EVP_CIPHER_CTX *);
 int EVP_CIPHER_block_size(const EVP_CIPHER *);

--- a/cryptography/primitives/block/base.py
+++ b/cryptography/primitives/block/base.py
@@ -44,12 +44,12 @@ class _CipherEncryptionContext(object):
     def update(self, data):
         if self._ctx is None:
             raise ValueError("Context was already finalized")
-        return self._backend.ciphers.update_encrypt_ctx(self._ctx, data)
+        return self._backend.ciphers.update_ctx(self._ctx, data)
 
     def finalize(self):
         if self._ctx is None:
             raise ValueError("Context was already finalized")
-        data = self._backend.ciphers.finalize_encrypt_ctx(self._ctx)
+        data = self._backend.ciphers.finalize_ctx(self._ctx)
         self._ctx = None
         return data
 
@@ -64,11 +64,11 @@ class _CipherDecryptionContext(object):
     def update(self, data):
         if self._ctx is None:
             raise ValueError("Context was already finalized")
-        return self._backend.ciphers.update_decrypt_ctx(self._ctx, data)
+        return self._backend.ciphers.update_ctx(self._ctx, data)
 
     def finalize(self):
         if self._ctx is None:
             raise ValueError("Context was already finalized")
-        data = self._backend.ciphers.finalize_decrypt_ctx(self._ctx)
+        data = self._backend.ciphers.finalize_ctx(self._ctx)
         self._ctx = None
         return data


### PR DESCRIPTION
OpenSSL has some methods that allow a bunch of duplicate code to be removed. Let's make use of them.

This change would allow us to potentially go back to a single CipherContext class for encryption/decryption if we wanted to.
