### PR TITLE
Add mgf1_hash_supported to the RSABackend interface

### DIFF
--- a/cryptography/hazmat/backends/interfaces.py
+++ b/cryptography/hazmat/backends/interfaces.py
@@ -106,6 +106,12 @@ class RSABackend(six.with_metaclass(abc.ABCMeta)):
         interface.
         """
 
+    @abc.abstractmethod
+    def mgf1_hash_supported(self, algorithm):
+        """
+        Return True if the hash algorithm is supported for MGF1 in PSS.
+        """
+
 
 class OpenSSLSerializationBackend(six.with_metaclass(abc.ABCMeta)):
     @abc.abstractmethod

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -249,6 +249,20 @@ A specific ``backend`` may provide one or more of these interfaces.
         :returns:
             :class:`~cryptography.hazmat.primitives.interfaces.AsymmetricVerificationContext`
 
+    .. method:: mgf1_hash_supported(algorithm)
+
+        Check if the specified ``algorithm`` is supported for use with
+        :class:`~cryptography.hazmat.primitives.asymmetric.padding.MGF1`
+        inside :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+        padding.
+
+        :param algorithm: An instance of a
+            :class:`~cryptography.hazmat.primitives.interfaces.HashAlgorithm`
+            provider.
+
+        :returns: ``True`` if the specified ``algorithm`` is supported by this
+            backend, otherwise ``False``.
+
 
 .. class:: OpenSSLSerializationBackend
 


### PR DESCRIPTION
This interface is needed to allow tests to check if the requested hash is supported by MGF1.
