### PR TITLE
0.9.8e Compatibility (CentOS/RHEL 5)

### DIFF
--- a/cryptography/hazmat/bindings/openssl/nid.py
+++ b/cryptography/hazmat/bindings/openssl/nid.py
@@ -33,6 +33,10 @@ static const int NID_sha512;
 static const int NID_sha224;
 static const int NID_sha;
 static const int NID_ecdsa_with_SHA1;
+static const int NID_ecdsa_with_SHA224;
+static const int NID_ecdsa_with_SHA256;
+static const int NID_ecdsa_with_SHA384;
+static const int NID_ecdsa_with_SHA512;
 static const int NID_crl_reason;
 static const int NID_pbe_WithSHA1And3_Key_TripleDES_CBC;
 static const int NID_subject_alt_name;
@@ -184,12 +188,6 @@ FUNCTIONS = """
 """
 
 MACROS = """
-/* These were added in OpenSSL 0.9.8g. When we drop support for RHEL/CentOS 5
-   we should be able to move these back to TYPES. */
-static const int NID_ecdsa_with_SHA224;
-static const int NID_ecdsa_with_SHA256;
-static const int NID_ecdsa_with_SHA384;
-static const int NID_ecdsa_with_SHA512;
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
This PR adds 0.9.8e compatibility so we can install on CentOS/RHEL 5 boxes that have an updated Python but default system OpenSSL (which is unfortunately very common).

I've temporarily added CentOS 5 to the PR builder as well, but will permanently add it to the build matrix for jenkins (both PR and master job) when this lands.
