### PR TITLE
switch around the order of our travis tests and enable fast failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,10 @@ matrix:
 
         - os: linux
           env: TOXENV=docs
-          compiler: clang
+          compiler: gcc
         - os: linux
           env: TOXENV=pep8
-          compiler: clang
+          compiler: gcc
         - os: linux
           env: TOXENV=py3pep8
-          compiler: clang
+          compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,29 @@
 language: c
 os:
-    - osx
     - linux
+    - osx
 compiler:
     - clang
     - gcc
 env:
     matrix:
-        - TOXENV=py26
-        - TOXENV=py27
-        - TOXENV=py32
-        - TOXENV=py33
-        - TOXENV=py34
-        - TOXENV=pypy
-        - TOXENV=pypy3
-        - TOXENV=py26 OPENSSL=0.9.8
-        - TOXENV=py27 OPENSSL=0.9.8
-        - TOXENV=py32 OPENSSL=0.9.8
-        - TOXENV=py33 OPENSSL=0.9.8
-        - TOXENV=py34 OPENSSL=0.9.8
-        - TOXENV=pypy OPENSSL=0.9.8
-        - TOXENV=pypy3 OPENSSL=0.9.8
         - TOXENV=docs
         - TOXENV=pep8
         - TOXENV=py3pep8
+        - TOXENV=py27
+        - TOXENV=py34
+        - TOXENV=py27 OPENSSL=0.9.8
+        - TOXENV=py34 OPENSSL=0.9.8
+        - TOXENV=py26
+        - TOXENV=py32
+        - TOXENV=py33
+        - TOXENV=pypy
+        - TOXENV=pypy3
+        - TOXENV=py26 OPENSSL=0.9.8
+        - TOXENV=py32 OPENSSL=0.9.8
+        - TOXENV=py33 OPENSSL=0.9.8
+        - TOXENV=pypy OPENSSL=0.9.8
+        - TOXENV=pypy3 OPENSSL=0.9.8
 
 install:
     - ./.travis/install.sh
@@ -42,6 +42,7 @@ notifications:
         skip_join: true
 
 matrix:
+    fast_finish: true
     exclude:
         # excluding pypy3 from linux configs until the ubuntu ppa has pypy3 available.
         - os: linux


### PR DESCRIPTION
An experiment to see if it makes sense to do fast failure on Travis. This reorders our tests to do docs, pep8, and py3pep8 first, then py27/py34 with OpenSSL 1.0.1 and 0.9.8 on linux. Ideally this would catch most failures early and waste less time on Travis.