### PR TITLE
Fix circular imports with available_backends()

### DIFF
--- a/cryptography/hazmat/backends/__init__.py
+++ b/cryptography/hazmat/backends/__init__.py
@@ -22,24 +22,24 @@ from cryptography.hazmat.bindings.openssl.binding import (
 )
 
 
-_available_backends = None
+_available_backends_list = None
 
 
-def available_backends():
-    global _available_backends
+def _available_backends():
+    global _available_backends_list
 
-    if _available_backends is None:
-        _available_backends = []
+    if _available_backends_list is None:
+        _available_backends_list = []
 
         if CommonCryptoBinding.is_available():
             from cryptography.hazmat.backends import commoncrypto
-            _available_backends.append(commoncrypto.backend)
+            _available_backends_list.append(commoncrypto.backend)
 
         if OpenSSLBinding.is_available():
             from cryptography.hazmat.backends import openssl
-            _available_backends.append(openssl.backend)
+            _available_backends_list.append(openssl.backend)
 
-    return _available_backends
+    return _available_backends_list
 
 
 _default_backend = None
@@ -49,6 +49,6 @@ def default_backend():
     global _default_backend
 
     if _default_backend is None:
-        _default_backend = MultiBackend(available_backends())
+        _default_backend = MultiBackend(_available_backends())
 
     return _default_backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from cryptography.hazmat.backends import available_backends
+from cryptography.hazmat.backends import _available_backends
 from cryptography.hazmat.backends.interfaces import (
     HMACBackend, CipherBackend, HashBackend, PBKDF2HMACBackend, RSABackend
 )
@@ -25,7 +25,7 @@ from .utils import check_for_iface, check_backend_support, select_backends
 
 def pytest_generate_tests(metafunc):
     names = metafunc.config.getoption("--backend")
-    selected_backends = select_backends(names, available_backends())
+    selected_backends = select_backends(names, _available_backends())
 
     if "backend" in metafunc.fixturenames:
         metafunc.parametrize("backend", selected_backends)


### PR DESCRIPTION
Fix for circular import issue in master that doesn't break `from cryptography.hazmat.backends import default_backend`
