### PR TITLE
Add link about installation dependencies

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -2,7 +2,7 @@ Getting started
 ===============
 
 Working on ``cryptography`` requires the installation of a small number of
-development dependencies in addition to the depedencies for `installation`_.
+development dependencies in addition to the dependencies for :doc:`/installation`.
 These are listed in ``dev-requirements.txt`` and they can be installed in a
 `virtualenv`_ using `pip`_. Once you've installed the dependencies, install
 ``cryptography`` in ``editable`` mode. For example:
@@ -88,4 +88,3 @@ The HTML documentation index can now be found at
 .. _`pip`: https://pypi.python.org/pypi/pip
 .. _`sphinx`: https://pypi.python.org/pypi/Sphinx
 .. _`reStructured Text`: http://sphinx-doc.org/rest.html
-.. _`installation`: https://cryptography.io/en/latest/installation/


### PR DESCRIPTION
Per our conversation on `#cryptography-dev`, this PR is to link to the installation dependencies needed to setup the dev environment.
