### PR TITLE
Fix (most) problems with LibreSSL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,7 @@ Changelog
   :mod:`~cryptography.hazmat.primitives.asymmetric.rsa`.
 * Added support for parsing X.509 names. See the
   :doc:`X.509 documentation</x509>` for more information.
+* Fixed building against LibreSSL, a compile-time substitute for OpenSSL.
 
 0.7.2 - 2015-01-16
 ~~~~~~~~~~~~~~~~~~

--- a/src/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/src/cryptography/hazmat/bindings/openssl/ssl.py
@@ -7,6 +7,14 @@ from __future__ import absolute_import, division, print_function
 INCLUDES = """
 #include <openssl/ssl.h>
 
+/* LibreSSL has removed support for compression, and with it the
+ * COMP_METHOD use in ssl.h. This is a hack to make the function types
+ * in this code match those in ssl.h.
+ */
+#ifdef LIBRESSL_VERSION_NUMBER
+#define COMP_METHOD void
+#endif
+
 typedef STACK_OF(SSL_CIPHER) Cryptography_STACK_OF_SSL_CIPHER;
 """
 

--- a/src/cryptography/hazmat/bindings/openssl/x509_vfy.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509_vfy.py
@@ -191,7 +191,7 @@ int X509_VERIFY_PARAM_set1_ip_asc(X509_VERIFY_PARAM *, const char *);
 
 CUSTOMIZATIONS = """
 /* OpenSSL 1.0.2+ verification error codes */
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
 static const long Cryptography_HAS_102_VERIFICATION_ERROR_CODES = 1;
 #else
 static const long Cryptography_HAS_102_VERIFICATION_ERROR_CODES = 0;
@@ -207,7 +207,7 @@ static const long X509_V_ERR_IP_ADDRESS_MISMATCH = 0;
 #endif
 
 /* OpenSSL 1.0.2+ verification parameters */
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
 static const long Cryptography_HAS_102_VERIFICATION_PARAMS = 1;
 #else
 static const long Cryptography_HAS_102_VERIFICATION_PARAMS = 0;

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -71,10 +71,13 @@ class TestOpenSSL(object):
 
         Unfortunately, this define does not appear to have a
         formal content definition, so for now we'll test to see
-        if it starts with OpenSSL as that appears to be true
-        for every OpenSSL.
+        if it starts with OpenSSL or LibreSSL as that appears
+        to be true for every OpenSSL-alike.
         """
-        assert backend.openssl_version_text().startswith("OpenSSL")
+        assert (
+            backend.openssl_version_text().startswith("OpenSSL") or
+            backend.openssl_version_text().startswith("LibreSSL")
+        )
 
     def test_supports_cipher(self):
         assert backend.cipher_supported(None, None) is False


### PR DESCRIPTION
These four commits fix most, but not all of the problems with LibreSSL. On my OpenBSD -current (as of 2015-02-13) system, the cryptography test suite passes with the following patches applied:

 * All in this pull request.
 * Removal of cryptodev (I'm not as confident in that patch as I am in this pull request, so I will be submitting it separately): https://github.com/anchor/cryptography/commit/27c62f5a5a0def2a82ca98eafcfb51a2547c7ff5
 * @Sp1l's patch to remove EGD: https://github.com/Sp1l/cryptography/commit/7c1874d5b94e931b7520151c6f59557036e2e889
  * Note that it does **not** work with all patches from the [pull request](https://github.com/pyca/cryptography/pull/1636) relating to EGD's removal, because that commit has been reverted and replaced with something that still assumes EGD's existence.

I have tried to provide sufficient explanation of what each commit is doing in the individual commit messages, but please let me know if clarification is needed.