### PR TITLE
Add GPG key fingerprint for lvh

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,7 +6,7 @@ PGP key fingerprints are enclosed in parentheses.
 * Alex Gaynor <alex.gaynor@gmail.com> (E27D 4AA0 1651 72CB C5D2  AF2B 125F 5C67 DFE9 4084)
 * Hynek Schlawack <hs@ox.cx> (C2A0 4F86 ACE2 8ADC F817 DBB7 AE25 3622 7F69 F181)
 * Donald Stufft <donald@stufft.io>
-* Laurens Van Houtven <_@lvh.io>
+* Laurens Van Houtven <_@lvh.io> (D9DC 4315 772F 8E91 DD22 B153 DFD1 3DF7 A8DD 569B)
 * Christian Heimes <christian@python.org>
 * Paul Kehrer <paul.l.kehrer@gmail.com>
 * Jarret Raim <jarito@gmail.com>


### PR DESCRIPTION
I have a new key, see revocation: https://gist.github.com/lvh/9412036

New key is forward-signed with old one.
