### PR TITLE
This actually returns an int

### DIFF
--- a/cryptography/hazmat/bindings/openssl/bignum.py
+++ b/cryptography/hazmat/bindings/openssl/bignum.py
@@ -92,7 +92,7 @@ MACROS = """
 int BN_zero(BIGNUM *);
 int BN_one(BIGNUM *);
 int BN_mod(BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
-BIGNUM *BN_cmp(const BIGNUM *, const BIGNUM *);
+int BN_cmp(const BIGNUM *, const BIGNUM *);
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
https://www.openssl.org/docs/crypto/BN_cmp.html

Oops.
