### PR TITLE
when setting SSL and SSL_CTX options in tests get current options first

### DIFF
--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -137,9 +137,11 @@ class TestOpenSSL(object):
         ctx = b.ffi.gc(ctx, b.lib.SSL_CTX_free)
         ssl = b.lib.SSL_new(ctx)
         ssl = b.ffi.gc(ssl, b.lib.SSL_free)
+        current_options = b.lib.SSL_get_mode(ssl)
         resp = b.lib.SSL_set_mode(ssl, b.lib.SSL_OP_ALL)
-        assert resp == b.lib.SSL_OP_ALL
-        assert b.lib.SSL_OP_ALL == b.lib.SSL_get_mode(ssl)
+        expected_options = current_options | b.lib.SSL_OP_ALL
+        assert resp == expected_options
+        assert b.lib.SSL_get_mode(ssl) == expected_options
 
     def test_windows_static_dynamic_libraries(self):
         assert "ssleay32mt" in _get_windows_libraries("static")


### PR DESCRIPTION
Fixes #1352
