### PR TITLE
Remove the CFFI requirement, which breaks pip install -U on PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ SIX_DEPENDENCY = "six>=1.4.1"
 VECTORS_DEPENDENCY = "cryptography_vectors=={0}".format(about['__version__'])
 
 requirements = [
-    CFFI_DEPENDENCY,
     "pyasn1",
     SIX_DEPENDENCY,
     SETUPTOOLS_DEPENDENCY
@@ -43,6 +42,9 @@ requirements = [
 
 if sys.version_info < (3, 4):
     requirements.append("enum34")
+
+if platform.python_implementation() != "PyPy":
+    requirements.append(CFFI_DEPENDENCY)
 
 # If you add a new dep here you probably need to add it in the tox.ini as well
 test_requirements = [


### PR DESCRIPTION
PyPy ships with CFFI, but pip install -U will upgrade it if a newer CFFI is available, which will break the CFFI installation (and PyPy itself).

I haven't tested this, this PR is half a reminder and half confirmation from @dstufft that this is the solution he was proposing.

CC @alex