### PR TITLE
Issue #1134: Use size_t as the per definition of aes.h . size_t translates correctly ...

### DIFF
--- a/cryptography/hazmat/bindings/openssl/aes.py
+++ b/cryptography/hazmat/bindings/openssl/aes.py
@@ -43,7 +43,7 @@ int AES_unwrap_key(AES_KEY *, const unsigned char *, unsigned char *,
    this in 1.0.0+. It is defined in macros because the function signature
    changed after 0.9.8 */
 void AES_ctr128_encrypt(const unsigned char *, unsigned char *,
-                        const unsigned size_t, const AES_KEY *,
+                        const size_t, const AES_KEY *,
                         unsigned char[], unsigned char[], unsigned int *);
 
 """


### PR DESCRIPTION
...to int or long based on arch type.
