### PR TITLE
[OpenSSL bindings] get cipher list + secure renegotation status

### DIFF
--- a/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/cryptography/hazmat/bindings/openssl/ssl.py
@@ -88,6 +88,7 @@ static const long SSL_OP_NO_TICKET;
 static const long SSL_OP_ALL;
 static const long SSL_OP_SINGLE_ECDH_USE;
 static const long SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
+static const long SSL_OP_LEGACY_SERVER_CONNECT;
 static const long SSL_VERIFY_PEER;
 static const long SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 static const long SSL_VERIFY_CLIENT_ONCE;


### PR DESCRIPTION
This is a continuation of #1012 with style fixes and conditional bindings added. Should build now with OpenSSL < 0.9.8m.

Adds support for the SSL_get_ciphers() function to extract more information and adds the macro to check if secure renegotiation is supported. 
