### PR TITLE
travis: Set variable for Darwin and check that.

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-if [[ "$(uname -s)" == 'Dawin' ]]; then
+if [[ "$(uname -s)" == 'Darwin' ]]; then
     DARWIN=true
 else
     DARWIN=false


### PR DESCRIPTION
There were a bunch of `$(uname -s) == 'Darwin'` calls which have now
been consolidated into one setting that's being checked everywhere.

Additionally one branch was inverted. We were using `if DARWIN; else`
everywhere except for in one place where the negated form was used. In
order to keep it consistent with the rest of the script the branches
have been swapped.
