### PR TITLE
[WIP] Disable duplicate CommonCrypto test runs on Travis

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -14,8 +14,8 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
         # of OpenSSL, but we only need to run the
         # CommonCrypto backend tests once. Exclude
         # CommonCrypto when we test against brew OpenSSL
-        export TOX_FLAGS="-- --backend=openssl"
+        export TOX_FLAGS="--backend=openssl"
     fi
 fi
 source ~/.venv/bin/activate
-tox -e $TOX_ENV $TOX_FLAGS
+tox -e $TOX_ENV -- $TOX_FLAGS


### PR DESCRIPTION
The Travis OS X jobs are run for two versions of OpenSSL, but we only need to run the CommonCrypto backend tests once.

This should speed up our full test suite run times by a decent amount, but does come at the cost of an increasingly complex set of travis scripts.
