### PR TITLE
Add pkey comparison function to bindings

### DIFF
--- a/cryptography/hazmat/bindings/openssl/evp.py
+++ b/cryptography/hazmat/bindings/openssl/evp.py
@@ -121,7 +121,7 @@ int EVP_PKEY_add1_attr_by_NID(EVP_PKEY *, int, int,
 int EVP_PKEY_add1_attr_by_txt(EVP_PKEY *, const char *, int,
                               const unsigned char *, int);
 
-int EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b);
+int EVP_PKEY_cmp(const EVP_PKEY *, const EVP_PKEY *);
 """
 
 MACROS = """


### PR DESCRIPTION
Expose the EVP_PKEY_cmp function, so that pyOpenSSL can implement
comparison methods on PKey.
