### PR TITLE
backport truncation for DSA digests

### DIFF
--- a/cryptography/hazmat/backends/openssl/dsa.py
+++ b/cryptography/hazmat/backends/openssl/dsa.py
@@ -15,11 +15,25 @@ from __future__ import absolute_import, division, print_function
 
 from cryptography import utils
 from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.backends.openssl.utils import _truncate_digest
 from cryptography.hazmat.primitives import hashes, interfaces
 from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives.interfaces import (
     DSAParametersWithNumbers, DSAPrivateKeyWithNumbers, DSAPublicKeyWithNumbers
 )
+
+
+def _truncate_digest_for_dsa(dsa_cdata, digest, backend):
+    """
+    This function truncates digests that are longer than a given DS
+    key's length so they can be signed. OpenSSL does this for us in
+    1.0.0c+ and it isn't needed in 0.9.8, but that leaves us with three
+    releases (1.0.0, 1.0.0a, and 1.0.0b) where this is a problem. This
+    truncation is not required in 0.9.8 because DSA is limited to SHA-1.
+    """
+
+    order_bits = backend._lib.BN_num_bits(dsa_cdata.q)
+    return _truncate_digest(digest, order_bits)
 
 
 @utils.register_interface(interfaces.AsymmetricVerificationContext)
@@ -40,6 +54,10 @@ class _DSAVerificationContext(object):
                                                 self._backend._lib.DSA_free)
 
         data_to_verify = self._hash_ctx.finalize()
+
+        data_to_verify = _truncate_digest_for_dsa(
+            self._dsa_cdata, data_to_verify, self._backend
+        )
 
         # The first parameter passed to DSA_verify is unused by OpenSSL but
         # must be an integer.
@@ -69,6 +87,9 @@ class _DSASignatureContext(object):
 
     def finalize(self):
         data_to_sign = self._hash_ctx.finalize()
+        data_to_sign = _truncate_digest_for_dsa(
+            self._private_key._dsa_cdata, data_to_sign, self._backend
+        )
         sig_buf_len = self._backend._lib.DSA_size(self._private_key._dsa_cdata)
         sig_buf = self._backend._ffi.new("unsigned char[]", sig_buf_len)
         buflen = self._backend._ffi.new("unsigned int *")

--- a/cryptography/hazmat/backends/openssl/utils.py
+++ b/cryptography/hazmat/backends/openssl/utils.py
@@ -1,0 +1,35 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+import six
+
+
+def _truncate_digest(digest, order_bits):
+    digest_len = len(digest)
+
+    if 8 * digest_len > order_bits:
+        digest_len = (order_bits + 7) // 8
+        digest = digest[:digest_len]
+
+    if 8 * digest_len > order_bits:
+        rshift = 8 - (order_bits & 0x7)
+        assert rshift > 0 and rshift < 8
+
+        mask = 0xFF >> rshift << rshift
+
+        # Set the bottom rshift bits to 0
+        digest = digest[:-1] + six.int2byte(six.indexbytes(digest, -1) & mask)
+
+    return digest


### PR DESCRIPTION
Fixes an issue with OpenSSL 1.0.0, 1.0.0a, and 1.0.0b. Changelog in the next PR.
