### PR TITLE
Add ASN1_TIME_free

### DIFF
--- a/cryptography/hazmat/bindings/openssl/asn1.py
+++ b/cryptography/hazmat/bindings/openssl/asn1.py
@@ -99,6 +99,7 @@ int i2a_ASN1_INTEGER(BIO *, ASN1_INTEGER *);
 
 /*  ASN1 TIME */
 ASN1_TIME *ASN1_TIME_new(void);
+void ASN1_TIME_free(ASN1_TIME *);
 ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *,
                                                    ASN1_GENERALIZEDTIME **);
 


### PR DESCRIPTION
Required function to solve a memory leak in pyOpenSSL in OpenSSL.crypto.Revoked._X509_REVOKED_dup().
