### PR TITLE
Sort the wordlist is a vaguely sensible way

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,6 +1,9 @@
 backend
 backends
+Backends
+Blowfish
 boolean
+Changelog
 ciphertext
 committer
 committers
@@ -10,7 +13,9 @@ cryptographically
 decrypt
 decrypted
 decrypting
+Docstrings
 fernet
+Fernet
 hazmat
 indistinguishability
 introspectability
@@ -19,13 +24,8 @@ iOS
 pickleable
 plaintext
 pseudorandom
+Schneier
 testability
 unencrypted
 unpadded
 unpadding
-Backends
-Blowfish
-Changelog
-Docstrings
-Fernet
-Schneier


### PR DESCRIPTION
This is `%!sort` in vim with LANG=en_US.UTF-8
