### PR TITLE
Fix comments in padding.py to be accurate

### DIFF
--- a/cryptography/hazmat/primitives/padding.py
+++ b/cryptography/hazmat/primitives/padding.py
@@ -86,8 +86,7 @@ class PKCS7(object):
 class _PKCS7PaddingContext(object):
     def __init__(self, block_size):
         self.block_size = block_size
-        # TODO: O(n ** 2) complexity for repeated concatentation, we should use
-        # zero-buffer (#193)
+        # TODO: more copies than necessary, we should use zero-buffer (#193)
         self._buffer = b""
 
     def update(self, data):
@@ -120,8 +119,7 @@ class _PKCS7PaddingContext(object):
 class _PKCS7UnpaddingContext(object):
     def __init__(self, block_size):
         self.block_size = block_size
-        # TODO: O(n ** 2) complexity for repeated concatentation, we should use
-        # zero-buffer (#193)
+        # TODO: more copies than necessary, we should use zero-buffer (#193)
         self._buffer = b""
 
     def update(self, data):


### PR DESCRIPTION
This is not in fact O(n *\* 2) because `len(self._buffer)` is bounded by `self.block_size`. This means that each `self._buffer += x` only copies O(len(x)) bytes, meaning the whole thing is linear.
