### PR TITLE
Include the fernet vectors in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include CONTRIBUTING.rst
 include README.rst
 
 recursive-include tests *.py
+recursive-include tests/vectors *
 recursive-include tests/hazmat/primitives/vectors *


### PR DESCRIPTION
We include the other vectors, so consistency!

cc: @dstufft
