### PR TITLE
Add support for querying the negotiated TLS/SSL version.

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/src/cryptography/hazmat/bindings/openssl/ssl.py
@@ -302,6 +302,7 @@ SSL_CTX *SSL_CTX_new(SSL_METHOD *);
 long SSL_CTX_get_timeout(const SSL_CTX *);
 
 const SSL_CIPHER *SSL_get_current_cipher(const SSL *);
+int SSL_version(const SSL *);
 
 /* SNI APIs were introduced in OpenSSL 1.0.0.  To continue to support
  * earlier versions some special handling of these is necessary.


### PR DESCRIPTION
This request makes it possible to see which version of TLS you actually end up with when the connection is negotiated.
