### PR TITLE
Update fernet.rst

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -16,7 +16,7 @@ symmetric (also known as "secret key") authenticated cryptography.
         >>> from cryptography.fernet import Fernet
         >>> key = Fernet.generate_key()
         >>> f = Fernet(key)
-        >>> token = f.encrypt(b"my deep dark secret")
+        >>> token = f.encrypt(b"MyDeepDarkSecreT")
         >>> token
         '...'
         >>> f.decrypt(token)


### PR DESCRIPTION
`key` must be the base64 encoded form of a URL safe byte-string, so the example should not include ' ' (space) characters.
