### PR TITLE
add AES key wrap bindings to commoncrypto

### DIFF
--- a/src/cryptography/hazmat/bindings/commoncrypto/binding.py
+++ b/src/cryptography/hazmat/bindings/commoncrypto/binding.py
@@ -20,6 +20,7 @@ class Binding(object):
         "common_hmac",
         "common_key_derivation",
         "common_cryptor",
+        "common_symmetric_key_wrap",
         "secimport",
         "secitem",
         "seckey",

--- a/src/cryptography/hazmat/bindings/commoncrypto/common_symmetric_key_wrap.py
+++ b/src/cryptography/hazmat/bindings/commoncrypto/common_symmetric_key_wrap.py
@@ -1,0 +1,37 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+INCLUDES = """
+#include <CommonCrypto/CommonSymmetricKeywrap.h>
+"""
+
+TYPES = """
+enum {
+    kCCWRAPAES = 1,
+};
+
+typedef uint32_t CCWrappingAlgorithm;
+"""
+
+FUNCTIONS = """
+int CCSymmetricKeyWrap(CCWrappingAlgorithm, const uint8_t *, const size_t,
+                        const uint8_t *, size_t, const uint8_t *, size_t,
+                        uint8_t *, size_t *);
+int CCSymmetricKeyUnwrap(CCWrappingAlgorithm algorithm, const uint8_t *,
+                         const size_t, const uint8_t *, size_t,
+                         const uint8_t *, size_t, uint8_t *, size_t *);
+size_t CCSymmetricWrappedSize(CCWrappingAlgorithm, size_t);
+size_t CCSymmetricUnwrappedSize(CCWrappingAlgorithm, size_t);
+
+"""
+
+MACROS = """
+"""
+
+CUSTOMIZATIONS = """
+"""
+
+CONDITIONAL_NAMES = {}


### PR DESCRIPTION
Some bindings for supporting RFC 3394 AES key wrap in the future (we already have this bound for OpenSSL).

refs #1733 
