### PR TITLE
Alter vector file loader to support passing read mode

### DIFF
--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 import base64
 import calendar
 import json
+import os
 import time
 
 import iso8601
@@ -24,7 +25,9 @@ import cryptography_vectors
 
 
 def json_parametrize(keys, filename):
-    vector_file = cryptography_vectors.open_vector_file('fernet', filename)
+    vector_file = cryptography_vectors.open_vector_file(
+        os.path.join('fernet', filename), "r"
+    )
     with vector_file:
         data = json.load(vector_file)
         return pytest.mark.parametrize(keys, [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -87,8 +87,8 @@ def der_encode_dsa_signature(r, s):
     return encoder.encode(sig)
 
 
-def load_vectors_from_file(filename, loader):
-    with cryptography_vectors.open_vector_file(filename) as vector_file:
+def load_vectors_from_file(filename, loader, mode="r"):
+    with cryptography_vectors.open_vector_file(filename, mode) as vector_file:
         return loader(vector_file)
 
 

--- a/vectors/cryptography_vectors/__init__.py
+++ b/vectors/cryptography_vectors/__init__.py
@@ -18,6 +18,6 @@ __all__ = [
 ]
 
 
-def open_vector_file(*args):
+def open_vector_file(filename, mode):
     base = os.path.dirname(__file__)
-    return open(os.path.join(base, *args), "r")
+    return open(os.path.join(base, filename), mode)


### PR DESCRIPTION
This will be used in the X.509 PR since we're loading binary files there.
