### PR TITLE
switch to HTTP basic auth for jenkins release automation

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -91,11 +91,14 @@ def release(version):
         "vectors/dist/cryptography_vectors-{0}*".format(version)
     )
 
+    username = getpass.getpass("Input the GitHub/Jenkins username: ")
     token = getpass.getpass("Input the Jenkins token: ")
     response = requests.post(
         "{0}/build".format(JENKINS_URL),
+        auth=requests.auth.HTTPBasicAuth(
+            username, token
+        ),
         params={
-            "token": token,
             "cause": "Building wheels for {0}".format(version)
         }
     )


### PR DESCRIPTION
refs #1006. This fix works in conjunction with some jenkins upgrades I did today.
