### PR TITLE
allow zero value bn using _bn_to_int in the openssl backend

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -327,7 +327,8 @@ class Backend(object):
             bn_num_bytes = (self._lib.BN_num_bits(bn) + 7) // 8
             bin_ptr = self._ffi.new("unsigned char[]", bn_num_bytes)
             bin_len = self._lib.BN_bn2bin(bn, bin_ptr)
-            assert bin_len > 0
+            # A zero length means the BN has value 0
+            assert bin_len >= 0
             assert bin_ptr != self._ffi.NULL
             return int.from_bytes(self._ffi.buffer(bin_ptr)[:bin_len], "big")
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -210,6 +210,10 @@ class TestOpenSSL(object):
         assert bn == bn_ptr
         assert backend._bn_to_int(bn_ptr) == value
 
+    def test_bn_to_int(self):
+        bn = backend._int_to_bn(0)
+        assert backend._bn_to_int(bn) == 0
+
 
 class TestOpenSSLRandomEngine(object):
     def teardown_method(self, method):


### PR DESCRIPTION
BNs can be zero (for example, path_length in basic constraints). Zero worked for py2 but failed on the py3 path.

This is needed for #1769 