### PR TITLE
deprecate DSA backend methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Changelog
 * Deprecated ``encrypt_rsa``, ``decrypt_rsa``, ``create_rsa_signature_ctx`` and
   ``create_rsa_verification_ctx`` on
   :class:`~cryptography.hazmat.backends.interfaces.RSABackend`.
+* Deprecated ``create_dsa_signature_ctx`` and ``create_dsa_verification_ctx``
+  on :class:`~cryptography.hazmat.backends.interfaces.DSABackend`.
 
 0.4 - 2014-05-03
 ~~~~~~~~~~~~~~~~

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -634,12 +634,24 @@ class Backend(object):
         return self.generate_dsa_private_key(parameters)
 
     def create_dsa_signature_ctx(self, private_key, algorithm):
+        warnings.warn(
+            "create_dsa_signature_ctx is deprecated and will be removed in "
+            "a future version.",
+            utils.DeprecatedIn05,
+            stacklevel=2
+        )
         dsa_cdata = self._dsa_cdata_from_private_key(private_key)
         key = _DSAPrivateKey(self, dsa_cdata)
         return _DSASignatureContext(self, key, algorithm)
 
     def create_dsa_verification_ctx(self, public_key, signature,
                                     algorithm):
+        warnings.warn(
+            "create_dsa_verification_ctx is deprecated and will be removed in "
+            "a future version.",
+            utils.DeprecatedIn05,
+            stacklevel=2
+        )
         dsa_cdata = self._dsa_cdata_from_public_key(public_key)
         key = _DSAPublicKey(self, dsa_cdata)
         return _DSAVerificationContext(self, key, signature, algorithm)

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -439,6 +439,8 @@ A specific ``backend`` may provide one or more of these interfaces.
 
     .. method:: create_dsa_signature_ctx(private_key, algorithm)
 
+        .. deprecated:: 0.5
+
         :param private_key: An instance of a
             :class:`~cryptography.hazmat.primitives.interfaces.DSAPrivateKey`
             provider.
@@ -451,6 +453,8 @@ A specific ``backend`` may provide one or more of these interfaces.
             :class:`~cryptography.hazmat.primitives.interfaces.AsymmetricSignatureContext`
 
     .. method:: create_dsa_verification_ctx(public_key, signature, algorithm)
+
+        .. deprecated:: 0.5
 
         :param public_key: An instance of a
             :class:`~cryptography.hazmat.primitives.interfaces.DSAPublicKey`

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -524,3 +524,25 @@ class TestDeprecatedRSABackendMethods(object):
             ct,
             padding.PKCS1v15()
         )
+
+
+class TestDeprecatedDSABackendMethods(object):
+    def test_create_dsa_signature_ctx(self):
+        params = dsa.DSAParameters.generate(1024, backend)
+        key = dsa.DSAPrivateKey.generate(params, backend)
+        pytest.deprecated_call(
+            backend.create_dsa_signature_ctx,
+            key,
+            hashes.SHA1()
+        )
+
+    def test_create_dsa_verification_ctx(self):
+        params = dsa.DSAParameters.generate(1024, backend)
+        key = dsa.DSAPrivateKey.generate(params, backend)
+        public_key = key.public_key()
+        pytest.deprecated_call(
+            backend.create_dsa_verification_ctx,
+            public_key,
+            b"\x00" * 128,
+            hashes.SHA1()
+        )


### PR DESCRIPTION
Deprecates `create_dsa_signature_ctx` and `create_dsa_verification_ctx`.
