### PR TITLE
more changelog entries from the 0.6 cycle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Changelog
   and
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublickeyWithNumbers`
   support.
-* Fix three GCM related bugs.
+* Work around three GCM related bugs in CommonCrypto and OpenSSL.
 
   * On the CommonCrypto backend adding AAD but not subsequently calling update
     would return null tag bytes.


### PR DESCRIPTION
#1345 should land before this is merged.
