### PR TITLE
Remove a binding causing compilation issues

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/crypto.py
+++ b/src/cryptography/hazmat/bindings/openssl/crypto.py
@@ -49,7 +49,6 @@ void OPENSSL_free(void *);
 MACROS = """
 void CRYPTO_add(int *, int, int);
 void CRYPTO_malloc_init(void);
-void CRYPTO_malloc_debug_init(void);
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
`CRYPTO_malloc_debug_init` has caused us quite a bit of heartache (from FreeBSD ports to [mysterious OS X issues](https://bugs.launchpad.net/pycrypto/+bug/1292177)). We're not using it and pyOpenSSL isn't using it either so I propose we just remove it for now.

This is technically a backwards compatibility break (albeit almost certainly not one that will affect anyone), so arguably we should list it in the changelog.

If others have a better idea for resolving this speak up!