### PR TITLE
Updating risk assessment to match CERT's language

### DIFF
--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -10,9 +10,9 @@ has some kind of local user access or because of how other software uses
 uninitialized memory.
 
 Python exposes no API for us to implement this reliably and as such almost all
-software in Python is potentially vulnerable to this attack. However the
-`CERT secure coding guidelines`_ consider this issue as "low severity,
-unlikely, expensive to repair" and we do not consider this a high risk for most
+software in Python is potentially vulnerable to this attack. The
+`CERT secure coding guidelines`_ assesses this issue as "Severity: medium,
+Likelihood: unlikely, Remediation Cost: expensive to repair" and we do not consider this a high risk for most
 users.
 
 .. _`Memory wiping`:  http://blogs.msdn.com/b/oldnewthing/archive/2013/05/29/10421912.aspx


### PR DESCRIPTION
The existing characterization doesn't match the CERT page it was linking to. There is a long history of security bugs in high-profile code from either compiled out or otherwise unseafe mem_set, eg: http://www.viva64.com/en/examples/v597/
If there is honest disagreement with CERT's assessment, fair enough, but we shouldn't cite CERT as saying this is a "low severity" issue. 
