### PR TITLE
Remove setuptools from the install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ with open(os.path.join(src_dir, "cryptography", "__about__.py")) as f:
     exec(f.read(), about)
 
 
-SETUPTOOLS_DEPENDENCY = "setuptools"
 CFFI_DEPENDENCY = "cffi>=0.8"
 SIX_DEPENDENCY = "six>=1.4.1"
 VECTORS_DEPENDENCY = "cryptography_vectors=={0}".format(about['__version__'])
@@ -38,7 +37,6 @@ requirements = [
     CFFI_DEPENDENCY,
     "pyasn1",
     SIX_DEPENDENCY,
-    SETUPTOOLS_DEPENDENCY
 ]
 
 if sys.version_info < (3, 4):


### PR DESCRIPTION
The code itself is a no-op as the setup.py will not even compile without
setuptools pre-existing. However, there are situations, specifically
related to pip install -U cryptography, or even worse pip install -U
something_that_depends_transitively_on_cryptography where certain
versions of setuptools and distribute can interact in ways as to make a
user's python install broken. Advice from the pypa folks is to never
directly depend on setuptools.
