### PR TITLE
Workaround for travis bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,25 @@ compiler:
     - clang
     - gcc
 env:
-    - TOX_ENV=py26
-    - TOX_ENV=py27
-    - TOX_ENV=py32
-    - TOX_ENV=py33
-    - TOX_ENV=pypy
-    - TOX_ENV=py26 OPENSSL=0.9.8
-    - TOX_ENV=py27 OPENSSL=0.9.8
-    - TOX_ENV=py32 OPENSSL=0.9.8
-    - TOX_ENV=py33 OPENSSL=0.9.8
-    - TOX_ENV=pypy OPENSSL=0.9.8
-    - TOX_ENV=docs
-    - TOX_ENV=pep8
-    - TOX_ENV=py3pep8
+    # this global section can be removed when
+    # https://github.com/travis-ci/travis-ci/issues/1844 is fixed
+    global:
+        - CI=true
+        - TRAVIS=true
+    matrix:
+        - TOX_ENV=py26
+        - TOX_ENV=py27
+        - TOX_ENV=py32
+        - TOX_ENV=py33
+        - TOX_ENV=pypy
+        - TOX_ENV=py26 OPENSSL=0.9.8
+        - TOX_ENV=py27 OPENSSL=0.9.8
+        - TOX_ENV=py32 OPENSSL=0.9.8
+        - TOX_ENV=py33 OPENSSL=0.9.8
+        - TOX_ENV=pypy OPENSSL=0.9.8
+        - TOX_ENV=docs
+        - TOX_ENV=pep8
+        - TOX_ENV=py3pep8
 
 install:
     - ./.travis/install.sh


### PR DESCRIPTION
Travis is currently not setting CI=true and TRAVIS=true in their OS X builds ([bug](https://github.com/travis-ci/travis-ci/issues/1844)).

This adds those variables as a workaround until they deploy the fix in a few weeks.
