### PR TITLE
make enum34 installation conditional on python < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,13 @@ VECTORS_DEPENDENCY = "cryptography_vectors=={0}".format(about['__version__'])
 
 requirements = [
     CFFI_DEPENDENCY,
-    "enum34",
     "pyasn1",
     SIX_DEPENDENCY,
     SETUPTOOLS_DEPENDENCY
 ]
+
+if sys.version_info < (3, 4):
+    requirements.append("enum34")
 
 # If you add a new dep here you probably need to add it in the tox.ini as well
 test_requirements = [


### PR DESCRIPTION
After talking with @dstufft we determined this is all we need (no setup.cfg required) since we're not a pure python package.

fixes #1547
