### PR TITLE
tox -e docs is broken

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,10 +21,10 @@ commands =
 deps =
     doc8
     pyenchant
-    readme>=0.5.1
     sphinx
     sphinx_rtd_theme
     sphinxcontrib-spelling
+    readme>=0.5.1
 basepython = python2.7
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html


### PR DESCRIPTION
I updated my `master`, ran tox and found that `tox -e docs` is broken. Here is the error log: https://gist.github.com/Ayrx/d89f0b519d3e5f2d6a82

Swapping the install order of the dependencies fixes the issue for me. Not sure why things were broken though.

/cc @dstufft 