### PR TITLE
increase delay waiting for wheel job to start

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -17,9 +17,9 @@ JENKINS_URL = "https://jenkins.cryptography.io/job/cryptography-wheel-builder"
 
 
 def wait_for_build_completed(session):
-    # Wait 3 seconds before actually checking if the build is complete, to
+    # Wait 20 seconds before actually checking if the build is complete, to
     # ensure that it had time to really start.
-    time.sleep(3)
+    time.sleep(20)
     while True:
         response = session.get(
             "{0}/lastBuild/api/json/".format(JENKINS_URL),


### PR DESCRIPTION
Based on the previous release 3 seconds is not enough. The python `jenkinsapi` package appears to wait 15 seconds (apparently sleeping like this is actually the "right" solution) but I'm a pessimist so 20 it is.

fixes #1543 
