### PR TITLE
add load_rsa_*_numbers functions

### DIFF
--- a/cryptography/hazmat/primitives/serialization.py
+++ b/cryptography/hazmat/primitives/serialization.py
@@ -24,3 +24,11 @@ def load_pem_pkcs8_private_key(data, password, backend):
     return backend.load_pkcs8_pem_private_key(
         data, password
     )
+
+
+def load_rsa_private_numbers(numbers, backend):
+    return backend.load_rsa_private_numbers(numbers)
+
+
+def load_rsa_public_numbers(numbers, backend):
+    return backend.load_rsa_public_numbers(numbers)

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -98,3 +98,41 @@ header that mentions the type of the serialized key. e.g.
     :raises UnsupportedAlgorithm: If the serialized key is of a type that
         is not supported by the backend or if the key is encrypted with a
         symmetric cipher that is not supported by the backend.
+
+
+RSA Numbers
+~~~~~~~~~~~
+
+.. function:: load_rsa_private_numbers(numbers, backend)
+
+    .. versionadded:: 0.5
+
+    Create a private key instance using the given backend and numbers.
+
+    :param numbers: An instance of
+        :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`.
+
+    :param backend: A
+        :class:`~cryptography.hazmat.backends.interfaces.RSABackend` provider.
+
+    :returns: A new instance of a private key.
+
+    :raises UnsupportedAlgorithm: If the given backend does not support loading
+        numbers.
+
+.. function:: load_rsa_public_numbers(numbers, backend)
+
+    .. versionadded:: 0.5
+
+    Create a public key instance using the given backend and numbers.
+
+    :param numbers: An instance of
+        :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicNumbers`.
+
+    :param backend: A
+        :class:`~cryptography.hazmat.backends.interfaces.RSABackend` provider.
+
+    :returns: A new instance of a public key.
+
+    :raises UnsupportedAlgorithm: If the given backend does not support loading
+        numbers.

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -23,9 +23,12 @@ from cryptography.exceptions import _Reasons
 from cryptography.hazmat.primitives.asymmetric import dsa, rsa
 from cryptography.hazmat.primitives.serialization import (
     load_pem_pkcs8_private_key,
-    load_pem_traditional_openssl_private_key
+    load_pem_traditional_openssl_private_key,
+    load_rsa_private_numbers,
+    load_rsa_public_numbers
 )
 
+from .fixtures_rsa import RSA_KEY_1024
 from .utils import _check_rsa_private_key, load_vectors_from_file
 from ...utils import raises_unsupported_algorithm
 
@@ -544,3 +547,30 @@ class TestPKCS8Serialisation(object):
                     pemfile.read().encode(), password, backend
                 )
             )
+
+
+@pytest.mark.rsa
+class TestLoadRSANumbers(object):
+    def test_load_private_numbers(self, backend):
+        numbers = rsa.RSAPrivateNumbers(
+            p=RSA_KEY_1024["p"],
+            q=RSA_KEY_1024["q"],
+            d=RSA_KEY_1024["private_exponent"],
+            dmp1=RSA_KEY_1024["dmp1"],
+            dmq1=RSA_KEY_1024["dmq1"],
+            iqmp=RSA_KEY_1024["iqmp"],
+            public_numbers=rsa.RSAPublicNumbers(
+                n=RSA_KEY_1024["modulus"],
+                e=RSA_KEY_1024["public_exponent"]
+            )
+        )
+        private_key = load_rsa_private_numbers(numbers, backend)
+        assert private_key
+
+    def test_load_public_numbers(self, backend):
+        numbers = rsa.RSAPublicNumbers(
+            n=RSA_KEY_1024["modulus"],
+            e=RSA_KEY_1024["public_exponent"]
+        )
+        public_key = load_rsa_public_numbers(numbers, backend)
+        assert public_key


### PR DESCRIPTION
This approach works, but will not be ideal in `MultiBackend` since there's no way to check if a backend supports loading `RSA*Numbers` without catching an exception (which I documented but no backend currently does).

An alternate approach would be to split the backend interface for `RSABackend` and make `RSANumbersLoading` a separate interface. Then `load_rsa_*_numbers` can check the backend provided and raise directly (and `MultiBackend` will be able to skip a backend that doesn't support it). I think that makes more sense, but do others agree?

fixes #1097
