### PR TITLE
Revert "Fixed #1494 -- switch which define we look for for SSLv3 disable...

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/src/cryptography/hazmat/bindings/openssl/ssl.py
@@ -15,7 +15,7 @@ TYPES = """
  * Internally invented symbols to tell which versions of SSL/TLS are supported.
 */
 static const long Cryptography_HAS_SSL2;
-static const long Cryptography_HAS_SSL3;
+static const long Cryptography_HAS_SSL3_METHOD;
 static const long Cryptography_HAS_TLSv1_1;
 static const long Cryptography_HAS_TLSv1_2;
 static const long Cryptography_HAS_SECURE_RENEGOTIATION;
@@ -387,13 +387,13 @@ SSL_METHOD* (*SSLv2_server_method)(void) = NULL;
 static const long Cryptography_HAS_SSL2 = 1;
 #endif
 
-#ifdef OPENSSL_NO_SSL3
-static const long Cryptography_HAS_SSL3 = 0;
+#ifdef OPENSSL_NO_SSL3_METHOD
+static const long Cryptography_HAS_SSL3_METHOD = 0;
 SSL_METHOD* (*SSLv3_method)(void) = NULL;
 SSL_METHOD* (*SSLv3_client_method)(void) = NULL;
 SSL_METHOD* (*SSLv3_server_method)(void) = NULL;
 #else
-static const long Cryptography_HAS_SSL3 = 1;
+static const long Cryptography_HAS_SSL3_METHOD = 1;
 #endif
 
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
@@ -566,7 +566,7 @@ CONDITIONAL_NAMES = {
         "SSLv2_server_method",
     ],
 
-    "Cryptography_HAS_SSL3": [
+    "Cryptography_HAS_SSL3_METHOD": [
         "SSLv3_method",
         "SSLv3_client_method",
         "SSLv3_server_method",


### PR DESCRIPTION
This reverts commit facea9a7861ac1ecc7948474766cae0f842b3469.

Fixes #1550 

This is causing significant issues for users of distributions where `OPENSSL_NO_SSL3` is currently defined. We should probably backport this fix to a 0.7.1 as well.
