### PR TITLE
Add more skip check lambdas

### DIFF
--- a/tests/hazmat/primitives/test_3des.py
+++ b/tests/hazmat/primitives/test_3des.py
@@ -39,6 +39,10 @@ class TestTripleDES_CBC(object):
         ],
         lambda keys, **kwargs: algorithms.TripleDES(binascii.unhexlify(keys)),
         lambda iv, **kwargs: modes.CBC(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.TripleDES("\x00" * 8), modes.CBC("\x00" * 8)
+        ),
+        skip_message="Does not support TripleDES CBC",
     )
 
     test_MMT = generate_encrypt_test(
@@ -53,6 +57,10 @@ class TestTripleDES_CBC(object):
             binascii.unhexlify(key1 + key2 + key3)
         ),
         lambda iv, **kwargs: modes.CBC(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.TripleDES("\x00" * 8), modes.CBC("\x00" * 8)
+        ),
+        skip_message="Does not support TripleDES CBC",
     )
 
 
@@ -69,6 +77,10 @@ class TestTripleDES_OFB(object):
         ],
         lambda keys, **kwargs: algorithms.TripleDES(binascii.unhexlify(keys)),
         lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.TripleDES("\x00" * 8), modes.OFB("\x00" * 8)
+        ),
+        skip_message="Does not support TripleDES OFB",
     )
 
     test_MMT = generate_encrypt_test(
@@ -83,6 +95,10 @@ class TestTripleDES_OFB(object):
             binascii.unhexlify(key1 + key2 + key3)
         ),
         lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.TripleDES("\x00" * 8), modes.OFB("\x00" * 8)
+        ),
+        skip_message="Does not support TripleDES OFB",
     )
 
 
@@ -99,6 +115,10 @@ class TestTripleDES_CFB(object):
         ],
         lambda keys, **kwargs: algorithms.TripleDES(binascii.unhexlify(keys)),
         lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.TripleDES("\x00" * 8), modes.CFB("\x00" * 8)
+        ),
+        skip_message="Does not support TripleDES CFB",
     )
 
     test_MMT = generate_encrypt_test(
@@ -113,4 +133,8 @@ class TestTripleDES_CFB(object):
             binascii.unhexlify(key1 + key2 + key3)
         ),
         lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.TripleDES("\x00" * 8), modes.CFB("\x00" * 8)
+        ),
+        skip_message="Does not support TripleDES CFB",
     )

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -47,6 +47,10 @@ class TestAES(object):
         ],
         lambda key, **kwargs: algorithms.AES(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.CBC(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 16), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
     )
 
     test_ECB = generate_encrypt_test(
@@ -71,6 +75,10 @@ class TestAES(object):
         ],
         lambda key, **kwargs: algorithms.AES(binascii.unhexlify(key)),
         lambda **kwargs: modes.ECB(),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 16), modes.ECB()
+        ),
+        skip_message="Does not support AES ECB",
     )
 
     test_OFB = generate_encrypt_test(
@@ -95,6 +103,10 @@ class TestAES(object):
         ],
         lambda key, **kwargs: algorithms.AES(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 16), modes.OFB("\x00" * 16)
+        ),
+        skip_message="Does not support AES OFB",
     )
 
     test_CFB = generate_encrypt_test(
@@ -119,6 +131,10 @@ class TestAES(object):
         ],
         lambda key, **kwargs: algorithms.AES(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 16), modes.CFB("\x00" * 16)
+        ),
+        skip_message="Does not support AES CFB",
     )
 
     test_CTR = generate_encrypt_test(


### PR DESCRIPTION
Some backends may not have cipher support at all, so doing skip checks everywhere is desirable.
