### PR TITLE
Variable bindings for SSL

### DIFF
--- a/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/cryptography/hazmat/bindings/openssl/ssl.py
@@ -16,12 +16,6 @@ INCLUDES = """
 """
 
 TYPES = """
-/* Internally invented symbol to tell us if SSLv2 is supported */
-static const int PYOPENSSL_NO_SSL2;
-
-/* Internally invented symbol to tell us if SNI is supported */
-static const int PYOPENSSL_TLSEXT_HOSTNAME;
-
 static const int SSL_FILETYPE_PEM;
 static const int SSL_FILETYPE_ASN1;
 static const int SSL_ERROR_NONE;
@@ -128,23 +122,4 @@ MACROS = """
 """
 
 CUSTOMIZATIONS = """
-#ifdef OPENSSL_NO_SSL2
-static const int PYOPENSSL_NO_SSL2 = 1;
-SSL_METHOD* (*SSLv2_method)() = NULL;
-SSL_METHOD* (*SSLv2_client_method)() = NULL;
-SSL_METHOD* (*SSLv2_server_method)() = NULL;
-#else
-static const int PYOPENSSL_NO_SSL2 = 0;
-#endif
-
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-static const int PYOPENSSL_TLSEXT_HOSTNAME = 1;
-#else
-static const int PYOPENSSL_TLSEXT_HOSTNAME = 0;
-void (*SSL_set_tlsext_host_name)(SSL *, char *) = NULL;
-const char* (*SSL_get_servername)(const SSL *, const int) = NULL;
-void (*SSL_CTX_set_tlsext_servername_callback)(
-    SSL_CTX *,
-    int (*cb)(const SSL *, int *, void *)) = NULL;
-#endif
 """


### PR DESCRIPTION
This includes the necessary customizations to make the variable declarations work.

There are two:  

```
static const int SSL_OP_NO_COMPRESSION;
static const int SSL_MODE_RELEASE_BUFFERS;
```

that appear not to be in 0.9.8, so I've removed them for now.
