### PR TITLE
How to link against homebrew OpenSSL on OS X

### DIFF
--- a/docs/hazmat/backends/openssl.rst
+++ b/docs/hazmat/backends/openssl.rst
@@ -44,9 +44,12 @@ Using your own OpenSSL on OS X
 ------------------------------
 
 To link cryptography against a custom version of OpenSSL you'll need to set
-``ARCHFLAGS``, ``LDFLAGS``, and ``CFLAGS``.
+``ARCHFLAGS``, ``LDFLAGS``, and ``CFLAGS``. OpenSSL can be installed via
+`Homebrew`_::
 
-An example using a `Homebrew`_ OpenSSL installation::
+    brew install openssl
+
+Then install cryptography linking against the brewed version::
 
     env ARCHFLAGS="-arch x86_64" LDFLAGS="-L/usr/local/opt/openssl/lib" CFLAGS="-I/usr/local/opt/openssl/include" pip install cryptography
 


### PR DESCRIPTION
Fixes #444

It might make sense to move these "Using your own" sections over to the binding docs rather than backend though. Thoughts?
