### PR TITLE
make our docs job nitpicky and fix every broken link

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -100,11 +100,8 @@ Changelog
   ``load_elliptic_curve_private_numbers`` and
   ``load_elliptic_curve_public_numbers`` on
   :class:`~cryptography.hazmat.backends.interfaces.EllipticCurveBackend`.
-* Added
-  :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurvePrivateKeyWithNumbers`
-  and
-  :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurvePublicKeyWithNumbers`
-  support.
+* Added ``EllipticCurvePrivateKeyWithNumbers`` and
+  ``EllipticCurvePublicKeyWithNumbers`` support.
 * Work around three GCM related bugs in CommonCrypto and OpenSSL.
 
   * On the CommonCrypto backend adding AAD but not subsequently calling update
@@ -133,17 +130,15 @@ Changelog
 0.5.2 - 2014-07-09
 ~~~~~~~~~~~~~~~~~~
 
-* Add
-  :class:`~cryptography.hazmat.backends.interfaces.TraditionalOpenSSLSerializationBackend`
-  support to :doc:`/hazmat/backends/multibackend`.
+* Add ``TraditionalOpenSSLSerializationBackend`` support to
+  :doc:`/hazmat/backends/multibackend`.
 * Fix compilation error on OS X 10.8 (Mountain Lion).
 
 0.5.1 - 2014-07-07
 ~~~~~~~~~~~~~~~~~~
 
-* Add
-  :class:`~cryptography.hazmat.backends.interfaces.PKCS8SerializationBackend`
-  support to :doc:`/hazmat/backends/multibackend`.
+* Add ``PKCS8SerializationBackend`` support to
+  :doc:`/hazmat/backends/multibackend`.
 
 0.5 - 2014-07-07
 ~~~~~~~~~~~~~~~~
@@ -164,36 +159,24 @@ Changelog
   :doc:`/hazmat/backends/commoncrypto` and :doc:`/hazmat/backends/openssl`.
 * Added ``AES`` :class:`~cryptography.hazmat.primitives.ciphers.modes.CTR`
   support to the OpenSSL backend when linked against 0.9.8.
-* Added
-  :class:`~cryptography.hazmat.backends.interfaces.PKCS8SerializationBackend`
-  and
-  :class:`~cryptography.hazmat.backends.interfaces.TraditionalOpenSSLSerializationBackend`
-  support to the :doc:`/hazmat/backends/openssl`.
+* Added ``PKCS8SerializationBackend`` and
+  ``TraditionalOpenSSLSerializationBackend`` support to the
+  :doc:`/hazmat/backends/openssl`.
 * Added :doc:`/hazmat/primitives/asymmetric/ec` and
   :class:`~cryptography.hazmat.backends.interfaces.EllipticCurveBackend`.
 * Added :class:`~cryptography.hazmat.primitives.ciphers.modes.ECB` support
   for :class:`~cryptography.hazmat.primitives.ciphers.algorithms.TripleDES` on
   :doc:`/hazmat/backends/commoncrypto` and :doc:`/hazmat/backends/openssl`.
-* Deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey` in
-  favor of backend specific providers of the
-  :class:`~cryptography.hazmat.primitives.interfaces.RSAPrivateKey` interface.
-* Deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey` in favor
-  of backend specific providers of the
-  :class:`~cryptography.hazmat.primitives.interfaces.RSAPublicKey` interface.
-* Deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey` in
-  favor of backend specific providers of the
-  :class:`~cryptography.hazmat.primitives.interfaces.DSAPrivateKey` interface.
-* Deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey` in favor
-  of backend specific providers of the
-  :class:`~cryptography.hazmat.primitives.interfaces.DSAPublicKey` interface.
-* Deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAParameters` in
-  favor of backend specific providers of the
-  :class:`~cryptography.hazmat.primitives.interfaces.DSAParameters` interface.
+* Deprecated the concrete ``RSAPrivateKey`` class in favor of backend
+  specific providers of the ``RSAPrivateKey`` interface.
+* Deprecated the concrete ``RSAPublicKey`` in favor of backend specific
+  providers of the ``RSAPublicKey`` interface.
+* Deprecated the concrete ``DSAPrivateKey`` class in favor of backend
+  specific providers of the ``DSAPrivateKey`` interface.
+* Deprecated the concrete ``DSAPublicKey`` class in favor of backend specific
+  providers of the ``DSAPublicKey`` interface.
+* Deprecated the concrete ``DSAParameters`` class in favor of backend specific
+  providers of the ``DSAParameters`` interface.
 * Deprecated ``encrypt_rsa``, ``decrypt_rsa``, ``create_rsa_signature_ctx`` and
   ``create_rsa_verification_ctx`` on
   :class:`~cryptography.hazmat.backends.interfaces.RSABackend`.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -168,15 +168,25 @@ Changelog
   for :class:`~cryptography.hazmat.primitives.ciphers.algorithms.TripleDES` on
   :doc:`/hazmat/backends/commoncrypto` and :doc:`/hazmat/backends/openssl`.
 * Deprecated the concrete ``RSAPrivateKey`` class in favor of backend
-  specific providers of the ``RSAPrivateKey`` interface.
+  specific providers of the
+  :class:`cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`
+  interface.
 * Deprecated the concrete ``RSAPublicKey`` in favor of backend specific
-  providers of the ``RSAPublicKey`` interface.
+  providers of the
+  :class:`cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`
+  interface.
 * Deprecated the concrete ``DSAPrivateKey`` class in favor of backend
-  specific providers of the ``DSAPrivateKey`` interface.
+  specific providers of the
+  :class:`cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`
+  interface.
 * Deprecated the concrete ``DSAPublicKey`` class in favor of backend specific
-  providers of the ``DSAPublicKey`` interface.
+  providers of the
+  :class:`cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey`
+  interface.
 * Deprecated the concrete ``DSAParameters`` class in favor of backend specific
-  providers of the ``DSAParameters`` interface.
+  providers of the
+  :class:`cryptography.hazmat.primitives.asymmetric.dsa.DSAParameters`
+  interface.
 * Deprecated ``encrypt_rsa``, ``decrypt_rsa``, ``create_rsa_signature_ctx`` and
   ``create_rsa_verification_ctx`` on
   :class:`~cryptography.hazmat.backends.interfaces.RSABackend`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,8 @@ if spelling is not None:
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+nitpicky = True
+
 # The suffix of source filenames.
 source_suffix = '.rst'
 
@@ -268,6 +270,6 @@ texinfo_documents = [
 # texinfo_show_urls = 'footnote'
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'https://docs.python.org/3': None}
 
 epub_theme = 'epub'

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -334,7 +334,7 @@ A specific ``backend`` may provide one or more of these interfaces.
             restricted to only the 1024-bit keys specified in FIPS 186-2.
 
         :return: A new instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.DSAPrivateKey`
+            :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`
             provider.
 
         :raises ValueError: This is raised if the key size is not supported
@@ -401,7 +401,7 @@ A specific ``backend`` may provide one or more of these interfaces.
     .. method:: elliptic_curve_supported(curve)
 
         :param curve: An instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurve`
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`
             provider.
 
         :returns: True if the elliptic curve is supported by this backend.
@@ -409,11 +409,11 @@ A specific ``backend`` may provide one or more of these interfaces.
     .. method:: elliptic_curve_signature_algorithm_supported(signature_algorithm, curve)
 
         :param signature_algorithm: An instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurveSignatureAlgorithm`
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurveSignatureAlgorithm`
             provider.
 
         :param curve: An instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurve`
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`
             provider.
 
         :returns: True if the signature algorithm and curve are supported by this backend.
@@ -421,27 +421,27 @@ A specific ``backend`` may provide one or more of these interfaces.
     .. method:: generate_elliptic_curve_private_key(curve)
 
         :param curve: An instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurve`
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`
             provider.
 
     .. method:: load_elliptic_curve_private_numbers(numbers)
 
         :param numbers: An instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurvePrivateNumbers`
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateNumbers`
             provider.
 
         :returns: An instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurvePrivateKey`
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKey`
             provider.
 
     .. method:: load_elliptic_curve_public_numbers(numbers)
 
         :param numbers: An instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurvePublicNumbers`
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers`
             provider.
 
         :returns: An instance of a
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurvePublicKey`
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey`
             provider.
 
 .. class:: PEMSerializationBackend

--- a/docs/hazmat/bindings/commoncrypto.rst
+++ b/docs/hazmat/bindings/commoncrypto.rst
@@ -17,7 +17,7 @@ available on Mac OS X versions 10.8 and above.
 
     .. attribute:: ffi
 
-        This is a :class:`cffi.FFI` instance. It can be used to allocate and
+        This is a ``cffi.FFI`` instance. It can be used to allocate and
         otherwise manipulate CommonCrypto structures.
 
     .. attribute:: lib

--- a/docs/hazmat/bindings/index.rst
+++ b/docs/hazmat/bindings/index.rst
@@ -3,7 +3,7 @@
 Bindings
 ========
 
-.. currentmodule:: cryptography.hazmat.bindings
+.. module:: cryptography.hazmat.bindings
 
 ``cryptography`` aims to provide low-level CFFI based bindings to multiple
 native C libraries. These provide no automatic initialization of the library

--- a/docs/hazmat/bindings/openssl.rst
+++ b/docs/hazmat/bindings/openssl.rst
@@ -16,7 +16,7 @@ versions may work but are **not tested or supported**.
 
     .. attribute:: ffi
 
-        This is a :class:`cffi.FFI` instance. It can be used to allocate and
+        This is a ``cffi.FFI`` instance. It can be used to allocate and
         otherwise manipulate OpenSSL structures.
 
     .. attribute:: lib

--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -3,7 +3,7 @@
 DSA
 ===
 
-.. currentmodule:: cryptography.hazmat.primitives.asymmetric.dsa
+.. module:: cryptography.hazmat.primitives.asymmetric.dsa
 
 `DSA`_ is a `public-key`_ algorithm for signing messages.
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -3,7 +3,7 @@
 Elliptic curve cryptography
 ===========================
 
-.. currentmodule:: cryptography.hazmat.primitives.asymmetric.ec
+.. module:: cryptography.hazmat.primitives.asymmetric.ec
 
 
 .. function:: generate_private_key(curve, backend)

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -3,7 +3,7 @@
 RSA
 ===
 
-.. currentmodule:: cryptography.hazmat.primitives.asymmetric.rsa
+.. module:: cryptography.hazmat.primitives.asymmetric.rsa
 
 `RSA`_ is a `public-key`_ algorithm for encrypting and signing messages.
 
@@ -307,7 +307,7 @@ is unavailable.
 
     .. attribute:: public_numbers
 
-        :type: :class:`~cryptography.hazmat.primitives.rsa.RSAPublicNumbers`
+        :type: :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicNumbers`
 
         The :class:`RSAPublicNumbers` which makes up the RSA public key
         associated with this RSA private key.
@@ -316,19 +316,19 @@ is unavailable.
 
         :type: int
 
-        ``p``, one of the two primes composing the :attr:`modulus`.
+        ``p``, one of the two primes composing ``n``.
 
     .. attribute:: q
 
         :type: int
 
-        ``q``, one of the two primes composing the :attr:`modulus`.
+        ``q``, one of the two primes composing ``n``.
 
     .. attribute:: d
 
         :type: int
 
-        The private exponent. Alias for :attr:`private_exponent`.
+        The private exponent.
 
     .. attribute:: dmp1
 

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -104,9 +104,9 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
         not encrypted. Or if the key was encrypted but no
         password was supplied.
 
-    :raises UnsupportedAlgorithm: If the serialized key is of a type that
-        is not supported by the backend or if the key is encrypted with a
-        symmetric cipher that is not supported by the backend.
+    :raises cryptography.exceptions.UnsupportedAlgorithm: If the serialized key
+        is of a type that is not supported by the backend or if the key is
+        encrypted with a symmetric cipher that is not supported by the backend.
 
 .. function:: load_pem_public_key(data, backend)
 
@@ -133,8 +133,8 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
     :raises ValueError: If the PEM data's structure could not be decoded
         successfully.
 
-    :raises UnsupportedAlgorithm: If the serialized key is of a type that
-        is not supported by the backend.
+    :raises cryptography.exceptions.UnsupportedAlgorithm: If the serialized key
+        is of a type that is not supported by the backend.
 
 
 OpenSSH Public Key
@@ -181,5 +181,5 @@ DSA keys look almost identical but begin with ``ssh-dss`` rather than
     :raises ValueError: If the OpenSSH data could not be properly decoded or
         if the key is not in the proper format.
 
-    :raises UnsupportedAlgorithm: If the serialized key is of a type that is
-        not supported.
+    :raises cryptography.exceptions.UnsupportedAlgorithm: If the serialized
+        key is of a type that is not supported.

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -3,7 +3,7 @@
 Message digests
 ===============
 
-.. currentmodule:: cryptography.hazmat.primitives.hashes
+.. module:: cryptography.hazmat.primitives.hashes
 
 .. class:: Hash(algorithm, backend)
 

--- a/docs/hazmat/primitives/interfaces.rst
+++ b/docs/hazmat/primitives/interfaces.rst
@@ -1,5 +1,7 @@
 .. hazmat::
 
+.. module:: cryptography.hazmat.primitives.interfaces
+
 Interfaces
 ==========
 
@@ -14,9 +16,6 @@ to document argument and return types.
 
 Symmetric ciphers
 -----------------
-
-.. currentmodule:: cryptography.hazmat.primitives.interfaces
-
 
 .. class:: CipherAlgorithm
 
@@ -75,9 +74,10 @@ Interfaces used by the symmetric cipher modes described in
         meets any necessary invariants. This should raise an exception if they
         are not met.
 
-        For example, the :class:`~cryptography.hazmat.primitives.modes.CBC`
-        mode uses this method to check that the provided initialization
-        vector's length matches the block size of the algorithm.
+        For example, the
+        :class:`~cryptography.hazmat.primitives.ciphers.modes.CBC` mode uses
+        this method to check that the provided initialization vector's length
+        matches the block size of the algorithm.
 
 
 .. class:: ModeWithInitializationVector

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -422,6 +422,7 @@ Insecure modes
 
 Interfaces
 ----------
+.. currentmodule:: cryptography.hazmat.primitives.interfaces
 
 .. class:: CipherContext
 
@@ -438,8 +439,8 @@ Interfaces
     recommended padding is
     :class:`~cryptography.hazmat.primitives.padding.PKCS7`. If you are using a
     stream cipher mode (such as
-    :class:`~cryptography.hazmat.primitives.modes.CTR`) you don't have to worry
-    about this.
+    :class:`~cryptography.hazmat.primitives.ciphers.modes.CTR`) you don't have
+    to worry about this.
 
     .. method:: update(data)
 

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -130,8 +130,8 @@ X.509 Certificate Object
 
         :type:
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey` or
-            :class:`~cryptography.hazmat.primitives.interfaces.DSAPublicKey` or
-            :class:`~cryptography.hazmat.primitives.interfaces.EllipticCurvePublicKey`
+            :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey` or
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey`
 
         The public key associated with the certificate.
 


### PR DESCRIPTION
By enabling `nitpicky` mode we can have our docs fail on any link that doesn't work. Turning this on revealed quite a few link mistakes. These are all now fixed.

One caveat of this change is that the changelog will need to be altered on occasion if we deprecate/remove something we linked.