### PR TITLE
add x509 extensions class and basic tests (no extensions supported)

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -196,6 +196,15 @@ X.509 Certificate Object
             >>> isinstance(cert.signature_hash_algorithm, hashes.SHA256)
             True
 
+    .. attribute:: extensions
+
+        :type: :class:`Extensions`
+
+        The extensions encoded in the certificate.
+
+        :raises cryptography.x509.DuplicateExtension: If more than one
+            extension of the same type is found within the certificate.
+
 .. class:: Name
 
     .. versionadded:: 0.8
@@ -275,6 +284,13 @@ X.509 Certificate Object
 
 X.509 Extensions
 ~~~~~~~~~~~~~~~~
+
+.. class:: Extensions
+
+    .. versionadded:: 0.9
+
+    An X.509 Extensions instance is an ordered list of extensions.  The object
+    is iterable to get every extension.
 
 .. class:: Extension
 
@@ -482,7 +498,7 @@ Signature Algorithm OIDs
 
 .. data:: OID_DSA_WITH_SHA256
 
-    Corresponds to the dotted string ``2.16.840.1.101.3.4.3.2"``. This is
+    Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.2"``. This is
     a SHA256 digest signed by a DSA key.
 
 .. _extension_oids:
@@ -508,6 +524,27 @@ Exceptions
         :type: int
 
         Returns the raw version that was parsed from the certificate.
+
+.. class:: DuplicateExtension
+
+    This is raised when more than one X.509 extension of the same type is
+    found within a certificate.
+
+    .. attribute:: oid
+
+        :type: :class:`ObjectIdentifier`
+
+        Returns the OID.
+
+.. class:: UnsupportedExtension
+
+    This is raised when a certificate contains an unsupported extension type.
+
+    .. attribute:: oid
+
+        :type: :class:`ObjectIdentifier`
+
+        Returns the OID.
 
 
 .. _`public key infrastructure`: https://en.wikipedia.org/wiki/Public_key_infrastructure

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -43,6 +43,7 @@ _OID_NAMES = {
     "2.16.840.1.101.3.4.3.1": "dsa-with-sha224",
     "2.16.840.1.101.3.4.3.2": "dsa-with-sha256",
     "2.5.29.19": "basicConstraints",
+    "2.5.29.15": "keyUsage",
 }
 
 
@@ -63,6 +64,18 @@ class InvalidVersion(Exception):
     def __init__(self, msg, parsed_version):
         super(InvalidVersion, self).__init__(msg)
         self.parsed_version = parsed_version
+
+
+class DuplicateExtension(Exception):
+    def __init__(self, msg, oid):
+        super(DuplicateExtension, self).__init__(msg)
+        self.oid = oid
+
+
+class UnsupportedExtension(Exception):
+    def __init__(self, msg, oid):
+        super(UnsupportedExtension, self).__init__(msg)
+        self.oid = oid
 
 
 class NameAttribute(object):
@@ -113,6 +126,9 @@ class ObjectIdentifier(object):
             _OID_NAMES.get(self._dotted_string, "Unknown OID")
         )
 
+    def __hash__(self):
+        return hash(self.dotted_string)
+
     dotted_string = utils.read_only_property("_dotted_string")
 
 
@@ -139,7 +155,19 @@ class Name(object):
         return len(self._attributes)
 
 
+OID_KEY_USAGE = ObjectIdentifier("2.5.29.15")
 OID_BASIC_CONSTRAINTS = ObjectIdentifier("2.5.29.19")
+
+
+class Extensions(object):
+    def __init__(self, extensions):
+        self._extensions = extensions
+
+    def __iter__(self):
+        return iter(self._extensions)
+
+    def __len__(self):
+        return len(self._extensions)
 
 
 class Extension(object):


### PR DESCRIPTION
Had to remove ``get_extension_for_oid`` since it's impossible to fully cover that method without a supported extension. Also had to move ``seen_oids`` to an inappropriate place temporarily, but it will be moved back in the next PR.