### PR TITLE
add a tox target to randomize tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,13 @@ deps =
 commands =
     flake8 .
 
+[testenv:randomorder]
+deps =
+    {[testenv]deps}
+    pytest-random
+commands =
+    py.test --capture=no --strict --random {posargs}
+
 [flake8]
 exclude = .tox,*.egg
 select = E,W,F,N,I


### PR DESCRIPTION
This will be added as a jenkins job as a sanity check against order dependence in our tests.
