### PR TITLE
RSA*Numbers serialization interfaces.

### DIFF
--- a/cryptography/hazmat/primitives/interfaces.py
+++ b/cryptography/hazmat/primitives/interfaces.py
@@ -549,3 +549,19 @@ class EllipticCurvePublicKey(object):
         """
         The EllipticCurve that this key is on.
         """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class RSAPrivateNumbersSerialization(object):
+    def rsa_private_numbers(self):
+        """
+        Returns an RSAPrivateNumbers.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class RSAPublicNumbersSerialization(object):
+    def rsa_public_numbers(self):
+        """
+        Returns an RSAPublicNumbers
+        """

--- a/docs/hazmat/primitives/interfaces.rst
+++ b/docs/hazmat/primitives/interfaces.rst
@@ -587,6 +587,40 @@ Asymmetric interfaces
 
     .. attribute:: name
 
+
+Key Serialization
+-----------------
+
+.. class:: RSAPrivateNumbersSerialziation
+
+    .. versionadded:: 0.5
+
+    .. method:: rsa_private_numbers()
+
+        Serialize to an
+        :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
+        representation.
+
+        :returns: An
+            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
+            instance.
+
+
+.. class:: RSAPublicNumberSerialization
+
+    .. versionadded:: 0.5
+
+    .. method:: rsa_public_numbers()
+
+        Serialize to an
+        :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicNumbers`
+        representation.
+
+        :returns: An
+            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicNumbers`
+            instance.
+
+
 Hash algorithms
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This defines the interfaces which indicate that you can serialize some object (probably an `RSA*Key` provider) as an `RSA*Numbers` instance.

It depends on #984 but was not based on the rsa-numbers branch to make it more reviewable in isolation.
