### PR TITLE
Make just one call to ffi.cdef for most of the definitions

### DIFF
--- a/cryptography/hazmat/bindings/utils.py
+++ b/cryptography/hazmat/bindings/utils.py
@@ -34,6 +34,7 @@ def build_ffi(module_prefix, modules, pre_include, post_include, libraries):
         condition.
     """
     ffi = cffi.FFI()
+    types = []
     includes = []
     functions = []
     macros = []
@@ -43,8 +44,7 @@ def build_ffi(module_prefix, modules, pre_include, post_include, libraries):
         __import__(module_name)
         module = sys.modules[module_name]
 
-        ffi.cdef(module.TYPES)
-
+        types.append(module.TYPES)
         macros.append(module.MACROS)
         functions.append(module.FUNCTIONS)
         includes.append(module.INCLUDES)
@@ -53,10 +53,7 @@ def build_ffi(module_prefix, modules, pre_include, post_include, libraries):
     # loop over the functions & macros after declaring all the types
     # so we can set interdependent types in different files and still
     # have them all defined before we parse the funcs & macros
-    for func in functions:
-        ffi.cdef(func)
-    for macro in macros:
-        ffi.cdef(macro)
+    ffi.cdef("\n".join(types + functions + macros))
 
     # We include functions here so that if we got any of their definitions
     # wrong, the underlying C compiler will explode. In C you are allowed


### PR DESCRIPTION
On master HEAD I get these results (extension module already built):

```
$ time python -S -c ''
real    0m0.020s
user    0m0.004s
sys     0m0.000s
$ time python -S -c 'from cryptography.hazmat.bindings.openssl.binding import Binding'
real    0m0.020s
user    0m0.012s
sys     0m0.004s
$ time python -S -c 'from cryptography.hazmat.bindings.openssl.binding import Binding; b = Binding()'
real    0m1.460s
user    0m1.268s
sys     0m0.012s
$ 
```

On the branch, these

```
$ time python -S -c ''
real    0m0.009s
user    0m0.000s
sys     0m0.004s
$ time python -S -c 'from cryptography.hazmat.bindings.openssl.binding import Binding'
real    0m0.023s
user    0m0.004s
sys     0m0.008s
$ time python -S -c 'from cryptography.hazmat.bindings.openssl.binding import Binding; b = Binding()'
real    0m0.555s
user    0m0.488s
sys     0m0.012s
$
```

I admit I don't really understand the comment above the code I changed, though.
