### PR TITLE
Supress the deprecation warnings by including an __APPLE__ only preamble.

### DIFF
--- a/cryptography/hazmat/bindings/openssl/backend.py
+++ b/cryptography/hazmat/bindings/openssl/backend.py
@@ -131,11 +131,13 @@ class Backend(object):
         #   int foo(short);
 
         lib = ffi.verify(
-            source="\n".join([_OSX_PRE_INCLUDE] +
-                             includes  +
-                             [_OSX_POST_INCLUDE] +
-                             functions +
-                             customizations),
+            source="\n".join(
+                [_OSX_PRE_INCLUDE] +
+                includes +
+                [_OSX_POST_INCLUDE] +
+                functions +
+                customizations
+            ),
             libraries=["crypto", "ssl"],
         )
 


### PR DESCRIPTION
I'm open to suggestions on a better place to put the preamble.

This brings us down to 31 warnings down from 425.

Related to #295
