### PR TITLE
Prepare to release.

### DIFF
--- a/cryptography/__about__.py
+++ b/cryptography/__about__.py
@@ -22,7 +22,7 @@ __summary__ = ("cryptography is a package designed to expose cryptographic "
                "recipes and primitives to Python developers.")
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "0.1.dev1"
+__version__ = "0.1"
 
 __author__ = ("Alex Gaynor, Hynek Schlawack, Donald Stufft, "
               "Laurens Van Houtven, Jean-Paul Calderone, Christian Heimes, "

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.1 - YYYY-MM-DD
+0.1 - 2014-01-08
 ~~~~~~~~~~~~~~~~
 
 * Initial release.


### PR DESCRIPTION
We've completed the first release milestone, however multithreaded pyOpenSSL is not expected to work with this version.

If we want to block release on the necessary threading support we should add an appropriate ticket or pr to the milestone and this can be rebased after it is completed.
