### PR TITLE
Changed methods on interface providers to have argument names match the interface.

### DIFF
--- a/cryptography/hazmat/backends/multibackend.py
+++ b/cryptography/hazmat/backends/multibackend.py
@@ -47,33 +47,33 @@ class MultiBackend(object):
             if isinstance(b, interface):
                 yield b
 
-    def cipher_supported(self, algorithm, mode):
+    def cipher_supported(self, cipher, mode):
         return any(
-            b.cipher_supported(algorithm, mode)
+            b.cipher_supported(cipher, mode)
             for b in self._filtered_backends(CipherBackend)
         )
 
-    def create_symmetric_encryption_ctx(self, algorithm, mode):
+    def create_symmetric_encryption_ctx(self, cipher, mode):
         for b in self._filtered_backends(CipherBackend):
             try:
-                return b.create_symmetric_encryption_ctx(algorithm, mode)
+                return b.create_symmetric_encryption_ctx(cipher, mode)
             except UnsupportedAlgorithm:
                 pass
         raise UnsupportedAlgorithm(
             "cipher {0} in {1} mode is not supported by this backend.".format(
-                algorithm.name, mode.name if mode else mode),
+                cipher.name, mode.name if mode else mode),
             _Reasons.UNSUPPORTED_CIPHER
         )
 
-    def create_symmetric_decryption_ctx(self, algorithm, mode):
+    def create_symmetric_decryption_ctx(self, cipher, mode):
         for b in self._filtered_backends(CipherBackend):
             try:
-                return b.create_symmetric_decryption_ctx(algorithm, mode)
+                return b.create_symmetric_decryption_ctx(cipher, mode)
             except UnsupportedAlgorithm:
                 pass
         raise UnsupportedAlgorithm(
             "cipher {0} in {1} mode is not supported by this backend.".format(
-                algorithm.name, mode.name if mode else mode),
+                cipher.name, mode.name if mode else mode),
             _Reasons.UNSUPPORTED_CIPHER
         )
 

--- a/cryptography/hazmat/backends/openssl/dsa.py
+++ b/cryptography/hazmat/backends/openssl/dsa.py
@@ -131,8 +131,8 @@ class _DSAPrivateKey(object):
 
     key_size = utils.read_only_property("_key_size")
 
-    def signer(self, algorithm):
-        return _DSASignatureContext(self._backend, self, algorithm)
+    def signer(self, signature_algorithm):
+        return _DSASignatureContext(self._backend, self, signature_algorithm)
 
     def private_numbers(self):
         return dsa.DSAPrivateNumbers(
@@ -180,9 +180,9 @@ class _DSAPublicKey(object):
 
     key_size = utils.read_only_property("_key_size")
 
-    def verifier(self, signature, algorithm):
+    def verifier(self, signature, signature_algorithm):
         return _DSAVerificationContext(
-            self._backend, self, signature, algorithm
+            self._backend, self, signature, signature_algorithm
         )
 
     def public_numbers(self):

--- a/cryptography/hazmat/primitives/hmac.py
+++ b/cryptography/hazmat/primitives/hmac.py
@@ -42,12 +42,12 @@ class HMAC(object):
         else:
             self._ctx = ctx
 
-    def update(self, msg):
+    def update(self, data):
         if self._ctx is None:
             raise AlreadyFinalized("Context was already finalized.")
-        if not isinstance(msg, bytes):
-            raise TypeError("msg must be bytes.")
-        self._ctx.update(msg)
+        if not isinstance(data, bytes):
+            raise TypeError("data must be bytes.")
+        self._ctx.update(data)
 
     def copy(self):
         if self._ctx is None:

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -38,15 +38,15 @@ class DummyCipherBackend(object):
     def __init__(self, supported_ciphers):
         self._ciphers = supported_ciphers
 
-    def cipher_supported(self, algorithm, mode):
-        return (type(algorithm), type(mode)) in self._ciphers
+    def cipher_supported(self, cipher, mode):
+        return (type(cipher), type(mode)) in self._ciphers
 
-    def create_symmetric_encryption_ctx(self, algorithm, mode):
-        if not self.cipher_supported(algorithm, mode):
+    def create_symmetric_encryption_ctx(self, cipher, mode):
+        if not self.cipher_supported(cipher, mode):
             raise UnsupportedAlgorithm("", _Reasons.UNSUPPORTED_CIPHER)
 
-    def create_symmetric_decryption_ctx(self, algorithm, mode):
-        if not self.cipher_supported(algorithm, mode):
+    def create_symmetric_decryption_ctx(self, cipher, mode):
+        if not self.cipher_supported(cipher, mode):
             raise UnsupportedAlgorithm("", _Reasons.UNSUPPORTED_CIPHER)
 
 
@@ -92,7 +92,7 @@ class DummyPBKDF2HMACBackend(object):
 
 @utils.register_interface(RSABackend)
 class DummyRSABackend(object):
-    def generate_rsa_private_key(self, public_exponent, private_key):
+    def generate_rsa_private_key(self, public_exponent, key_size):
         pass
 
     def rsa_padding_supported(self, padding):


### PR DESCRIPTION
This is important because it means passing things as keyword arguments will work consistently
