### PR TITLE
Use a pycon codeblock instead...

### DIFF
--- a/docs/random-numbers.rst
+++ b/docs/random-numbers.rst
@@ -13,7 +13,7 @@ provided random number generator, which is available as ``os.urandom()``. For
 example, if you need 16 bytes of random data for an initialization vector, you
 can obtain them with:
 
-.. doctest::
+.. code-block:: pycon
 
     >>> import os
     >>> os.urandom(16)


### PR DESCRIPTION
There is a 6% chance that this random string will contain a single quote and cause the doctest to fail.
