### PR TITLE
Ignore six eggs, not a full dozen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ _build/
 cffi-*.egg
 pycparser-*.egg
 pytest-*.egg
+six-*.egg
 dist/
 htmlcov/


### PR DESCRIPTION
After running the install and test suite, ended up with an egg for six. This ignores it.

Should we just use *.egg instead or do we need to be explicit?
