### PR TITLE
add some comments to note the duplication between setup.py and tox.ini

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ requirements = [
     SIX_DEPENDENCY
 ]
 
+# If you add a new dep here you probably need to add it in the tox.ini as well
 test_requirements = [
     "pytest",
     "pretend",

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py26,py27,pypy,py32,py33,py34,docs,pep8,py3pep8
 
 [testenv]
+# If you add a new dep here you probably need to add it in setup.py as well
 deps =
     coverage
     iso8601


### PR DESCRIPTION
After conversation in #764 it appears fixing #687 is probably best accomplished just by putting comments to note the duplicate dependency locations.
