### PR TITLE
Change invalid source verification to prevent distutils stderr output

### DIFF
--- a/tests/hazmat/bindings/test_bindings.py
+++ b/tests/hazmat/bindings/test_bindings.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.bindings.openssl.binding import Binding
 
 def dummy_initializer():
     ffi = cffi.FFI()
-    ffi.verify(source="#include <fake_header.h>")
+    ffi.verify(source="random text that won't compile")
 
 
 def test_binding_available():


### PR DESCRIPTION
This is a potential fix to #408. If people don't like this approach it can be closed.
