### PR TITLE
Reorder OpenSSL libraries on the linker command-line

### DIFF
--- a/cryptography/hazmat/bindings/openssl/binding.py
+++ b/cryptography/hazmat/bindings/openssl/binding.py
@@ -96,9 +96,10 @@ class Binding(object):
         # OpenSSL goes by a different library name on different operating
         # systems.
         if sys.platform != "win32":
-            # In some circumstances, the order in which these libs are specified
-            # on the linker command-line is significant; libssl must come before
-            # libcrypto (http://marc.info/?l=openssl-users&m=135361825921871)
+            # In some circumstances, the order in which these libs are
+            # specified on the linker command-line is significant;
+            # libssl must come before libcrypto
+            # (http://marc.info/?l=openssl-users&m=135361825921871)
             libraries = ["ssl", "crypto"]
         else:  # pragma: no cover
             link_type = os.environ.get("PYCA_WINDOWS_LINK_TYPE", "static")


### PR DESCRIPTION
I had some issues getting cryptography to work with static versions of libssl and libcrypto, along the lines of:

```
cffi.ffiplatform.VerificationError: importing '/path/to/cryptography-0.5.1/cryptography/hazmat/bindings/__pycache__/_Cryptography_cffi_79a5b0a3x3a8a382.so': /path/to/cryptography-0.5.1/cryptography/hazmat/bindings/__pycache__/_Cryptography_cffi_79a5b0a3x3a8a382.so: undefined symbol: SRP_Calc_A
```

It turns out that swapping the order of "-lcrypto" and "-lssl" in the link command resolved this. Apparently, this is a known issue in some dark corners of the internet (e.g. http://marc.info/?l=openssl-users&m=135361825921871)
