### PR TITLE
monkeypatch PYCA_WINDOWS_LINK_TYPE in the tests to fix #1624

### DIFF
--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import os
-
 import pytest
 
 from cryptography.hazmat.bindings.openssl.binding import (
@@ -138,7 +136,7 @@ class TestOpenSSL(object):
 
     def test_libraries(self, monkeypatch):
         assert _get_libraries("darwin") == ["ssl", "crypto"]
-        monkeypatch.setitem(os.environ, 'PYCA_WINDOWS_LINK_TYPE', 'static')
+        monkeypatch.setenv('PYCA_WINDOWS_LINK_TYPE', 'static')
         assert "ssleay32mt" in _get_libraries("win32")
 
     def test_windows_static_dynamic_libraries(self):

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
+
 import pytest
 
 from cryptography.hazmat.bindings.openssl.binding import (
@@ -134,8 +136,9 @@ class TestOpenSSL(object):
         assert resp == expected_options
         assert b.lib.SSL_get_mode(ssl) == expected_options
 
-    def test_libraries(self):
+    def test_libraries(self, monkeypatch):
         assert _get_libraries("darwin") == ["ssl", "crypto"]
+        monkeypatch.setitem(os.environ, 'PYCA_WINDOWS_LINK_TYPE', 'static')
         assert "ssleay32mt" in _get_libraries("win32")
 
     def test_windows_static_dynamic_libraries(self):


### PR DESCRIPTION
Corrects an issue where a test would fail if the `PYCA_WINDOWS_LINK_TYPE` environment variable was set to `dynamic`.

refs #1624 