### PR TITLE
WIP: DH implementation

### DIFF
--- a/cryptography/exceptions.py
+++ b/cryptography/exceptions.py
@@ -23,6 +23,7 @@ class _Reasons(object):
     UNSUPPORTED_PUBLIC_KEY_ALGORITHM = object()
     UNSUPPORTED_ELLIPTIC_CURVE = object()
     UNSUPPORTED_SERIALIZATION = object()
+    UNSUPPORTED_KEY_EXCHANGE = object()
 
 
 class UnsupportedAlgorithm(Exception):

--- a/cryptography/hazmat/backends/interfaces.py
+++ b/cryptography/hazmat/backends/interfaces.py
@@ -290,3 +290,8 @@ class PKCS8SerializationBackend(object):
         Load a private key from PEM encoded data, using password if the data
         is encrypted.
         """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DHBackend(object):
+    pass

--- a/cryptography/hazmat/backends/interfaces.py
+++ b/cryptography/hazmat/backends/interfaces.py
@@ -294,4 +294,39 @@ class PKCS8SerializationBackend(object):
 
 @six.add_metaclass(abc.ABCMeta)
 class DHBackend(object):
-    pass
+    @abc.abstractmethod
+    def generate_dh_parameters(self, key_size):
+        """
+        Generate a DHParameters instance with a modulus of key_size bits.
+        """
+
+    @abc.abstractmethod
+    def generate_dh_private_key(self, parameters):
+        """
+        Generate a DHPrivateKey instance with parameters as a DHParameters
+        object.
+        """
+
+    @abc.abstractmethod
+    def generate_dh_private_key_and_parameters(self, key_size):
+        """
+        Generate a DHPrivateKey instance using key size only.
+        """
+
+    @abc.abstractmethod
+    def load_dh_private_numbers(self, numbers):
+        """
+        Returns a DHPrivateKey provider.
+        """
+
+    @abc.abstractmethod
+    def load_dh_public_numbers(self, numbers):
+        """
+        Returns a DHPublicKey provider.
+        """
+
+    @abc.abstractmethod
+    def load_dh_parameter_numbers(self, numbers):
+        """
+        Returns a DHParameters provider.
+        """

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -32,6 +32,9 @@ from cryptography.hazmat.backends.openssl.ciphers import (
     _AESCTRCipherContext, _CipherContext
 )
 from cryptography.hazmat.backends.openssl.cmac import _CMACContext
+from cryptography.hazmat.backends.openssl.dh import (
+    _DHParameters, _DHPrivateKey, _DHPublicKey, _DHKeyAgreementContext
+)
 from cryptography.hazmat.backends.openssl.dsa import (
     _DSAParameters, _DSAPrivateKey, _DSAPublicKey,
     _DSASignatureContext, _DSAVerificationContext

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -33,7 +33,7 @@ from cryptography.hazmat.backends.openssl.ciphers import (
 )
 from cryptography.hazmat.backends.openssl.cmac import _CMACContext
 from cryptography.hazmat.backends.openssl.dh import (
-    _DHParameters, _DHPrivateKey, _DHPublicKey, _DHKeyExchangeContext
+    _DHParameters, _DHPrivateKey, _DHPublicKey
 )
 from cryptography.hazmat.backends.openssl.dsa import (
     _DSAParameters, _DSAPrivateKey, _DSAPublicKey,
@@ -1095,7 +1095,6 @@ class Backend(object):
         return _DHPrivateKey(self, dh_key_cdata)
 
     def load_dh_private_numbers(self, numbers):
-        #dh._check_dh_private_numbers(numbers)
         parameter_numbers = numbers.public_numbers.parameter_numbers
 
         dh_cdata = self._lib.DH_new()
@@ -1107,7 +1106,6 @@ class Backend(object):
         dh_cdata.pub_key = self._int_to_bn(numbers.public_numbers.y)
         dh_cdata.priv_key = self._int_to_bn(numbers.x)
 
-
         codes = self._ffi.new("int[]", 1)
         res = self._lib.DH_check(dh_cdata, codes)
         assert res == 1
@@ -1116,7 +1114,6 @@ class Backend(object):
         return _DHPrivateKey(self, dh_cdata)
 
     def load_dh_public_numbers(self, numbers):
-        #dh._check_dh_parameters(numbers.parameter_numbers)
         dh_cdata = self._lib.DH_new()
         assert dh_cdata != self._ffi.NULL
         dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
@@ -1128,7 +1125,6 @@ class Backend(object):
         return _DHPublicKey(self, dh_cdata)
 
     def load_dh_parameter_numbers(self, numbers):
-        #dh._check_dh_parameters(numbers)
         dh_cdata = self._lib.DH_new()
         assert dh_cdata != self._ffi.NULL
         dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
@@ -1137,7 +1133,6 @@ class Backend(object):
         dh_cdata.g = self._int_to_bn(numbers.g)
 
         return _DHParameters(self, dh_cdata)
-
 
 
 class GetCipherByName(object):

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -1067,7 +1067,7 @@ class Backend(object):
         dh_param_cdata = self._ffi.gc(dh_param_cdata, self._lib.DH_free)
 
         res = self._lib.DH_generate_parameters_ex(
-            dh_param_cdata
+            dh_param_cdata,
             key_size,
             generator,
             self._ffi.NULL

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -69,6 +69,7 @@ _OpenSSLError = collections.namedtuple("_OpenSSLError",
 
 @utils.register_interface(CipherBackend)
 @utils.register_interface(CMACBackend)
+@utils.register_interface(DHBackend)
 @utils.register_interface(DSABackend)
 @utils.register_interface(EllipticCurveBackend)
 @utils.register_interface(HashBackend)

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -333,6 +333,8 @@ class Backend(object):
         )
 
     def _bn_to_int(self, bn):
+        assert bn != self._ffi.NULL
+
         if six.PY3:
             # Python 3 has constant time from_bytes, so use that.
 
@@ -359,6 +361,8 @@ class Backend(object):
         ownership of the object). Be sure to register it for GC if it will
         be discarded after use.
         """
+
+        assert (bn is None) or (bn is not None and bn != self._ffi.NULL)
 
         if bn is None:
             bn = self._ffi.NULL

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -1118,9 +1118,9 @@ class Backend(object):
         assert dh_cdata != self._ffi.NULL
         dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
 
-        dh_cdata.p = self._int_to_bn(numbers.parameter_numbers.p)
-        dh_cdata.g = self._int_to_bn(numbers.parameter_numbers.g)
-        dh_cdata.pub_key = self._int_to_bn(numbers.y)
+        dh_cdata.p = self._int_to_bn(numbers.parameter_numbers.modulus)
+        dh_cdata.g = self._int_to_bn(numbers.parameter_numbers.generator)
+        dh_cdata.pub_key = self._int_to_bn(numbers.public_value)
 
         return _DHPublicKey(self, dh_cdata)
 

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -1090,6 +1090,51 @@ class Backend(object):
 
         return _DHPrivateKey(self, dh_key_cdata)
 
+    def load_dh_private_numbers(self, numbers):
+        #dh._check_dh_private_numbers(numbers)
+        parameter_numbers = numbers.public_numbers.parameter_numbers
+
+        dh_cdata = self._lib.DH_new()
+        assert dh_cdata != self._ffi.NULL
+        dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
+
+        dh_cdata.p = self._int_to_bn(parameter_numbers.p)
+        dh_cdata.g = self._int_to_bn(parameter_numbers.g)
+        dh_cdata.pub_key = self._int_to_bn(numbers.public_numbers.y)
+        dh_cdata.priv_key = self._int_to_bn(numbers.x)
+
+
+        codes = self._ffi.new("int[]", 1)
+        res = self._lib.DH_check(dh_cdata, codes)
+        assert res == 1
+        assert codes[0] in (0, 6, 2, 4)
+
+        return _DHPrivateKey(self, dh_cdata)
+
+    def load_dh_public_numbers(self, numbers):
+        #dh._check_dh_parameters(numbers.parameter_numbers)
+        dh_cdata = self._lib.DH_new()
+        assert dh_cdata != self._ffi.NULL
+        dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
+
+        dh_cdata.p = self._int_to_bn(numbers.parameter_numbers.p)
+        dh_cdata.g = self._int_to_bn(numbers.parameter_numbers.g)
+        dh_cdata.pub_key = self._int_to_bn(numbers.y)
+
+        return _DHPublicKey(self, dh_cdata)
+
+    def load_dh_parameter_numbers(self, numbers):
+        #dh._check_dh_parameters(numbers)
+        dh_cdata = self._lib.DH_new()
+        assert dh_cdata != self._ffi.NULL
+        dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
+
+        dh_cdata.p = self._int_to_bn(numbers.p)
+        dh_cdata.g = self._int_to_bn(numbers.g)
+
+        return _DHParameters(self, dh_cdata)
+
+
 
 class GetCipherByName(object):
     def __init__(self, fmt):

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -33,7 +33,7 @@ from cryptography.hazmat.backends.openssl.ciphers import (
 )
 from cryptography.hazmat.backends.openssl.cmac import _CMACContext
 from cryptography.hazmat.backends.openssl.dh import (
-    _DHParameters, _DHPrivateKey, _DHPublicKey, _DHKeyAgreementContext
+    _DHParameters, _DHPrivateKey, _DHPublicKey, _DHKeyExchangeContext
 )
 from cryptography.hazmat.backends.openssl.dsa import (
     _DSAParameters, _DSAPrivateKey, _DSAPublicKey,

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -24,9 +24,9 @@ from cryptography.exceptions import (
     InternalError, UnsupportedAlgorithm, _Reasons
 )
 from cryptography.hazmat.backends.interfaces import (
-    CMACBackend, CipherBackend, DSABackend, EllipticCurveBackend, HMACBackend,
-    HashBackend, PBKDF2HMACBackend, PKCS8SerializationBackend, RSABackend,
-    TraditionalOpenSSLSerializationBackend
+    CMACBackend, CipherBackend, DHBackend, DSABackend, EllipticCurveBackend,
+    HMACBackend, HashBackend, PBKDF2HMACBackend, PKCS8SerializationBackend,
+    RSABackend, TraditionalOpenSSLSerializationBackend
 )
 from cryptography.hazmat.backends.openssl.ciphers import (
     _AESCTRCipherContext, _CipherContext

--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -1079,19 +1079,15 @@ class Backend(object):
     def generate_dh_private_key(self, parameters):
         dh_key_cdata = self._lib.DH_new()
         assert dh_key_cdata != self._ffi.NULL
-        dh_param_cdata = self._ffi.gc(dh_param_cdata, self._lib.DH_free)
+        dh_key_cdata = self._ffi.gc(dh_key_cdata, self._lib.DH_free)
 
         dh_key_cdata.p = self._lib.BN_dup(parameters._dh_cdata.p)
-        dh_key_cdata.q = self._lib.BN_dup(parameters._dh_cdata.q)
+        dh_key_cdata.g = self._lib.BN_dup(parameters._dh_cdata.g)
 
-        res = DH_generate_key(dh_key_cdata)
+        res = self._lib.DH_generate_key(dh_key_cdata)
         assert res == 1
 
         return _DHPrivateKey(self, dh_key_cdata)
-
-    def generate_dh_private_key_and_parameters(self, key_size):
-        return self.generate_dh_private_key(
-            self.generate_dh_parameters(key_size))
 
 
 class GetCipherByName(object):

--- a/cryptography/hazmat/backends/openssl/dh.py
+++ b/cryptography/hazmat/backends/openssl/dh.py
@@ -1,0 +1,18 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+from cryptography import utils
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import dh

--- a/cryptography/hazmat/backends/openssl/dh.py
+++ b/cryptography/hazmat/backends/openssl/dh.py
@@ -19,7 +19,7 @@ from cryptography.hazmat.primitives import interfaces
 from cryptography.hazmat.primitives.asymmetric import dh
 
 
-@utils.register_interface(interfaces.DHParameters)
+@utils.register_interface(interfaces.DHParametersWithNumbers)
 class _DHParameters(object):
     def __init__(self, backend, dh_cdata):
         self._backend = backend

--- a/cryptography/hazmat/backends/openssl/dh.py
+++ b/cryptography/hazmat/backends/openssl/dh.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import, division, print_function
 
 from cryptography import utils
-from cryptography.exceptions import _Reasons, UnsupportedAlgorithm
+from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.primitives import interfaces
 from cryptography.hazmat.primitives.asymmetric import dh
 

--- a/cryptography/hazmat/backends/openssl/dh.py
+++ b/cryptography/hazmat/backends/openssl/dh.py
@@ -112,10 +112,17 @@ def _agree_tls_key(private_key, public_value, backend):
 
     if res == -1:
         errors = backend._consume_errors()
-        _handle_dh_compute_key_error(errors, backend)
+        return _handle_dh_compute_key_error(errors, backend)
     else:
-        return ffi.buffer(buf)[:key_size]
+        assert res >= 1
 
+        key = ffi.buffer(buf)[:res]
+        pad = key_size - len(key)
+
+        if pad > 0:
+            key = (b"\x00" * pad) + key
+
+        return key
 
 class _DHKeyExchangeContext(object):
     def __init__(self, private_key, exchange_algorithm):

--- a/cryptography/hazmat/backends/openssl/dh.py
+++ b/cryptography/hazmat/backends/openssl/dh.py
@@ -134,21 +134,30 @@ def _agree_tls_key(private_key, public_value, backend):
 
         return key
 
+
 class _DHKeyExchangeContext(object):
     def __init__(self, private_key, exchange_algorithm):
         self._private_key = private_key
         self._exchange_algorithm = exchange_algorithm
         self._backend = private_key._backend
 
-    def agree(self, public_value):
         if isinstance(self._exchange_algorithm, dh.TLSKeyExchange):
-            return _agree_tls_key(
-                self._private_key,
-                public_value,
-                self._backend
-            )
+            self._agree_func = self._agree_tls
         else:
-            raise UnsupportedAlgorithm(_Reasons.UNSUPPORTED_KEY_EXCHANGE)
+            raise UnsupportedAlgorithm(
+                "Only TLS key exchange is supported by this backend.",
+                _Reasons.UNSUPPORTED_KEY_EXCHANGE
+            )
+
+    def agree(self, public_value):
+        return self._agree_func(public_value)
+
+    def _agree_tls(self, public_value):
+        return _agree_tls_key(
+            self._private_key,
+            public_value,
+            self._backend
+        )
 
 
 @utils.register_interface(interfaces.DHPublicKeyWithNumbers)

--- a/cryptography/hazmat/backends/openssl/dh.py
+++ b/cryptography/hazmat/backends/openssl/dh.py
@@ -16,3 +16,22 @@ from __future__ import absolute_import, division, print_function
 from cryptography import utils
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric import dh
+
+
+class _DHKeyAgreementContext(object):
+    def __init__(self, private_key, backend):
+        self._private_key = private_key
+        self._backend = backend
+
+    def agree(self, public_key):
+        lib = self._backend._lib
+        ffi = self._backend._ffi
+
+        key_size = lib.DH_size(private_key)
+
+        buf = ffi.new("char[]", key_size)
+        res = lib.DH_compute_key(
+            key_buf, public_key, private_key
+        )
+        assert res != -1
+        return ffi.buffer(buf)[:key_size]

--- a/cryptography/hazmat/bindings/openssl/dh.py
+++ b/cryptography/hazmat/bindings/openssl/dh.py
@@ -27,6 +27,9 @@ typedef struct dh_st {
     BIGNUM *priv_key;
     /* Public DH value g^x */
     BIGNUM *pub_key;
+    /* X9.42/RFC 2631 */
+    BIGNUM *q;
+    BIGNUM *j;
     ...;
 } DH;
 """

--- a/cryptography/hazmat/bindings/openssl/err.py
+++ b/cryptography/hazmat/bindings/openssl/err.py
@@ -29,6 +29,8 @@ struct ERR_string_data_st {
 };
 typedef struct ERR_string_data_st ERR_STRING_DATA;
 
+static const int ERR_LIB_DH;
+static const int ERR_LIB_EVP;
 static const int ERR_LIB_EVP;
 static const int ERR_LIB_EC;
 static const int ERR_LIB_PEM;
@@ -100,6 +102,10 @@ static const int ASN1_R_UNSUPPORTED_PUBLIC_KEY_TYPE;
 static const int ASN1_R_UNSUPPORTED_TYPE;
 static const int ASN1_R_WRONG_TAG;
 static const int ASN1_R_WRONG_TYPE;
+
+static const int DH_F_COMPUTE_KEY;
+
+static const int DH_R_INVALID_PUBKEY;
 
 static const int EVP_F_AES_INIT_KEY;
 static const int EVP_F_D2I_PKEY;

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -15,6 +15,9 @@ from __future__ import absolute_import, division, print_function
 
 import six
 
+from cryptography import utils
+from cryptography.hazmat.primitives import interfaces
+
 
 def generate_parameters(generator, key_size, backend):
     return backend.generate_dh_parameters(generator, key_size)
@@ -84,3 +87,8 @@ class DHParameterNumbers(object):
     @property
     def generator(self):
         return self._generator
+
+
+@utils.register_interface(interfaces.DHExchangeAlgorithm)
+class TLSKeyExchange(object):
+    pass

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -1,0 +1,75 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+
+class DHPrivateNumbers(object):
+    def __init__(self, public_numbers, private_value):
+        if not isinstance(public_numbers, DHPublicNumbers):
+            raise TypeError("public_numbers must be an instance of "
+                            "DHPublicNumbers.")
+
+        if not isinstance(private_value, int):
+            raise TypeError("private_value must be an integer.")
+
+        self._public_numbers = public_numbers
+        self._private_value = private_value
+
+    @property
+    def public_numbers(self):
+        return self._public_numbers
+
+    @property
+    def private_value(self):
+        return self._private_value
+
+
+class DHPublicNumbers(object):
+    def __init__(self, parameters, public_value):
+        if not isinstance(parameters, DHParameters):
+            raise TypeError("parameters must be an instance of DHParameters.")
+
+        if not isinstance(public_value, int):
+            raise TypeError("public_value must be an integer.")
+
+        self._parameters = parameters
+        self._public_value = public_value
+
+    @property
+    def public_value(self):
+        return self._public_value
+
+    @property
+    def parameters(self):
+        return self._parameters
+
+
+class DHParameters(object):
+    def __init__(self, modulus, generator):
+        if (
+            not isinstance(modulus, int) or
+            not isinstance(generator, int)
+        ):
+            raise TypeError("modulus and generator must be integers")
+
+        self._modulus = modulus
+        self._generator = generator
+
+    @property
+    def modulus(self):
+        return self._modulus
+
+    @property
+    def generator(self):
+        return self._generator

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -111,7 +111,7 @@ class DHParameterNumbers(object):
         return self._generator
 
     def parameters(self, backend):
-        backend.load_dh_parameter_numbers(self)
+        return backend.load_dh_parameter_numbers(self)
 
 
 @utils.register_interface(interfaces.DHExchangeAlgorithm)

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -14,6 +14,14 @@
 from __future__ import absolute_import, division, print_function
 
 
+def generate_parameters(key_size, backend):
+    return backend.generate_dh_parameters(2, key_size)
+
+
+def generate_private_key(key_size, backend):
+    return backend.generate_dh_private_key_and_parameters(2, key_size)
+
+
 class DHPrivateNumbers(object):
     def __init__(self, public_numbers, private_value):
         if not isinstance(public_numbers, DHPublicNumbers):
@@ -37,8 +45,9 @@ class DHPrivateNumbers(object):
 
 class DHPublicNumbers(object):
     def __init__(self, parameters, public_value):
-        if not isinstance(parameters, DHParameters):
-            raise TypeError("parameters must be an instance of DHParameters.")
+        if not isinstance(parameters, DHParameterNumbers):
+            raise TypeError(
+                "parameters must be an instance of DHParameterNumbers.")
 
         if not isinstance(public_value, int):
             raise TypeError("public_value must be an integer.")

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -55,7 +55,7 @@ class DHPublicNumbers(object):
         return self._parameters
 
 
-class DHParameters(object):
+class DHParameterNumbers(object):
     def __init__(self, modulus, generator):
         if (
             not isinstance(modulus, int) or

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -14,12 +14,12 @@
 from __future__ import absolute_import, division, print_function
 
 
-def generate_parameters(key_size, backend):
-    return backend.generate_dh_parameters(2, key_size)
+def generate_parameters(generator, key_size, backend):
+    return backend.generate_dh_parameters(generator, key_size)
 
 
-def generate_private_key(key_size, backend):
-    return backend.generate_dh_private_key_and_parameters(2, key_size)
+def generate_private_key(generator, key_size, backend):
+    return backend.generate_dh_private_key_and_parameters(generator, key_size)
 
 
 class DHPrivateNumbers(object):

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -33,7 +33,7 @@ class DHPrivateNumbers(object):
             raise TypeError("public_numbers must be an instance of "
                             "DHPublicNumbers.")
 
-        if not isinstance(private_value, int):
+        if not isinstance(private_value, six.integer_types):
             raise TypeError("private_value must be an integer.")
 
         self._public_numbers = public_numbers
@@ -46,6 +46,13 @@ class DHPrivateNumbers(object):
     @property
     def private_value(self):
         return self._private_value
+
+    @property
+    def x(self):
+        return self._private_value
+
+    def private_key(self, backend):
+        return backend.load_dh_private_numbers(self)
 
 
 class DHPublicNumbers(object):
@@ -65,8 +72,15 @@ class DHPublicNumbers(object):
         return self._public_value
 
     @property
+    def y(self):
+        return self._public_value
+
+    @property
     def parameter_numbers(self):
         return self._parameters
+
+    def public_key(self, backend):
+        return backend.load_dh_public_numbers(self)
 
 
 class DHParameterNumbers(object):
@@ -87,6 +101,17 @@ class DHParameterNumbers(object):
     @property
     def generator(self):
         return self._generator
+
+    @property
+    def p(self):
+        return self._modulus
+
+    @property
+    def g(self):
+        return self._generator
+
+    def parameters(self, backend):
+        backend.load_dh_parameter_numbers(self)
 
 
 @utils.register_interface(interfaces.DHExchangeAlgorithm)

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -13,6 +13,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import six
+
 
 def generate_parameters(generator, key_size, backend):
     return backend.generate_dh_parameters(generator, key_size)
@@ -44,15 +46,15 @@ class DHPrivateNumbers(object):
 
 
 class DHPublicNumbers(object):
-    def __init__(self, parameters, public_value):
-        if not isinstance(parameters, DHParameterNumbers):
+    def __init__(self, parameter_numbers, public_value):
+        if not isinstance(parameter_numbers, DHParameterNumbers):
             raise TypeError(
                 "parameters must be an instance of DHParameterNumbers.")
 
-        if not isinstance(public_value, int):
+        if not isinstance(public_value, six.integer_types):
             raise TypeError("public_value must be an integer.")
 
-        self._parameters = parameters
+        self._parameters = parameter_numbers
         self._public_value = public_value
 
     @property
@@ -60,15 +62,15 @@ class DHPublicNumbers(object):
         return self._public_value
 
     @property
-    def parameters(self):
+    def parameter_numbers(self):
         return self._parameters
 
 
 class DHParameterNumbers(object):
     def __init__(self, modulus, generator):
         if (
-            not isinstance(modulus, int) or
-            not isinstance(generator, int)
+            not isinstance(modulus, six.integer_types) or
+            not isinstance(generator, six.integer_types)
         ):
             raise TypeError("modulus and generator must be integers")
 

--- a/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -23,10 +23,6 @@ def generate_parameters(generator, key_size, backend):
     return backend.generate_dh_parameters(generator, key_size)
 
 
-def generate_private_key(generator, key_size, backend):
-    return backend.generate_dh_private_key_and_parameters(generator, key_size)
-
-
 class DHPrivateNumbers(object):
     def __init__(self, public_numbers, private_value):
         if not isinstance(public_numbers, DHPublicNumbers):

--- a/cryptography/hazmat/primitives/interfaces.py
+++ b/cryptography/hazmat/primitives/interfaces.py
@@ -456,3 +456,75 @@ class EllipticCurvePublicKey(object):
         """
         The EllipticCurve that this key is on.
         """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DHParameters(object):
+    @abc.abstractmethod
+    def generate_private_key(self):
+        """
+        Generates and returns a DHPrivateKey.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DHParametersWithNumbers(DSAParameters):
+    @abc.abstractmethod
+    def parameter_numbers(self):
+        """
+        Returns a DHParameterNumbers.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DHPrivateKey(object):
+    @abc.abstractproperty
+    def key_size(self):
+        """
+        The bit length of the prime modulus.
+        """
+
+    @abc.abstractmethod
+    def public_key(self):
+        """
+        The DHPublicKey associated with this private key.
+        """
+
+    @abc.abstractmethod
+    def parameters(self):
+        """
+        The DHParameters object associated with this private key.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DHPrivateKeyWithNumbers(DHPrivateKey):
+    @abc.abstractmethod
+    def private_numbers(self):
+        """
+        Returns a DHPrivateNumbers.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DHPublicKey(object):
+    @abc.abstractproperty
+    def key_size(self):
+        """
+        The bit length of the prime modulus.
+        """
+
+    @abc.abstractmethod
+    def parameters(self):
+        """
+        The DHParameters object associated with this public key.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DHPublicKeyWithNumbers(DHPublicKey):
+    @abc.abstractmethod
+    def public_numbers(self):
+        """
+        Returns a DHPublicNumbers.
+        """

--- a/cryptography/hazmat/primitives/interfaces.py
+++ b/cryptography/hazmat/primitives/interfaces.py
@@ -528,3 +528,8 @@ class DHPublicKeyWithNumbers(DHPublicKey):
         """
         Returns a DHPublicNumbers.
         """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DHExchangeAlgorithm(object):
+    pass

--- a/cryptography/hazmat/primitives/interfaces.py
+++ b/cryptography/hazmat/primitives/interfaces.py
@@ -468,7 +468,7 @@ class DHParameters(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class DHParametersWithNumbers(DSAParameters):
+class DHParametersWithNumbers(DHParameters):
     @abc.abstractmethod
     def parameter_numbers(self):
         """

--- a/docs/hazmat/primitives/asymmetric/dh.rst
+++ b/docs/hazmat/primitives/asymmetric/dh.rst
@@ -1,0 +1,64 @@
+.. hazmat::
+
+Diffie-Hellman Key Exchange
+===========================
+
+.. currentmodule:: cryptography.hazmat.primitives.asymmetric.dh
+
+
+.. class:: DHPrivateNumbers(private_value, public_numbers)
+
+    .. versionadded:: 0.6
+
+    The collection of integers that make up a Diffie-Hellman private key.
+
+    .. attribute:: public_numbers
+
+        :type: :class:`~cryptography.hazmat.primitives.asymmetric.dh.DHPublicNumbers`
+
+        The :class:`DHPublicNumbers` which makes up the DH public
+        key associated with this DH private key.
+
+    .. attribute:: private_value
+
+        :type: int
+
+        The private value.
+
+
+.. class:: DHPublicNumbers(parameters, public_value)
+
+    .. versionadded:: 0.6
+
+    The collection of integers that make up a Diffie-Hellman public key.
+
+     .. attribute:: parameters
+
+        :type: :class:`~cryptography.hazmat.primitives.dh.DHParameters`
+
+        The parameters for this DH group.
+
+    .. attribute:: public_value
+
+        :type: int
+
+        The public value.
+
+
+.. class:: DHParameters(modulus, generator)
+
+    .. versionadded:: 0.6
+
+    The collection of integers that define a Diffie-Hellman group.
+
+    .. attribute:: modulus
+
+        :type: int
+
+        The prime modulus value.
+
+    .. attribute:: generator
+
+        :type: int
+
+        The generator value.

--- a/docs/hazmat/primitives/asymmetric/index.rst
+++ b/docs/hazmat/primitives/asymmetric/index.rst
@@ -9,5 +9,6 @@ Asymmetric algorithms
     dsa
     ec
     rsa
+    dh
     padding
     serialization

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -14,6 +14,7 @@ crypto
 cryptographic
 cryptographically
 Debian
+Diffie
 decrypt
 decrypted
 decrypting

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,4 @@ markers =
     pkcs8_serialization: this test requires a backend providing PKCS8SerializationBackend
     supported: parametrized test requiring only_if and skip_message
     elliptic: this test requires a backend providing EllipticCurveBackend
+    dh: this test requires a backend providing DHBackend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ import pytest
 
 from cryptography.hazmat.backends import _available_backends
 from cryptography.hazmat.backends.interfaces import (
-    CMACBackend, CipherBackend, DSABackend, EllipticCurveBackend, HMACBackend,
-    HashBackend, PBKDF2HMACBackend, PKCS8SerializationBackend, RSABackend,
-    TraditionalOpenSSLSerializationBackend
+    CMACBackend, CipherBackend, DHBackend, DSABackend, EllipticCurveBackend,
+    HMACBackend, HashBackend, PBKDF2HMACBackend, PKCS8SerializationBackend,
+    RSABackend, TraditionalOpenSSLSerializationBackend
 )
 from .utils import check_backend_support, check_for_iface, select_backends
 
@@ -48,6 +48,7 @@ def pytest_runtest_setup(item):
     )
     check_for_iface("pkcs8_serialization", PKCS8SerializationBackend, item)
     check_for_iface("elliptic", EllipticCurveBackend, item)
+    check_for_iface("dh", DHBackend, item)
     check_backend_support(item)
 
 

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -97,17 +97,17 @@ class TestDH(object):
         assert isinstance(public, interfaces.DHPublicKey)
         assert public.key_size == 512
 
-    def test_exchange(self, backend):
+    def test_tls_exchange(self, backend):
         parameters = dh.generate_parameters(2, 512, backend)
         assert isinstance(parameters, interfaces.DHParameters)
 
         key1 = parameters.generate_private_key()
         key2 = parameters.generate_private_key()
 
-        exch = key1.exchange()
+        exch = key1.exchange(dh.TLSKeyExchange())
         symkey1 = exch.agree(key2.public_key().public_numbers.public_value)
         assert symkey1
 
-        exch = key2.exchange()
+        exch = key2.exchange(dh.TLSKeyExchange())
         symkey2 = exch.agree(key1.public_key().public_numbers.public_value)
         assert symkey1 == symkey2

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -156,7 +156,7 @@ class TestDH(object):
             load_kasvs_dh_vectors
         )
     )
-    def test_generate_kasvs_dh(self, vector, backend):
+    def test_kasvs_generate_private_key(self, vector, backend):
         parameter_numbers = dh.DHParameterNumbers(
             modulus=vector['p'],
             generator=vector['g']
@@ -181,7 +181,7 @@ class TestDH(object):
             load_kasvs_dh_vectors
         )
     )
-    def test_kasvs_dh(self, vector, backend):
+    def test_kasvs_agree_key(self, vector, backend):
         parameters = dh.DHParameterNumbers(
             modulus=vector['p'],
             generator=vector['g']

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -224,15 +224,18 @@ class TestDH(object):
         key1 = privnum1.private_key(backend)
         key2 = privnum2.private_key(backend)
 
+        pubkey1 = pubnum1.public_key(backend)
+        pubkey2 = pubnum2.public_key(backend)
+
         exch1 = key1.exchange(dh.TLSKeyExchange())
         agreed_key1 = exch1.agree(
-            key2.public_key().public_numbers.public_value
+            pubkey2.public_numbers.public_value
         )
         assert agreed_key1
 
         exch2 = key2.exchange(dh.TLSKeyExchange())
         agreed_key2 = exch2.agree(
-            key1.public_key().public_numbers.public_value
+            pubkey1.public_numbers.public_value
         )
         assert agreed_key2
 

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from cryptography.hazmat.primitives.asymmetric import dh
+
+
+def test_dh_parameters():
+    params = dh.DHParameters(
+        65537, 3
+    )
+
+    assert params.modulus == 65537
+    assert params.generator == 3
+
+    with pytest.raises(TypeError):
+        dh.DHParameters(
+            None, 3
+        )
+
+    with pytest.raises(TypeError):
+        dh.DHParameters(
+            65537, None
+        )
+
+    with pytest.raises(TypeError):
+        dh.DHParameters(
+            None, None
+        )
+
+
+def test_dh_numbers():
+    params = dh.DHParameters(
+        65537, 3
+    )
+
+    public = dh.DHPublicNumbers(
+        params, 1
+    )
+
+    assert public.parameters is params
+    assert public.public_value == 1
+
+    with pytest.raises(TypeError):
+        dh.DHPublicNumbers(
+            None, 1
+        )
+
+    with pytest.raises(TypeError):
+        dh.DHPublicNumbers(
+            params, None
+        )
+
+    private = dh.DHPrivateNumbers(
+        public, 1
+    )
+
+    assert private.public_numbers is public
+    assert private.private_value == 1
+
+    with pytest.raises(TypeError):
+        dh.DHPrivateNumbers(
+            None, 1
+        )
+
+    with pytest.raises(TypeError):
+        dh.DHPrivateNumbers(
+            public, None
+        )

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -1,12 +1,26 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
 import pytest
 
 from cryptography.hazmat.primitives.asymmetric import dh
+from cryptography.hazmat.primitives import interfaces
 
 
 def test_dh_parameters():
-    params = dh.DHParameters(
+    params = dh.DHParameterNumbers(
         65537, 3
     )
 
@@ -14,23 +28,23 @@ def test_dh_parameters():
     assert params.generator == 3
 
     with pytest.raises(TypeError):
-        dh.DHParameters(
+        dh.DHParameterNumbers(
             None, 3
         )
 
     with pytest.raises(TypeError):
-        dh.DHParameters(
+        dh.DHParameterNumbers(
             65537, None
         )
 
     with pytest.raises(TypeError):
-        dh.DHParameters(
+        dh.DHParameterNumbers(
             None, None
         )
 
 
 def test_dh_numbers():
-    params = dh.DHParameters(
+    params = dh.DHParameterNumbers(
         65537, 3
     )
 
@@ -67,3 +81,10 @@ def test_dh_numbers():
         dh.DHPrivateNumbers(
             public, None
         )
+
+
+@pytest.mark.dh
+class TestDH(object):
+    def test_generate_dh_parameters(self, backend):
+        parameters = dh.generate_parameters(1024, backend)
+        assert isinstance(parameters, interfaces.DHParameters)

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -52,7 +52,7 @@ def test_dh_numbers():
         params, 1
     )
 
-    assert public.parameters is params
+    assert public.parameter_numbers is params
     assert public.public_value == 1
 
     with pytest.raises(TypeError):
@@ -85,10 +85,29 @@ def test_dh_numbers():
 
 @pytest.mark.dh
 class TestDH(object):
-    def test_generate_dh_parameters(self, backend):
+    def test_generate_dh(self, backend):
         parameters = dh.generate_parameters(2, 512, backend)
         assert isinstance(parameters, interfaces.DHParameters)
 
         key = parameters.generate_private_key()
         assert isinstance(key, interfaces.DHPrivateKey)
         assert key.key_size == 512
+
+        public = key.public_key()
+        assert isinstance(public, interfaces.DHPublicKey)
+        assert public.key_size == 512
+
+    def test_exchange(self, backend):
+        parameters = dh.generate_parameters(2, 512, backend)
+        assert isinstance(parameters, interfaces.DHParameters)
+
+        key1 = parameters.generate_private_key()
+        key2 = parameters.generate_private_key()
+
+        exch = key1.exchange()
+        symkey1 = exch.agree(key2.public_key().public_numbers.public_value)
+        assert symkey1
+
+        exch = key2.exchange()
+        symkey2 = exch.agree(key1.public_key().public_numbers.public_value)
+        assert symkey1 == symkey2

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -86,5 +86,9 @@ def test_dh_numbers():
 @pytest.mark.dh
 class TestDH(object):
     def test_generate_dh_parameters(self, backend):
-        parameters = dh.generate_parameters(1024, backend)
+        parameters = dh.generate_parameters(2, 512, backend)
         assert isinstance(parameters, interfaces.DHParameters)
+
+        key = parameters.generate_private_key()
+        assert isinstance(key, interfaces.DHPrivateKey)
+        assert key.key_size == 512

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -19,8 +19,8 @@ import pytest
 
 from cryptography import utils
 from cryptography.exceptions import _Reasons
-from cryptography.hazmat.primitives.asymmetric import dh
 from cryptography.hazmat.primitives import interfaces
+from cryptography.hazmat.primitives.asymmetric import dh
 from cryptography.utils import bit_length
 
 from ...utils import (

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -94,11 +94,10 @@ class TestDH(object):
         with pytest.raises(ValueError):
             dh.generate_parameters(2, 511, backend)
 
-    @pytest.mark.parametrize(
-        ("generator", "key_size"),
-        [(2, 512)]
-    )
-    def test_generate_dh(self, generator, key_size, backend):
+    def test_generate_dh(self, backend):
+        generator = 2
+        key_size = 512
+
         parameters = dh.generate_parameters(generator, key_size, backend)
         assert isinstance(parameters, interfaces.DHParameters)
 
@@ -115,11 +114,11 @@ class TestDH(object):
             assert isinstance(parameter_numbers, dh.DHParameterNumbers)
             assert bit_length(parameter_numbers.modulus) == key_size
 
+        if isinstance(public, interfaces.DHPublicKeyWithNumbers):
+            assert isinstance(public.public_numbers, dh.DHPublicNumbers)
+
         if isinstance(key, interfaces.DHPrivateKeyWithNumbers):
             assert isinstance(key.private_numbers, dh.DHPrivateNumbers)
-
-        if isinstance(key, interfaces.DHPublicKeyWithNumbers):
-            assert isinstance(key.public_numbers, dh.DHPublicNumbers)
 
     def test_tls_exchange(self, backend):
         parameters = dh.generate_parameters(2, 512, backend)

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -126,9 +126,11 @@ class TestDH(object):
 
         if isinstance(public, interfaces.DHPublicKeyWithNumbers):
             assert isinstance(public.public_numbers, dh.DHPublicNumbers)
+            assert isinstance(public.parameters(), interfaces.DHParameters)
 
         if isinstance(key, interfaces.DHPrivateKeyWithNumbers):
             assert isinstance(key.private_numbers, dh.DHPrivateNumbers)
+            assert isinstance(key.parameters(), interfaces.DHParameters)
 
     def test_tls_exchange(self, backend):
         parameters = dh.generate_parameters(2, 512, backend)

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -107,7 +107,19 @@ class TestDH(object):
         exch = key1.exchange(dh.TLSKeyExchange())
         symkey1 = exch.agree(key2.public_key().public_numbers.public_value)
         assert symkey1
+        assert len(symkey1) == 512//8
 
         exch = key2.exchange(dh.TLSKeyExchange())
         symkey2 = exch.agree(key1.public_key().public_numbers.public_value)
         assert symkey1 == symkey2
+
+    def test_bad_tls_exchange(self, backend):
+        parameters = dh.generate_parameters(2, 512, backend)
+        assert isinstance(parameters, interfaces.DHParameters)
+
+        key1 = parameters.generate_private_key()
+
+        exch = key1.exchange(dh.TLSKeyExchange())
+
+        with pytest.raises(ValueError):
+            exch.agree(1)


### PR DESCRIPTION
This is an implementation of DH suitable for use in TLS. However it also leaves room for X9.42/RFC 2631 DH exchange in the future.

This flexibility will be achieved by adding a `DHExchangeAlgorithm` interface, instances of which are passed to `key.agree` to work out which key validations to apply and also by adding a new `DSAParameters` variant to hold the additional values used in X9.42 to verify public key and parameter groups.

The words "exchange" and "agree" are both used in this PR. "Agree" refers to the act of taking the received key material and computing the shared key value. "Exchange" refers to the rest of the process.

TODO:

- [x] PR for vector loader
- [x] PR for numbers
- [ ] PR for interfaces
- [ ] PR for implementation