### PR TITLE
Remove EVP_R_DISABLED_FOR_FIPS definition

### DIFF
--- a/cryptography/hazmat/bindings/openssl/err.py
+++ b/cryptography/hazmat/bindings/openssl/err.py
@@ -151,7 +151,6 @@ static const int EVP_R_CTRL_OPERATION_NOT_IMPLEMENTED;
 static const int EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH;
 static const int EVP_R_DECODE_ERROR;
 static const int EVP_R_DIFFERENT_KEY_TYPES;
-static const int EVP_R_DISABLED_FOR_FIPS;
 static const int EVP_R_ENCODE_ERROR;
 static const int EVP_R_INITIALIZATION_ERROR;
 static const int EVP_R_INPUT_NOT_INITIALIZED;


### PR DESCRIPTION
Since we don't use it (and neither does PyOpenSSL) let's remove it for now. Fixes #712.
