### PR TITLE
some fixes to silence cl.exe compiler warnings on windows

### DIFF
--- a/cryptography/hazmat/bindings/openssl/engine.py
+++ b/cryptography/hazmat/bindings/openssl/engine.py
@@ -34,16 +34,19 @@ typedef ... *ENGINE_DIGESTS_PTR;
 typedef ... ENGINE_CMD_DEFN;
 typedef ... UI_METHOD;
 
-static const unsigned int ENGINE_METHOD_RSA;
-static const unsigned int ENGINE_METHOD_DSA;
-static const unsigned int ENGINE_METHOD_RAND;
-static const unsigned int ENGINE_METHOD_ECDH;
-static const unsigned int ENGINE_METHOD_ECDSA;
-static const unsigned int ENGINE_METHOD_CIPHERS;
-static const unsigned int ENGINE_METHOD_DIGESTS;
-static const unsigned int ENGINE_METHOD_STORE;
-static const unsigned int ENGINE_METHOD_ALL;
-static const unsigned int ENGINE_METHOD_NONE;
+/* These defines are cast to unsigned int in the headers, but cffi's codegen
+   causes warnings on Windows. Since they're all very small it is safe to make
+   them signed long and silence the warning. */
+static const long ENGINE_METHOD_RSA;
+static const long ENGINE_METHOD_DSA;
+static const long ENGINE_METHOD_RAND;
+static const long ENGINE_METHOD_ECDH;
+static const long ENGINE_METHOD_ECDSA;
+static const long ENGINE_METHOD_CIPHERS;
+static const long ENGINE_METHOD_DIGESTS;
+static const long ENGINE_METHOD_STORE;
+static const long ENGINE_METHOD_ALL;
+static const long ENGINE_METHOD_NONE;
 """
 
 FUNCTIONS = """

--- a/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/cryptography/hazmat/bindings/openssl/ssl.py
@@ -82,7 +82,7 @@ static const long SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG;
 static const long SSL_OP_NO_QUERY_MTU;
 static const long SSL_OP_COOKIE_EXCHANGE;
 static const long SSL_OP_NO_TICKET;
-static const long SSL_OP_ALL;
+static const uint64_t SSL_OP_ALL;
 static const long SSL_OP_SINGLE_ECDH_USE;
 static const long SSL_VERIFY_PEER;
 static const long SSL_VERIFY_FAIL_IF_NO_PEER_CERT;


### PR DESCRIPTION
Do not merge.
