### PR TITLE
Removed bogus, unused section from travis install script

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -44,9 +44,6 @@ if [[ "$DARWIN" = true ]]; then
             pyenv install 3.4.2
             pyenv global 3.4.2
             ;;
-        py3pep8)
-            sudo apt-get install python3.3 python3.3-dev
-            ;;
         pypy)
             brew upgrade pyenv
             pyenv install pypy-2.4.0


### PR DESCRIPTION
We don't run py3pep8 checks on OS X, and if we did, this code was nonsense since OS X doesn't have apt-get
