### PR TITLE
backport EVP_R_DISABLED_FOR_FIPS removal, increment for 0.2.2

### DIFF
--- a/cryptography/__about__.py
+++ b/cryptography/__about__.py
@@ -22,7 +22,7 @@ __summary__ = ("cryptography is a package designed to expose cryptographic "
                "recipes and primitives to Python developers.")
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"

--- a/cryptography/hazmat/bindings/openssl/err.py
+++ b/cryptography/hazmat/bindings/openssl/err.py
@@ -151,7 +151,6 @@ static const int EVP_R_CTRL_OPERATION_NOT_IMPLEMENTED;
 static const int EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH;
 static const int EVP_R_DECODE_ERROR;
 static const int EVP_R_DIFFERENT_KEY_TYPES;
-static const int EVP_R_DISABLED_FOR_FIPS;
 static const int EVP_R_ENCODE_ERROR;
 static const int EVP_R_INITIALIZATION_ERROR;
 static const int EVP_R_INPUT_NOT_INITIALIZED;

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,14 @@
 Changelog
 =========
 
+0.2.2 - 2014-03-03
+~~~~~~~~~~~~~~~~~~
+
+* Removed a constant definition that was causing compilation problems with specific versions of OpenSSL.
+
 0.2.1 - 2014-02-22
 ~~~~~~~~~~~~~~~~~~
+
 * Fix a bug where importing cryptography from multiple paths could cause initialization to fail.
 
 0.2 - 2014-02-20


### PR DESCRIPTION
PR against 0.2.x branch to fix a compilation issue with certain versions of OpenSSL that don't have `EVP_R_DISABLED_FOR_FIPS`.

Once this lands we should submit another PR to add the 0.2.2 changelog entry to master's changelog.rst
