### PR TITLE
Add X509_V_ERR_APPLICATION_VERIFICATION

### DIFF
--- a/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/cryptography/hazmat/bindings/openssl/ssl.py
@@ -117,6 +117,7 @@ static const int SSL_MODE_AUTO_RETRY;
 static const int SSL3_RANDOM_SIZE;
 typedef ... X509_STORE_CTX;
 static const int X509_V_OK;
+static const int X509_V_ERR_APPLICATION_VERIFICATION;
 typedef ... SSL_METHOD;
 typedef ... SSL_CTX;
 


### PR DESCRIPTION
This constant is useful when doing custom verifications.

That said we should consider to expose _all_ of them (cf http://www.openssl.org/docs/apps/verify.html#DIAGNOSTICS ).  This is the only one that is likely set by a user though.
