### PR TITLE
Renamed _bn_ctx_manager().

### DIFF
--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -1049,12 +1049,12 @@ class Backend(object):
         return curve_nid
 
     @contextmanager
-    def _bn_ctx_manager(self):
+    def _tmp_bn_ctx(self):
         bn_ctx = self._lib.BN_CTX_new()
         assert bn_ctx != self._ffi.NULL
         bn_ctx = self._ffi.gc(bn_ctx, self._lib.BN_CTX_free)
+        self._lib.BN_CTX_start(bn_ctx)
         try:
-            self._lib.BN_CTX_start(bn_ctx)
             yield bn_ctx
         finally:
             self._lib.BN_CTX_end(bn_ctx)
@@ -1098,7 +1098,7 @@ class Backend(object):
 
         assert set_func and get_func
 
-        with self._bn_ctx_manager() as bn_ctx:
+        with self._tmp_bn_ctx() as bn_ctx:
             check_x = self._lib.BN_CTX_get(bn_ctx)
             check_y = self._lib.BN_CTX_get(bn_ctx)
 

--- a/cryptography/hazmat/backends/openssl/ec.py
+++ b/cryptography/hazmat/backends/openssl/ec.py
@@ -38,7 +38,7 @@ def _truncate_digest_for_ecdsa(ec_key_cdata, digest, backend):
 
     group = _lib.EC_KEY_get0_group(ec_key_cdata)
 
-    with backend._bn_ctx_manager() as bn_ctx:
+    with backend._tmp_bn_ctx() as bn_ctx:
         order = _lib.BN_CTX_get(bn_ctx)
         assert order != _ffi.NULL
 


### PR DESCRIPTION
The existing name is confusing because it's ambigious about the fact that ctx belongs to bn or manager. The name doesn't need to say it's a manager anyways, so now it better describes what it does.
