### PR TITLE
Remove separate vector file loaders and replace with one

### DIFF
--- a/tests/hazmat/primitives/test_3des.py
+++ b/tests/hazmat/primitives/test_3des.py
@@ -23,12 +23,12 @@ import os
 from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 from .utils import generate_encrypt_test
-from ...utils import load_nist_vectors_from_file
+from ...utils import load_nist_vectors
 
 
 class TestTripleDES_CBC(object):
     test_KAT = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "3DES", "CBC"),
         [
             "TCBCinvperm.rsp",
@@ -42,7 +42,7 @@ class TestTripleDES_CBC(object):
     )
 
     test_MMT = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "3DES", "CBC"),
         [
             "TCBCMMT1.rsp",
@@ -58,7 +58,7 @@ class TestTripleDES_CBC(object):
 
 class TestTripleDES_OFB(object):
     test_KAT = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "3DES", "OFB"),
         [
             "TOFBpermop.rsp",
@@ -72,7 +72,7 @@ class TestTripleDES_OFB(object):
     )
 
     test_MMT = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "3DES", "OFB"),
         [
             "TOFBMMT1.rsp",
@@ -88,7 +88,7 @@ class TestTripleDES_OFB(object):
 
 class TestTripleDES_CFB(object):
     test_KAT = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "3DES", "CFB"),
         [
             "TCFB64invperm.rsp",
@@ -102,7 +102,7 @@ class TestTripleDES_CFB(object):
     )
 
     test_MMT = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "3DES", "CFB"),
         [
             "TCFB64MMT1.rsp",

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -20,13 +20,13 @@ from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 from .utils import generate_encrypt_test
 from ...utils import (
-    load_nist_vectors_from_file, load_openssl_vectors_from_file
+    load_nist_vectors, load_openssl_vectors,
 )
 
 
 class TestAES(object):
     test_CBC = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "AES", "CBC"),
         [
             "CBCGFSbox128.rsp",
@@ -50,7 +50,7 @@ class TestAES(object):
     )
 
     test_ECB = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "AES", "ECB"),
         [
             "ECBGFSbox128.rsp",
@@ -74,7 +74,7 @@ class TestAES(object):
     )
 
     test_OFB = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "AES", "OFB"),
         [
             "OFBGFSbox128.rsp",
@@ -98,7 +98,7 @@ class TestAES(object):
     )
 
     test_CFB = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "AES", "CFB"),
         [
             "CFB128GFSbox128.rsp",
@@ -122,7 +122,7 @@ class TestAES(object):
     )
 
     test_CTR = generate_encrypt_test(
-        load_openssl_vectors_from_file,
+        load_openssl_vectors,
         os.path.join("ciphers", "AES", "CTR"),
         ["aes-128-ctr.txt", "aes-192-ctr.txt", "aes-256-ctr.txt"],
         lambda key, iv: algorithms.AES(binascii.unhexlify(key)),

--- a/tests/hazmat/primitives/test_arc4.py
+++ b/tests/hazmat/primitives/test_arc4.py
@@ -19,12 +19,12 @@ import os
 from cryptography.hazmat.primitives.ciphers import algorithms
 
 from .utils import generate_stream_encryption_test
-from ...utils import load_nist_vectors_from_file
+from ...utils import load_nist_vectors
 
 
 class TestARC4(object):
     test_rfc = generate_stream_encryption_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "ARC4"),
         [
             "rfc-6229-40.txt",

--- a/tests/hazmat/primitives/test_blowfish.py
+++ b/tests/hazmat/primitives/test_blowfish.py
@@ -19,12 +19,12 @@ import os
 from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 from .utils import generate_encrypt_test
-from ...utils import load_nist_vectors_from_file
+from ...utils import load_nist_vectors
 
 
 class TestBlowfish(object):
     test_ECB = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
         ["bf-ecb.txt"],
         lambda key: algorithms.Blowfish(binascii.unhexlify(key)),
@@ -36,7 +36,7 @@ class TestBlowfish(object):
     )
 
     test_CBC = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
         ["bf-cbc.txt"],
         lambda key, iv: algorithms.Blowfish(binascii.unhexlify(key)),
@@ -48,7 +48,7 @@ class TestBlowfish(object):
     )
 
     test_OFB = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
         ["bf-ofb.txt"],
         lambda key, iv: algorithms.Blowfish(binascii.unhexlify(key)),
@@ -60,7 +60,7 @@ class TestBlowfish(object):
     )
 
     test_CFB = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
         ["bf-cfb.txt"],
         lambda key, iv: algorithms.Blowfish(binascii.unhexlify(key)),

--- a/tests/hazmat/primitives/test_camellia.py
+++ b/tests/hazmat/primitives/test_camellia.py
@@ -20,13 +20,13 @@ from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 from .utils import generate_encrypt_test
 from ...utils import (
-    load_cryptrec_vectors_from_file, load_openssl_vectors_from_file
+    load_cryptrec_vectors, load_openssl_vectors
 )
 
 
 class TestCamellia(object):
     test_ECB = generate_encrypt_test(
-        load_cryptrec_vectors_from_file,
+        load_cryptrec_vectors,
         os.path.join("ciphers", "Camellia"),
         [
             "camellia-128-ecb.txt",
@@ -42,7 +42,7 @@ class TestCamellia(object):
     )
 
     test_CBC = generate_encrypt_test(
-        load_openssl_vectors_from_file,
+        load_openssl_vectors,
         os.path.join("ciphers", "Camellia"),
         ["camellia-cbc.txt"],
         lambda key, iv: algorithms.Camellia(binascii.unhexlify(key)),
@@ -54,7 +54,7 @@ class TestCamellia(object):
     )
 
     test_OFB = generate_encrypt_test(
-        load_openssl_vectors_from_file,
+        load_openssl_vectors,
         os.path.join("ciphers", "Camellia"),
         ["camellia-ofb.txt"],
         lambda key, iv: algorithms.Camellia(binascii.unhexlify(key)),
@@ -66,7 +66,7 @@ class TestCamellia(object):
     )
 
     test_CFB = generate_encrypt_test(
-        load_openssl_vectors_from_file,
+        load_openssl_vectors,
         os.path.join("ciphers", "Camellia"),
         ["camellia-cfb.txt"],
         lambda key, iv: algorithms.Camellia(binascii.unhexlify(key)),

--- a/tests/hazmat/primitives/test_cast5.py
+++ b/tests/hazmat/primitives/test_cast5.py
@@ -19,12 +19,12 @@ import os
 from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 from .utils import generate_encrypt_test
-from ...utils import load_nist_vectors_from_file
+from ...utils import load_nist_vectors
 
 
 class TestCAST5(object):
     test_ECB = generate_encrypt_test(
-        lambda path: load_nist_vectors_from_file(path),
+        load_nist_vectors,
         os.path.join("ciphers", "CAST5"),
         ["cast5-ecb.txt"],
         lambda key: algorithms.CAST5(binascii.unhexlify((key))),

--- a/tests/hazmat/primitives/test_hash_vectors.py
+++ b/tests/hazmat/primitives/test_hash_vectors.py
@@ -18,12 +18,12 @@ import os
 from cryptography.hazmat.primitives import hashes
 
 from .utils import generate_hash_test, generate_long_string_hash_test
-from ...utils import load_hash_vectors_from_file
+from ...utils import load_hash_vectors
 
 
 class TestSHA1(object):
     test_SHA1 = generate_hash_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         os.path.join("hashes", "SHA1"),
         [
             "SHA1LongMsg.rsp",
@@ -37,7 +37,7 @@ class TestSHA1(object):
 
 class TestSHA224(object):
     test_SHA224 = generate_hash_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         os.path.join("hashes", "SHA2"),
         [
             "SHA224LongMsg.rsp",
@@ -51,7 +51,7 @@ class TestSHA224(object):
 
 class TestSHA256(object):
     test_SHA256 = generate_hash_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         os.path.join("hashes", "SHA2"),
         [
             "SHA256LongMsg.rsp",
@@ -65,7 +65,7 @@ class TestSHA256(object):
 
 class TestSHA384(object):
     test_SHA384 = generate_hash_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         os.path.join("hashes", "SHA2"),
         [
             "SHA384LongMsg.rsp",
@@ -79,7 +79,7 @@ class TestSHA384(object):
 
 class TestSHA512(object):
     test_SHA512 = generate_hash_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         os.path.join("hashes", "SHA2"),
         [
             "SHA512LongMsg.rsp",
@@ -93,7 +93,7 @@ class TestSHA512(object):
 
 class TestRIPEMD160(object):
     test_RIPEMD160 = generate_hash_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         os.path.join("hashes", "ripemd160"),
         [
             "ripevectors.txt",
@@ -113,7 +113,7 @@ class TestRIPEMD160(object):
 
 class TestWhirlpool(object):
     test_whirlpool = generate_hash_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         os.path.join("hashes", "whirlpool"),
         [
             "iso-test-vectors.txt",
@@ -135,7 +135,7 @@ class TestWhirlpool(object):
 
 class TestMD5(object):
     test_md5 = generate_hash_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         os.path.join("hashes", "MD5"),
         [
             "rfc-1321.txt",

--- a/tests/hazmat/primitives/test_hmac_vectors.py
+++ b/tests/hazmat/primitives/test_hmac_vectors.py
@@ -16,12 +16,12 @@ from __future__ import absolute_import, division, print_function
 from cryptography.hazmat.primitives import hashes
 
 from .utils import generate_hmac_test
-from ...utils import load_hash_vectors_from_file
+from ...utils import load_hash_vectors
 
 
 class TestHMAC_MD5(object):
     test_hmac_md5 = generate_hmac_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         "HMAC",
         [
             "rfc-2202-md5.txt",
@@ -34,7 +34,7 @@ class TestHMAC_MD5(object):
 
 class TestHMAC_SHA1(object):
     test_hmac_sha1 = generate_hmac_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         "HMAC",
         [
             "rfc-2202-sha1.txt",
@@ -47,7 +47,7 @@ class TestHMAC_SHA1(object):
 
 class TestHMAC_SHA224(object):
     test_hmac_sha224 = generate_hmac_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         "HMAC",
         [
             "rfc-4231-sha224.txt",
@@ -60,7 +60,7 @@ class TestHMAC_SHA224(object):
 
 class TestHMAC_SHA256(object):
     test_hmac_sha256 = generate_hmac_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         "HMAC",
         [
             "rfc-4231-sha256.txt",
@@ -73,7 +73,7 @@ class TestHMAC_SHA256(object):
 
 class TestHMAC_SHA384(object):
     test_hmac_sha384 = generate_hmac_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         "HMAC",
         [
             "rfc-4231-sha384.txt",
@@ -86,7 +86,7 @@ class TestHMAC_SHA384(object):
 
 class TestHMAC_SHA512(object):
     test_hmac_sha512 = generate_hmac_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         "HMAC",
         [
             "rfc-4231-sha512.txt",
@@ -99,7 +99,7 @@ class TestHMAC_SHA512(object):
 
 class TestHMAC_RIPEMD160(object):
     test_hmac_ripemd160 = generate_hmac_test(
-        load_hash_vectors_from_file,
+        load_hash_vectors,
         "HMAC",
         [
             "rfc-2286-ripemd160.txt",

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -8,6 +8,8 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import hmac
 from cryptography.hazmat.primitives.ciphers import Cipher
 
+from ...utils import load_vectors_from_file
+
 
 def generate_encrypt_test(param_loader, path, file_names, cipher_factory,
                           mode_factory, only_if=lambda backend: True,
@@ -15,7 +17,10 @@ def generate_encrypt_test(param_loader, path, file_names, cipher_factory,
     def test_encryption(self):
         for backend in _ALL_BACKENDS:
             for file_name in file_names:
-                for params in param_loader(os.path.join(path, file_name)):
+                for params in load_vectors_from_file(
+                    os.path.join(path, file_name),
+                    param_loader
+                ):
                     yield (
                         encrypt_test,
                         backend,
@@ -55,7 +60,10 @@ def generate_stream_encryption_test(param_loader, path, file_names,
     def test_stream_encryption(self):
         for backend in _ALL_BACKENDS:
             for file_name in file_names:
-                for params in param_loader(os.path.join(path, file_name)):
+                for params in load_vectors_from_file(
+                    os.path.join(path, file_name),
+                    param_loader
+                ):
                     yield (
                         stream_encryption_test,
                         backend,
@@ -93,7 +101,10 @@ def generate_hash_test(param_loader, path, file_names, hash_cls,
     def test_hash(self):
         for backend in _ALL_BACKENDS:
             for file_name in file_names:
-                for params in param_loader(os.path.join(path, file_name)):
+                for params in load_vectors_from_file(
+                    os.path.join(path, file_name),
+                    param_loader
+                ):
                     yield (
                         hash_test,
                         backend,
@@ -173,7 +184,10 @@ def generate_hmac_test(param_loader, path, file_names, algorithm,
     def test_hmac(self):
         for backend in _ALL_BACKENDS:
             for file_name in file_names:
-                for params in param_loader(os.path.join(path, file_name)):
+                for params in load_vectors_from_file(
+                    os.path.join(path, file_name),
+                    param_loader
+                ):
                     yield (
                         hmac_test,
                         backend,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,10 +17,8 @@ import textwrap
 import pytest
 
 from .utils import (
-    load_nist_vectors, load_nist_vectors_from_file, load_cryptrec_vectors,
-    load_cryptrec_vectors_from_file, load_openssl_vectors,
-    load_openssl_vectors_from_file, load_hash_vectors,
-    load_hash_vectors_from_file
+    load_nist_vectors, load_vectors_from_file, load_cryptrec_vectors,
+    load_openssl_vectors, load_hash_vectors,
 )
 
 
@@ -91,8 +89,9 @@ def test_load_nist_vectors():
 
 
 def test_load_nist_vectors_from_file():
-    assert load_nist_vectors_from_file(
-        os.path.join("ciphers", "AES", "CBC", "CBCGFSbox128.rsp")
+    assert load_vectors_from_file(
+        os.path.join("ciphers", "AES", "CBC", "CBCGFSbox128.rsp"),
+        load_nist_vectors
     ) == [
         {
             "key": b"00000000000000000000000000000000",
@@ -236,8 +235,9 @@ def test_load_cryptrec_vectors_invalid():
 
 
 def test_load_cryptrec_vectors_from_file_encrypt():
-    test_set = load_cryptrec_vectors_from_file(
+    test_set = load_vectors_from_file(
         os.path.join("ciphers", "Camellia", "camellia-128-ecb.txt"),
+        load_cryptrec_vectors
     )
     assert test_set[0] == (
         {
@@ -301,8 +301,9 @@ def test_load_openssl_vectors():
 
 
 def test_load_openssl_vectors_from_file():
-    test_list = load_openssl_vectors_from_file(
-        os.path.join("ciphers", "Camellia", "camellia-ofb.txt")
+    test_list = load_vectors_from_file(
+        os.path.join("ciphers", "Camellia", "camellia-ofb.txt"),
+        load_openssl_vectors
     )
     assert len(test_list) == 24
     assert test_list[:4] == [
@@ -392,8 +393,9 @@ def test_load_hash_vectors_bad_data():
 
 
 def test_load_hash_vectors_from_file():
-    test_list = load_hash_vectors_from_file(
-        os.path.join("hashes", "MD5", "rfc-1321.txt")
+    test_list = load_vectors_from_file(
+        os.path.join("hashes", "MD5", "rfc-1321.txt"),
+        load_hash_vectors
     )
     assert len(test_list) == 7
     assert test_list[:4] == [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,14 @@
 import os.path
 
 
+def load_vectors_from_file(filename, loader):
+    base = os.path.join(
+        os.path.dirname(__file__), "hazmat", "primitives", "vectors",
+    )
+    with open(os.path.join(base, filename), "r") as vector_file:
+        return loader(vector_file)
+
+
 def load_nist_vectors(vector_data):
     section = None
     count = None
@@ -52,23 +60,6 @@ def load_nist_vectors(vector_data):
     return [v for k, v in sorted(data.items(), key=lambda kv: kv[0])]
 
 
-def load_nist_vectors_from_file(filename):
-    base = os.path.join(
-        os.path.dirname(__file__), "hazmat", "primitives", "vectors",
-    )
-    with open(os.path.join(base, filename), "r") as vector_file:
-        return load_nist_vectors(vector_file)
-
-
-def load_cryptrec_vectors_from_file(filename):
-    base = os.path.join(
-        os.path.dirname(__file__),
-        "hazmat", "primitives", "vectors",
-    )
-    with open(os.path.join(base, filename), "r") as vector_file:
-        return load_cryptrec_vectors(vector_file)
-
-
 def load_cryptrec_vectors(vector_data):
     cryptrec_list = []
 
@@ -95,15 +86,6 @@ def load_cryptrec_vectors(vector_data):
         else:
             raise ValueError("Invalid line in file '{}'".format(line))
     return cryptrec_list
-
-
-def load_openssl_vectors_from_file(filename):
-    base = os.path.join(
-        os.path.dirname(__file__),
-        "hazmat", "primitives", "vectors",
-    )
-    with open(os.path.join(base, filename), "r") as vector_file:
-        return load_openssl_vectors(vector_file)
 
 
 def load_openssl_vectors(vector_data):
@@ -167,11 +149,3 @@ def load_hash_vectors(vector_data):
         else:
             raise ValueError("Unknown line in hash vector")
     return vectors
-
-
-def load_hash_vectors_from_file(filename):
-    base = os.path.join(
-        os.path.dirname(__file__), "hazmat", "primitives", "vectors"
-    )
-    with open(os.path.join(base, filename), "r") as vector_file:
-        return load_hash_vectors(vector_file)


### PR DESCRIPTION
With the simplification to load_nist_vectors we can replace all the separate _from_file functions with a single load_vectors_from_file.
