### PR TITLE
Rename RSAs key_length to key_size

### DIFF
--- a/cryptography/hazmat/primitives/interfaces.py
+++ b/cryptography/hazmat/primitives/interfaces.py
@@ -185,7 +185,7 @@ class RSAPrivateKey(six.with_metaclass(abc.ABCMeta)):
         """
 
     @abc.abstractproperty
-    def key_length(self):
+    def key_size(self):
         """
         The bit length of the public modulus.
         """
@@ -241,7 +241,7 @@ class RSAPublicKey(six.with_metaclass(abc.ABCMeta)):
         """
 
     @abc.abstractproperty
-    def key_length(self):
+    def key_size(self):
         """
         The bit length of the public modulus.
         """

--- a/docs/hazmat/primitives/interfaces.rst
+++ b/docs/hazmat/primitives/interfaces.rst
@@ -130,7 +130,7 @@ Asymmetric Interfaces
 
         The public exponent.
 
-    .. attribute:: key_length
+    .. attribute:: key_size
 
         :type: int
 
@@ -179,7 +179,7 @@ Asymmetric Interfaces
 
         The public modulus.
 
-    .. attribute:: key_length
+    .. attribute:: key_size
 
         :type: int
 


### PR DESCRIPTION
So that it matches the existing documented CipherContext stuff.

Consistency, we should do more of that.
