### PR TITLE
Fix Travis OS X Builds

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -6,8 +6,9 @@ set -x
 if [[ "$(uname -s)" == "Darwin" ]]; then
     eval "$(pyenv init -)"
     if [[ "${OPENSSL}" != "0.9.8" ]]; then
-        # so set our flags to use homebrew openssl
-        export ARCHFLAGS="-arch x86_64"
+        # set our flags to use homebrew openssl and not error on
+        # unused compiler args (looking at you mno-fused-madd)
+        export ARCHFLAGS="-arch x86_64 -Wno-error=unused-command-line-argument-hard-error-in-future"
         export LDFLAGS="-L/usr/local/opt/openssl/lib"
         export CFLAGS="-I/usr/local/opt/openssl/include"
         # The Travis OS X jobs are run for two versions
@@ -15,6 +16,8 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
         # CommonCrypto backend tests once. Exclude
         # CommonCrypto when we test against brew OpenSSL
         export TOX_FLAGS="--backend=openssl"
+    else
+        export ARCHFLAGS="-Wno-error=unused-command-line-argument-hard-error-in-future"
     fi
 fi
 source ~/.venv/bin/activate


### PR DESCRIPTION
Travis is upgrading to xcode 5.1 with updated clang. This means `-fno-fused-madd` problems. This PR adds the requisite `-Wno-error=unused-command-line-argument-hard-error-in-future` to fix it.
