### PR TITLE
add DER backend interfaces

### DIFF
--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -468,6 +468,30 @@ A specific ``backend`` may provide one or more of these interfaces.
             serialized data contains.
         :raises ValueError: If the data could not be deserialized.
 
+.. class:: DERSerializationBackend
+
+    .. versionadded:: 0.8
+
+    A backend with methods for working with DER encoded keys.
+
+    .. method:: load_der_private_key(data, password)
+
+        :param bytes data: DER data to load.
+        :param bytes password: The password to use if the data is encrypted.
+            Should be ``None`` if the data is not encrypted.
+        :return: A new instance of the appropriate type of private key that the
+            serialized data contains.
+        :raises ValueError: If the data could not be deserialized.
+        :raises cryptography.exceptions.UnsupportedAlgorithm: If the data is
+            encrypted with an unsupported algorithm.
+
+    .. method:: load_der_public_key(data)
+
+        :param bytes data: DER data to load.
+        :return: A new instance of the appropriate type of public key
+            serialized data contains.
+        :raises ValueError: If the data could not be deserialized.
+
 .. class:: X509Backend
 
     .. versionadded:: 0.7

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -233,6 +233,22 @@ class PEMSerializationBackend(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
+class DERSerializationBackend(object):
+    @abc.abstractmethod
+    def load_der_private_key(self, data, password):
+        """
+        Loads a priate key from DER encoded data. Uses the provided password
+        if the data is encrypted.
+        """
+
+    @abc.abstractmethod
+    def load_der_public_key(self, data):
+        """
+        Loads a public key from DER encoded data.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
 class X509Backend(object):
     @abc.abstractmethod
     def load_pem_x509_certificate(self, data):

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -237,7 +237,7 @@ class DERSerializationBackend(object):
     @abc.abstractmethod
     def load_der_private_key(self, data, password):
         """
-        Loads a priate key from DER encoded data. Uses the provided password
+        Loads a private key from DER encoded data. Uses the provided password
         if the data is encrypted.
         """
 


### PR DESCRIPTION
Backend interface for loading asymmetric DER encoded keys. We need to be able to load private and public keys with the following types:

**Private Key Types**
* PKCS8 unencrypted
* PKCS8 encrypted
* traditional OpenSSL unencrypted (the encrypted form of this is a PEM specific thing so it doesn't exist for DER)

**Public Key Types**
* PKCS8 unencrypted
* traditional OpenSSL unencrypted

It turns out to be pretty easy to make this interface the same as PEM when implementing it so here we go.

refs #1573 