### PR TITLE
Adding binding for void *X509V3_EXT_d2i(X509_EXTENSION *ext);

### DIFF
--- a/cryptography/hazmat/bindings/openssl/x509v3.py
+++ b/cryptography/hazmat/bindings/openssl/x509v3.py
@@ -83,7 +83,7 @@ void X509V3_set_ctx(X509V3_CTX *, X509 *, X509 *, X509_REQ *, X509_CRL *, int);
 X509_EXTENSION *X509V3_EXT_nconf(CONF *, X509V3_CTX *, char *, char *);
 int GENERAL_NAME_print(BIO *, GENERAL_NAME *);
 void GENERAL_NAMES_free(GENERAL_NAMES *);
-void *X509V3_EXT_d2i(X509_EXTENSION *ext);
+void *X509V3_EXT_d2i(X509_EXTENSION *);
 """
 
 MACROS = """


### PR DESCRIPTION
Can we add bindings for this function so that in pyopenssl we can grab the translated X509 structure according to its extension type. Other wise we have to do cruft like _lib.X509V3_EXT_get(self._extension) to obtain function pointers to the allocation, d2i and invoke those function pointers. It looks like some pyOpenSSL guys are mimicing the method calls made by X509V3_EXT_d2i in absense of it.
