### PR TITLE
Set OPENSSL_EC_NAMED_CURVE on our EC_KEY instances

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -850,6 +850,8 @@ class Backend(object):
             res = self._lib.EC_KEY_check_key(ec_cdata)
             assert res == 1
 
+            self._mark_asn1_named_ec_curve(ec_cdata)
+
             return _EllipticCurvePrivateKey(self, ec_cdata)
         else:
             raise UnsupportedAlgorithm(
@@ -882,6 +884,8 @@ class Backend(object):
             ec_cdata, self._int_to_bn(numbers.private_value))
         assert res == 1
 
+        self._mark_asn1_named_ec_curve(ec_cdata)
+
         return _EllipticCurvePrivateKey(self, ec_cdata)
 
     def elliptic_curve_public_key_from_numbers(self, numbers):
@@ -902,6 +906,8 @@ class Backend(object):
 
         ec_cdata = self._ec_key_set_public_key_affine_coordinates(
             ec_cdata, numbers.x, numbers.y)
+
+        self._mark_asn1_named_ec_curve(ec_cdata)
 
         return _EllipticCurvePublicKey(self, ec_cdata)
 
@@ -924,6 +930,18 @@ class Backend(object):
                 _Reasons.UNSUPPORTED_ELLIPTIC_CURVE
             )
         return curve_nid
+
+    def _mark_asn1_named_ec_curve(self, ec_cdata):
+        """
+        Set the named curve flag on the EC_KEY. This causes OpenSSL to
+        serialise EC keys along with their curve OID which makes
+        deserialisation easier.
+        """
+
+        self._lib.EC_KEY_set_asn1_flag(
+            ec_cdata,
+            self._backend._lib.OPENSSL_EC_NAMED_CURVE
+        )
 
     @contextmanager
     def _tmp_bn_ctx(self):

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -167,6 +167,8 @@ class _EllipticCurvePrivateKey(object):
         res = self._backend._lib.EC_KEY_set_public_key(public_ec_key, point)
         assert res == 1
 
+        self._backend._mark_asn1_named_ec_curve(public_ec_key)
+
         return _EllipticCurvePublicKey(
             self._backend, public_ec_key
         )


### PR DESCRIPTION
This means any X.509 certs generated from our keys will be encoded
along with the curve OID so that we can still load them afterwards.

http://wiki.openssl.org/index.php/Elliptic_Curve_Cryptography#Named_Curves
