### PR TITLE
s/Format/PrivateFormat

### DIFF
--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -94,7 +94,7 @@ to serialize the key.
     >>> from cryptography.hazmat.primitives import serialization
     >>> pem = private_key.private_bytes(
     ...    encoding=serialization.Encoding.PEM,
-    ...    format=serialization.Format.PKCS8,
+    ...    format=serialization.PrivateFormat.PKCS8,
     ...    encryption_algorithm=serialization.BestAvailableEncryption(b'mypassword')
     ... )
     >>> pem.splitlines()[0]
@@ -107,7 +107,7 @@ It is also possible to serialize without encryption using
 
     >>> pem = private_key.private_bytes(
     ...    encoding=serialization.Encoding.PEM,
-    ...    format=serialization.Format.TraditionalOpenSSL,
+    ...    format=serialization.PrivateFormat.TraditionalOpenSSL,
     ...    encryption_algorithm=serialization.NoEncryption()
     ... )
     >>> pem.splitlines()[0]
@@ -540,10 +540,10 @@ Key interfaces
         :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM` or
         :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`),
         format (
-        :attr:`~cryptography.hazmat.primitives.serialization.Format.TraditionalOpenSSL`
+        :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.TraditionalOpenSSL`
         or
-        :attr:`~cryptography.hazmat.primitives.serialization.Format.PKCS8`) and
-        encryption algorithm (such as
+        :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`)
+        and encryption algorithm (such as
         :class:`~cryptography.hazmat.primitives.serialization.BestAvailableEncryption`
         or :class:`~cryptography.hazmat.primitives.serialization.NoEncryption`)
         are chosen to define the exact serialization.
@@ -552,7 +552,8 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
 
         :param format: A value from the
-            :class:`~cryptography.hazmat.primitives.serialization.Format` enum.
+            :class:`~cryptography.hazmat.primitives.serialization.PrivateFormat`
+            enum.
 
         :param encryption_algorithm: An instance of an object conforming to the
             :class:`~cryptography.hazmat.primitives.serialization.KeySerializationEncryption`

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -286,11 +286,11 @@ DSA keys look almost identical but begin with ``ssh-dss`` rather than
 Serialization Formats
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. class:: Format
+.. class:: PrivateFormat
 
     .. versionadded:: 0.8
 
-    An enumeration for key formats. Used with
+    An enumeration for private key formats. Used with
     :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.private_bytes`.
 
     .. attribute:: TraditionalOpenSSL

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1098,17 +1098,19 @@ class Backend(object):
         if not isinstance(encoding, serialization.Encoding):
             raise TypeError("encoding must be an item from the Encoding enum")
 
-        if not isinstance(format, serialization.Format):
-            raise TypeError("format must be an item from the Format enum")
+        if not isinstance(format, serialization.PrivateFormat):
+            raise TypeError(
+                "format must be an item from the PrivateFormat enum"
+            )
 
         # This is a temporary check until we land DER serialization.
         if encoding is not serialization.Encoding.PEM:
             raise ValueError("Only PEM encoding is supported by this backend")
 
-        if format is serialization.Format.PKCS8:
+        if format is serialization.PrivateFormat.PKCS8:
             write_bio = self._lib.PEM_write_bio_PKCS8PrivateKey
             key = evp_pkey
-        elif format is serialization.Format.TraditionalOpenSSL:
+        elif format is serialization.PrivateFormat.TraditionalOpenSSL:
             write_bio = traditional_write_func
             key = cdata
 

--- a/src/cryptography/hazmat/primitives/serialization.py
+++ b/src/cryptography/hazmat/primitives/serialization.py
@@ -174,7 +174,7 @@ class Encoding(Enum):
     DER = "DER"
 
 
-class Format(Enum):
+class PrivateFormat(Enum):
     PKCS8 = "PKCS8"
     TraditionalOpenSSL = "TraditionalOpenSSL"
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -504,7 +504,7 @@ class TestRSAPEMSerialization(object):
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                serialization.Format.PKCS8,
+                serialization.PrivateFormat.PKCS8,
                 serialization.BestAvailableEncryption(password)
             )
 
@@ -513,6 +513,6 @@ class TestRSAPEMSerialization(object):
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.DER,
-                serialization.Format.PKCS8,
+                serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption()
             )

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1753,8 +1753,8 @@ class TestRSAPEMWriter(object):
         ("fmt", "password"),
         itertools.product(
             [
-                serialization.Format.TraditionalOpenSSL,
-                serialization.Format.PKCS8
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.PrivateFormat.PKCS8
             ],
             [
                 b"s",
@@ -1781,7 +1781,10 @@ class TestRSAPEMWriter(object):
 
     @pytest.mark.parametrize(
         "fmt",
-        [serialization.Format.TraditionalOpenSSL, serialization.Format.PKCS8],
+        [
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.PrivateFormat.PKCS8
+        ],
     )
     def test_private_bytes_unencrypted_pem(self, backend, fmt):
         key = RSA_KEY_2048.private_key(backend)
@@ -1810,7 +1813,7 @@ class TestRSAPEMWriter(object):
         key = serialization.load_pem_private_key(key_bytes, None, backend)
         serialized = key.private_bytes(
             serialization.Encoding.PEM,
-            serialization.Format.TraditionalOpenSSL,
+            serialization.PrivateFormat.TraditionalOpenSSL,
             serialization.NoEncryption()
         )
         assert serialized == key_bytes
@@ -1821,7 +1824,7 @@ class TestRSAPEMWriter(object):
         with pytest.raises(TypeError):
             key.private_bytes(
                 "notencoding",
-                serialization.Format.PKCS8,
+                serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption()
             )
 
@@ -1841,7 +1844,7 @@ class TestRSAPEMWriter(object):
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                serialization.Format.TraditionalOpenSSL,
+                serialization.PrivateFormat.TraditionalOpenSSL,
                 "notanencalg"
             )
 
@@ -1851,6 +1854,6 @@ class TestRSAPEMWriter(object):
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                serialization.Format.TraditionalOpenSSL,
+                serialization.PrivateFormat.TraditionalOpenSSL,
                 DummyKeyEncryption()
             )


### PR DESCRIPTION
Public formats are sufficiently different from private formats that we should have them be different enums. This renames Format to PrivateFormat to make way for a PublicFormat in the near future (see: #1706).