### PR TITLE
use pip install --user on travis

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -103,7 +103,7 @@ else
     esac
 fi
 
-sudo pip install virtualenv
+pip install --user virtualenv
 virtualenv ~/.venv
 source ~/.venv/bin/activate
 pip install tox coveralls


### PR DESCRIPTION
This attempts to use the Travis cache + wheels to speed up our builds a bit. Also dropped the use of sudo in favor of `pip install --user`.