### PR TITLE
Revert "simplify our DSA parameter copying"

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -602,9 +602,12 @@ class Backend(object):
         return _DSAParameters(self, ctx)
 
     def generate_dsa_private_key(self, parameters):
-        ctx = self._lib.DSAparams_dup(parameters._dsa_cdata)
+        ctx = self._lib.DSA_new()
         assert ctx != self._ffi.NULL
         ctx = self._ffi.gc(ctx, self._lib.DSA_free)
+        ctx.p = self._lib.BN_dup(parameters._dsa_cdata.p)
+        ctx.q = self._lib.BN_dup(parameters._dsa_cdata.q)
+        ctx.g = self._lib.BN_dup(parameters._dsa_cdata.g)
 
         self._lib.DSA_generate_key(ctx)
 

--- a/src/cryptography/hazmat/bindings/openssl/dsa.py
+++ b/src/cryptography/hazmat/bindings/openssl/dsa.py
@@ -48,8 +48,6 @@ int DSA_verify(int, const unsigned char *, int, const unsigned char *, int,
 MACROS = """
 int DSA_generate_parameters_ex(DSA *, int, unsigned char *, int,
                                int *, unsigned long *, BN_GENCB *);
-// This is a macro in OpenSSL < 1.0.0
-DSA *DSAparams_dup(DSA *);
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
This reverts commit 900657823720f377f81825d0190b5bf64780982b.

Turns out the way this macro is defined in older OpenSSLs does not play
nice with older gcc. See:
https://rt.openssl.org/Ticket/Display.html?id=1546&user=guest&pass=guest