### PR TITLE
Switch to codecov.io from coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
     - ./.travis/run.sh
 
 after_success:
-    - source ~/.venv/bin/activate && coveralls
+    - source ~/.venv/bin/activate && codecov
 
 notifications:
     irc:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -109,4 +109,4 @@ fi
 
 virtualenv ~/.venv
 source ~/.venv/bin/activate
-pip install tox coveralls
+pip install tox codecov

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Cryptography
 .. image:: https://travis-ci.org/pyca/cryptography.svg?branch=master
     :target: https://travis-ci.org/pyca/cryptography
 
-.. image:: https://coveralls.io/repos/pyca/cryptography/badge.png?branch=master
-    :target: https://coveralls.io/r/pyca/cryptography?branch=master
+.. image:: https://codecov.io/github/pyca/cryptography/coverage.svg?branch=master
+    :target: https://codecov.io/github/pyca/cryptography?branch=master
 
 
 ``cryptography`` is a package which provides cryptographic recipes and


### PR DESCRIPTION
Coveralls doesn't care at all about branch coverage reporting, it just cares about lines (https://github.com/lemurheavy/coveralls-public/issues/31). [We are already choosing to generate branch coverage stats](https://github.com/pyca/cryptography/blob/master/.coveragerc#L2), but coveralls just ignores them. [codecov.io](http://codecov.io) incorporates branch data into their test coverage reporting. You can see an example [here using pyca/cryptography](https://codecov.io/github/frewsxcv/cryptography?ref=codecov) (keep in mind I disabled osx support when this ran).
