### PR TITLE
Export X509_STORE_load_locations and X509_STORE_set_default_paths 

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/x509_vfy.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509_vfy.py
@@ -131,7 +131,7 @@ int X509_verify_cert(X509_STORE_CTX *);
 X509_STORE *X509_STORE_new(void);
 void X509_STORE_free(X509_STORE *);
 int X509_STORE_add_cert(X509_STORE *, X509 *);
-int X509_STORE_load_locations (X509_STORE *, const char *, const char *);
+int X509_STORE_load_locations(X509_STORE *, const char *, const char *);
 int X509_STORE_set_default_paths(X509_STORE *);
 
 /* X509_STORE_CTX */


### PR DESCRIPTION
Hi. I faced with necessity to verify certificates offline and found that some OpenSSL functions required for this task are missed. OpenSSL provides X509_STORE_CTX for certificate verification, X509_STORE_CTX uses X509_STORE as input, but some functions that allow to configure store are missed. This pull request adds 2 functions X509_STORE_load_locations and X509_STORE_set_default_paths that can be used to configure X509_STORE. 
