### PR TITLE
Change exception in use

### DIFF
--- a/cryptography/hazmat/primitives/twofactor/hotp.py
+++ b/cryptography/hazmat/primitives/twofactor/hotp.py
@@ -31,7 +31,7 @@ class HOTP(object):
             raise ValueError("Length of HOTP has to be between 6 to 8.")
 
         if not isinstance(algorithm, (SHA1, SHA256, SHA512)):
-            raise ValueError("Algorithm must be SHA1, SHA256 or SHA512")
+            raise TypeError("Algorithm must be SHA1, SHA256 or SHA512")
 
         self._key = key
         self._length = length

--- a/docs/hazmat/primitives/twofactor.rst
+++ b/docs/hazmat/primitives/twofactor.rst
@@ -47,7 +47,7 @@ codes (HMAC).
         provider.
     :raises ValueError: This is raised if the provided ``key`` is shorter than
         128 bits or if the ``length`` parameter is not 6, 7 or 8.
-    :raises ValueError: This is raised if the provided ``algorithm`` is not
+    :raises TypeError: This is raised if the provided ``algorithm`` is not
         :class:`~cryptography.hazmat.primitives.hashes.SHA1()`,
         :class:`~cryptography.hazmat.primitives.hashes.SHA256()` or
         :class:`~cryptography.hazmat.primitives.hashes.SHA512()`.
@@ -142,7 +142,7 @@ similar to the following code.
         provider.
     :raises ValueError: This is raised if the provided ``key`` is shorter than
         128 bits or if the ``length`` parameter is not 6, 7 or 8.
-    :raises ValueError: This is raised if the provided ``algorithm`` is not
+    :raises TypeError: This is raised if the provided ``algorithm`` is not
         :class:`~cryptography.hazmat.primitives.hashes.SHA1()`,
         :class:`~cryptography.hazmat.primitives.hashes.SHA256()` or
         :class:`~cryptography.hazmat.primitives.hashes.SHA512()`.

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -46,7 +46,7 @@ class TestHOTP(object):
     def test_invalid_algorithm(self, backend):
         secret = os.urandom(16)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             HOTP(secret, 6, MD5(), backend)
 
     @pytest.mark.parametrize("params", vectors)


### PR DESCRIPTION
`UnsupportedAlgorithm` thus far has been used to express that a backend doesn't support an algorithm, here it's used to indicate that the algorithm isn't supported by the spec.
