### PR TITLE
new openssl bindings for parsing some x509 extensions

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/x509.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509.py
@@ -139,6 +139,7 @@ int X509_get_ext_count(X509 *);
 int X509_add_ext(X509 *, X509_EXTENSION *, int);
 X509_EXTENSION *X509_EXTENSION_dup(X509_EXTENSION *);
 X509_EXTENSION *X509_get_ext(X509 *, int);
+int X509_get_ext_by_NID(X509 *, int, int);
 int X509_EXTENSION_get_critical(X509_EXTENSION *);
 ASN1_OBJECT *X509_EXTENSION_get_object(X509_EXTENSION *);
 void X509_EXTENSION_free(X509_EXTENSION *);

--- a/src/cryptography/hazmat/bindings/openssl/x509v3.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509v3.py
@@ -55,6 +55,11 @@ typedef struct {
 } EDIPARTYNAME;
 
 typedef struct {
+    int ca;
+    ASN1_INTEGER *pathlen;
+} BASIC_CONSTRAINTS;
+
+typedef struct {
     int type;
     union {
         char *ptr;
@@ -80,6 +85,12 @@ typedef struct {
 } GENERAL_NAME;
 
 typedef struct stack_st_GENERAL_NAME GENERAL_NAMES;
+
+typedef struct {
+    ASN1_OCTET_STRING *keyid;
+    GENERAL_NAMES *issuer;
+    ASN1_INTEGER *serial;
+} AUTHORITY_KEYID;
 
 typedef ... Cryptography_LHASH_OF_CONF_VALUE;
 """


### PR DESCRIPTION
This will allow us to build support for basic constraints and authority key identifier extensions.