### PR TITLE
potential fix for compiler error on win32 platform

### DIFF
--- a/cryptography/hazmat/backends/openssl/asn1.py
+++ b/cryptography/hazmat/backends/openssl/asn1.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+from .defines import is_defined
 
 
 INCLUDES = """
@@ -55,7 +55,7 @@ static const int MBSTRING_UTF8;
 # This is required because typical Windows OpenSSL binaries are compiled with
 # OPENSSL_EXPORT_VAR_AS_FUNCTION. Without the right typedef here the compiler
 # will error on ASN1_ITEM_ptr
-if sys.platform == "win32":
+if is_defined("OPENSSL_EXPORT_VAR_AS_FUNCTION"):
     TYPES += "typedef const ASN1_ITEM * ASN1_ITEM_EXP(void);"
 else:
     TYPES += "typedef const ASN1_ITEM ASN1_ITEM_EXP;"

--- a/cryptography/hazmat/backends/openssl/defines.py
+++ b/cryptography/hazmat/backends/openssl/defines.py
@@ -1,0 +1,43 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+import cffi
+
+header = "#include <openssl/opensslconf.h>"
+isdefined_template = """
+uint8_t Cryptography_is_defined_{0}() {{
+#ifdef {0}
+    return 1;
+#else
+    return 0;
+#endif
+}}
+"""
+
+ffi = cffi.FFI()
+defines = ["OPENSSL_EXPORT_VAR_AS_FUNCTION", "OPENSSL_THREADS"]
+source = []
+
+for define in defines:
+    func_name = "Cryptography_is_defined_{0}".format(define)
+    ffi.cdef("uint8_t {0}();".format(func_name))
+    source.append(isdefined_template.format(define))
+
+lib = ffi.verify(source=header + "\n" + "\n".join(source))
+
+
+def is_defined(define):
+    func_name = "Cryptography_is_defined_{0}".format(define)
+    return getattr(lib, func_name)()


### PR DESCRIPTION
I really don't like this fix. Pulling logic like this into these submodules is irksome. Open to better ideas!

This will also cause coverage to sink below 100% until we enable a windows build slave.
