### PR TITLE
Don't raise SystemError it's not for you.

### DIFF
--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -153,7 +153,7 @@ class Backend(object):
                         "the block length"
                     )
 
-        raise SystemError(
+        raise ValueError(
             "Unknown error code from OpenSSL, you should probably file a bug."
         )
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -76,20 +76,20 @@ class TestOpenSSL(object):
             cipher.encryptor()
 
     def test_handle_unknown_error(self):
-        with pytest.raises(SystemError):
+        with pytest.raises(ValueError):
             backend._handle_error_code(0, 0, 0)
 
-        with pytest.raises(SystemError):
+        with pytest.raises(ValueError):
             backend._handle_error_code(backend._lib.ERR_LIB_EVP, 0, 0)
 
-        with pytest.raises(SystemError):
+        with pytest.raises(ValueError):
             backend._handle_error_code(
                 backend._lib.ERR_LIB_EVP,
                 backend._lib.EVP_F_EVP_ENCRYPTFINAL_EX,
                 0
             )
 
-        with pytest.raises(SystemError):
+        with pytest.raises(ValueError):
             backend._handle_error_code(
                 backend._lib.ERR_LIB_EVP,
                 backend._lib.EVP_F_EVP_DECRYPTFINAL_EX,


### PR DESCRIPTION
From http://docs.python.org/2/library/exceptions.html#exceptions.SystemError

"Raised when the interpreter finds an internal error, but the
situation does not look so serious to cause it to abandon all hope.
The associated value is a string indicating what went wrong (in
low-level terms).

You should report this to the author or maintainer of your Python
interpreter. Be sure to report the version of the Python interpreter
(sys.version; it is also printed at the start of an interactive
Python session), the exact error message (the exception’s associated
value) and if possible the source of the program that triggered the
error."

ValueError still doesn't feel quite right, but it's definitely an improvement.  Suggestions welcome.
