### PR TITLE
Work around for side effects in setup.py script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,31 +181,36 @@ def keywords_with_side_effects(argv):
         'sdist',
         'upload',
     )
+
     def is_short_option(argument):
         """Check whether a command line argument is a short option."""
         return len(argument) >= 2 and argument[0] == '-' and argument[1] != '-'
+
     def expand_short_options(argument):
         """Expand combined short options into canonical short options."""
         return ('-' + char for char in argument[1:])
+
     def argument_without_setup_requirements(argv, i):
         """Check whether a command line argument needs setup requirements."""
         if argv[i] in no_setup_requires_arguments:
             # Simple case: An argument which is either an option or a command
             # which doesn't need setup requirements.
             return True
-        elif is_short_option(argv[i]) and all(option in
-                no_setup_requires_arguments for option in
-                expand_short_options(argv[i])):
+        elif (is_short_option(argv[i]) and
+              all(option in no_setup_requires_arguments
+                  for option in expand_short_options(argv[i]))):
             # Not so simple case: Combined short options none of which need
             # setup requirements.
             return True
-        elif argv[i - 1 : i] == ['--egg-base']:
+        elif argv[i - 1:i] == ['--egg-base']:
             # Tricky case: --egg-info takes an argument which should not make
             # us use setup_requires (defeating the purpose of this code).
             return True
         else:
             return False
-    if all(argument_without_setup_requirements(argv, i) for i in range(1, len(argv))):
+
+    if all(argument_without_setup_requirements(argv, i)
+           for i in range(1, len(argv))):
         return {
             "cmdclass": {
                 "build": DummyCFFIBuild,


### PR DESCRIPTION
As reported in https://github.com/pyca/cryptography/issues/1253 I ran into problems with `setup_requires` and related magic in the `setup.py` script of the cryptography package. Thanks to your comments in https://github.com/pyca/cryptography/issues/1253 I now understand why `setup.py` does what it does and why this is required (the `cffi` package requires it to build extension modules).

As suggested by @dstufft I went source diving setuptools and distutils, unfortunately I came back disappointed and without a solution. Because I'd like to help make things better and not just complain I decided to try a different route in getting https://github.com/pyca/cryptography/issues/1253 resolved: I looked for other projects with similar problems. Fairly quickly I ran into https://github.com/pypa/pip/issues/25 which describes almost the same issue and suggests a solution to the problem. That solution was implemented for SciPy (see [their setup.py script](https://github.com/scipy/scipy/blob/master/setup.py)) and it seems to work well for them.

I implemented the same solution in the `setup.py` script of the cryptography package and would like you to review and hopefully merge this minor change. It may be a bit pragmatic but it completely avoids the problem reported in https://github.com/pyca/cryptography/issues/1253 so if you ask me it's definitely worth it. I've tested creating a source distribution of the cryptography package and installing that and with the changes it works fine and as I originally expected it to: During pip's metadata discovery phase it doesn't do anything funky, only once pip invokes `python setup.py install` are the `setup_requires` dependencies installed and the extension modules compiled.

Thanks for your time and for the comments in https://github.com/pyca/cryptography/issues/1253.
