### PR TITLE
Integrate py.test enabling `python setup.py test`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class PyTest(TestCommand):
         TestCommand.finalize_options(self)
         self.test_args = []
         self.test_suite = True
-        
+
     def run_tests(self):
         # Import here because in module scope the eggs are not loaded.
         import pytest


### PR DESCRIPTION
Integrate py.test according to: https://pytest.org/latest/goodpractises.html#integration-with-setuptools-test-commands

Enables use of standard python setup.py test command. 

Very handy for OS packagers & porters for QA, in this case the FreeBSD Port for cryptography which just landed.
