### PR TITLE
Add Next Protocol Negotiation functions for OpenSSL

### DIFF
--- a/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/cryptography/hazmat/bindings/openssl/ssl.py
@@ -326,18 +326,18 @@ const SSL_METHOD* Cryptography_SSL_CTX_get_method(const SSL_CTX*);
  * versions some special handling of these is necessary.
  */
 void SSL_CTX_set_next_protos_advertised_cb(SSL_CTX *,
-                                           int (*) (SSL *,
-                                                    const unsigned char **,
-                                                    unsigned int *,
-                                                    void *),
+                                           int (*)(SSL *,
+                                                   const unsigned char **,
+                                                   unsigned int *,
+                                                   void *),
                                            void *);
 void SSL_CTX_set_next_proto_select_cb(SSL_CTX *,
-                                      int (*) (SSL *,
-                                               unsigned char **,
-                                               unsigned char *,
-                                               const unsigned char *,
-                                               unsigned int,
-                                               void *),
+                                      int (*)(SSL *,
+                                              unsigned char **,
+                                              unsigned char *,
+                                              const unsigned char *,
+                                              unsigned int,
+                                              void *),
                                       void *);
 int SSL_select_next_proto(unsigned char **, unsigned char *,
                           const unsigned char *, unsigned int,


### PR DESCRIPTION
Next Protocol Negotiation was added in OpenSSL 1.0.1. This pull request would expose the necessary functions for use in pyca/pyopenssl#79.

I've had some testing 'fun' with this, probably because I've got no experience with CFFI or with OpenSSL. I'm opening this PR to see whether your CI infrastructure likes it or not. If it doesn't, I'll try to chase down why.
