### PR TITLE
String literals are const char*.

### DIFF
--- a/cryptography/hazmat/backends/openssl/opensslv.py
+++ b/cryptography/hazmat/backends/openssl/opensslv.py
@@ -17,7 +17,7 @@ INCLUDES = """
 
 TYPES = """
 static const int OPENSSL_VERSION_NUMBER;
-static char *const OPENSSL_VERSION_TEXT;
+static const char *const OPENSSL_VERSION_TEXT;
 """
 
 FUNCTIONS = """

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -141,17 +141,17 @@ this:
 
 .. code-block:: c
 
-    #define SOME_INTEGER 0x0;
-    #define SOME_UINTEGER (unsigned int)0x0001;
-    #define SOME_STRING "hello";
+    #define SOME_INTEGER_LITERAL 0x0;
+    #define SOME_UNSIGNED_INTEGER_LITERAL 0x0001U;
+    #define SOME_STRING_LITERAL "hello";
 
 ...it should be added to the bindings like so:
 
 .. code-block:: c
 
-    static const int SOME_INTEGER;
-    static const unsigned int SOME_UINTEGER;
-    static char *const SOME_STRING;
+    static const int SOME_INTEGER_LITERAL;
+    static const unsigned int SOME_UNSIGNED_INTEGER_LITERAL;
+    static const char *const SOME_STRING_LITERAL;
 
 Documentation
 -------------


### PR DESCRIPTION
GCC won't whine with -Wall because so much code isn't const correct but
writing to a string literal is undefined. -Wwrite-strings is the warning
flag to enable to spot these.
