### PR TITLE
add some new bindings for using the PKCS8_PRIV_KEY_INFO struct

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/evp.py
+++ b/src/cryptography/hazmat/bindings/openssl/evp.py
@@ -119,6 +119,8 @@ int EVP_PKEY_add1_attr_by_txt(EVP_PKEY *, const char *, int,
                               const unsigned char *, int);
 
 int EVP_PKEY_cmp(const EVP_PKEY *, const EVP_PKEY *);
+
+EVP_PKEY *EVP_PKCS82PKEY(PKCS8_PRIV_KEY_INFO *);
 """
 
 MACROS = """

--- a/src/cryptography/hazmat/bindings/openssl/x509.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509.py
@@ -71,6 +71,8 @@ typedef struct {
 
 typedef ... NETSCAPE_SPKI;
 
+typedef ... PKCS8_PRIV_KEY_INFO;
+
 static const int X509_FLAG_COMPAT;
 static const int X509_FLAG_NO_HEADER;
 static const int X509_FLAG_NO_VERSION;
@@ -224,6 +226,9 @@ DSA *d2i_DSA_PUBKEY_bio(BIO *, DSA **);
 int i2d_DSA_PUBKEY_bio(BIO *, DSA *);
 DSA *d2i_DSAPrivateKey_bio(BIO *, DSA **);
 int i2d_DSAPrivateKey_bio(BIO *, DSA *);
+
+PKCS8_PRIV_KEY_INFO *d2i_PKCS8_PRIV_KEY_INFO_bio(BIO *,
+                                                 PKCS8_PRIV_KEY_INFO **);
 """
 
 MACROS = """


### PR DESCRIPTION
Turns out OpenSSL 0.9.8's `d2i_PKCS8PrivateKey_bio` can't handle unencrypted PKCS8. We need these bindings to handle the unencrypted ones.

refs #1573 , #1610