### PR TITLE
simplify our DSA parameter copying

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -602,12 +602,9 @@ class Backend(object):
         return _DSAParameters(self, ctx)
 
     def generate_dsa_private_key(self, parameters):
-        ctx = self._lib.DSA_new()
+        ctx = self._lib.DSAparams_dup(parameters._dsa_cdata)
         assert ctx != self._ffi.NULL
         ctx = self._ffi.gc(ctx, self._lib.DSA_free)
-        ctx.p = self._lib.BN_dup(parameters._dsa_cdata.p)
-        ctx.q = self._lib.BN_dup(parameters._dsa_cdata.q)
-        ctx.g = self._lib.BN_dup(parameters._dsa_cdata.g)
 
         self._lib.DSA_generate_key(ctx)
 

--- a/src/cryptography/hazmat/bindings/openssl/dsa.py
+++ b/src/cryptography/hazmat/bindings/openssl/dsa.py
@@ -48,6 +48,8 @@ int DSA_verify(int, const unsigned char *, int, const unsigned char *, int,
 MACROS = """
 int DSA_generate_parameters_ex(DSA *, int, unsigned char *, int,
                                int *, unsigned long *, BN_GENCB *);
+// This is a macro in OpenSSL < 1.0.0
+DSA *DSAparams_dup(DSA *);
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
Use `DSAparams_dup` instead of duping ourselves and assigning to the struct.