### PR TITLE
remove SSL_OP_MSIE_SSLV2_RSA_PADDING

### DIFF
--- a/cryptography/hazmat/backends/openssl/ssl.py
+++ b/cryptography/hazmat/backends/openssl/ssl.py
@@ -54,7 +54,6 @@ static const int SSL_OP_NETSCAPE_CHALLENGE_BUG;
 static const int SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG;
 static const int SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG;
 static const int SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER;
-static const int SSL_OP_MSIE_SSLV2_RSA_PADDING;
 static const int SSL_OP_SSLEAY_080_CLIENT_DH_BUG;
 static const int SSL_OP_TLS_D5_BUG;
 static const int SSL_OP_TLS_BLOCK_PADDING_BUG;


### PR DESCRIPTION
According to the header it has had "no effect since 0.9.7h and 0.9.8b", but more importantly they decided to re-use the constant value (huh?) in an upcoming OpenSSL release so anyone running bleeding edge will get an undeclared error on the old name. This fixes #350

To see the commit where they reused the define:
https://github.com/openssl/openssl/commit/dece3209f299ebcd82414868ee39b2c6feb3be0a
