### PR TITLE
0.5.1 version bump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.5.1 - 2014-07-07
+~~~~~~~~~~~~~~~~~~
+
+* Add
+  :class:`~cryptography.hazmat.backends.interfaces.PKCS8SerializationBackend`
+  support to :doc:`/hazmat/backends/multibackend`.
+
 0.5 - 2014-07-07
 ~~~~~~~~~~~~~~~~
 

--- a/cryptography/__about__.py
+++ b/cryptography/__about__.py
@@ -22,7 +22,7 @@ __summary__ = ("cryptography is a package which provides cryptographic recipes"
                " and primitives to Python developers.")
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "0.5"
+__version__ = "0.5.1"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -22,7 +22,7 @@ __summary__ = "Test vectors for the cryptography package."
 
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "0.5"
+__version__ = "0.5.1"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"


### PR DESCRIPTION
Since we haven't landed anything else doing a 0.5.1 to correct the `PKCS8SerializationBackend` omission in `MultiBackend` seems like a good idea. This will bump the version and I'll do a 0.5.1 release after it merges.
