### PR TITLE
workaround a netbsd bug where they did not compile with d1_meth.c

### DIFF
--- a/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/cryptography/hazmat/bindings/openssl/ssl.py
@@ -411,7 +411,7 @@ SSL_CTX *(*SSL_set_SSL_CTX)(SSL *, SSL_CTX *) = NULL;
 #  include <sys/param.h>
 #  if (__NetBSD_Version__ < 699003800)
 static const long Cryptography_HAS_NETBSD_D1_METH = 0;
-const SSL_METHOD *DTLSv1_method)(void) {
+const SSL_METHOD *DTLSv1_method(void) {
     return NULL;
 }
 #  else


### PR DESCRIPTION
This is a potential fix for NetBSD's crazy bug where they didn't compile with d1_meth.c but left the headers present. It is fixed upstream but we should decide whether we want to land this fix or have the packagers for NetBSD maintain this patch themselves.
