### PR TITLE
Tell py.test to only run the tests from the local tests dir.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,8 @@ class PyTest(test):
     def run_tests(self):
         # Import here because in module scope the eggs are not loaded.
         import pytest
-        errno = pytest.main(self.test_args)
+        test_args = [os.path.join(base_dir, "tests")]
+        errno = pytest.main(test_args)
         sys.exit(errno)
 
 


### PR DESCRIPTION
Right now if you have a virtualenv or something in the same directory it will recurse into it to run tests.