### PR TITLE
Support for traditional OpenSSL and PKCS8 RSA private key serialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,7 +83,7 @@ Changelog
   and deprecated
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithNumbers`.
 * Added
-  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.dump`
+  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.as_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,7 +83,7 @@ Changelog
   and deprecated
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithNumbers`.
 * Added
-  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.as_bytes`
+  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.private_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,6 +78,14 @@ Changelog
   support loading DER encoded public keys.
 * Fixed building against LibreSSL, a compile-time substitute for OpenSSL.
 * FreeBSD 9.2 was removed from the continuous integration system.
+* Added
+  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`
+  and deprecated
+  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithNumbers`.
+* Added
+  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.dump`
+  to
+  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`.
 
 0.7.2 - 2015-01-16
 ~~~~~~~~~~~~~~~~~~

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -95,7 +95,7 @@ to serialize the key.
     >>> pem = private_key.dump(
     ...    encoding=serialization.Encoding.PEM,
     ...    fmt=serialization.Format.PKCS8,
-    ...    encryption_type=serialization.BestAvailableEncryption(b'mypassword')
+    ...    encryption_algorithm=serialization.BestAvailableEncryption(b'mypassword')
     ... )
     >>> pem.splitlines()[0]
     '-----BEGIN ENCRYPTED PRIVATE KEY-----'
@@ -107,8 +107,8 @@ It is also possible to serialize without encryption using
 
     >>> pem = private_key.dump(
     ...    encoding=serialization.Encoding.PEM,
-    ...    fmt=serialization.Format.PKCS8,
-    ...    encryption_type=serialization.NoEncryption()
+    ...    fmt=serialization.Format.TraditionalOpenSSL,
+    ...    encryption_algorithm=serialization.NoEncryption()
     ... )
     >>> pem.splitlines()[0]
     '-----BEGIN RSA PRIVATE KEY-----'
@@ -534,7 +534,7 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
             instance.
 
-    .. method:: dump(encoding, fmt, encryption_type)
+    .. method:: dump(encoding, fmt, encryption_algorithm)
 
         Dump the key to PEM encoded bytes using the serializer provided.
 
@@ -544,7 +544,7 @@ Key interfaces
         :param fmt: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.Format` enum.
 
-        :param encryption_type: An instance of an object conforming to the
+        :param encryption_algorithm: An instance of an object conforming to the
             :class:`~cryptography.hazmat.primitives.serialization.KeySerializationEncryption`
             interface.
 

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -83,7 +83,7 @@ There is also support for :func:`loading public keys in the SSH format
 Key serialization
 ~~~~~~~~~~~~~~~~~
 
-If you have a previously loaded or generated key that has the
+If you have a key that you've loaded or generated which implements the
 :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`
 interface you can use
 :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.as_bytes`

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -94,7 +94,7 @@ to serialize the key.
     >>> from cryptography.hazmat.primitives import serialization
     >>> pem = private_key.as_bytes(
     ...    encoding=serialization.Encoding.PEM,
-    ...    fmt=serialization.Format.PKCS8,
+    ...    format=serialization.Format.PKCS8,
     ...    encryption_algorithm=serialization.BestAvailableEncryption(b'mypassword')
     ... )
     >>> pem.splitlines()[0]
@@ -107,7 +107,7 @@ It is also possible to serialize without encryption using
 
     >>> pem = private_key.as_bytes(
     ...    encoding=serialization.Encoding.PEM,
-    ...    fmt=serialization.Format.TraditionalOpenSSL,
+    ...    format=serialization.Format.TraditionalOpenSSL,
     ...    encryption_algorithm=serialization.NoEncryption()
     ... )
     >>> pem.splitlines()[0]
@@ -534,14 +534,18 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
             instance.
 
-    .. method:: as_bytes(encoding, fmt, encryption_algorithm)
+    .. method:: as_bytes(encoding, format, encryption_algorithm)
 
-        Serialize the key to bytes.
+        Allows serialization of the key to bytes. Encoding (PEM or DER), format
+        (TraditionalOpenSSL or PKCS8) and encryption algorithm (such as
+        :class:`~cryptography.hazmat.primitives.serialization.BestAvailableEncryption`
+        or :class:`~cryptography.hazmat.primitives.serialization.NoEncryption`)
+        are chosen to define the exact serialization.
 
         :param encoding: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
 
-        :param fmt: A value from the
+        :param format: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.Format` enum.
 
         :param encryption_algorithm: An instance of an object conforming to the

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -80,6 +80,37 @@ password. If the key is encrypted we can pass a ``bytes`` object as the
 There is also support for :func:`loading public keys in the SSH format
 <cryptography.hazmat.primitives.serialization.load_ssh_public_key>`.
 
+Key serialization
+~~~~~~~~~~~~~~~~~
+
+If you have a previously loaded or generated key that has the
+:class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`
+interface you can use
+:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.dump`
+to serialize the key.
+
+.. doctest::
+
+    >>> from cryptography.hazmat.primitives import serialization
+    >>> pem = private_key.dump(
+    ...    serialization.PKCS8(serialization.Encoding.PEM),
+    ...    serialization.BestAvailable(b'passwordgoeshere')
+    ... )
+    >>> pem.splitlines()[0]
+    '-----BEGIN ENCRYPTED PRIVATE KEY-----'
+
+It is also possible to serialize without encryption using
+:class:`~cryptography.hazmat.primitives.serialization.NoEncryption`.
+
+.. doctest::
+
+    >>> pem = private_key.dump(
+    ...    serialization.TraditionalOpenSSL(serialization.Encoding.PEM),
+    ...    serialization.NoEncryption()
+    ... )
+    >>> pem.splitlines()[0]
+    '-----BEGIN RSA PRIVATE KEY-----'
+
 Signing
 ~~~~~~~
 
@@ -483,6 +514,37 @@ Key interfaces
         :returns: An
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
             instance.
+
+
+.. class:: RSAPrivateKeyWithSerialization
+
+    .. versionadded:: 0.8
+
+    Extends :class:`RSAPrivateKey`.
+
+    .. method:: private_numbers()
+
+        Create a
+        :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
+        object.
+
+        :returns: An
+            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
+            instance.
+
+    .. method:: dump(serializer, encryption_type)
+
+        Dump the key to PEM encoded bytes using the serializer provided.
+
+        :param serializer: An instance of
+            :class:`~cryptography.hazmat.primitives.serialization.TraditionalOpenSSL`
+            or :class:`~cryptography.hazmat.primitives.serialization.PKCS8`
+
+        :param encryption_type: An instance of an object conforming to the
+            :class:`~cryptography.hazmat.primitives.serialization.KeySerializationEncryption`
+            interface.
+
+        :return bytes: Serialized key.
 
 
 .. class:: RSAPublicKey

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -536,8 +536,14 @@ Key interfaces
 
     .. method:: as_bytes(encoding, format, encryption_algorithm)
 
-        Allows serialization of the key to bytes. Encoding (PEM or DER), format
-        (TraditionalOpenSSL or PKCS8) and encryption algorithm (such as
+        Allows serialization of the key to bytes. Encoding (
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM` or
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`),
+        format (
+        :attr:`~cryptography.hazmat.primitives.serialization.Format.TraditionalOpenSSL`
+        or
+        :attr:`~cryptography.hazmat.primitives.serialization.Format.PKCS8`) and
+        encryption algorithm (such as
         :class:`~cryptography.hazmat.primitives.serialization.BestAvailableEncryption`
         or :class:`~cryptography.hazmat.primitives.serialization.NoEncryption`)
         are chosen to define the exact serialization.

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -86,13 +86,13 @@ Key serialization
 If you have a key that you've loaded or generated which implements the
 :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`
 interface you can use
-:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.as_bytes`
+:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.private_bytes`
 to serialize the key.
 
 .. doctest::
 
     >>> from cryptography.hazmat.primitives import serialization
-    >>> pem = private_key.as_bytes(
+    >>> pem = private_key.private_bytes(
     ...    encoding=serialization.Encoding.PEM,
     ...    format=serialization.Format.PKCS8,
     ...    encryption_algorithm=serialization.BestAvailableEncryption(b'mypassword')
@@ -105,7 +105,7 @@ It is also possible to serialize without encryption using
 
 .. doctest::
 
-    >>> pem = private_key.as_bytes(
+    >>> pem = private_key.private_bytes(
     ...    encoding=serialization.Encoding.PEM,
     ...    format=serialization.Format.TraditionalOpenSSL,
     ...    encryption_algorithm=serialization.NoEncryption()
@@ -534,7 +534,7 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
             instance.
 
-    .. method:: as_bytes(encoding, format, encryption_algorithm)
+    .. method:: private_bytes(encoding, format, encryption_algorithm)
 
         Allows serialization of the key to bytes. Encoding (
         :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM` or

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -86,13 +86,13 @@ Key serialization
 If you have a previously loaded or generated key that has the
 :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`
 interface you can use
-:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.dump`
+:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.as_bytes`
 to serialize the key.
 
 .. doctest::
 
     >>> from cryptography.hazmat.primitives import serialization
-    >>> pem = private_key.dump(
+    >>> pem = private_key.as_bytes(
     ...    encoding=serialization.Encoding.PEM,
     ...    fmt=serialization.Format.PKCS8,
     ...    encryption_algorithm=serialization.BestAvailableEncryption(b'mypassword')
@@ -105,7 +105,7 @@ It is also possible to serialize without encryption using
 
 .. doctest::
 
-    >>> pem = private_key.dump(
+    >>> pem = private_key.as_bytes(
     ...    encoding=serialization.Encoding.PEM,
     ...    fmt=serialization.Format.TraditionalOpenSSL,
     ...    encryption_algorithm=serialization.NoEncryption()
@@ -534,9 +534,9 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
             instance.
 
-    .. method:: dump(encoding, fmt, encryption_algorithm)
+    .. method:: as_bytes(encoding, fmt, encryption_algorithm)
 
-        Dump the key to PEM encoded bytes using the serializer provided.
+        Serialize the key to bytes.
 
         :param encoding: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -93,8 +93,9 @@ to serialize the key.
 
     >>> from cryptography.hazmat.primitives import serialization
     >>> pem = private_key.dump(
-    ...    serialization.PKCS8(serialization.Encoding.PEM),
-    ...    serialization.BestAvailable(b'passwordgoeshere')
+    ...    encoding=serialization.Encoding.PEM,
+    ...    fmt=serialization.Format.PKCS8,
+    ...    encryption_type=serialization.BestAvailableEncryption(b'mypassword')
     ... )
     >>> pem.splitlines()[0]
     '-----BEGIN ENCRYPTED PRIVATE KEY-----'
@@ -105,8 +106,9 @@ It is also possible to serialize without encryption using
 .. doctest::
 
     >>> pem = private_key.dump(
-    ...    serialization.TraditionalOpenSSL(serialization.Encoding.PEM),
-    ...    serialization.NoEncryption()
+    ...    encoding=serialization.Encoding.PEM,
+    ...    fmt=serialization.Format.PKCS8,
+    ...    encryption_type=serialization.NoEncryption()
     ... )
     >>> pem.splitlines()[0]
     '-----BEGIN RSA PRIVATE KEY-----'
@@ -532,13 +534,15 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
             instance.
 
-    .. method:: dump(serializer, encryption_type)
+    .. method:: dump(encoding, fmt, encryption_type)
 
         Dump the key to PEM encoded bytes using the serializer provided.
 
-        :param serializer: An instance of
-            :class:`~cryptography.hazmat.primitives.serialization.TraditionalOpenSSL`
-            or :class:`~cryptography.hazmat.primitives.serialization.PKCS8`
+        :param encoding: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+        :param fmt: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.Format` enum.
 
         :param encryption_type: An instance of an object conforming to the
             :class:`~cryptography.hazmat.primitives.serialization.KeySerializationEncryption`

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -323,7 +323,7 @@ Serialization Encryption Types
 
     Objects with this interface are usable as encryption types with methods
     like
-    :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.dump`.
+    :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.as_bytes`.
     All other classes in this section represent the available choices for
     encryption and have this interface.
 

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -80,7 +80,7 @@ methods.
         >>> key = load_pem_private_key(pem_data, password=None, backend=default_backend())
         >>> if isinstance(key, rsa.RSAPrivateKey):
         ...     signature = sign_with_rsa_key(key, message)
-        ... elif isinstance(key, interfaces.DSAPrivateKey):
+        ... elif isinstance(key, dsa.DSAPrivateKey):
         ...     signature = sign_with_dsa_key(key, message)
         ... else:
         ...     raise TypeError
@@ -294,9 +294,14 @@ Serialization Formats
 
     .. attribute:: TraditionalOpenSSL
 
-        Frequently known as PKCS#1 format.
+        Frequently known as PKCS#1 format. Still a widely used format, but
+        generally considered legacy.
 
     .. attribute:: PKCS8
+
+        A more modern format for serializing keys which allows for better
+        encryption. Choose this unless you have explicit legacy compatibility
+        requirements.
 
 Serialization Encodings
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -75,7 +75,7 @@ methods.
     .. doctest::
 
         >>> from cryptography.hazmat.backends import default_backend
-        >>> from cryptography.hazmat.primitives.asymmetric import rsa
+        >>> from cryptography.hazmat.primitives.asymmetric import dsa, rsa
         >>> from cryptography.hazmat.primitives.serialization import load_pem_private_key
         >>> key = load_pem_private_key(pem_data, password=None, backend=default_backend())
         >>> if isinstance(key, rsa.RSAPrivateKey):

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -75,12 +75,12 @@ methods.
     .. doctest::
 
         >>> from cryptography.hazmat.backends import default_backend
-        >>> from cryptography.hazmat.primitives.asymmetric import dsa, rsa
+        >>> from cryptography.hazmat.primitives.asymmetric import rsa
         >>> from cryptography.hazmat.primitives.serialization import load_pem_private_key
         >>> key = load_pem_private_key(pem_data, password=None, backend=default_backend())
         >>> if isinstance(key, rsa.RSAPrivateKey):
         ...     signature = sign_with_rsa_key(key, message)
-        ... elif isinstance(key, dsa.DSAPrivateKey):
+        ... elif isinstance(key, interfaces.DSAPrivateKey):
         ...     signature = sign_with_dsa_key(key, message)
         ... else:
         ...     raise TypeError
@@ -283,30 +283,37 @@ DSA keys look almost identical but begin with ``ssh-dss`` rather than
     :raises cryptography.exceptions.UnsupportedAlgorithm: If the serialized
         key is of a type that is not supported.
 
-Serializers
-~~~~~~~~~~~
+Serialization Formats
+~~~~~~~~~~~~~~~~~~~~~
 
-Instances of these classes can be passed to methods like
-:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.dump`.
-
-.. class:: PKCS8(encoding)
+.. class:: Format
 
     .. versionadded:: 0.8
 
-    A serializer for the PKCS #8 format.
+    An enumeration for key formats.
 
-    :param encoding: A value from the
-        :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+    .. attribute:: TraditionalOpenSSL
 
-.. class:: TraditionalOpenSSL(encoding)
+        Frequently known as PKCS#1 format.
+
+    .. attribute:: PKCS8
+
+Serialization Encodings
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: Encoding
 
     .. versionadded:: 0.8
 
-    A serializer for the traditional OpenSSL (sometimes known as PKCS #1)
-    format.
+    An enumeration for encoding types.
 
-    :param encoding: A value from the
-        :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+    .. attribute:: PEM
+
+        For PEM format. This is a base64 format with delimiters.
+
+    .. attribute:: DER
+
+        For DER format. This is a binary format.
 
 
 Serialization Encryption Types
@@ -320,7 +327,7 @@ Serialization Encryption Types
     All other classes in this section represent the available choices for
     encryption and have this interface.
 
-.. class:: BestAvailable
+.. class:: BestAvailableEncryption(password)
 
     Encrypt using the best available encryption for a given key's backend.
     This is a curated encryption choice and the algorithm may change over
@@ -331,22 +338,3 @@ Serialization Encryption Types
 .. class:: NoEncryption
 
     Do not encrypt.
-
-
-Utility Classes
-~~~~~~~~~~~~~~~
-
-.. class:: Encoding
-
-    .. versionadded:: 0.8
-
-    An enumeration for encoding types. Used by :class:`PKCS8` and
-    :class:`TraditionalOpenSSL`.
-
-    .. attribute:: PEM
-
-        For PEM format. This is a base64 format with delimiters.
-
-    .. attribute:: DER
-
-        For DER format. This is a binary format.

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -3,7 +3,7 @@
 Key Serialization
 =================
 
-.. currentmodule:: cryptography.hazmat.primitives.serialization
+.. module:: cryptography.hazmat.primitives.serialization
 
 .. testsetup::
 
@@ -282,3 +282,71 @@ DSA keys look almost identical but begin with ``ssh-dss`` rather than
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: If the serialized
         key is of a type that is not supported.
+
+Serializers
+~~~~~~~~~~~
+
+Instances of these classes can be passed to methods like
+:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.dump`.
+
+.. class:: PKCS8(encoding)
+
+    .. versionadded:: 0.8
+
+    A serializer for the PKCS #8 format.
+
+    :param encoding: A value from the
+        :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+.. class:: TraditionalOpenSSL(encoding)
+
+    .. versionadded:: 0.8
+
+    A serializer for the traditional OpenSSL (sometimes known as PKCS #1)
+    format.
+
+    :param encoding: A value from the
+        :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+
+Serialization Encryption Types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: KeySerializationEncryption
+
+    Objects with this interface are usable as encryption types with methods
+    like
+    :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.dump`.
+    All other classes in this section represent the available choices for
+    encryption and have this interface.
+
+.. class:: BestAvailable
+
+    Encrypt using the best available encryption for a given key's backend.
+    This is a curated encryption choice and the algorithm may change over
+    time.
+
+    :param bytes password: The password to use for encryption.
+
+.. class:: NoEncryption
+
+    Do not encrypt.
+
+
+Utility Classes
+~~~~~~~~~~~~~~~
+
+.. class:: Encoding
+
+    .. versionadded:: 0.8
+
+    An enumeration for encoding types. Used by :class:`PKCS8` and
+    :class:`TraditionalOpenSSL`.
+
+    .. attribute:: PEM
+
+        For PEM format. This is a base64 format with delimiters.
+
+    .. attribute:: DER
+
+        For DER format. This is a binary format.

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -290,7 +290,8 @@ Serialization Formats
 
     .. versionadded:: 0.8
 
-    An enumeration for key formats.
+    An enumeration for key formats. Used with
+    :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.private_bytes`.
 
     .. attribute:: TraditionalOpenSSL
 
@@ -310,7 +311,8 @@ Serialization Encodings
 
     .. versionadded:: 0.8
 
-    An enumeration for encoding types.
+    An enumeration for encoding types. Used with
+    :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.private_bytes`.
 
     .. attribute:: PEM
 
@@ -328,9 +330,10 @@ Serialization Encryption Types
 
     Objects with this interface are usable as encryption types with methods
     like
-    :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.as_bytes`.
+    :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.private_bytes`.
     All other classes in this section represent the available choices for
-    encryption and have this interface.
+    encryption and have this interface. They are used with
+    :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.private_bytes`.
 
 .. class:: BestAvailableEncryption(password)
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -44,6 +44,8 @@ pseudorandom
 pyOpenSSL
 Schneier
 scrypt
+Serializers
+serializer
 Solaris
 Tanja
 testability

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -565,7 +565,7 @@ class _RSAPrivateKey(object):
             )
         )
 
-    def as_bytes(self, encoding, format, encryption_algorithm):
+    def private_bytes(self, encoding, format, encryption_algorithm):
         if not isinstance(encoding, Encoding):
             raise TypeError("encoding must be an item from the Encoding enum")
 

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -565,21 +565,21 @@ class _RSAPrivateKey(object):
             )
         )
 
-    def as_bytes(self, encoding, fmt, encryption_algorithm):
+    def as_bytes(self, encoding, format, encryption_algorithm):
         if not isinstance(encoding, Encoding):
             raise TypeError("encoding must be an item from the Encoding enum")
 
-        if not isinstance(fmt, Format):
+        if not isinstance(format, Format):
             raise TypeError("format must be an item from the Format enum")
 
         # This is a temporary check until we land DER serialization.
-        if encoding != Encoding.PEM:
+        if encoding is not Encoding.PEM:
             raise ValueError("Only PEM encoding is supported by this backend")
 
-        if fmt == Format.PKCS8:
+        if format is Format.PKCS8:
             write_bio = self._backend._lib.PEM_write_bio_PKCS8PrivateKey
             key = self._evp_pkey
-        elif fmt == Format.TraditionalOpenSSL:
+        elif format is Format.TraditionalOpenSSL:
             write_bio = self._backend._lib.PEM_write_bio_RSAPrivateKey
             key = self._rsa_cdata
 

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -565,7 +565,7 @@ class _RSAPrivateKey(object):
             )
         )
 
-    def dump(self, encoding, fmt, encryption_algorithm):
+    def as_bytes(self, encoding, fmt, encryption_algorithm):
         if not isinstance(encoding, Encoding):
             raise TypeError("encoding must be an item from the Encoding enum")
 

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -17,8 +17,13 @@ from cryptography.hazmat.primitives.asymmetric import (
 from cryptography.hazmat.primitives.asymmetric.padding import (
     AsymmetricPadding, MGF1, OAEP, PKCS1v15, PSS
 )
-from cryptography.hazmat.primitives.interfaces import (
-    RSAPrivateKeyWithNumbers, RSAPublicKeyWithNumbers
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    RSAPrivateKeyWithNumbers, RSAPrivateKeyWithSerialization,
+    RSAPublicKeyWithNumbers
+)
+from cryptography.hazmat.primitives.serialization import (
+    BestAvailable, Encoding, KeySerializationEncryption, NoEncryption, PKCS8,
+    TraditionalOpenSSL
 )
 
 
@@ -507,6 +512,7 @@ class _RSAVerificationContext(object):
 
 
 @utils.register_interface(RSAPrivateKeyWithNumbers)
+@utils.register_interface(RSAPrivateKeyWithSerialization)
 class _RSAPrivateKey(object):
     def __init__(self, backend, rsa_cdata):
         self._backend = backend
@@ -558,6 +564,57 @@ class _RSAPrivateKey(object):
                 n=self._backend._bn_to_int(self._rsa_cdata.n),
             )
         )
+
+    def dump(self, serializer, encryption_algorithm):
+        if isinstance(serializer, PKCS8):
+            write_bio = self._backend._lib.PEM_write_bio_PKCS8PrivateKey
+            key = self._evp_pkey
+        elif isinstance(serializer, TraditionalOpenSSL):
+            write_bio = self._backend._lib.PEM_write_bio_RSAPrivateKey
+            key = self._rsa_cdata
+        else:
+            raise TypeError("serializer must be PKCS8 or TraditionalOpenSSL")
+
+        if serializer.encoding != Encoding.PEM:
+            raise ValueError("Only PEM encoding is supported by this backend")
+
+        if not isinstance(encryption_algorithm, KeySerializationEncryption):
+            raise TypeError(
+                "Encryption algorithm must be a KeySerializationEncryption "
+                "instance"
+            )
+
+        if isinstance(encryption_algorithm, NoEncryption):
+            password = b""
+            passlen = 0
+            evp_cipher = self._backend._ffi.NULL
+        elif isinstance(encryption_algorithm, BestAvailable):
+            # This is a curated value that we will update over time.
+            evp_cipher = self._backend._lib.EVP_get_cipherbyname(
+                b"aes-256-cbc"
+            )
+            password = encryption_algorithm.password
+            passlen = len(password)
+            if passlen > 1023:
+                raise ValueError(
+                    "Passwords longer than 1023 bytes are not supported by "
+                    "this backend"
+                )
+        else:
+            raise ValueError("Unsupported encryption type")
+
+        bio = self._backend._create_mem_bio()
+        res = write_bio(
+            bio,
+            key,
+            evp_cipher,
+            password,
+            passlen,
+            self._backend._ffi.NULL,
+            self._backend._ffi.NULL
+        )
+        assert res == 1
+        return self._backend._read_mem_bio(bio)
 
 
 @utils.register_interface(RSAPublicKeyWithNumbers)

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -50,14 +50,21 @@ class RSAPrivateKeyWithSerialization(RSAPrivateKey):
         """
 
     @abc.abstractmethod
-    def dump(self, serializer, encryption_algorithm):
+    def dump(self, encoding, fmt, encryption_algorithm):
         """
-        Returns the PEM encoded key.
+        Returns the dumped key.
         """
 
 
-# DeprecatedIn08
-RSAPrivateKeyWithNumbers = RSAPrivateKeyWithSerialization
+RSAPrivateKeyWithNumbers = utils.deprecated(
+    RSAPrivateKeyWithSerialization,
+    __name__,
+    (
+        "The RSAPrivateKeyWithNumbers interface has been renamed to "
+        "RSAPrivateKeyWithSerialization"
+    ),
+    utils.DeprecatedIn08
+)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -42,12 +42,22 @@ class RSAPrivateKey(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class RSAPrivateKeyWithNumbers(RSAPrivateKey):
+class RSAPrivateKeyWithSerialization(RSAPrivateKey):
     @abc.abstractmethod
     def private_numbers(self):
         """
         Returns an RSAPrivateNumbers.
         """
+
+    @abc.abstractmethod
+    def dump(self, serializer, encryption_algorithm):
+        """
+        Returns the PEM encoded key.
+        """
+
+
+# DeprecatedIn08
+RSAPrivateKeyWithNumbers = RSAPrivateKeyWithSerialization
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -50,9 +50,9 @@ class RSAPrivateKeyWithSerialization(RSAPrivateKey):
         """
 
     @abc.abstractmethod
-    def dump(self, encoding, fmt, encryption_algorithm):
+    def as_bytes(self, encoding, fmt, encryption_algorithm):
         """
-        Returns the dumped key.
+        Returns the key serialized as bytes.
         """
 
 

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -50,7 +50,7 @@ class RSAPrivateKeyWithSerialization(RSAPrivateKey):
         """
 
     @abc.abstractmethod
-    def as_bytes(self, encoding, format, encryption_algorithm):
+    def private_bytes(self, encoding, format, encryption_algorithm):
         """
         Returns the key serialized as bytes.
         """

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -50,7 +50,7 @@ class RSAPrivateKeyWithSerialization(RSAPrivateKey):
         """
 
     @abc.abstractmethod
-    def as_bytes(self, encoding, fmt, encryption_algorithm):
+    def as_bytes(self, encoding, format, encryption_algorithm):
         """
         Returns the key serialized as bytes.
         """

--- a/src/cryptography/hazmat/primitives/interfaces/__init__.py
+++ b/src/cryptography/hazmat/primitives/interfaces/__init__.py
@@ -289,11 +289,12 @@ RSAPrivateKey = utils.deprecated(
 )
 
 RSAPrivateKeyWithNumbers = utils.deprecated(
-    rsa.RSAPrivateKeyWithNumbers,
+    rsa.RSAPrivateKeyWithSerialization,
     __name__,
     (
         "The RSAPrivateKeyWithNumbers interface has moved to the "
-        "cryptography.hazmat.primitives.asymmetric.rsa module"
+        "cryptography.hazmat.primitives.asymmetric.rsa module and has been "
+        "renamed RSAPrivateKeyWithSerialization"
     ),
     utils.DeprecatedIn08
 )

--- a/src/cryptography/hazmat/primitives/serialization.py
+++ b/src/cryptography/hazmat/primitives/serialization.py
@@ -174,24 +174,9 @@ class Encoding(Enum):
     DER = "DER"
 
 
-class PKCS8(object):
-    def __init__(self, encoding):
-        if not isinstance(encoding, Encoding):
-            raise TypeError(
-                "Encoding must be an element from the Encoding enum"
-            )
-
-        self.encoding = encoding
-
-
-class TraditionalOpenSSL(object):
-    def __init__(self, encoding):
-        if not isinstance(encoding, Encoding):
-            raise TypeError(
-                "Encoding must be an element from the Encoding enum"
-            )
-
-        self.encoding = encoding
+class Format(Enum):
+    PKCS8 = "PKCS8"
+    TraditionalOpenSSL = "TraditionalOpenSSL"
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -200,7 +185,7 @@ class KeySerializationEncryption(object):
 
 
 @utils.register_interface(KeySerializationEncryption)
-class BestAvailable(object):
+class BestAvailableEncryption(object):
     def __init__(self, password):
         if not isinstance(password, bytes) or len(password) == 0:
             raise ValueError("Password must be 1 or more bytes.")

--- a/src/cryptography/hazmat/primitives/serialization.py
+++ b/src/cryptography/hazmat/primitives/serialization.py
@@ -4,11 +4,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+import abc
 import base64
 import struct
+from enum import Enum
 
 import six
 
+from cryptography import utils
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 
@@ -164,3 +167,47 @@ else:
             data = data[4:]
 
         return result
+
+
+class Encoding(Enum):
+    PEM = "PEM"
+    DER = "DER"
+
+
+class PKCS8(object):
+    def __init__(self, encoding):
+        if not isinstance(encoding, Encoding):
+            raise TypeError(
+                "Encoding must be an element from the Encoding enum"
+            )
+
+        self.encoding = encoding
+
+
+class TraditionalOpenSSL(object):
+    def __init__(self, encoding):
+        if not isinstance(encoding, Encoding):
+            raise TypeError(
+                "Encoding must be an element from the Encoding enum"
+            )
+
+        self.encoding = encoding
+
+
+@six.add_metaclass(abc.ABCMeta)
+class KeySerializationEncryption(object):
+    pass
+
+
+@utils.register_interface(KeySerializationEncryption)
+class BestAvailable(object):
+    def __init__(self, password):
+        if not isinstance(password, bytes) or len(password) == 0:
+            raise ValueError("Password must be 1 or more bytes.")
+
+        self.password = password
+
+
+@utils.register_interface(KeySerializationEncryption)
+class NoEncryption(object):
+    pass

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -12,6 +12,7 @@ import warnings
 
 # DeprecatedIn07 objects exist. This comment exists to remind developers to
 # look for them when it's time for the ninth release cycle deprecation dance.
+# DeprecatedIn08 objects also exist.
 
 DeprecatedIn08 = PendingDeprecationWarning
 

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -12,7 +12,6 @@ import warnings
 
 # DeprecatedIn07 objects exist. This comment exists to remind developers to
 # look for them when it's time for the ninth release cycle deprecation dance.
-# DeprecatedIn08 objects also exist.
 
 DeprecatedIn08 = PendingDeprecationWarning
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -503,18 +503,16 @@ class TestRSAPEMSerialization(object):
         key = RSA_KEY_2048.private_key(backend)
         with pytest.raises(ValueError):
             key.dump(
-                serialization.PKCS8(
-                    serialization.Encoding.PEM
-                ),
-                serialization.BestAvailable(password)
+                serialization.Encoding.PEM,
+                serialization.Format.PKCS8,
+                serialization.BestAvailableEncryption(password)
             )
 
     def test_unsupported_key_encoding(self):
         key = RSA_KEY_2048.private_key(backend)
         with pytest.raises(ValueError):
             key.dump(
-                serialization.PKCS8(
-                    serialization.Encoding.DER
-                ),
+                serialization.Encoding.DER,
+                serialization.Format.PKCS8,
                 serialization.NoEncryption()
             )

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -502,7 +502,7 @@ class TestRSAPEMSerialization(object):
         password = b"x" * 1024
         key = RSA_KEY_2048.private_key(backend)
         with pytest.raises(ValueError):
-            key.as_bytes(
+            key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.Format.PKCS8,
                 serialization.BestAvailableEncryption(password)
@@ -511,7 +511,7 @@ class TestRSAPEMSerialization(object):
     def test_unsupported_key_encoding(self):
         key = RSA_KEY_2048.private_key(backend)
         with pytest.raises(ValueError):
-            key.as_bytes(
+            key.private_bytes(
                 serialization.Encoding.DER,
                 serialization.Format.PKCS8,
                 serialization.NoEncryption()

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -502,7 +502,7 @@ class TestRSAPEMSerialization(object):
         password = b"x" * 1024
         key = RSA_KEY_2048.private_key(backend)
         with pytest.raises(ValueError):
-            key.dump(
+            key.as_bytes(
                 serialization.Encoding.PEM,
                 serialization.Format.PKCS8,
                 serialization.BestAvailableEncryption(password)
@@ -511,7 +511,7 @@ class TestRSAPEMSerialization(object):
     def test_unsupported_key_encoding(self):
         key = RSA_KEY_2048.private_key(backend)
         with pytest.raises(ValueError):
-            key.dump(
+            key.as_bytes(
                 serialization.Encoding.DER,
                 serialization.Format.PKCS8,
                 serialization.NoEncryption()

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -15,11 +15,12 @@ import pytest
 
 from cryptography import utils
 from cryptography.exceptions import InternalError, _Reasons
+from cryptography.hazmat.backends.interfaces import RSABackend
 from cryptography.hazmat.backends.openssl.backend import (
     Backend, backend
 )
 from cryptography.hazmat.backends.openssl.ec import _sn_to_elliptic_curve
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, padding
 from cryptography.hazmat.primitives.ciphers import (
     BlockCipherAlgorithm, Cipher, CipherAlgorithm
@@ -27,7 +28,7 @@ from cryptography.hazmat.primitives.ciphers import (
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.modes import CBC, CTR, Mode
 
-from ..primitives.fixtures_rsa import RSA_KEY_512
+from ..primitives.fixtures_rsa import RSA_KEY_2048, RSA_KEY_512
 from ...utils import load_vectors_from_file, raises_unsupported_algorithm
 
 
@@ -493,3 +494,27 @@ class TestOpenSSLEllipticCurve(object):
     def test_sn_to_elliptic_curve_not_supported(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_ELLIPTIC_CURVE):
             _sn_to_elliptic_curve(backend, b"fake")
+
+
+@pytest.mark.requires_backend_interface(interface=RSABackend)
+class TestRSAPEMSerialization(object):
+    def test_password_length_limit(self):
+        password = b"x" * 1024
+        key = RSA_KEY_2048.private_key(backend)
+        with pytest.raises(ValueError):
+            key.dump(
+                serialization.PKCS8(
+                    serialization.Encoding.PEM
+                ),
+                serialization.BestAvailable(password)
+            )
+
+    def test_unsupported_key_encoding(self):
+        key = RSA_KEY_2048.private_key(backend)
+        with pytest.raises(ValueError):
+            key.dump(
+                serialization.PKCS8(
+                    serialization.Encoding.DER
+                ),
+                serialization.NoEncryption()
+            )

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1764,10 +1764,10 @@ class TestRSAPEMWriter(object):
             ]
         )
     )
-    def test_dump_encrypted_pem(self, backend, fmt, password):
+    def test_as_bytes_encrypted_pem(self, backend, fmt, password):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
-        serialized = key.dump(
+        serialized = key.as_bytes(
             serialization.Encoding.PEM,
             fmt,
             serialization.BestAvailableEncryption(password)
@@ -1783,10 +1783,10 @@ class TestRSAPEMWriter(object):
         "fmt",
         (serialization.Format.TraditionalOpenSSL, serialization.Format.PKCS8),
     )
-    def test_dump_unencrypted_pem(self, backend, fmt):
+    def test_as_bytes_unencrypted_pem(self, backend, fmt):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
-        serialized = key.dump(
+        serialized = key.as_bytes(
             serialization.Encoding.PEM,
             fmt,
             serialization.NoEncryption()
@@ -1798,41 +1798,41 @@ class TestRSAPEMWriter(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
-    def test_dump_invalid_encoding(self, backend):
+    def test_as_bytes_invalid_encoding(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
-            key.dump(
+            key.as_bytes(
                 "notencoding",
                 serialization.Format.PKCS8,
                 serialization.NoEncryption()
             )
 
-    def test_dump_invalid_format(self, backend):
+    def test_as_bytes_invalid_format(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
-            key.dump(
+            key.as_bytes(
                 serialization.Encoding.PEM,
                 "invalidformat",
                 serialization.NoEncryption()
             )
 
-    def test_dump_invalid_encryption_algorithm(self, backend):
+    def test_as_bytes_invalid_encryption_algorithm(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
-            key.dump(
+            key.as_bytes(
                 serialization.Encoding.PEM,
                 serialization.Format.TraditionalOpenSSL,
                 "notanencalg"
             )
 
-    def test_dump_unsupported_encryption_type(self, backend):
+    def test_as_bytes_unsupported_encryption_type(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
-            key.dump(
+            key.as_bytes(
                 serialization.Encoding.PEM,
                 serialization.Format.TraditionalOpenSSL,
                 DummyKeyEncryption()

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1764,10 +1764,10 @@ class TestRSAPEMWriter(object):
             ]
         )
     )
-    def test_as_bytes_encrypted_pem(self, backend, fmt, password):
+    def test_private_bytes_encrypted_pem(self, backend, fmt, password):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
-        serialized = key.as_bytes(
+        serialized = key.private_bytes(
             serialization.Encoding.PEM,
             fmt,
             serialization.BestAvailableEncryption(password)
@@ -1783,10 +1783,10 @@ class TestRSAPEMWriter(object):
         "fmt",
         [serialization.Format.TraditionalOpenSSL, serialization.Format.PKCS8],
     )
-    def test_as_bytes_unencrypted_pem(self, backend, fmt):
+    def test_private_bytes_unencrypted_pem(self, backend, fmt):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
-        serialized = key.as_bytes(
+        serialized = key.private_bytes(
             serialization.Encoding.PEM,
             fmt,
             serialization.NoEncryption()
@@ -1798,7 +1798,7 @@ class TestRSAPEMWriter(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
-    def test_as_bytes_traditional_openssl_unencrypted_pem(self, backend):
+    def test_private_bytes_traditional_openssl_unencrypted_pem(self, backend):
         key_bytes = load_vectors_from_file(
             os.path.join(
                 "asymmetric",
@@ -1808,48 +1808,48 @@ class TestRSAPEMWriter(object):
             lambda pemfile: pemfile.read().encode()
         )
         key = serialization.load_pem_private_key(key_bytes, None, backend)
-        serialized = key.as_bytes(
+        serialized = key.private_bytes(
             serialization.Encoding.PEM,
             serialization.Format.TraditionalOpenSSL,
             serialization.NoEncryption()
         )
         assert serialized == key_bytes
 
-    def test_as_bytes_invalid_encoding(self, backend):
+    def test_private_bytes_invalid_encoding(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
-            key.as_bytes(
+            key.private_bytes(
                 "notencoding",
                 serialization.Format.PKCS8,
                 serialization.NoEncryption()
             )
 
-    def test_as_bytes_invalid_format(self, backend):
+    def test_private_bytes_invalid_format(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
-            key.as_bytes(
+            key.private_bytes(
                 serialization.Encoding.PEM,
                 "invalidformat",
                 serialization.NoEncryption()
             )
 
-    def test_as_bytes_invalid_encryption_algorithm(self, backend):
+    def test_private_bytes_invalid_encryption_algorithm(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
-            key.as_bytes(
+            key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.Format.TraditionalOpenSSL,
                 "notanencalg"
             )
 
-    def test_as_bytes_unsupported_encryption_type(self, backend):
+    def test_private_bytes_unsupported_encryption_type(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
-            key.as_bytes(
+            key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.Format.TraditionalOpenSSL,
                 DummyKeyEncryption()

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1781,7 +1781,7 @@ class TestRSAPEMWriter(object):
 
     @pytest.mark.parametrize(
         "fmt",
-        (serialization.Format.TraditionalOpenSSL, serialization.Format.PKCS8),
+        [serialization.Format.TraditionalOpenSSL, serialization.Format.PKCS8],
     )
     def test_as_bytes_unencrypted_pem(self, backend, fmt):
         key = RSA_KEY_2048.private_key(backend)

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1798,6 +1798,23 @@ class TestRSAPEMWriter(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
+    def test_as_bytes_traditional_openssl_unencrypted_pem(self, backend):
+        key_bytes = load_vectors_from_file(
+            os.path.join(
+                "asymmetric",
+                "Traditional_OpenSSL_Serialization",
+                "testrsa.pem"
+            ),
+            lambda pemfile: pemfile.read().encode()
+        )
+        key = serialization.load_pem_private_key(key_bytes, None, backend)
+        serialized = key.as_bytes(
+            serialization.Encoding.PEM,
+            serialization.Format.TraditionalOpenSSL,
+            serialization.NoEncryption()
+        )
+        assert serialized == key_bytes
+
     def test_as_bytes_invalid_encoding(self, backend):
         key = RSA_KEY_2048.private_key(backend)
         _skip_if_no_serialization(key, backend)

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -18,9 +18,8 @@ from cryptography.hazmat.backends.interfaces import (
 )
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from cryptography.hazmat.primitives.serialization import (
-    BestAvailable, Encoding, PKCS8, TraditionalOpenSSL, load_der_private_key,
-    load_der_public_key, load_pem_private_key, load_pem_public_key,
-    load_ssh_public_key
+    BestAvailableEncryption, load_der_private_key, load_der_public_key,
+    load_pem_private_key, load_pem_public_key, load_ssh_public_key
 )
 
 
@@ -1162,25 +1161,11 @@ class TestECDSASSHSerialization(object):
             load_ssh_public_key(ssh_key, backend)
 
 
-@pytest.mark.parametrize(
-    "serializer",
-    [PKCS8, TraditionalOpenSSL]
-)
-class TestSerializers(object):
-    def test_invalid_encoding(self, serializer):
-        with pytest.raises(TypeError):
-            serializer("thing")
-
-    def test_valid_params(self, serializer):
-        fmt = serializer(Encoding.PEM)
-        assert isinstance(fmt, (PKCS8, TraditionalOpenSSL))
-
-
 class TestKeySerializationEncryptionTypes(object):
     def test_non_bytes_password(self):
         with pytest.raises(ValueError):
-            BestAvailable(object())
+            BestAvailableEncryption(object())
 
     def test_encryption_with_zero_length_password(self):
         with pytest.raises(ValueError):
-            BestAvailable(b"")
+            BestAvailableEncryption(b"")

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -18,8 +18,9 @@ from cryptography.hazmat.backends.interfaces import (
 )
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from cryptography.hazmat.primitives.serialization import (
-    load_der_private_key, load_der_public_key, load_pem_private_key,
-    load_pem_public_key, load_ssh_public_key
+    BestAvailable, Encoding, PKCS8, TraditionalOpenSSL, load_der_private_key,
+    load_der_public_key, load_pem_private_key, load_pem_public_key,
+    load_ssh_public_key
 )
 
 
@@ -1159,3 +1160,27 @@ class TestECDSASSHSerialization(object):
         )
         with pytest.raises(ValueError):
             load_ssh_public_key(ssh_key, backend)
+
+
+@pytest.mark.parametrize(
+    "serializer",
+    [PKCS8, TraditionalOpenSSL]
+)
+class TestSerializers(object):
+    def test_invalid_encoding(self, serializer):
+        with pytest.raises(TypeError):
+            serializer("thing")
+
+    def test_valid_params(self, serializer):
+        fmt = serializer(Encoding.PEM)
+        assert isinstance(fmt, (PKCS8, TraditionalOpenSSL))
+
+
+class TestKeySerializationEncryptionTypes(object):
+    def test_non_bytes_password(self):
+        with pytest.raises(ValueError):
+            BestAvailable(object())
+
+    def test_encryption_with_zero_length_password(self):
+        with pytest.raises(ValueError):
+            BestAvailable(b"")


### PR DESCRIPTION
This temporarily uses the backend to do it until the alternate approach is ready. DSA/ECDSA and public key support will follow if this is deemed worthy.