### PR TITLE
[WIP] AES keywrap support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization`.
 * Add support for parsing X.509 certificate signing requests (CSRs) with
   :func:`~cryptography.x509.load_pem_x509_csr`.
+* Add support for AES key wrapping with
+  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_wrap` and
+  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap`.
 
 0.8.1 - 2015-03-20
 ~~~~~~~~~~~~~~~~~~

--- a/docs/hazmat/backends/commoncrypto.rst
+++ b/docs/hazmat/backends/commoncrypto.rst
@@ -16,6 +16,7 @@ CommonCrypto backend is only supported on OS X versions 10.8 and above.
 
     It implements the following interfaces:
 
+    * :class:`~cryptography.hazmat.backends.interfaces.AESKeyWrapBackend`
     * :class:`~cryptography.hazmat.backends.interfaces.CipherBackend`
     * :class:`~cryptography.hazmat.backends.interfaces.HashBackend`
     * :class:`~cryptography.hazmat.backends.interfaces.HMACBackend`

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -518,3 +518,26 @@ A specific ``backend`` may provide one or more of these interfaces.
 
         :returns: An instance of
             :class:`~cryptography.x509.CertificateSigningRequest`.
+
+.. class:: AESKeyWrapBackend
+
+    .. versionadded:: 0.9
+
+    A backend with methods for wrapping/unwrapping data using the AES key wrap
+    specification.
+
+    .. method:: aes_key_wrap(wrapping_key, key_to_wrap)
+
+        :param bytes wrapping_key: The wrapping key.
+
+        :param bytes key_to_wrap: The key to wrap.
+
+        :return bytes: The wrapped key.
+
+    .. method:: aes_key_unwrap(wrapping_key, wrapped_key)
+
+        :param bytes wrapping_key: The wrapping key.
+
+        :param bytes wrapped_key: The key to unwrap.
+
+        :return bytes: The unwrapped key.

--- a/docs/hazmat/backends/openssl.rst
+++ b/docs/hazmat/backends/openssl.rst
@@ -13,6 +13,7 @@ Red Hat Enterprise Linux 5) and greater. Earlier versions may work but are
 
     It implements the following interfaces:
 
+    * :class:`~cryptography.hazmat.backends.interfaces.AESKeyWrapBackend`
     * :class:`~cryptography.hazmat.backends.interfaces.CipherBackend`
     * :class:`~cryptography.hazmat.backends.interfaces.CMACBackend`
     * :class:`~cryptography.hazmat.backends.interfaces.DERSerializationBackend`

--- a/docs/hazmat/primitives/index.rst
+++ b/docs/hazmat/primitives/index.rst
@@ -11,6 +11,7 @@ Primitives
     symmetric-encryption
     padding
     key-derivation-functions
+    keywrap
     asymmetric/index
     constant-time
     interfaces

--- a/docs/hazmat/primitives/keywrap.rst
+++ b/docs/hazmat/primitives/keywrap.rst
@@ -1,0 +1,41 @@
+.. hazmat::
+
+.. module:: cryptography.hazmat.primitives.keywrap
+
+Key wrapping
+============
+
+Key wrapping is a cryptographic construct that uses symmetric encryption to
+encapsulate key material.
+
+.. function:: aes_key_wrap(wrapping_key, key_to_wrap, backend)
+
+    :param bytes wrapping_key: The wrapping key.
+
+    :param bytes key_to_wrap: The key to wrap.
+
+    :param backend: An
+        :class:`~cryptography.hazmat.backends.interfaces.AESKeyWrapBackend`
+        provider.
+
+    :return bytes: The wrapped key as bytes.
+
+.. function:: aes_key_unwrap(wrapping_key, wrapped_key, backend)
+
+    :param bytes wrapping_key: The wrapping key.
+
+    :param bytes wrapped_key: The wrapped key.
+
+    :param backend: An
+        :class:`~cryptography.hazmat.backends.interfaces.AESKeyWrapBackend`
+        provider.
+
+    :return bytes: The unwrapped key as bytes.
+
+Exceptions
+~~~~~~~~~~
+
+.. class:: InvalidUnwrap
+
+    This is raised when a wrapped key fails to unwrap. It can be caused by a
+    corrupted or invalid wrapped key or an invalid wrapping key.

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -267,3 +267,24 @@ class X509Backend(object):
         """
         Load an X.509 CSR from PEM encoded data.
         """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AESKeyWrapBackend(object):
+    @abc.abstractmethod
+    def aes_key_wrap(self, wrapping_key, key_to_wrap):
+        """
+        Wrap a key using the AES Key Wrap (RFC 3394) specification.
+        """
+
+    @abc.abstractmethod
+    def aes_key_unwrap(self, wrapping_key, wrapped_key):
+        """
+        Unwrap a key using the AES Key Wrap (RFC 3394) specification.
+        """
+
+    @abc.abstractmethod
+    def aes_key_wrap_supported(self):
+        """
+        Reports whether the backend's underlying library supports key wrap.
+        """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -15,9 +15,9 @@ from cryptography.exceptions import (
     InternalError, UnsupportedAlgorithm, _Reasons
 )
 from cryptography.hazmat.backends.interfaces import (
-    CMACBackend, CipherBackend, DERSerializationBackend, DSABackend,
-    EllipticCurveBackend, HMACBackend, HashBackend, PBKDF2HMACBackend,
-    PEMSerializationBackend, RSABackend, X509Backend
+    AESKeyWrapBackend, CMACBackend, CipherBackend, DERSerializationBackend,
+    DSABackend, EllipticCurveBackend, HMACBackend, HashBackend,
+    PBKDF2HMACBackend, PEMSerializationBackend, RSABackend, X509Backend
 )
 from cryptography.hazmat.backends.openssl.ciphers import (
     _AESCTRCipherContext, _CipherContext
@@ -38,7 +38,7 @@ from cryptography.hazmat.backends.openssl.x509 import (
     _Certificate, _CertificateSigningRequest
 )
 from cryptography.hazmat.bindings.openssl.binding import Binding
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes, keywrap, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from cryptography.hazmat.primitives.asymmetric.padding import (
     MGF1, OAEP, PKCS1v15, PSS
@@ -56,6 +56,7 @@ _OpenSSLError = collections.namedtuple("_OpenSSLError",
                                        ["code", "lib", "func", "reason"])
 
 
+@utils.register_interface(AESKeyWrapBackend)
 @utils.register_interface(CipherBackend)
 @utils.register_interface(CMACBackend)
 @utils.register_interface(DERSerializationBackend)
@@ -1026,6 +1027,49 @@ class Backend(object):
             ec_cdata, numbers.x, numbers.y)
 
         return _EllipticCurvePublicKey(self, ec_cdata)
+
+    def aes_key_wrap(self, wrapping_key, key_to_wrap):
+        wraplen = len(wrapping_key)
+        assert wraplen == 16 or wraplen == 24 or wraplen == 32
+        key = self._ffi.new("AES_KEY *")
+        res = self._lib.AES_set_encrypt_key(
+            wrapping_key, len(wrapping_key) * 8, key
+        )
+        assert res == 0
+        buflen = len(key_to_wrap) + 8
+        buf = self._ffi.new("char[]", buflen)
+        # This is the iv defined by RFC 3394. If we don't set it OpenSSL
+        # will default it. But let's not take that on trust.
+        iv = b'\xa6\xa6\xa6\xa6\xa6\xa6\xa6\xa6'
+        res = self._lib.AES_wrap_key(
+            key, iv, buf, key_to_wrap, len(key_to_wrap)
+        )
+        assert res == buflen
+        return self._ffi.buffer(buf)[:]
+
+    def aes_key_unwrap(self, wrapping_key, wrapped_key):
+        wraplen = len(wrapping_key)
+        assert wraplen == 16 or wraplen == 24 or wraplen == 32
+        assert len(wrapped_key) % 8 == 0
+        key = self._ffi.new("AES_KEY *")
+        res = self._lib.AES_set_decrypt_key(
+            wrapping_key, len(wrapping_key) * 8, key
+        )
+        assert res == 0
+        buflen = len(wrapped_key) - 8
+        buf = self._ffi.new("char[]", buflen)
+        # This is the iv defined by RFC 3394. If we don't set it OpenSSL
+        # will default it. But let's not take that on trust.
+        iv = b'\xa6\xa6\xa6\xa6\xa6\xa6\xa6\xa6'
+        res = self._lib.AES_unwrap_key(
+            key, iv, buf, wrapped_key, len(wrapped_key)
+        )
+        if res == 0:
+            raise keywrap.InvalidUnwrap
+        return self._ffi.buffer(buf)[:]
+
+    def aes_key_wrap_supported(self):
+        return self._lib.Cryptography_HAS_AES_WRAP == 1
 
     def _elliptic_curve_to_nid(self, curve):
         """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1069,7 +1069,13 @@ class Backend(object):
         return self._ffi.buffer(buf)[:]
 
     def aes_key_wrap_supported(self):
-        return self._lib.Cryptography_HAS_AES_WRAP == 1
+        # There was a bug in OpenSSL 0.9.8h through 0.9.8o that causes
+        # incorrect wrap/unwrap. We solve this by disabling key wrap for
+        # versions less than 0.9.8p.
+        return (
+            self._lib.Cryptography_HAS_AES_WRAP == 1 and
+            self._lib.SSLeay() > 0x0090810f
+        )
 
     def _elliptic_curve_to_nid(self, curve):
         """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1072,9 +1072,12 @@ class Backend(object):
         # There was a bug in OpenSSL 0.9.8h through 0.9.8o that causes
         # incorrect wrap/unwrap. We solve this by disabling key wrap for
         # versions less than 0.9.8p.
+        # Unfortunately this same bug is present in OpenSSL 1.0.0 and 1.0.0a so
+        # we have to verify it's >= 0.9.8p but < 1.0.0 OR >= 1.0.0b
+        version = self._lib.SSLeay()
         return (
-            self._lib.Cryptography_HAS_AES_WRAP == 1 and
-            self._lib.SSLeay() > 0x0090810f
+            self._lib.Cryptography_HAS_AES_WRAP and
+            (0x1000000f > version > 0x0090810f or version >= 0x1000002f)
         )
 
     def _elliptic_curve_to_nid(self, curve):

--- a/src/cryptography/hazmat/primitives/keywrap.py
+++ b/src/cryptography/hazmat/primitives/keywrap.py
@@ -1,0 +1,37 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+
+def aes_key_wrap(wrapping_key, key_to_wrap, backend):
+    if len(wrapping_key) not in [16, 24, 32]:
+        raise ValueError("The wrapping key must be a valid AES key length")
+
+    if len(key_to_wrap) < 16:
+        raise ValueError("The key to wrap must be at least 16 bytes")
+
+    if len(key_to_wrap) % 8 != 0:
+        raise ValueError("The key to wrap must be a multiple of 8 bytes")
+
+    # TODO: backend test for key wrap support?
+    # TODO: multibackend support
+    return backend.aes_key_wrap(wrapping_key, key_to_wrap)
+
+
+def aes_key_unwrap(wrapping_key, wrapped_key, backend):
+    if len(wrapped_key) < 24:
+        raise ValueError("Must be at least 24 bytes")
+
+    if len(wrapped_key) % 8 != 0:
+        raise ValueError("The wrapped key must be a multiple of 8 bytes")
+
+    if len(wrapping_key) not in [16, 24, 32]:
+        raise ValueError("The wrapping key must be a valid AES key length")
+
+    return backend.aes_key_unwrap(wrapping_key, wrapped_key)
+
+
+class InvalidUnwrap(Exception):
+    pass

--- a/tests/hazmat/primitives/test_keywrap.py
+++ b/tests/hazmat/primitives/test_keywrap.py
@@ -1,0 +1,99 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import binascii
+import os
+
+import pytest
+
+from cryptography.hazmat.backends.interfaces import AESKeyWrapBackend
+from cryptography.hazmat.primitives import keywrap
+
+from .utils import _load_all_params
+from ...utils import load_nist_vectors
+
+
+@pytest.mark.requires_backend_interface(interface=AESKeyWrapBackend)
+class TestAESKeyWrap(object):
+    @pytest.mark.parametrize(
+        "params",
+        _load_all_params(
+            os.path.join("keywrap", "kwtestvectors"),
+            ["KW_AE_128.txt", "KW_AE_192.txt", "KW_AE_256.txt"],
+            load_nist_vectors
+        )
+    )
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.aes_key_wrap_supported(),
+        skip_message="Does not support AES key wrap (RFC 3394)",
+    )
+    def test_wrap(self, backend, params):
+        wrapping_key = binascii.unhexlify(params["k"])
+        key_to_wrap = binascii.unhexlify(params["p"])
+        wrapped_key = keywrap.aes_key_wrap(wrapping_key, key_to_wrap, backend)
+        assert params["c"] == binascii.hexlify(wrapped_key)
+
+    @pytest.mark.parametrize(
+        "params",
+        _load_all_params(
+            os.path.join("keywrap", "kwtestvectors"),
+            ["KW_AD_128.txt", "KW_AD_192.txt", "KW_AD_256.txt"],
+            load_nist_vectors
+        )
+    )
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.aes_key_wrap_supported(),
+        skip_message="Does not support AES key wrap (RFC 3394)",
+    )
+    def test_unwrap(self, backend, params):
+        wrapping_key = binascii.unhexlify(params["k"])
+        wrapped_key = binascii.unhexlify(params["c"])
+        if params.get("fail") is True:
+            with pytest.raises(keywrap.InvalidUnwrap):
+                keywrap.aes_key_unwrap(wrapping_key, wrapped_key, backend)
+        else:
+            unwrapped_key = keywrap.aes_key_unwrap(
+                wrapping_key, wrapped_key, backend
+            )
+            assert params["p"] == binascii.hexlify(unwrapped_key)
+
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.aes_key_wrap_supported(),
+        skip_message="Does not support AES key wrap (RFC 3394)",
+    )
+    def test_wrap_invalid_key_length(self, backend):
+        with pytest.raises(ValueError):
+            keywrap.aes_key_wrap(b"badkey", b"sixteen_byte_key", backend)
+
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.aes_key_wrap_supported(),
+        skip_message="Does not support AES key wrap (RFC 3394)",
+    )
+    def test_unwrap_invalid_key_length(self, backend):
+        with pytest.raises(ValueError):
+            keywrap.aes_key_unwrap(b"badkey", b"\x00" * 24, backend)
+
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.aes_key_wrap_supported(),
+        skip_message="Does not support AES key wrap (RFC 3394)",
+    )
+    def test_wrap_invalid_key_to_wrap_length(self, backend):
+        with pytest.raises(ValueError):
+            keywrap.aes_key_wrap(b"sixteen_byte_key", b"\x00" * 15, backend)
+
+        with pytest.raises(ValueError):
+            keywrap.aes_key_wrap(b"sixteen_byte_key", b"\x00" * 23, backend)
+
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.aes_key_wrap_supported(),
+        skip_message="Does not support AES key wrap (RFC 3394)",
+    )
+    def test_unwrap_invalid_wrapped_key_length(self, backend):
+        with pytest.raises(ValueError):
+            keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 16, backend)
+
+        with pytest.raises(ValueError):
+            keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 27, backend)


### PR DESCRIPTION
This is being put up for general review of approach. multibackend support is missing and it may be worth implementing EVP keywrap support for 1.0.2. Additionally, we should decide if the supported check on the backend makes sense. Unfortunately OpenSSL didn't add key wrap support until 0.9.8h, which CentOS 5 does not have.