### PR TITLE
switch to static linking on windows and update installation page

### DIFF
--- a/cryptography/hazmat/bindings/openssl/binding.py
+++ b/cryptography/hazmat/bindings/openssl/binding.py
@@ -98,7 +98,7 @@ class Binding(object):
         if sys.platform != "win32":
             libraries = ["crypto", "ssl"]
         else:  # pragma: no cover
-            link_type = os.environ.get("PYCA_OPENSSL_INSTALL", "static")
+            link_type = os.environ.get("PYCA_WINDOWS_LINK_TYPE", "static")
             libraries = _get_windows_libraries(link_type)
 
         cls.ffi, cls.lib = build_ffi(
@@ -161,10 +161,10 @@ class Binding(object):
 def _get_windows_libraries(link_type):
     if link_type == "dynamic":
         return ["libeay32", "ssleay32", "advapi32"]
-    elif link_type == "static":
+    elif link_type == "static" or link_type == "":
         return ["libeay32mt", "ssleay32mt", "advapi32",
                 "crypt32", "gdi32", "user32", "ws2_32"]
     else:
         raise ValueError(
-            "PYCA_OPENSSL_INSTALL must be 'static' or 'dynamic'"
+            "PYCA_WINDOWS_LINK_TYPE must be 'static' or 'dynamic'"
         )

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,15 +55,15 @@ include the corresponding locations.For example:
     C:\> pip install cryptography
 
 You can also choose to build statically or dynamically using the
-``PYCA_OPENSSL_INSTALL`` variable. Allowed values are ``static`` (default) and
-``dynamic``.
+``PYCA_WINDOWS_LINK_TYPE`` variable. Allowed values are ``static`` (default)
+and ``dynamic``.
 
 .. code-block:: console
 
     C:\> \path\to\vcvarsall.bat x86_amd64
     C:\> set LIB=C:\OpenSSL\lib\VC\static;C:\OpenSSL\lib;%LIB%
     C:\> set INCLUDE=C:\OpenSSL\include;%INCLUDE%
-    C:\> set PYCA_OPENSSL_INSTALL=dynamic
+    C:\> set PYCA_WINDOWS_LINK_TYPE=dynamic
     C:\> pip install cryptography
 
 Building cryptography on Linux

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -143,6 +143,8 @@ class TestOpenSSL(object):
     def test_windows_static_dynamic_libraries(self):
         assert "ssleay32mt" in _get_windows_libraries("static")
 
+        assert "ssleay32mt" in _get_windows_libraries("")
+
         assert "ssleay32" in _get_windows_libraries("dynamic")
 
         with pytest.raises(ValueError):


### PR DESCRIPTION
fixes #1121

crypt32, gdi32, user32, and ws2_32 are required to make it statically link successfully, but are not required for dynamic linking.

At the moment this results in a wheel that is ~978k for 64-bit windows (as opposed to 248kb for our previous release). Not a big deal.
