### PR TITLE
Run py.test with capture=no for more faster.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     coverage
     pretend
 commands =
-    coverage run --source=cryptography/,tests/ -m pytest --strict
+    coverage run --source=cryptography/,tests/ -m pytest --capture=no --strict
     coverage report -m
 
 [testenv:docs]
@@ -24,7 +24,7 @@ commands =
 # Temporarily disable coverage on pypy because of performance problems with
 # coverage.py on pypy.
 [testenv:pypy]
-commands = py.test
+commands = py.test --capture=no
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
This seems to shave ~20s off of each test run.
