### PR TITLE
bump version and add 0.8.1 changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.8.1 - 2015-03-20
+~~~~~~~~~~~~~~~~~~
+
+* Updated Windows wheels to be compiled against OpenSSL 1.0.2a.
+
 0.8 - 2015-03-08
 ~~~~~~~~~~~~~~~~
 

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -14,7 +14,7 @@ __summary__ = ("cryptography is a package which provides cryptographic recipes"
                " and primitives to Python developers.")
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "0.8"
+__version__ = "0.8.1"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -14,7 +14,7 @@ __summary__ = "Test vectors for the cryptography package."
 
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "0.8"
+__version__ = "0.8.1"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"


### PR DESCRIPTION
This should be merged once windows installers for 1.0.2a are available at http://slproweb.com/products/Win32OpenSSL.html