### PR TITLE
Disabled implicit compile. Refs #1463

### DIFF
--- a/cryptography/hazmat/bindings/openssl/binding.py
+++ b/cryptography/hazmat/bindings/openssl/binding.py
@@ -105,15 +105,17 @@ class Binding(object):
             link_type = os.environ.get("PYCA_WINDOWS_LINK_TYPE", "static")
             libraries = _get_windows_libraries(link_type)
 
-        cls.ffi, cls.lib = build_ffi_for_binding(
+        cls.ffi, lib = build_ffi_for_binding(
             module_prefix=cls._module_prefix,
             modules=cls._modules,
             pre_include=_OSX_PRE_INCLUDE,
             post_include=_OSX_POST_INCLUDE,
             libraries=libraries,
         )
-        res = cls.lib.Cryptography_add_osrandom_engine()
-        assert res != 0
+        def cb(lib):
+            res = lib.Cryptography_add_osrandom_engine()
+            assert res != 0
+        cls.lib = lib._add_callback(cb)
 
     @classmethod
     def init_static_locks(cls):

--- a/cryptography/hazmat/bindings/utils.py
+++ b/cryptography/hazmat/bindings/utils.py
@@ -76,46 +76,40 @@ def build_ffi_for_binding(module_prefix, modules, pre_include="",
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     )
-    lib = LazyLibraryWithConditionals(lib._verifier, modules, module_prefix)
-    return ffi, lib
+    cb = lambda lib: _remove_conditions(lib, modules, module_prefix)
+    return ffi, lib._add_callback(cb)
 
 
 class LazyLibrary(object):
-    def __init__(self, verifier):
+    def __init__(self, verifier, callbacks=[]):
         self._lock = threading.Lock()
         self._verifier = verifier
+        self._callbacks = callbacks
         self._lib = None
 
-    def __getattr__(self, name):
-        if self._lib is None:
-            with self._lock:
-                if self._lib is None:
-                    self._lib = self._verifier.load_library()
-        return getattr(self._lib, name)
-
-
-class LazyLibraryWithConditionals(object):
-    def __init__(self, verifier, modules, module_prefix):
-        self._lock = threading.Lock()
-        self._verifier = verifier
-        self._lib = None
-        self._modules = modules
-        self._module_prefix = module_prefix
+    def _add_callback(self, cb):
+        assert self._lib is None
+        return LazyLibrary(self._verifier, self._callbacks + [cb])
 
     def __getattr__(self, name):
         if self._lib is None:
             with self._lock:
                 if self._lib is None:
                     lib = self._verifier.load_library()
-                    for name in self._modules:
-                        module_name = self._module_prefix + name
-                        module = sys.modules[module_name]
-                        for condition, names in module.CONDITIONAL_NAMES.items():
-                            if not getattr(lib, condition):
-                                for name in names:
-                                    delattr(lib, name)
+                    for cb in self._callbacks:
+                        cb(lib)
                     self._lib = lib
         return getattr(self._lib, name)
+
+
+def _remove_conditions(lib, modules, module_prefix):
+    for name in modules:
+        module_name = module_prefix + name
+        module = sys.modules[module_name]
+        for condition, names in module.CONDITIONAL_NAMES.items():
+            if not getattr(lib, condition):
+                for name in names:
+                    delattr(lib, name)
 
 
 def _compile_module(*args, **kwargs):


### PR DESCRIPTION
Ideally I would like to have some py.test hook we could use so this is re-compiled when starting the tests (for integration wiht py.test --looponfail).
