### PR TITLE
Remove raw numbers properties from the RSA*Key interfaces

### DIFF
--- a/cryptography/hazmat/primitives/interfaces.py
+++ b/cryptography/hazmat/primitives/interfaces.py
@@ -192,24 +192,6 @@ class RSAPrivateKey(object):
         """
 
     @abc.abstractproperty
-    def modulus(self):
-        """
-        The public modulus of the RSA key.
-        """
-
-    @abc.abstractproperty
-    def public_exponent(self):
-        """
-        The public exponent of the RSA key.
-        """
-
-    @abc.abstractproperty
-    def private_exponent(self):
-        """
-        The private exponent of the RSA key.
-        """
-
-    @abc.abstractproperty
     def key_size(self):
         """
         The bit length of the public modulus.
@@ -219,58 +201,6 @@ class RSAPrivateKey(object):
     def public_key(self):
         """
         The RSAPublicKey associated with this private key.
-        """
-
-    @abc.abstractproperty
-    def n(self):
-        """
-        The public modulus of the RSA key. Alias for modulus.
-        """
-
-    @abc.abstractproperty
-    def p(self):
-        """
-        One of the two primes used to generate d.
-        """
-
-    @abc.abstractproperty
-    def q(self):
-        """
-        One of the two primes used to generate d.
-        """
-
-    @abc.abstractproperty
-    def d(self):
-        """
-        The private exponent. This can be calculated using p and q. Alias for
-        private_exponent.
-        """
-
-    @abc.abstractproperty
-    def dmp1(self):
-        """
-        A Chinese remainder theorem coefficient used to speed up RSA
-        calculations.  Calculated as: d mod (p-1)
-        """
-
-    @abc.abstractproperty
-    def dmq1(self):
-        """
-        A Chinese remainder theorem coefficient used to speed up RSA
-        calculations.  Calculated as: d mod (q-1)
-        """
-
-    @abc.abstractproperty
-    def iqmp(self):
-        """
-        A Chinese remainder theorem coefficient used to speed up RSA
-        calculations. The modular inverse of q modulo p
-        """
-
-    @abc.abstractproperty
-    def e(self):
-        """
-        The public exponent of the RSA key. Alias for public_exponent.
         """
 
 
@@ -283,33 +213,9 @@ class RSAPublicKey(object):
         """
 
     @abc.abstractproperty
-    def modulus(self):
-        """
-        The public modulus of the RSA key.
-        """
-
-    @abc.abstractproperty
-    def public_exponent(self):
-        """
-        The public exponent of the RSA key.
-        """
-
-    @abc.abstractproperty
     def key_size(self):
         """
         The bit length of the public modulus.
-        """
-
-    @abc.abstractproperty
-    def n(self):
-        """
-        The public modulus of the RSA key. Alias for modulus.
-        """
-
-    @abc.abstractproperty
-    def e(self):
-        """
-        The public exponent of the RSA key. Alias for public_exponent.
         """
 
 

--- a/docs/hazmat/primitives/interfaces.rst
+++ b/docs/hazmat/primitives/interfaces.rst
@@ -157,80 +157,11 @@ Asymmetric interfaces
 
         An RSA public key object corresponding to the values of the private key.
 
-    .. attribute:: modulus
-
-        :type: int
-
-        The public modulus.
-
-    .. attribute:: public_exponent
-
-        :type: int
-
-        The public exponent.
-
-    .. attribute:: private_exponent
-
-        :type: int
-
-        The private exponent.
-
     .. attribute:: key_size
 
         :type: int
 
         The bit length of the modulus.
-
-    .. attribute:: p
-
-        :type: int
-
-        ``p``, one of the two primes composing the :attr:`modulus`.
-
-    .. attribute:: q
-
-        :type: int
-
-        ``q``, one of the two primes composing the :attr:`modulus`.
-
-    .. attribute:: d
-
-        :type: int
-
-        The private exponent. Alias for :attr:`private_exponent`.
-
-    .. attribute:: dmp1
-
-        :type: int
-
-        A `Chinese remainder theorem`_ coefficient used to speed up RSA
-        operations. Calculated as: d mod (p-1)
-
-    .. attribute:: dmq1
-
-        :type: int
-
-        A `Chinese remainder theorem`_ coefficient used to speed up RSA
-        operations. Calculated as: d mod (q-1)
-
-    .. attribute:: iqmp
-
-        :type: int
-
-        A `Chinese remainder theorem`_ coefficient used to speed up RSA
-        operations. Calculated as: q\ :sup:`-1` mod p
-
-    .. attribute:: n
-
-        :type: int
-
-        The public modulus. Alias for :attr:`modulus`.
-
-    .. attribute:: e
-
-        :type: int
-
-        The public exponent. Alias for :attr:`public_exponent`.
 
 
 .. class:: RSAPublicKey
@@ -281,35 +212,11 @@ Asymmetric interfaces
 
         :return bytes: Encrypted data.
 
-    .. attribute:: modulus
-
-        :type: int
-
-        The public modulus.
-
     .. attribute:: key_size
 
         :type: int
 
         The bit length of the modulus.
-
-    .. attribute:: public_exponent
-
-        :type: int
-
-        The public exponent.
-
-    .. attribute:: n
-
-        :type: int
-
-        The public modulus. Alias for :attr:`modulus`.
-
-    .. attribute:: e
-
-        :type: int
-
-        The public exponent. Alias for :attr:`public_exponent`.
 
 
 .. class:: DSAParameters


### PR DESCRIPTION
refs #1026. The concrete class in `rsa.py` still possesses them for backwards compatibility purposes (and will be deprecated in a subsequent PR).
