### PR TITLE
Parse X509 Requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Changelog
   and
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization`.
 * Add support for parsing X.509 requests with
-  :func:`~cryptography.x509.load_pem_x509_request`.
+  :func:`~cryptography.x509.load_pem_x509_csr`.
 
 0.8.1 - 2015-03-20
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithSerialization`,
   and
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization`.
-* Add support for parsing X.509 CSRs (certificate signing requests) with
+* Add support for parsing X.509 certificate signing requests (CSRs) with
   :func:`~cryptography.x509.load_pem_x509_csr`.
 
 0.8.1 - 2015-03-20

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithSerialization`,
   and
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization`.
-* Add support for parsing X.509 requests with
+* Add support for parsing X.509 CSRs (certificate signing requests) with
   :func:`~cryptography.x509.load_pem_x509_csr`.
 
 0.8.1 - 2015-03-20

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithSerialization`,
   and
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization`.
+* Add support for parsing X.509 requests with
+  :func:`~cryptography.x509.load_pem_x509_request`.
 
 0.8.1 - 2015-03-20
 ~~~~~~~~~~~~~~~~~~

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -510,10 +510,10 @@ A specific ``backend`` may provide one or more of these interfaces.
 
         :returns: An instance of :class:`~cryptography.x509.Certificate`.
 
-    .. method:: load_pem_x509_request(data)
+    .. method:: load_pem_x509_csr(data)
 
         .. versionadded:: 0.9
 
         :param bytes data: PEM formatted certificate request data.
 
-        :returns: An instance of :class:`~cryptography.x509.Request`.
+        :returns: An instance of :class:`~cryptography.x509.CSR`.

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -509,3 +509,11 @@ A specific ``backend`` may provide one or more of these interfaces.
         :param bytes data: DER formatted certificate data.
 
         :returns: An instance of :class:`~cryptography.x509.Certificate`.
+
+    .. method:: load_pem_x509_request(data)
+
+        .. versionadded:: 0.9
+
+        :param bytes data: PEM formatted certificate request data.
+
+        :returns: An instance of :class:`~cryptography.x509.Request`.

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -516,4 +516,5 @@ A specific ``backend`` may provide one or more of these interfaces.
 
         :param bytes data: PEM formatted certificate request data.
 
-        :returns: An instance of :class:`~cryptography.x509.CSR`.
+        :returns: An instance of
+            :class:`~cryptography.x509.CertificateSigningRequest`.

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -514,7 +514,7 @@ A specific ``backend`` may provide one or more of these interfaces.
 
         .. versionadded:: 0.9
 
-        :param bytes data: PEM formatted certificate request data.
+        :param bytes data: PEM formatted certificate signing request data.
 
         :returns: An instance of
             :class:`~cryptography.x509.CertificateSigningRequest`.

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -84,8 +84,8 @@ Loading CSRs
 
     .. versionadded:: 0.9
 
-    Deserialize a certificate request from PEM encoded data. PEM requests are
-    base64 decoded and have delimiters that look like
+    Deserialize a certificate signing request from PEM encoded data. PEM
+    requests are base64 decoded and have delimiters that look like
     ``-----BEGIN CERTIFICATE REQUEST-----``. This is also known as PKCS#10
     format.
 
@@ -263,8 +263,8 @@ X.509 Certificate Object
             ...     print(ext)
             <Extension(oid=<ObjectIdentifier(oid=2.5.29.19, name=basicConstraints)>, critical=True, value=<BasicConstraints(ca=True, path_length=None)>)>
 
-X.509 CSR Object
-~~~~~~~~~~~~~~~~
+X.509 CSR (Certificate Signing Request) Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. class:: CSR
 

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -7,6 +7,29 @@ X.509 is an ITU-T standard for a `public key infrastructure`_. X.509v3 is
 defined in :rfc:`5280` (which obsoletes :rfc:`2459` and :rfc:`3280`). X.509
 certificates are commonly used in protocols like `TLS`_.
 
+.. testsetup::
+
+    pem_req_data = b"""
+    -----BEGIN CERTIFICATE REQUEST-----
+    MIIC0zCCAbsCAQAwWTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCElsbGlub2lzMRAw
+    DgYDVQQHDAdDaGljYWdvMREwDwYDVQQKDAhyNTA5IExMQzESMBAGA1UEAwwJaGVs
+    bG8uY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhZx+Mo9VRd9
+    vsnWWa6NBCws21rZ0+1B/JGgB4hDsZS7iDE4Bj5z4idheFRtl8bBbdjPknq7BfoF
+    8v15Zq/Zv7i2xMSDL+LUrTBZezRd4bRTGqCm6YJ5EYkhqdcqeZleHCFImguHoq1J
+    Fh0+kObQrTHXw3ZP57a3o1IvyIUA3nNoCBL0QQhwBXaDXOojMKNR+bqB5ve8GS1y
+    Elr0AM/+cJsfaIahNQUgFKx3Eu3GeEOMKYOAG1lycgdQdmTUybLrT3U7vkClTseM
+    xHg1r5En7ALjONIhqRuq3rddYahrP8HXozb3zUy3cJ7P6IeaosuvNzvMXOX9P6HD
+    Ha9urDAJ1wIDAQABoDUwMwYJKoZIhvcNAQkOMSYwJDAiBgNVHREEGzAZggl3b3Js
+    ZC5jb22CDHdoYXRldmVyLmNvbTANBgkqhkiG9w0BAQUFAAOCAQEAS4Ro6h+z52SK
+    YSLCYARpnEu/rmh4jdqndt8naqcNb6uLx9mlKZ2W9on9XDjnSdQD9q+ZP5aZfESw
+    R0+rJhW9ZrNa/g1pt6M24ihclHYDAxYMWxT1z/TXXGM3TmZZ6gfYlNE1kkBuODHa
+    UYsR/1Ht1E1EsmmUimt2n+zQR2K8T9Coa+boaUW/GsTEuz1aaJAkj5ZvTDiIhRG4
+    AOCqFZOLAQmCCNgJnnspD9hDz/Ons085LF5wnYjN4/Nsk5tS6AGs3xjZ3jPoOGGn
+    82WQ9m4dBGoVDZXsobVTaN592JEYwN5iu72zRn7Einb4V4H5y3yD2dD4yWPlt4pk
+    5wFkeYsZEA==
+    -----END CERTIFICATE REQUEST-----
+    """.strip()
+
 
 Loading Certificates
 ~~~~~~~~~~~~~~~~~~~~
@@ -97,29 +120,6 @@ Loading Certificate Signing Requests
 
     :returns: An instance of
         :class:`~cryptography.x509.CertificateSigningRequest`.
-
-.. testsetup::
-
-    pem_req_data = b"""
-    -----BEGIN CERTIFICATE REQUEST-----
-    MIIC0zCCAbsCAQAwWTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCElsbGlub2lzMRAw
-    DgYDVQQHDAdDaGljYWdvMREwDwYDVQQKDAhyNTA5IExMQzESMBAGA1UEAwwJaGVs
-    bG8uY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhZx+Mo9VRd9
-    vsnWWa6NBCws21rZ0+1B/JGgB4hDsZS7iDE4Bj5z4idheFRtl8bBbdjPknq7BfoF
-    8v15Zq/Zv7i2xMSDL+LUrTBZezRd4bRTGqCm6YJ5EYkhqdcqeZleHCFImguHoq1J
-    Fh0+kObQrTHXw3ZP57a3o1IvyIUA3nNoCBL0QQhwBXaDXOojMKNR+bqB5ve8GS1y
-    Elr0AM/+cJsfaIahNQUgFKx3Eu3GeEOMKYOAG1lycgdQdmTUybLrT3U7vkClTseM
-    xHg1r5En7ALjONIhqRuq3rddYahrP8HXozb3zUy3cJ7P6IeaosuvNzvMXOX9P6HD
-    Ha9urDAJ1wIDAQABoDUwMwYJKoZIhvcNAQkOMSYwJDAiBgNVHREEGzAZggl3b3Js
-    ZC5jb22CDHdoYXRldmVyLmNvbTANBgkqhkiG9w0BAQUFAAOCAQEAS4Ro6h+z52SK
-    YSLCYARpnEu/rmh4jdqndt8naqcNb6uLx9mlKZ2W9on9XDjnSdQD9q+ZP5aZfESw
-    R0+rJhW9ZrNa/g1pt6M24ihclHYDAxYMWxT1z/TXXGM3TmZZ6gfYlNE1kkBuODHa
-    UYsR/1Ht1E1EsmmUimt2n+zQR2K8T9Coa+boaUW/GsTEuz1aaJAkj5ZvTDiIhRG4
-    AOCqFZOLAQmCCNgJnnspD9hDz/Ons085LF5wnYjN4/Nsk5tS6AGs3xjZ3jPoOGGn
-    82WQ9m4dBGoVDZXsobVTaN592JEYwN5iu72zRn7Einb4V4H5y3yD2dD4yWPlt4pk
-    5wFkeYsZEA==
-    -----END CERTIFICATE REQUEST-----
-    """.strip()
 
 .. doctest::
 

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -77,10 +77,10 @@ Loading Certificates
     >>> cert.serial
     2
 
-Loading Certificate Requests
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Loading CSRs
+~~~~~~~~~~~~
 
-.. function:: load_pem_x509_request(data, backend)
+.. function:: load_pem_x509_csr(data, backend)
 
     .. versionadded:: 0.9
 
@@ -95,7 +95,7 @@ Loading Certificate Requests
         :class:`~cryptography.hazmat.backends.interfaces.X509Backend`
         interface.
 
-    :returns: An instance of :class:`~cryptography.x509.Request`.
+    :returns: An instance of :class:`~cryptography.x509.CSR`.
 
 .. testsetup::
 
@@ -125,7 +125,7 @@ Loading Certificate Requests
     >>> from cryptography import x509
     >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import hashes
-    >>> request = x509.load_pem_x509_request(pem_req_data, default_backend())
+    >>> request = x509.load_pem_x509_csr(pem_req_data, default_backend())
     >>> isinstance(request.signature_hash_algorithm, hashes.SHA1)
     True
 
@@ -263,10 +263,10 @@ X.509 Certificate Object
             ...     print(ext)
             <Extension(oid=<ObjectIdentifier(oid=2.5.29.19, name=basicConstraints)>, critical=True, value=<BasicConstraints(ca=True, path_length=None)>)>
 
-X.509 Certificate Request Object
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+X.509 CSR Object
+~~~~~~~~~~~~~~~~
 
-.. class:: Request
+.. class:: CSR
 
     .. versionadded:: 0.9
 

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -77,6 +77,58 @@ Loading Certificates
     >>> cert.serial
     2
 
+Loading Certificate Requests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. function:: load_pem_x509_request(data, backend)
+
+    .. versionadded:: 0.9
+
+    Deserialize a certificate request from PEM encoded data. PEM requests are
+    base64 decoded and have delimiters that look like
+    ``-----BEGIN CERTIFICATE REQUEST-----``. This is also known as PKCS#10
+    format.
+
+    :param bytes data: The PEM encoded request data.
+
+    :param backend: A backend supporting the
+        :class:`~cryptography.hazmat.backends.interfaces.X509Backend`
+        interface.
+
+    :returns: An instance of :class:`~cryptography.x509.Request`.
+
+.. testsetup::
+
+    pem_req_data = b"""
+    -----BEGIN CERTIFICATE REQUEST-----
+    MIIC0zCCAbsCAQAwWTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCElsbGlub2lzMRAw
+    DgYDVQQHDAdDaGljYWdvMREwDwYDVQQKDAhyNTA5IExMQzESMBAGA1UEAwwJaGVs
+    bG8uY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqhZx+Mo9VRd9
+    vsnWWa6NBCws21rZ0+1B/JGgB4hDsZS7iDE4Bj5z4idheFRtl8bBbdjPknq7BfoF
+    8v15Zq/Zv7i2xMSDL+LUrTBZezRd4bRTGqCm6YJ5EYkhqdcqeZleHCFImguHoq1J
+    Fh0+kObQrTHXw3ZP57a3o1IvyIUA3nNoCBL0QQhwBXaDXOojMKNR+bqB5ve8GS1y
+    Elr0AM/+cJsfaIahNQUgFKx3Eu3GeEOMKYOAG1lycgdQdmTUybLrT3U7vkClTseM
+    xHg1r5En7ALjONIhqRuq3rddYahrP8HXozb3zUy3cJ7P6IeaosuvNzvMXOX9P6HD
+    Ha9urDAJ1wIDAQABoDUwMwYJKoZIhvcNAQkOMSYwJDAiBgNVHREEGzAZggl3b3Js
+    ZC5jb22CDHdoYXRldmVyLmNvbTANBgkqhkiG9w0BAQUFAAOCAQEAS4Ro6h+z52SK
+    YSLCYARpnEu/rmh4jdqndt8naqcNb6uLx9mlKZ2W9on9XDjnSdQD9q+ZP5aZfESw
+    R0+rJhW9ZrNa/g1pt6M24ihclHYDAxYMWxT1z/TXXGM3TmZZ6gfYlNE1kkBuODHa
+    UYsR/1Ht1E1EsmmUimt2n+zQR2K8T9Coa+boaUW/GsTEuz1aaJAkj5ZvTDiIhRG4
+    AOCqFZOLAQmCCNgJnnspD9hDz/Ons085LF5wnYjN4/Nsk5tS6AGs3xjZ3jPoOGGn
+    82WQ9m4dBGoVDZXsobVTaN592JEYwN5iu72zRn7Einb4V4H5y3yD2dD4yWPlt4pk
+    5wFkeYsZEA==
+    -----END CERTIFICATE REQUEST-----
+    """.strip()
+
+.. doctest::
+
+    >>> from cryptography import x509
+    >>> from cryptography.hazmat.backends import default_backend
+    >>> from cryptography.hazmat.primitives import hashes
+    >>> request = x509.load_pem_x509_request(pem_req_data, default_backend())
+    >>> isinstance(request.signature_hash_algorithm, hashes.SHA1)
+    True
+
 X.509 Certificate Object
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -210,6 +262,49 @@ X.509 Certificate Object
             >>> for ext in cert.extensions:
             ...     print(ext)
             <Extension(oid=<ObjectIdentifier(oid=2.5.29.19, name=basicConstraints)>, critical=True, value=<BasicConstraints(ca=True, path_length=None)>)>
+
+X.509 Certificate Request Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: Request
+
+    .. versionadded:: 0.9
+
+    .. method:: public_key()
+
+        :type:
+            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey` or
+            :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey` or
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey`
+
+        The public key associated with the request.
+
+        .. doctest::
+
+            >>> from cryptography.hazmat.primitives.asymmetric import rsa
+            >>> public_key = request.public_key()
+            >>> isinstance(public_key, rsa.RSAPublicKey)
+            True
+
+    .. attribute:: subject
+
+        :type: :class:`Name`
+
+        The :class:`Name` of the subject.
+
+    .. attribute:: signature_hash_algorithm
+
+        :type: :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+
+        Returns the
+        :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm` which
+        was used in signing this request.
+
+        .. doctest::
+
+            >>> from cryptography.hazmat.primitives import hashes
+            >>> isinstance(request.signature_hash_algorithm, hashes.SHA1)
+            True
 
 .. class:: Name
 

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -77,14 +77,14 @@ Loading Certificates
     >>> cert.serial
     2
 
-Loading CSRs
-~~~~~~~~~~~~
+Loading Certificate Signing Requests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. function:: load_pem_x509_csr(data, backend)
 
     .. versionadded:: 0.9
 
-    Deserialize a certificate signing request from PEM encoded data. PEM
+    Deserialize a certificate signing request (CSR) from PEM encoded data. PEM
     requests are base64 decoded and have delimiters that look like
     ``-----BEGIN CERTIFICATE REQUEST-----``. This is also known as PKCS#10
     format.
@@ -95,7 +95,8 @@ Loading CSRs
         :class:`~cryptography.hazmat.backends.interfaces.X509Backend`
         interface.
 
-    :returns: An instance of :class:`~cryptography.x509.CSR`.
+    :returns: An instance of
+        :class:`~cryptography.x509.CertificateSigningRequest`.
 
 .. testsetup::
 
@@ -125,8 +126,8 @@ Loading CSRs
     >>> from cryptography import x509
     >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import hashes
-    >>> request = x509.load_pem_x509_csr(pem_req_data, default_backend())
-    >>> isinstance(request.signature_hash_algorithm, hashes.SHA1)
+    >>> csr = x509.load_pem_x509_csr(pem_req_data, default_backend())
+    >>> isinstance(csr.signature_hash_algorithm, hashes.SHA1)
     True
 
 X.509 Certificate Object
@@ -266,7 +267,7 @@ X.509 Certificate Object
 X.509 CSR (Certificate Signing Request) Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. class:: CSR
+.. class:: CertificateSigningRequest
 
     .. versionadded:: 0.9
 
@@ -282,7 +283,7 @@ X.509 CSR (Certificate Signing Request) Object
         .. doctest::
 
             >>> from cryptography.hazmat.primitives.asymmetric import rsa
-            >>> public_key = request.public_key()
+            >>> public_key = csr.public_key()
             >>> isinstance(public_key, rsa.RSAPublicKey)
             True
 
@@ -303,7 +304,7 @@ X.509 CSR (Certificate Signing Request) Object
         .. doctest::
 
             >>> from cryptography.hazmat.primitives import hashes
-            >>> isinstance(request.signature_hash_algorithm, hashes.SHA1)
+            >>> isinstance(csr.signature_hash_algorithm, hashes.SHA1)
             True
 
 .. class:: Name

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -3,10 +3,6 @@ X.509
 
 .. currentmodule:: cryptography.x509
 
-X.509 is an ITU-T standard for a `public key infrastructure`_. X.509v3 is
-defined in :rfc:`5280` (which obsoletes :rfc:`2459` and :rfc:`3280`). X.509
-certificates are commonly used in protocols like `TLS`_.
-
 .. testsetup::
 
     pem_req_data = b"""
@@ -30,6 +26,33 @@ certificates are commonly used in protocols like `TLS`_.
     -----END CERTIFICATE REQUEST-----
     """.strip()
 
+    pem_data = b"""
+    -----BEGIN CERTIFICATE-----
+    MIIDfDCCAmSgAwIBAgIBAjANBgkqhkiG9w0BAQsFADBFMQswCQYDVQQGEwJVUzEf
+    MB0GA1UEChMWVGVzdCBDZXJ0aWZpY2F0ZXMgMjAxMTEVMBMGA1UEAxMMVHJ1c3Qg
+    QW5jaG9yMB4XDTEwMDEwMTA4MzAwMFoXDTMwMTIzMTA4MzAwMFowQDELMAkGA1UE
+    BhMCVVMxHzAdBgNVBAoTFlRlc3QgQ2VydGlmaWNhdGVzIDIwMTExEDAOBgNVBAMT
+    B0dvb2QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCQWJpHYo37
+    Xfb7oJSPe+WvfTlzIG21WQ7MyMbGtK/m8mejCzR6c+f/pJhEH/OcDSMsXq8h5kXa
+    BGqWK+vSwD/Pzp5OYGptXmGPcthDtAwlrafkGOS4GqIJ8+k9XGKs+vQUXJKsOk47
+    RuzD6PZupq4s16xaLVqYbUC26UcY08GpnoLNHJZS/EmXw1ZZ3d4YZjNlpIpWFNHn
+    UGmdiGKXUPX/9H0fVjIAaQwjnGAbpgyCumWgzIwPpX+ElFOUr3z7BoVnFKhIXze+
+    VmQGSWxZxvWDUN90Ul0tLEpLgk3OVxUB4VUGuf15OJOpgo1xibINPmWt14Vda2N9
+    yrNKloJGZNqLAgMBAAGjfDB6MB8GA1UdIwQYMBaAFOR9X9FclYYILAWuvnW2ZafZ
+    XahmMB0GA1UdDgQWBBRYAYQkG7wrUpRKPaUQchRR9a86yTAOBgNVHQ8BAf8EBAMC
+    AQYwFwYDVR0gBBAwDjAMBgpghkgBZQMCATABMA8GA1UdEwEB/wQFMAMBAf8wDQYJ
+    KoZIhvcNAQELBQADggEBADWHlxbmdTXNwBL/llwhQqwnazK7CC2WsXBBqgNPWj7m
+    tvQ+aLG8/50Qc2Sun7o2VnwF9D18UUe8Gj3uPUYH+oSI1vDdyKcjmMbKRU4rk0eo
+    3UHNDXwqIVc9CQS9smyV+x1HCwL4TTrq+LXLKx/qVij0Yqk+UJfAtrg2jnYKXsCu
+    FMBQQnWCGrwa1g1TphRp/RmYHnMynYFmZrXtzFz+U9XEA7C+gPq4kqDI/iVfIT1s
+    6lBtdB50lrDVwl2oYfAvW/6sC2se2QleZidUmrziVNP4oEeXINokU6T6p//HM1FG
+    QYw2jOvpKcKtWCSAnegEbgsGYzATKjmPJPJ0npHFqzM=
+    -----END CERTIFICATE-----
+    """.strip()
+
+X.509 is an ITU-T standard for a `public key infrastructure`_. X.509v3 is
+defined in :rfc:`5280` (which obsoletes :rfc:`2459` and :rfc:`3280`). X.509
+certificates are commonly used in protocols like `TLS`_.
 
 Loading Certificates
 ~~~~~~~~~~~~~~~~~~~~
@@ -66,32 +89,6 @@ Loading Certificates
 
     :returns: An instance of :class:`~cryptography.x509.Certificate`.
 
-.. testsetup::
-
-    pem_data = b"""
-    -----BEGIN CERTIFICATE-----
-    MIIDfDCCAmSgAwIBAgIBAjANBgkqhkiG9w0BAQsFADBFMQswCQYDVQQGEwJVUzEf
-    MB0GA1UEChMWVGVzdCBDZXJ0aWZpY2F0ZXMgMjAxMTEVMBMGA1UEAxMMVHJ1c3Qg
-    QW5jaG9yMB4XDTEwMDEwMTA4MzAwMFoXDTMwMTIzMTA4MzAwMFowQDELMAkGA1UE
-    BhMCVVMxHzAdBgNVBAoTFlRlc3QgQ2VydGlmaWNhdGVzIDIwMTExEDAOBgNVBAMT
-    B0dvb2QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCQWJpHYo37
-    Xfb7oJSPe+WvfTlzIG21WQ7MyMbGtK/m8mejCzR6c+f/pJhEH/OcDSMsXq8h5kXa
-    BGqWK+vSwD/Pzp5OYGptXmGPcthDtAwlrafkGOS4GqIJ8+k9XGKs+vQUXJKsOk47
-    RuzD6PZupq4s16xaLVqYbUC26UcY08GpnoLNHJZS/EmXw1ZZ3d4YZjNlpIpWFNHn
-    UGmdiGKXUPX/9H0fVjIAaQwjnGAbpgyCumWgzIwPpX+ElFOUr3z7BoVnFKhIXze+
-    VmQGSWxZxvWDUN90Ul0tLEpLgk3OVxUB4VUGuf15OJOpgo1xibINPmWt14Vda2N9
-    yrNKloJGZNqLAgMBAAGjfDB6MB8GA1UdIwQYMBaAFOR9X9FclYYILAWuvnW2ZafZ
-    XahmMB0GA1UdDgQWBBRYAYQkG7wrUpRKPaUQchRR9a86yTAOBgNVHQ8BAf8EBAMC
-    AQYwFwYDVR0gBBAwDjAMBgpghkgBZQMCATABMA8GA1UdEwEB/wQFMAMBAf8wDQYJ
-    KoZIhvcNAQELBQADggEBADWHlxbmdTXNwBL/llwhQqwnazK7CC2WsXBBqgNPWj7m
-    tvQ+aLG8/50Qc2Sun7o2VnwF9D18UUe8Gj3uPUYH+oSI1vDdyKcjmMbKRU4rk0eo
-    3UHNDXwqIVc9CQS9smyV+x1HCwL4TTrq+LXLKx/qVij0Yqk+UJfAtrg2jnYKXsCu
-    FMBQQnWCGrwa1g1TphRp/RmYHnMynYFmZrXtzFz+U9XEA7C+gPq4kqDI/iVfIT1s
-    6lBtdB50lrDVwl2oYfAvW/6sC2se2QleZidUmrziVNP4oEeXINokU6T6p//HM1FG
-    QYw2jOvpKcKtWCSAnegEbgsGYzATKjmPJPJ0npHFqzM=
-    -----END CERTIFICATE-----
-    """.strip()
-
 .. doctest::
 
     >>> from cryptography import x509
@@ -109,8 +106,8 @@ Loading Certificate Signing Requests
 
     Deserialize a certificate signing request (CSR) from PEM encoded data. PEM
     requests are base64 decoded and have delimiters that look like
-    ``-----BEGIN CERTIFICATE REQUEST-----``. This is also known as PKCS#10
-    format.
+    ``-----BEGIN CERTIFICATE REQUEST-----``. This format is also known as
+    PKCS#10.
 
     :param bytes data: The PEM encoded request data.
 

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -263,7 +263,7 @@ class X509Backend(object):
         """
 
     @abc.abstractmethod
-    def load_pem_x509_request(self, data):
+    def load_pem_x509_csr(self, data):
         """
-        Load an X.509 request from PEM encoded data.
+        Load an X.509 CSR from PEM encoded data.
         """

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -261,3 +261,9 @@ class X509Backend(object):
         """
         Load an X.509 certificate from DER encoded data.
         """
+
+    @abc.abstractmethod
+    def load_pem_x509_request(self, data):
+        """
+        Load an X.509 request from PEM encoded data.
+        """

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -326,9 +326,7 @@ class MultiBackend(object):
         )
 
     def load_pem_x509_csr(self, data):
-        for b in self._filtered_backends(
-            X509Backend
-        ):
+        for b in self._filtered_backends(X509Backend):
             return b.load_pem_x509_csr(data)
 
         raise UnsupportedAlgorithm(

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -324,3 +324,14 @@ class MultiBackend(object):
             "This backend does not support X.509.",
             _Reasons.UNSUPPORTED_X509
         )
+
+    def load_pem_x509_request(self, data):
+        for b in self._filtered_backends(
+            X509Backend
+        ):
+            return b.load_pem_x509_request(data)
+
+        raise UnsupportedAlgorithm(
+            "This backend does not support X.509.",
+            _Reasons.UNSUPPORTED_X509
+        )

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -325,11 +325,11 @@ class MultiBackend(object):
             _Reasons.UNSUPPORTED_X509
         )
 
-    def load_pem_x509_request(self, data):
+    def load_pem_x509_csr(self, data):
         for b in self._filtered_backends(
             X509Backend
         ):
-            return b.load_pem_x509_request(data)
+            return b.load_pem_x509_csr(data)
 
         raise UnsupportedAlgorithm(
             "This backend does not support X.509.",

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -34,7 +34,7 @@ from cryptography.hazmat.backends.openssl.hmac import _HMACContext
 from cryptography.hazmat.backends.openssl.rsa import (
     _RSAPrivateKey, _RSAPublicKey
 )
-from cryptography.hazmat.backends.openssl.x509 import _Certificate
+from cryptography.hazmat.backends.openssl.x509 import _Certificate, _Request
 from cryptography.hazmat.bindings.openssl.binding import Binding
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
@@ -819,6 +819,18 @@ class Backend(object):
 
         x509 = self._ffi.gc(x509, self._lib.X509_free)
         return _Certificate(self, x509)
+
+    def load_pem_x509_request(self, data):
+        mem_bio = self._bytes_to_bio(data)
+        x509_req = self._lib.PEM_read_bio_X509_REQ(
+            mem_bio.bio, self._ffi.NULL, self._ffi.NULL, self._ffi.NULL
+        )
+        if x509_req == self._ffi.NULL:
+            self._consume_errors()
+            raise ValueError("Unable to load request")
+
+        x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)
+        return _Request(self, x509_req)
 
     def _load_key(self, openssl_read_func, convert_func, data, password):
         mem_bio = self._bytes_to_bio(data)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -34,7 +34,7 @@ from cryptography.hazmat.backends.openssl.hmac import _HMACContext
 from cryptography.hazmat.backends.openssl.rsa import (
     _RSAPrivateKey, _RSAPublicKey
 )
-from cryptography.hazmat.backends.openssl.x509 import _Certificate, _Request
+from cryptography.hazmat.backends.openssl.x509 import _CSR, _Certificate
 from cryptography.hazmat.bindings.openssl.binding import Binding
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
@@ -820,7 +820,7 @@ class Backend(object):
         x509 = self._ffi.gc(x509, self._lib.X509_free)
         return _Certificate(self, x509)
 
-    def load_pem_x509_request(self, data):
+    def load_pem_x509_csr(self, data):
         mem_bio = self._bytes_to_bio(data)
         x509_req = self._lib.PEM_read_bio_X509_REQ(
             mem_bio.bio, self._ffi.NULL, self._ffi.NULL, self._ffi.NULL
@@ -830,7 +830,7 @@ class Backend(object):
             raise ValueError("Unable to load request")
 
         x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)
-        return _Request(self, x509_req)
+        return _CSR(self, x509_req)
 
     def _load_key(self, openssl_read_func, convert_func, data, password):
         mem_bio = self._bytes_to_bio(data)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -34,7 +34,9 @@ from cryptography.hazmat.backends.openssl.hmac import _HMACContext
 from cryptography.hazmat.backends.openssl.rsa import (
     _RSAPrivateKey, _RSAPublicKey
 )
-from cryptography.hazmat.backends.openssl.x509 import _CSR, _Certificate
+from cryptography.hazmat.backends.openssl.x509 import (
+    _Certificate, _CertificateSigningRequest
+)
 from cryptography.hazmat.bindings.openssl.binding import Binding
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
@@ -830,7 +832,7 @@ class Backend(object):
             raise ValueError("Unable to load request")
 
         x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)
-        return _CSR(self, x509_req)
+        return _CertificateSigningRequest(self, x509_req)
 
     def _load_key(self, openssl_read_func, convert_func, data, password):
         mem_bio = self._bytes_to_bio(data)

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -218,8 +218,8 @@ class _Certificate(object):
         return x509.BasicConstraints(ca, path_length)
 
 
-@utils.register_interface(x509.CSR)
-class _CSR(object):
+@utils.register_interface(x509.CertificateSigningRequest)
+class _CertificateSigningRequest(object):
     def __init__(self, backend, x509_req):
         self._backend = backend
         self._x509_req = x509_req

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -216,3 +216,32 @@ class _Certificate(object):
             path_length = self._backend._bn_to_int(bn)
 
         return x509.BasicConstraints(ca, path_length)
+
+
+@utils.register_interface(x509.Request)
+class _Request(object):
+    def __init__(self, backend, x509_req):
+        self._backend = backend
+        self._x509_req = x509_req
+
+    def public_key(self):
+        pkey = self._backend._lib.X509_REQ_get_pubkey(self._x509_req)
+        assert pkey != self._backend._ffi.NULL
+        pkey = self._backend._ffi.gc(pkey, self._backend._lib.EVP_PKEY_free)
+        return self._backend._evp_pkey_to_public_key(pkey)
+
+    @property
+    def subject(self):
+        subject = self._backend._lib.X509_REQ_get_subject_name(self._x509_req)
+        assert subject != self._backend._ffi.NULL
+        return _build_x509_name(self._backend, subject)
+
+    @property
+    def signature_hash_algorithm(self):
+        oid = _obj2txt(self._backend, self._x509_req.sig_alg.algorithm)
+        try:
+            return x509._SIG_OIDS_TO_HASH[oid]
+        except KeyError:
+            raise UnsupportedAlgorithm(
+                "Signature algorithm OID:{0} not recognized".format(oid)
+            )

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -218,8 +218,8 @@ class _Certificate(object):
         return x509.BasicConstraints(ca, path_length)
 
 
-@utils.register_interface(x509.Request)
-class _Request(object):
+@utils.register_interface(x509.CSR)
+class _CSR(object):
     def __init__(self, backend, x509_req):
         self._backend = backend
         self._x509_req = x509_req

--- a/src/cryptography/hazmat/bindings/openssl/x509.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509.py
@@ -44,7 +44,10 @@ typedef struct {
 
 typedef ... X509_EXTENSIONS;
 
-typedef ... X509_REQ;
+typedef struct {
+    X509_ALGOR *sig_alg;
+    ...;
+} X509_REQ;
 
 typedef struct {
     ASN1_INTEGER *serialNumber;

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -60,6 +60,10 @@ def load_der_x509_certificate(data, backend):
     return backend.load_der_x509_certificate(data)
 
 
+def load_pem_x509_request(data, backend):
+    return backend.load_pem_x509_request(data)
+
+
 class InvalidVersion(Exception):
     def __init__(self, msg, parsed_version):
         super(InvalidVersion, self).__init__(msg)
@@ -322,6 +326,28 @@ class Certificate(object):
     def issuer(self):
         """
         Returns the issuer name object.
+        """
+
+    @abc.abstractproperty
+    def subject(self):
+        """
+        Returns the subject name object.
+        """
+
+    @abc.abstractproperty
+    def signature_hash_algorithm(self):
+        """
+        Returns a HashAlgorithm corresponding to the type of the digest signed
+        in the certificate.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Request(object):
+    @abc.abstractmethod
+    def public_key(self):
+        """
+        Returns the public key
         """
 
     @abc.abstractproperty

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -343,7 +343,7 @@ class Certificate(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class CSR(object):
+class CertificateSigningRequest(object):
     @abc.abstractmethod
     def public_key(self):
         """

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -60,8 +60,8 @@ def load_der_x509_certificate(data, backend):
     return backend.load_der_x509_certificate(data)
 
 
-def load_pem_x509_request(data, backend):
-    return backend.load_pem_x509_request(data)
+def load_pem_x509_csr(data, backend):
+    return backend.load_pem_x509_csr(data)
 
 
 class InvalidVersion(Exception):
@@ -343,7 +343,7 @@ class Certificate(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Request(object):
+class CSR(object):
     @abc.abstractmethod
     def public_key(self):
         """

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -197,6 +197,9 @@ class DummyX509Backend(object):
     def load_der_x509_certificate(self, data):
         pass
 
+    def load_pem_x509_request(self, data):
+        pass
+
 
 class TestMultiBackend(object):
     def test_ciphers(self):
@@ -472,9 +475,12 @@ class TestMultiBackend(object):
 
         backend.load_pem_x509_certificate(b"certdata")
         backend.load_der_x509_certificate(b"certdata")
+        backend.load_pem_x509_request(b"reqdata")
 
         backend = MultiBackend([])
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
             backend.load_pem_x509_certificate(b"certdata")
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
             backend.load_der_x509_certificate(b"certdata")
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
+            backend.load_pem_x509_request(b"reqdata")

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -197,7 +197,7 @@ class DummyX509Backend(object):
     def load_der_x509_certificate(self, data):
         pass
 
-    def load_pem_x509_request(self, data):
+    def load_pem_x509_csr(self, data):
         pass
 
 
@@ -475,7 +475,7 @@ class TestMultiBackend(object):
 
         backend.load_pem_x509_certificate(b"certdata")
         backend.load_der_x509_certificate(b"certdata")
-        backend.load_pem_x509_request(b"reqdata")
+        backend.load_pem_x509_csr(b"reqdata")
 
         backend = MultiBackend([])
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
@@ -483,4 +483,4 @@ class TestMultiBackend(object):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
             backend.load_der_x509_certificate(b"certdata")
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
-            backend.load_pem_x509_request(b"reqdata")
+            backend.load_pem_x509_csr(b"reqdata")

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -343,7 +343,7 @@ class TestRSACertificate(object):
     def test_load_rsa_certificate_request(self, backend):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
-            x509.load_pem_x509_request,
+            x509.load_pem_x509_csr,
             backend
         )
         assert isinstance(request.signature_hash_algorithm, hashes.SHA1)
@@ -362,7 +362,7 @@ class TestRSACertificate(object):
     def test_unsupported_signature_hash_algorithm_request(self, backend):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_md4.pem"),
-            x509.load_pem_x509_request,
+            x509.load_pem_x509_csr,
             backend
         )
         with pytest.raises(UnsupportedAlgorithm):
@@ -423,7 +423,7 @@ class TestDSACertificate(object):
     def test_load_dsa_request(self, backend):
         request = _load_cert(
             os.path.join("x509", "requests", "dsa_sha1.pem"),
-            x509.load_pem_x509_request,
+            x509.load_pem_x509_csr,
             backend
         )
         assert isinstance(request.signature_hash_algorithm, hashes.SHA1)
@@ -479,7 +479,7 @@ class TestECDSACertificate(object):
         _skip_curve_unsupported(backend, ec.SECP384R1())
         request = _load_cert(
             os.path.join("x509", "requests", "ec_sha256.pem"),
-            x509.load_pem_x509_request,
+            x509.load_pem_x509_csr,
             backend
         )
         assert isinstance(request.signature_hash_algorithm, hashes.SHA256)

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -340,6 +340,34 @@ class TestRSACertificate(object):
         with pytest.raises(UnsupportedAlgorithm):
             cert.signature_hash_algorithm
 
+    def test_load_rsa_certificate_request(self, backend):
+        request = _load_cert(
+            os.path.join("x509", "requests", "rsa_sha1.pem"),
+            x509.load_pem_x509_request,
+            backend
+        )
+        assert isinstance(request.signature_hash_algorithm, hashes.SHA1)
+        public_key = request.public_key()
+        assert isinstance(public_key, rsa.RSAPublicKey)
+        subject = request.subject
+        assert isinstance(subject, x509.Name)
+        assert list(subject) == [
+            x509.NameAttribute(x509.OID_COUNTRY_NAME, 'US'),
+            x509.NameAttribute(x509.OID_STATE_OR_PROVINCE_NAME, 'Texas'),
+            x509.NameAttribute(x509.OID_LOCALITY_NAME, 'Austin'),
+            x509.NameAttribute(x509.OID_ORGANIZATION_NAME, 'PyCA'),
+            x509.NameAttribute(x509.OID_COMMON_NAME, 'cryptography.io'),
+        ]
+
+    def test_unsupported_signature_hash_algorithm_request(self, backend):
+        request = _load_cert(
+            os.path.join("x509", "requests", "rsa_md4.pem"),
+            x509.load_pem_x509_request,
+            backend
+        )
+        with pytest.raises(UnsupportedAlgorithm):
+            request.signature_hash_algorithm
+
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
@@ -392,6 +420,25 @@ class TestDSACertificate(object):
                 "822ff5d234e073b901cf5941f58e1f538e71d40d", 16
             )
 
+    def test_load_dsa_request(self, backend):
+        request = _load_cert(
+            os.path.join("x509", "requests", "dsa_sha1.pem"),
+            x509.load_pem_x509_request,
+            backend
+        )
+        assert isinstance(request.signature_hash_algorithm, hashes.SHA1)
+        public_key = request.public_key()
+        assert isinstance(public_key, dsa.DSAPublicKey)
+        subject = request.subject
+        assert isinstance(subject, x509.Name)
+        assert list(subject) == [
+            x509.NameAttribute(x509.OID_COMMON_NAME, 'cryptography.io'),
+            x509.NameAttribute(x509.OID_ORGANIZATION_NAME, 'PyCA'),
+            x509.NameAttribute(x509.OID_COUNTRY_NAME, 'US'),
+            x509.NameAttribute(x509.OID_STATE_OR_PROVINCE_NAME, 'Texas'),
+            x509.NameAttribute(x509.OID_LOCALITY_NAME, 'Austin'),
+        ]
+
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
@@ -427,6 +474,26 @@ class TestECDSACertificate(object):
         )
         with pytest.raises(NotImplementedError):
             cert.public_key()
+
+    def test_load_ecdsa_certificate_request(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP384R1())
+        request = _load_cert(
+            os.path.join("x509", "requests", "ec_sha256.pem"),
+            x509.load_pem_x509_request,
+            backend
+        )
+        assert isinstance(request.signature_hash_algorithm, hashes.SHA256)
+        public_key = request.public_key()
+        assert isinstance(public_key, ec.EllipticCurvePublicKey)
+        subject = request.subject
+        assert isinstance(subject, x509.Name)
+        assert list(subject) == [
+            x509.NameAttribute(x509.OID_COMMON_NAME, 'cryptography.io'),
+            x509.NameAttribute(x509.OID_ORGANIZATION_NAME, 'PyCA'),
+            x509.NameAttribute(x509.OID_COUNTRY_NAME, 'US'),
+            x509.NameAttribute(x509.OID_STATE_OR_PROVINCE_NAME, 'Texas'),
+            x509.NameAttribute(x509.OID_LOCALITY_NAME, 'Austin'),
+        ]
 
 
 class TestNameAttribute(object):

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -359,6 +359,10 @@ class TestRSACertificate(object):
             x509.NameAttribute(x509.OID_COMMON_NAME, 'cryptography.io'),
         ]
 
+    def test_invalid_certificate_request_pem(self, backend):
+        with pytest.raises(ValueError):
+            x509.load_pem_x509_csr(b"notacsr", backend)
+
     def test_unsupported_signature_hash_algorithm_request(self, backend):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_md4.pem"),


### PR DESCRIPTION
Adds limited X509 request parsing. No extensions, no version (do we even care?), no verification.

Depends on #1697 