### PR TITLE
link the CONTRIBUTING.rst to the development section of our docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,9 +10,9 @@ Examples of contributions include:
 * Bug reports and patch reviews
 
 Extensive contribution guidelines are available in the repository at
-``docs/contributing.rst``, or online at:
+``docs/development/index.rst``, or online at:
 
-https://cryptography.io/en/latest/contributing/
+https://cryptography.io/en/latest/development/
 
 Security issues
 ---------------


### PR DESCRIPTION
It was still linked to the old contributing section that was refactored.

As exarkun pointed out in IRC, https://cryptography.io/en/latest/contributing/ is still a functional link. Does RTD not purge pages that are no longer being generated?
