### PR TITLE
add __ne__ and __eq__ methods to RSA, DSA, and EC numbers classes

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -60,6 +60,9 @@ class DSAParameterNumbers(object):
         return backend.load_dsa_parameter_numbers(self)
 
     def __eq__(self, other):
+        if not isinstance(other, DSAParameterNumbers):
+            return NotImplemented
+
         return self.p == other.p and self.q == other.q and self.g == other.g
 
     def __ne__(self, other):
@@ -86,6 +89,9 @@ class DSAPublicNumbers(object):
         return backend.load_dsa_public_numbers(self)
 
     def __eq__(self, other):
+        if not isinstance(other, DSAPublicNumbers):
+            return NotImplemented
+
         return (
             self.y == other.y and
             self.parameter_numbers == other.parameter_numbers
@@ -114,6 +120,9 @@ class DSAPrivateNumbers(object):
         return backend.load_dsa_private_numbers(self)
 
     def __eq__(self, other):
+        if not isinstance(other, DSAPrivateNumbers):
+            return NotImplemented
+
         return (
             self.x == other.x and self.public_numbers == other.public_numbers
         )

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -162,6 +162,9 @@ class EllipticCurvePublicNumbers(object):
     y = utils.read_only_property("_y")
 
     def __eq__(self, other):
+        if not isinstance(other, EllipticCurvePublicNumbers):
+            return NotImplemented
+
         return (
             self.x == other.x and
             self.y == other.y and
@@ -197,6 +200,9 @@ class EllipticCurvePrivateNumbers(object):
     public_numbers = utils.read_only_property("_public_numbers")
 
     def __eq__(self, other):
+        if not isinstance(other, EllipticCurvePrivateNumbers):
+            return NotImplemented
+
         return (
             self.private_value == other.private_value and
             self.public_numbers == other.public_numbers

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -161,6 +161,9 @@ class RSAPrivateNumbers(object):
         return backend.load_rsa_private_numbers(self)
 
     def __eq__(self, other):
+        if not isinstance(other, RSAPrivateNumbers):
+            return NotImplemented
+
         return (
             self.p == other.p and
             self.q == other.q and
@@ -196,6 +199,9 @@ class RSAPublicNumbers(object):
         return "<RSAPublicNumbers(e={0}, n={1})>".format(self._e, self._n)
 
     def __eq__(self, other):
+        if not isinstance(other, RSAPublicNumbers):
+            return NotImplemented
+
         return self.e == other.e and self.n == other.n
 
     def __ne__(self, other):

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -717,6 +717,7 @@ class TestDSANumberEquality(object):
         assert param != dsa.DSAParameterNumbers(1, 2, 4)
         assert param != dsa.DSAParameterNumbers(1, 1, 3)
         assert param != dsa.DSAParameterNumbers(2, 2, 3)
+        assert param != object()
 
     def test_public_numbers_eq(self):
         pub = dsa.DSAPublicNumbers(1, dsa.DSAParameterNumbers(1, 2, 3))
@@ -728,6 +729,7 @@ class TestDSANumberEquality(object):
         assert pub != dsa.DSAPublicNumbers(1, dsa.DSAParameterNumbers(2, 2, 3))
         assert pub != dsa.DSAPublicNumbers(1, dsa.DSAParameterNumbers(1, 3, 3))
         assert pub != dsa.DSAPublicNumbers(1, dsa.DSAParameterNumbers(1, 2, 4))
+        assert pub != object()
 
     def test_private_numbers_eq(self):
         pub = dsa.DSAPublicNumbers(1, dsa.DSAParameterNumbers(1, 2, 3))
@@ -766,3 +768,4 @@ class TestDSANumberEquality(object):
                 1, dsa.DSAParameterNumbers(1, 2, 4)
             )
         )
+        assert priv != object()

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -372,6 +372,7 @@ class TestECNumbersEquality(object):
         assert pub != ec.EllipticCurvePublicNumbers(1, 2, ec.SECP384R1())
         assert pub != ec.EllipticCurvePublicNumbers(1, 3, ec.SECP192R1())
         assert pub != ec.EllipticCurvePublicNumbers(2, 2, ec.SECP192R1())
+        assert pub != object()
 
     def test_private_numbers_eq(self):
         pub = ec.EllipticCurvePublicNumbers(1, 2, ec.SECP192R1())
@@ -395,3 +396,4 @@ class TestECNumbersEquality(object):
         assert priv != ec.EllipticCurvePrivateNumbers(
             1, ec.EllipticCurvePublicNumbers(1, 2, ec.SECP521R1())
         )
+        assert priv != object()

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1661,6 +1661,7 @@ class TestRSANumbersEquality(object):
         num = RSAPublicNumbers(1, 2)
         assert num != RSAPublicNumbers(2, 2)
         assert num != RSAPublicNumbers(1, 3)
+        assert num != object()
 
     def test_private_numbers_eq(self):
         pub = RSAPublicNumbers(1, 2)
@@ -1696,3 +1697,4 @@ class TestRSANumbersEquality(object):
         assert num != RSAPrivateNumbers(
             1, 2, 3, 4, 5, 6, RSAPublicNumbers(1, 3)
         )
+        assert num != object()


### PR DESCRIPTION
fixes #1449 

These probably need to be documented somewhere. Suggestions?
