### PR TITLE
Fix ":param:" syntax in KDF docs

### DIFF
--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -179,7 +179,7 @@ Different KDFs are suitable for different tasks such as:
     :param bytes info: Application specific context information.  If ``None``
         is explicitly passed an empty byte string will be used.
 
-    :params backend: A
+    :param backend: A
         :class:`~cryptography.hazmat.backends.interfaces.HMACBackend`
         provider.
 


### PR DESCRIPTION
The KDF docs contain `:params ...:` instead of `:param ...:`, causing Sphinx to render it improperly.
