### PR TITLE
Remove cryptodev engine support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,7 +68,7 @@ Changelog
   :mod:`~cryptography.hazmat.primitives.asymmetric.rsa`.
 * Added support for parsing X.509 names. See the
   :doc:`X.509 documentation</x509>` for more information.
-* Removed support for OpenSSL's cryptodev engine.
+* Removed support for OpenSSL's ``cryptodev`` engine.
 
 0.7.2 - 2015-01-16
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,7 @@ Changelog
   :mod:`~cryptography.hazmat.primitives.asymmetric.rsa`.
 * Added support for parsing X.509 names. See the
   :doc:`X.509 documentation</x509>` for more information.
+* Removed support for OpenSSL's cryptodev engine.
 
 0.7.2 - 2015-01-16
 ~~~~~~~~~~~~~~~~~~

--- a/src/cryptography/hazmat/bindings/openssl/engine.py
+++ b/src/cryptography/hazmat/bindings/openssl/engine.py
@@ -49,7 +49,6 @@ int ENGINE_init(ENGINE *);
 int ENGINE_finish(ENGINE *);
 void ENGINE_load_openssl(void);
 void ENGINE_load_dynamic(void);
-void ENGINE_load_cryptodev(void);
 void ENGINE_load_builtin_engines(void);
 void ENGINE_cleanup(void);
 ENGINE *ENGINE_get_default_RSA(void);


### PR DESCRIPTION
This was removed from LibreSSL, but is still present in OpenSSL. It
can't be wrapped in an #ifndef, because cffi doesn't know how to handle
that case.

I'm actually not sure if this is the best possible solution, but I'm not
familiar enough with cffi to make that call myself. The cryptography
test suite still passes with this patch applied, which is why I've
submitted it anyway; if this is the wrong fix, please advise as to a
better approach and I'll revise it.