### PR TITLE
Remove the curve parameter from OpenSSL EC keys

### DIFF
--- a/cryptography/hazmat/backends/openssl/backend.py
+++ b/cryptography/hazmat/backends/openssl/backend.py
@@ -1065,28 +1065,6 @@ class Backend(object):
             )
         return curve_nid
 
-    def _ec_key_curve_sn(self, ec_key):
-        group = self._lib.EC_KEY_get0_group(ec_key)
-        assert group != self._ffi.NULL
-
-        nid = self._lib.EC_GROUP_get_curve_name(group)
-        assert nid != self._lib.NID_undef
-
-        curve_name = self._lib.OBJ_nid2sn(nid)
-        assert curve_name != self._ffi.NULL
-
-        sn = self._ffi.string(curve_name).decode('ascii')
-        return sn
-
-    def _sn_to_elliptic_curve(self, sn):
-        try:
-            return ec._CURVE_TYPES[sn]()
-        except KeyError:
-            raise UnsupportedAlgorithm(
-                "{0} is not a supported elliptic curve".format(sn),
-                _Reasons.UNSUPPORTED_ELLIPTIC_CURVE
-            )
-
     @contextmanager
     def _tmp_bn_ctx(self):
         bn_ctx = self._lib.BN_CTX_new()

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -27,6 +27,7 @@ from cryptography.exceptions import InternalError, _Reasons
 from cryptography.hazmat.backends.openssl.backend import (
     Backend, backend
 )
+from cryptography.hazmat.backends.openssl.ec import _sn_to_elliptic_curve
 from cryptography.hazmat.primitives import hashes, interfaces
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher
@@ -509,7 +510,7 @@ class TestOpenSSLEllipticCurve(object):
 
     def test_sn_to_elliptic_curve_not_supported(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_ELLIPTIC_CURVE):
-            backend._sn_to_elliptic_curve(b"fake")
+            _sn_to_elliptic_curve(backend, b"fake")
 
 
 class TestDeprecatedRSABackendMethods(object):


### PR DESCRIPTION
This parameter serves no purpose. Might as well just let the key objects handle getting the data out of the ec_cdata.
