### PR TITLE
Expose the innards of DH and DSA

### DIFF
--- a/cryptography/hazmat/bindings/openssl/bignum.py
+++ b/cryptography/hazmat/bindings/openssl/bignum.py
@@ -47,6 +47,9 @@ char *BN_bn2hex(const BIGNUM *);
 int BN_hex2bn(BIGNUM **, const char *);
 int BN_dec2bn(BIGNUM **, const char *);
 
+int BN_bn2bin(const BIGNUM *, unsigned char *);
+BIGNUM *BN_bin2bn(const unsigned char *, int, BIGNUM *);
+
 int BN_num_bits(const BIGNUM *);
 """
 

--- a/cryptography/hazmat/bindings/openssl/dh.py
+++ b/cryptography/hazmat/bindings/openssl/dh.py
@@ -16,7 +16,13 @@ INCLUDES = """
 """
 
 TYPES = """
-typedef ... DH;
+typedef struct dh_st {
+    BIGNUM *p;              // prime number (shared)
+    BIGNUM *g;              // generator of Z_p (shared)
+    BIGNUM *priv_key;       // private DH value x
+    BIGNUM *pub_key;        // public DH value g^x
+    ...;
+} DH;
 """
 
 FUNCTIONS = """

--- a/cryptography/hazmat/bindings/openssl/dsa.py
+++ b/cryptography/hazmat/bindings/openssl/dsa.py
@@ -16,7 +16,14 @@ INCLUDES = """
 """
 
 TYPES = """
-typedef ... DSA;
+typedef struct dsa_st {
+    BIGNUM *p;              // prime number (public)
+    BIGNUM *q;              // 160-bit subprime, q | p-1 (public)
+    BIGNUM *g;              // generator of subgroup (public)
+    BIGNUM *priv_key;       // private key x
+    BIGNUM *pub_key;        // public key y = g^x
+    ...;
+} DSA;
 """
 
 FUNCTIONS = """


### PR DESCRIPTION
So we can manually construct or serialise keys at some point.

Also BN2BIN stuff because JWK uses the base64 version of this
representation.
