### PR TITLE
Interfaces for loading OpenSSL "traditional" format private keys.

### DIFF
--- a/cryptography/hazmat/backends/interfaces.py
+++ b/cryptography/hazmat/backends/interfaces.py
@@ -105,3 +105,12 @@ class RSABackend(six.with_metaclass(abc.ABCMeta)):
         Returns an object conforming to the AsymmetricVerificationContext
         interface.
         """
+
+
+class OpenSSLSerializationBackend(six.with_metaclass(abc.ABCMeta)):
+    @abc.abstractmethod
+    def load_openssl_pem_private_key(data, password, backend):
+        """
+        Load a private key from PEM encoded data, using password if the data
+        is encrypted.
+        """

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -248,3 +248,26 @@ A specific ``backend`` may provide one or more of these interfaces.
 
         :returns:
             :class:`~cryptography.hazmat.primitives.interfaces.AsymmetricVerificationContext`
+
+
+.. class:: OpenSSLSerializationBackend
+
+    .. versionadded:: 0.3
+
+    A backend with methods for working with OpenSSL's "traditional" PKCS #1
+    style key serialization.
+
+    .. method:: load_openssl_pem_private_key(data, password)
+       
+        :param bytes data: PEM data to deserialize.
+
+        :param bytes password: The password to use if this data is encrypted.
+            Should be None if the data is not encrypted.
+
+        :return: A new instance of
+            :class:`~cryptography.hazmat.primitives.serialization.OpenSSLPrivateKey`
+
+        :raises ValueError: If the data could not be deserialized correctly.
+
+        :raises cryptography.exceptions.UnsupportedAlgorithm: If the data is
+            encrypted with an unsupported algorithm.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -13,6 +13,8 @@ cryptographically
 decrypt
 decrypted
 decrypting
+deserialize
+deserialized
 Docstrings
 fernet
 Fernet


### PR DESCRIPTION
Not saving them though because encrypting them is complicated by our cipher API :(

PKCS#8 is going to look pretty much the same but with different names for now.
