### PR TITLE
add readthedocs badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ Cryptography
     :target: https://pypi.python.org/pypi/cryptography/
     :alt: Latest Version
 
+.. image:: https://readthedocs.org/projects/cryptography/badge/?version=latest
+    :target: https://cryptography.io
+    :alt: Latest Docs
+
 .. image:: https://travis-ci.org/pyca/cryptography.svg?branch=master
     :target: https://travis-ci.org/pyca/cryptography
 


### PR DESCRIPTION
fixes #1307 

This was a starter issue but having a prominent image in our pypi listing for the docs is important.
