### PR TITLE
Added a tox/travis just for running flake8 under py3k

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - TOX_ENV=pypy CC=clang
     - TOX_ENV=docs
     - TOX_ENV=pep8
+    - TOX_ENV=py3pep8
 
 install:
     - "[[ ${TOX_ENV} == pypy ]] && sudo add-apt-repository -y ppa:pypy/ppa || true"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,docs,pep8
+envlist = py26,py27,pypy,py32,py33,docs,pep8,py3pep8
 
 [testenv]
 deps =
@@ -19,6 +19,11 @@ commands =
     sphinx-build -W -b linkcheck docs docs/_build/html
 
 [testenv:pep8]
+deps = flake8
+commands = flake8 .
+
+[testenv:py3pep8]
+basepython = python3.3
 deps = flake8
 commands = flake8 .
 


### PR DESCRIPTION
This is useful because it catches things like "xrange is not defined"
