### PR TITLE
Adding binding for GENERAL_NAMES_free method

### DIFF
--- a/cryptography/hazmat/bindings/openssl/x509v3.py
+++ b/cryptography/hazmat/bindings/openssl/x509v3.py
@@ -82,6 +82,7 @@ FUNCTIONS = """
 void X509V3_set_ctx(X509V3_CTX *, X509 *, X509 *, X509_REQ *, X509_CRL *, int);
 X509_EXTENSION *X509V3_EXT_nconf(CONF *, X509V3_CTX *, char *, char *);
 int GENERAL_NAME_print(BIO *, GENERAL_NAME *);
+void GENERAL_NAMES_free(GENERAL_NAMES *);
 """
 
 MACROS = """


### PR DESCRIPTION
adds binding for GENERAL_NAMES_free(GENERAL_NAMES *) 
Allows fix for pyopenssl issue https://github.com/pyca/pyopenssl/issues/139
