### PR TITLE
add py34 target for python 3.4 CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,docs,pep8,py3pep8
+envlist = py26,py27,pypy,py32,py33,py34,docs,pep8,py3pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
refs #814

Prerequisite for us to add python 3.4 to our build matrix.
