### PR TITLE
move hmac/cmac to mac module, move MACContext to mac module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ Changelog
   now load elliptic curve public keys.
 * Added
   :func:`~cryptography.hazmat.primitives.asymmetric.rsa.rsa_recover_prime_factors`
+* :mod:`cryptography.hazmat.primitives.mac.hmac` and
+  :mod:`cryptography.hazmat.primitives.mac.cmac` were moved to the
+  :mod:`~cryptography.hazmat.primitives.mac` module.
+* :class:`~cryptography.hazmat.primitives.mac.MACContext` was moved from
+  :mod:`~cryptography.hazmat.primitives.interfaces` to
+  :mod:`~cryptography.hazmat.primitives.mac`.
 * :class:`~cryptography.hazmat.primitives.kdf.KeyDerivationFunction` was moved
   from :mod:`~cryptography.hazmat.primitives.interfaces` to
   :mod:`~cryptography.hazmat.primitives.kdf`.
@@ -94,7 +100,7 @@ Changelog
   :class:`~cryptography.fernet.MultiFernet`.
 * More bit-lengths are now supported for ``p`` and ``q`` when loading DSA keys
   from numbers.
-* Added :class:`~cryptography.hazmat.primitives.interfaces.MACContext` as a
+* Added :class:`~cryptography.hazmat.primitives.mac.MACContext` as a
   common interface for CMAC and HMAC and deprecated
   :class:`~cryptography.hazmat.primitives.interfaces.CMACContext`.
 * Added support for encoding and decoding :rfc:`6979` signatures in
@@ -238,7 +244,7 @@ Changelog
   policy.
 * Added :class:`~cryptography.hazmat.primitives.ciphers.algorithms.SEED`
   support.
-* Added :class:`~cryptography.hazmat.primitives.cmac.CMAC`.
+* Added :class:`~cryptography.hazmat.primitives.mac.cmac.CMAC`.
 * Added decryption support to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`
   and encryption support to

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -114,7 +114,7 @@ Specifically it uses:
   :class:`~cryptography.hazmat.primitives.ciphers.modes.CBC` mode with a
   128-bit key for encryption; using
   :class:`~cryptography.hazmat.primitives.padding.PKCS7` padding.
-* :class:`~cryptography.hazmat.primitives.hmac.HMAC` using
+* :class:`~cryptography.hazmat.primitives.mac.hmac.HMAC` using
   :class:`~cryptography.hazmat.primitives.hashes.SHA256` for authentication.
 * Initialization vectors are generated using ``os.urandom()``.
 

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -164,7 +164,7 @@ A specific ``backend`` may provide one or more of these interfaces.
     .. method:: create_cmac_ctx(algorithm)
 
         Create a
-        :class:`~cryptography.hazmat.primitives.interfaces.CMACContext` that
+        :class:`~cryptography.hazmat.primitives.mac.MACContext` that
         uses the specified ``algorithm`` to calculate a message authentication code.
 
         :param algorithm: An instance of a
@@ -172,7 +172,7 @@ A specific ``backend`` may provide one or more of these interfaces.
             provider.
 
         :returns:
-            :class:`~cryptography.hazmat.primitives.interfaces.CMACContext`
+            :class:`~cryptography.hazmat.primitives.mac.MACContext`
 
 
 .. class:: PBKDF2HMACBackend

--- a/docs/hazmat/primitives/interfaces.rst
+++ b/docs/hazmat/primitives/interfaces.rst
@@ -56,7 +56,8 @@ In 0.8 the key derivation function interface was moved to the
 
 .. class:: CMACContext
 
-    :class:`CMACContext` has been deprecated in favor of :class:`MACContext`.
+    :class:`CMACContext` has been deprecated in favor of
+    :class:`~cryptography.hazmat.primitives.mac.MACContext`.
 
     .. versionadded:: 0.4
 
@@ -72,31 +73,6 @@ In 0.8 the key derivation function interface was moved to the
 
         :return: A :class:`~cryptography.hazmat.primitives.interfaces.CMACContext`
             that is a copy of the current context.
-
-.. class:: MACContext
-
-    .. versionadded:: 0.7
-
-    .. method:: update(data)
-
-        :param bytes data: The data you want to authenticate.
-
-    .. method:: finalize()
-
-        :return: The message authentication code.
-
-    .. method:: copy()
-
-        :return: A
-            :class:`~cryptography.hazmat.primitives.interfaces.MACContext` that
-            is a copy of the current context.
-
-    .. method:: verify(signature)
-
-        :param bytes signature: The signature to verify.
-
-        :raises cryptography.exceptions.InvalidSignature: This is raised when
-            the provided signature does not match the expected signature.
 
 
 .. _`CMAC`: https://en.wikipedia.org/wiki/CMAC

--- a/docs/hazmat/primitives/mac/cmac.rst
+++ b/docs/hazmat/primitives/mac/cmac.rst
@@ -3,7 +3,7 @@
 Cipher-based message authentication code
 ========================================
 
-.. currentmodule:: cryptography.hazmat.primitives.cmac
+.. module:: cryptography.hazmat.primitives.mac.cmac
 
 .. testsetup::
 
@@ -27,7 +27,7 @@ A subset of CMAC with the AES-128 algorithm is described in :rfc:`4493`.
     .. doctest::
 
         >>> from cryptography.hazmat.backends import default_backend
-        >>> from cryptography.hazmat.primitives import cmac
+        >>> from cryptography.hazmat.primitives.mac import cmac
         >>> from cryptography.hazmat.primitives.ciphers import algorithms
         >>> c = cmac.CMAC(algorithms.AES(key), backend=default_backend())
         >>> c.update(b"message to authenticate")

--- a/docs/hazmat/primitives/mac/hmac.rst
+++ b/docs/hazmat/primitives/mac/hmac.rst
@@ -3,7 +3,7 @@
 Hash-based message authentication codes
 =======================================
 
-.. currentmodule:: cryptography.hazmat.primitives.hmac
+.. module:: cryptography.hazmat.primitives.mac.hmac
 
 .. testsetup::
 
@@ -28,7 +28,8 @@ of a message.
     .. doctest::
 
         >>> from cryptography.hazmat.backends import default_backend
-        >>> from cryptography.hazmat.primitives import hashes, hmac
+        >>> from cryptography.hazmat.primitives import hashes
+        >>> from cryptography.hazmat.primitives.mac import hmac
         >>> h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
         >>> h.update(b"message to hash")
         >>> h.finalize()

--- a/docs/hazmat/primitives/mac/index.rst
+++ b/docs/hazmat/primitives/mac/index.rst
@@ -16,3 +16,4 @@ HMAC?`_
 
     cmac
     hmac
+    interfaces

--- a/docs/hazmat/primitives/mac/interfaces.rst
+++ b/docs/hazmat/primitives/mac/interfaces.rst
@@ -1,0 +1,28 @@
+.. hazmat::
+
+Interfaces
+==========
+.. module:: cryptography.hazmat.primitives.mac
+
+.. class:: MACContext
+
+    .. versionadded:: 0.7
+
+    .. method:: update(data)
+
+        :param bytes data: The data you want to authenticate.
+
+    .. method:: finalize()
+
+        :return: The message authentication code.
+
+    .. method:: copy()
+
+        :return: A :class:`MACContext` that is a copy of the current context.
+
+    .. method:: verify(signature)
+
+        :param bytes signature: The signature to verify.
+
+        :raises cryptography.exceptions.InvalidSignature: This is raised when
+            the provided signature does not match the expected signature.

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -16,7 +16,7 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.primitives.hmac import HMAC
+from cryptography.hazmat.primitives.mac.hmac import HMAC
 
 
 class InvalidToken(Exception):

--- a/src/cryptography/hazmat/backends/commoncrypto/hmac.py
+++ b/src/cryptography/hazmat/backends/commoncrypto/hmac.py
@@ -8,10 +8,10 @@ from cryptography import utils
 from cryptography.exceptions import (
     InvalidSignature, UnsupportedAlgorithm, _Reasons
 )
-from cryptography.hazmat.primitives import constant_time, hashes, interfaces
+from cryptography.hazmat.primitives import constant_time, hashes, mac
 
 
-@utils.register_interface(interfaces.MACContext)
+@utils.register_interface(mac.MACContext)
 @utils.register_interface(hashes.HashContext)
 class _HMACContext(object):
     def __init__(self, backend, key, algorithm, ctx=None):

--- a/src/cryptography/hazmat/backends/openssl/cmac.py
+++ b/src/cryptography/hazmat/backends/openssl/cmac.py
@@ -9,11 +9,11 @@ from cryptography import utils
 from cryptography.exceptions import (
     InvalidSignature, UnsupportedAlgorithm, _Reasons
 )
-from cryptography.hazmat.primitives import constant_time, interfaces
+from cryptography.hazmat.primitives import constant_time, mac
 from cryptography.hazmat.primitives.ciphers.modes import CBC
 
 
-@utils.register_interface(interfaces.MACContext)
+@utils.register_interface(mac.MACContext)
 class _CMACContext(object):
     def __init__(self, backend, algorithm, ctx=None):
         if not backend.cmac_algorithm_supported(algorithm):

--- a/src/cryptography/hazmat/backends/openssl/hmac.py
+++ b/src/cryptography/hazmat/backends/openssl/hmac.py
@@ -9,10 +9,10 @@ from cryptography import utils
 from cryptography.exceptions import (
     InvalidSignature, UnsupportedAlgorithm, _Reasons
 )
-from cryptography.hazmat.primitives import constant_time, hashes, interfaces
+from cryptography.hazmat.primitives import constant_time, hashes, mac
 
 
-@utils.register_interface(interfaces.MACContext)
+@utils.register_interface(mac.MACContext)
 @utils.register_interface(hashes.HashContext)
 class _HMACContext(object):
     def __init__(self, backend, key, algorithm, ctx=None):

--- a/src/cryptography/hazmat/primitives/cmac.py
+++ b/src/cryptography/hazmat/primitives/cmac.py
@@ -5,62 +5,14 @@
 from __future__ import absolute_import, division, print_function
 
 from cryptography import utils
-from cryptography.exceptions import (
-    AlreadyFinalized, UnsupportedAlgorithm, _Reasons
+from cryptography.hazmat.primitives.mac import cmac
+
+CMAC = utils.deprecated(
+    cmac.CMAC,
+    __name__,
+    (
+        "The CMAC class has moved to the "
+        "cryptography.hazmat.primitives.mac.cmac module"
+    ),
+    utils.DeprecatedIn08
 )
-from cryptography.hazmat.backends.interfaces import CMACBackend
-from cryptography.hazmat.primitives import ciphers, interfaces
-
-
-@utils.register_interface(interfaces.MACContext)
-class CMAC(object):
-    def __init__(self, algorithm, backend, ctx=None):
-        if not isinstance(backend, CMACBackend):
-            raise UnsupportedAlgorithm(
-                "Backend object does not implement CMACBackend.",
-                _Reasons.BACKEND_MISSING_INTERFACE
-            )
-
-        if not isinstance(algorithm, ciphers.BlockCipherAlgorithm):
-            raise TypeError(
-                "Expected instance of BlockCipherAlgorithm."
-            )
-        self._algorithm = algorithm
-
-        self._backend = backend
-        if ctx is None:
-            self._ctx = self._backend.create_cmac_ctx(self._algorithm)
-        else:
-            self._ctx = ctx
-
-    def update(self, data):
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        if not isinstance(data, bytes):
-            raise TypeError("data must be bytes.")
-        self._ctx.update(data)
-
-    def finalize(self):
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        digest = self._ctx.finalize()
-        self._ctx = None
-        return digest
-
-    def verify(self, signature):
-        if not isinstance(signature, bytes):
-            raise TypeError("signature must be bytes.")
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-
-        ctx, self._ctx = self._ctx, None
-        ctx.verify(signature)
-
-    def copy(self):
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        return CMAC(
-            self._algorithm,
-            backend=self._backend,
-            ctx=self._ctx.copy()
-        )

--- a/src/cryptography/hazmat/primitives/hmac.py
+++ b/src/cryptography/hazmat/primitives/hmac.py
@@ -5,65 +5,14 @@
 from __future__ import absolute_import, division, print_function
 
 from cryptography import utils
-from cryptography.exceptions import (
-    AlreadyFinalized, UnsupportedAlgorithm, _Reasons
+from cryptography.hazmat.primitives.mac import hmac
+
+HMAC = utils.deprecated(
+    hmac.HMAC,
+    __name__,
+    (
+        "The HMAC class has moved to the "
+        "cryptography.hazmat.primitives.mac.hmac module"
+    ),
+    utils.DeprecatedIn08
 )
-from cryptography.hazmat.backends.interfaces import HMACBackend
-from cryptography.hazmat.primitives import hashes, interfaces
-
-
-@utils.register_interface(interfaces.MACContext)
-@utils.register_interface(hashes.HashContext)
-class HMAC(object):
-    def __init__(self, key, algorithm, backend, ctx=None):
-        if not isinstance(backend, HMACBackend):
-            raise UnsupportedAlgorithm(
-                "Backend object does not implement HMACBackend.",
-                _Reasons.BACKEND_MISSING_INTERFACE
-            )
-
-        if not isinstance(algorithm, hashes.HashAlgorithm):
-            raise TypeError("Expected instance of hashes.HashAlgorithm.")
-        self._algorithm = algorithm
-
-        self._backend = backend
-        self._key = key
-        if ctx is None:
-            self._ctx = self._backend.create_hmac_ctx(key, self.algorithm)
-        else:
-            self._ctx = ctx
-
-    algorithm = utils.read_only_property("_algorithm")
-
-    def update(self, data):
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        if not isinstance(data, bytes):
-            raise TypeError("data must be bytes.")
-        self._ctx.update(data)
-
-    def copy(self):
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        return HMAC(
-            self._key,
-            self.algorithm,
-            backend=self._backend,
-            ctx=self._ctx.copy()
-        )
-
-    def finalize(self):
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        digest = self._ctx.finalize()
-        self._ctx = None
-        return digest
-
-    def verify(self, signature):
-        if not isinstance(signature, bytes):
-            raise TypeError("signature must be bytes.")
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-
-        ctx, self._ctx = self._ctx, None
-        ctx.verify(signature)

--- a/src/cryptography/hazmat/primitives/interfaces/__init__.py
+++ b/src/cryptography/hazmat/primitives/interfaces/__init__.py
@@ -4,12 +4,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-import abc
-
-import six
-
 from cryptography import utils
-from cryptography.hazmat.primitives import ciphers, hashes
+from cryptography.hazmat.primitives import ciphers, hashes, mac
 from cryptography.hazmat.primitives.asymmetric import (
     AsymmetricSignatureContext, AsymmetricVerificationContext, dsa, ec,
     padding, rsa
@@ -358,33 +354,16 @@ KeyDerivationFunction = utils.deprecated(
     utils.DeprecatedIn08
 )
 
+MACContext = utils.deprecated(
+    mac.MACContext,
+    __name__,
+    (
+        "The MACContext interface has moved to the "
+        "cryptography.hazmat.primitives.mac module"
+    ),
+    utils.DeprecatedIn08
+)
 
-@six.add_metaclass(abc.ABCMeta)
-class MACContext(object):
-    @abc.abstractmethod
-    def update(self, data):
-        """
-        Processes the provided bytes.
-        """
-
-    @abc.abstractmethod
-    def finalize(self):
-        """
-        Returns the message authentication code as bytes.
-        """
-
-    @abc.abstractmethod
-    def copy(self):
-        """
-        Return a MACContext that is a copy of the current context.
-        """
-
-    @abc.abstractmethod
-    def verify(self, signature):
-        """
-        Checks if the generated message authentication code matches the
-        signature.
-        """
 
 # DeprecatedIn07
 CMACContext = MACContext

--- a/src/cryptography/hazmat/primitives/mac/__init__.py
+++ b/src/cryptography/hazmat/primitives/mac/__init__.py
@@ -1,0 +1,37 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import abc
+
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class MACContext(object):
+    @abc.abstractmethod
+    def update(self, data):
+        """
+        Processes the provided bytes.
+        """
+
+    @abc.abstractmethod
+    def finalize(self):
+        """
+        Returns the message authentication code as bytes.
+        """
+
+    @abc.abstractmethod
+    def copy(self):
+        """
+        Return a MACContext that is a copy of the current context.
+        """
+
+    @abc.abstractmethod
+    def verify(self, signature):
+        """
+        Checks if the generated message authentication code matches the
+        signature.
+        """

--- a/src/cryptography/hazmat/primitives/mac/cmac.py
+++ b/src/cryptography/hazmat/primitives/mac/cmac.py
@@ -1,0 +1,67 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+from cryptography import utils
+from cryptography.exceptions import (
+    AlreadyFinalized, UnsupportedAlgorithm, _Reasons
+)
+from cryptography.hazmat.backends.interfaces import CMACBackend
+from cryptography.hazmat.primitives import ciphers
+from cryptography.hazmat.primitives.mac import MACContext
+
+
+@utils.register_interface(MACContext)
+class CMAC(object):
+    def __init__(self, algorithm, backend, ctx=None):
+        if not isinstance(backend, CMACBackend):
+            raise UnsupportedAlgorithm(
+                "Backend object does not implement CMACBackend.",
+                _Reasons.BACKEND_MISSING_INTERFACE
+            )
+
+        if not isinstance(algorithm, ciphers.BlockCipherAlgorithm):
+            raise TypeError(
+                "Expected instance of BlockCipherAlgorithm."
+            )
+        self._algorithm = algorithm
+
+        self._backend = backend
+        if ctx is None:
+            self._ctx = self._backend.create_cmac_ctx(self._algorithm)
+        else:
+            self._ctx = ctx
+
+    def update(self, data):
+        if self._ctx is None:
+            raise AlreadyFinalized("Context was already finalized.")
+        if not isinstance(data, bytes):
+            raise TypeError("data must be bytes.")
+        self._ctx.update(data)
+
+    def finalize(self):
+        if self._ctx is None:
+            raise AlreadyFinalized("Context was already finalized.")
+        digest = self._ctx.finalize()
+        self._ctx = None
+        return digest
+
+    def verify(self, signature):
+        if not isinstance(signature, bytes):
+            raise TypeError("signature must be bytes.")
+        if self._ctx is None:
+            raise AlreadyFinalized("Context was already finalized.")
+
+        ctx, self._ctx = self._ctx, None
+        ctx.verify(signature)
+
+    def copy(self):
+        if self._ctx is None:
+            raise AlreadyFinalized("Context was already finalized.")
+        return CMAC(
+            self._algorithm,
+            backend=self._backend,
+            ctx=self._ctx.copy()
+        )

--- a/src/cryptography/hazmat/primitives/mac/hmac.py
+++ b/src/cryptography/hazmat/primitives/mac/hmac.py
@@ -1,0 +1,70 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+from cryptography import utils
+from cryptography.exceptions import (
+    AlreadyFinalized, UnsupportedAlgorithm, _Reasons
+)
+from cryptography.hazmat.backends.interfaces import HMACBackend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.mac import MACContext
+
+
+@utils.register_interface(MACContext)
+@utils.register_interface(hashes.HashContext)
+class HMAC(object):
+    def __init__(self, key, algorithm, backend, ctx=None):
+        if not isinstance(backend, HMACBackend):
+            raise UnsupportedAlgorithm(
+                "Backend object does not implement HMACBackend.",
+                _Reasons.BACKEND_MISSING_INTERFACE
+            )
+
+        if not isinstance(algorithm, hashes.HashAlgorithm):
+            raise TypeError("Expected instance of hashes.HashAlgorithm.")
+        self._algorithm = algorithm
+
+        self._backend = backend
+        self._key = key
+        if ctx is None:
+            self._ctx = self._backend.create_hmac_ctx(key, self.algorithm)
+        else:
+            self._ctx = ctx
+
+    algorithm = utils.read_only_property("_algorithm")
+
+    def update(self, data):
+        if self._ctx is None:
+            raise AlreadyFinalized("Context was already finalized.")
+        if not isinstance(data, bytes):
+            raise TypeError("data must be bytes.")
+        self._ctx.update(data)
+
+    def copy(self):
+        if self._ctx is None:
+            raise AlreadyFinalized("Context was already finalized.")
+        return HMAC(
+            self._key,
+            self.algorithm,
+            backend=self._backend,
+            ctx=self._ctx.copy()
+        )
+
+    def finalize(self):
+        if self._ctx is None:
+            raise AlreadyFinalized("Context was already finalized.")
+        digest = self._ctx.finalize()
+        self._ctx = None
+        return digest
+
+    def verify(self, signature):
+        if not isinstance(signature, bytes):
+            raise TypeError("signature must be bytes.")
+        if self._ctx is None:
+            raise AlreadyFinalized("Context was already finalized.")
+
+        ctx, self._ctx = self._ctx, None
+        ctx.verify(signature)


### PR DESCRIPTION
This is a potential solution to moving `MACContext`. It deprecates and moves `hmac` and `cmac` into a new `mac` module. Advantage: Completes our interface diaspora. Disadvantage: deprecates and moves `hmac` and `cmac`.

refs #1508 
