### PR TITLE
Add test marks to fernet so backends without cipher (or AES/CBC) will skip

### DIFF
--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -25,6 +25,7 @@ import six
 
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 
 def json_parametrize(keys, fname):
@@ -37,7 +38,14 @@ def json_parametrize(keys, fname):
     ])
 
 
+@pytest.mark.cipher
 class TestFernet(object):
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 32), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
+    )
     @json_parametrize(
         ("secret", "now", "iv", "src", "token"), "generate.json",
     )
@@ -50,6 +58,12 @@ class TestFernet(object):
         )
         assert actual_token == token.encode("ascii")
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 32), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
+    )
     @json_parametrize(
         ("secret", "now", "src", "ttl_sec", "token"), "verify.json",
     )
@@ -61,6 +75,12 @@ class TestFernet(object):
         payload = f.decrypt(token.encode("ascii"), ttl=ttl_sec)
         assert payload == src.encode("ascii")
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 32), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
+    )
     @json_parametrize(("secret", "token", "now", "ttl_sec"), "invalid.json")
     def test_invalid(self, secret, token, now, ttl_sec, backend, monkeypatch):
         f = Fernet(secret.encode("ascii"), backend=backend)
@@ -69,16 +89,34 @@ class TestFernet(object):
         with pytest.raises(InvalidToken):
             f.decrypt(token.encode("ascii"), ttl=ttl_sec)
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 32), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
+    )
     def test_invalid_start_byte(self, backend):
         f = Fernet(Fernet.generate_key(), backend=backend)
         with pytest.raises(InvalidToken):
             f.decrypt(base64.urlsafe_b64encode(b"\x81"))
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 32), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
+    )
     def test_timestamp_too_short(self, backend):
         f = Fernet(Fernet.generate_key(), backend=backend)
         with pytest.raises(InvalidToken):
             f.decrypt(base64.urlsafe_b64encode(b"\x80abc"))
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 32), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
+    )
     def test_unicode(self, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         with pytest.raises(TypeError):
@@ -86,6 +124,12 @@ class TestFernet(object):
         with pytest.raises(TypeError):
             f.decrypt(six.u(""))
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 32), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
+    )
     @pytest.mark.parametrize("message", [b"", b"Abc!", b"\x00\xFF\x00\x80"])
     def test_roundtrips(self, message, backend):
         f = Fernet(Fernet.generate_key(), backend=backend)
@@ -95,6 +139,12 @@ class TestFernet(object):
         f = Fernet(Fernet.generate_key())
         assert f._backend is default_backend()
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            algorithms.AES("\x00" * 32), modes.CBC("\x00" * 16)
+        ),
+        skip_message="Does not support AES CBC",
+    )
     def test_bad_key(self, backend):
         with pytest.raises(ValueError):
             Fernet(base64.urlsafe_b64encode(b"abc"), backend=backend)


### PR DESCRIPTION
The marks are as follows:
- class level mark for cipher support in general. Any backend without cipher support will completely skip the class.
- method level marks for AES-256-CBC support
