### PR TITLE
remove ASN1_ITEM_ptr macro

### DIFF
--- a/cryptography/hazmat/backends/openssl/asn1.py
+++ b/cryptography/hazmat/backends/openssl/asn1.py
@@ -102,7 +102,6 @@ ASN1_VALUE *ASN1_item_d2i(ASN1_VALUE **, const unsigned char **, long,
 
 MACROS = """
 ASN1_TIME *M_ASN1_TIME_dup(void *);
-ASN1_ITEM *ASN1_ITEM_ptr(ASN1_ITEM *);
 
 /* These aren't macros these arguments are all const X on openssl > 1.0.x */
 


### PR DESCRIPTION
This macro is unused in our current codebase and is causing compile
errors with cl.exe on windows (C2063 error). Removing until such time as
we need it.
