### PR TITLE
Rename OpenSSLSerializationBackend

### DIFF
--- a/cryptography/hazmat/backends/interfaces.py
+++ b/cryptography/hazmat/backends/interfaces.py
@@ -141,9 +141,9 @@ class DSABackend(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class OpenSSLSerializationBackend(object):
+class TraditionalOpenSSLSerializationBackend(object):
     @abc.abstractmethod
-    def load_openssl_pem_private_key(self, data, password):
+    def load_traditional_openssl_pem_private_key(self, data, password):
         """
         Load a private key from PEM encoded data, using password if the data
         is encrypted.

--- a/cryptography/hazmat/bindings/openssl/err.py
+++ b/cryptography/hazmat/bindings/openssl/err.py
@@ -138,6 +138,7 @@ static const int EVP_F_RC5_CTRL;
 static const int EVP_R_AES_KEY_SETUP_FAILED;
 static const int EVP_R_ASN1_LIB;
 static const int EVP_R_BAD_BLOCK_LENGTH;
+static const int EVP_R_BAD_DECRYPT;
 static const int EVP_R_BAD_KEY_LENGTH;
 static const int EVP_R_BN_DECODE_ERROR;
 static const int EVP_R_BN_PUBKEY_ERROR;

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -276,7 +276,7 @@ A specific ``backend`` may provide one or more of these interfaces.
             provider.
 
 
-.. class:: OpenSSLSerializationBackend
+.. class:: TraditionalOpenSSLSerializationBackend
 
     .. versionadded:: 0.3
 
@@ -290,8 +290,8 @@ A specific ``backend`` may provide one or more of these interfaces.
         :param bytes password: The password to use if this data is encrypted.
             Should be None if the data is not encrypted.
 
-        :return: A new instance of
-            :class:`~cryptography.hazmat.primitives.serialization.OpenSSLPrivateKey`
+        :return: A new instance of the appropriate private key or public key
+            that the serialized data contains.
 
         :raises ValueError: If the data could not be deserialized correctly.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -25,6 +25,7 @@ interoperable
 introspectability
 invariants
 iOS
+metadata
 pickleable
 plaintext
 pseudorandom

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,5 @@ markers =
     hmac: this test requires a backend providing HMACBackend
     pbkdf2hmac: this test requires a backend providing PBKDF2HMACBackend
     rsa: this test requires a backend providing RSABackend
+    traditional_openssl_serialization: this test requires a backend providing TraditionalOpenSSLSerializationBackend
     supported: parametrized test requiring only_if and skip_message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ import pytest
 from cryptography.hazmat.backends import _available_backends
 from cryptography.hazmat.backends.interfaces import (
     CMACBackend, CipherBackend, DSABackend, HMACBackend, HashBackend,
-    PBKDF2HMACBackend, RSABackend
+    PBKDF2HMACBackend, RSABackend, TraditionalOpenSSLSerializationBackend
 )
 from .utils import check_backend_support, check_for_iface, select_backends
 
@@ -40,6 +40,11 @@ def pytest_runtest_setup(item):
     check_for_iface("pbkdf2hmac", PBKDF2HMACBackend, item)
     check_for_iface("dsa", DSABackend, item)
     check_for_iface("rsa", RSABackend, item)
+    check_for_iface(
+        "traditional_openssl_serialization",
+        TraditionalOpenSSLSerializationBackend,
+        item
+    )
     check_backend_support(item)
 
 

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -26,7 +26,9 @@ from cryptography.exceptions import _Reasons
 from cryptography.hazmat.primitives import hashes, interfaces
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
-from .utils import generate_rsa_verification_test
+from .utils import (
+    _check_rsa_private_key, generate_rsa_verification_test
+)
 from ...utils import (
     load_pkcs1_vectors, load_rsa_nist_vectors, load_vectors_from_file,
     raises_unsupported_algorithm
@@ -40,24 +42,6 @@ class DummyPadding(object):
 
 class DummyMGF(object):
     _salt_length = 0
-
-
-def _check_rsa_private_key(skey):
-    assert skey
-    assert skey.modulus
-    assert skey.public_exponent
-    assert skey.private_exponent
-    assert skey.p * skey.q == skey.modulus
-    assert skey.key_size
-    assert skey.dmp1 == rsa.rsa_crt_dmp1(skey.d, skey.p)
-    assert skey.dmq1 == rsa.rsa_crt_dmq1(skey.d, skey.q)
-    assert skey.iqmp == rsa.rsa_crt_iqmp(skey.p, skey.q)
-
-    pkey = skey.public_key()
-    assert pkey
-    assert skey.modulus == pkey.modulus
-    assert skey.public_exponent == pkey.public_exponent
-    assert skey.key_size == pkey.key_size
 
 
 def _flatten_pkcs1_examples(vectors):

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -406,3 +406,21 @@ def rsa_verification_test(backend, params, hash_alg, pad_factory):
             verifier.verify()
     else:
         verifier.verify()
+
+
+def _check_rsa_private_key(skey):
+    assert skey
+    assert skey.modulus
+    assert skey.public_exponent
+    assert skey.private_exponent
+    assert skey.p * skey.q == skey.modulus
+    assert skey.key_size
+    assert skey.dmp1 == rsa.rsa_crt_dmp1(skey.d, skey.p)
+    assert skey.dmq1 == rsa.rsa_crt_dmq1(skey.d, skey.q)
+    assert skey.iqmp == rsa.rsa_crt_iqmp(skey.p, skey.q)
+
+    pkey = skey.public_key()
+    assert pkey
+    assert skey.modulus == pkey.modulus
+    assert skey.public_exponent == pkey.public_exponent
+    assert skey.key_size == pkey.key_size


### PR DESCRIPTION
Also moves a utility method, adds a error code binding the backend needs and adds the iface mark for the tests.
