### PR TITLE
Ignore all eggs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ _build/
 .cache/
 *.egg-info/
 .coverage
-cffi-*.egg
-pycparser-*.egg
-pytest-*.egg
-six-*.egg
+*.egg
 dist/
 htmlcov/


### PR DESCRIPTION
Per @alex via #434, taking out all eggs within the `.gitignore`.
