### PR TITLE
Build our c-exts in place before running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest
     ./vectors
 commands =
+    python setup.py build_ext --inplace
     coverage run -m pytest --capture=no --strict {posargs}
     coverage report -m
 


### PR DESCRIPTION
We need to do this because coverage and pytest both add `.` to the sys.path, which causes us to import cryptography from `.` instead of from the site-packages directory. This will ensure that the extensions are built and are put inplace so that we do not need to rely on the implicit compile in CFFI.
