### PR TITLE
require cffi >= 0.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join(base_dir, "cryptography", "__about__.py")) as f:
     exec(f.read(), about)
 
 
-CFFI_DEPENDENCY = "cffi>=0.8.1"
+CFFI_DEPENDENCY = "cffi>=0.8"
 SIX_DEPENDENCY = "six>=1.4.1"
 
 requirements = [


### PR DESCRIPTION
Anonymous enums (which we will be using in CommonCrypto's bindings shortly) do not work in some older versions.
