### PR TITLE
Specify the epub theme to fix the epub build on RTD.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -270,3 +270,5 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
+
+epub_theme = 'epub'


### PR DESCRIPTION
Currently it tries to use the RTD theme which produces invalid XHTML.
