### PR TITLE
add NIDs for x509 name parsing

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/nid.py
+++ b/src/cryptography/hazmat/bindings/openssl/nid.py
@@ -211,6 +211,11 @@ static const int NID_organizationalUnitName;
 static const int NID_serialNumber;
 static const int NID_surname;
 static const int NID_givenName;
+static const int NID_title;
+static const int NID_generationQualifier;
+static const int NID_dnQualifier;
+static const int NID_pseudonym;
+static const int NID_domainComponent;
 static const int NID_pkcs9_emailAddress;
 """
 


### PR DESCRIPTION
Please let all these be defined in every OpenSSL we support *crosses fingers*