### PR TITLE
Doc fixes

### DIFF
--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -105,19 +105,19 @@ Numbers
 
         :type: int
 
-        The public modulus.
+        The public modulus. Synonym for the ``modulus`` attribute.
 
     .. attribute:: q
 
         :type: int
 
-        The sub-group order.
+        The sub-group order. Synonym for the ``subgroup_order`` attribute.
 
     .. attribute:: g
 
         :type: int
 
-        The generator.
+        The generator. Synonnym for the ``generator`` attribute.
 
     .. method:: parameters(backend)
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -63,7 +63,7 @@ Elliptic Curve Signature Algorithms
 
         :type: :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers`
 
-        The :class:`EllipticCurvePublicNumbers` which makes up the EC public
+        The :class:`EllipticCurvePublicNumbers` that make up the EC public
         key associated with this EC private key.
 
     .. attribute:: private_value


### PR DESCRIPTION
We have these alias values on DSA that don't seem to be documented at all. There are also some now deprecated alias values on RSA which I don't think we have over on RSA*Numbers too, I guess we should fix that?
