### PR TITLE
Minor refactorings

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -669,7 +669,7 @@ class Backend(object):
 
     def dsa_parameters_supported(self, p, q, g):
         if self._lib.OPENSSL_VERSION_NUMBER < 0x1000000f:
-            return (utils.bit_length(p) <= 1024 and utils.bit_length(q) <= 160)
+            return utils.bit_length(p) <= 1024 and utils.bit_length(q) <= 160
         else:
             return True
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -475,20 +475,20 @@ class Backend(object):
         pointer.
         """
 
-        type = evp_pkey.type
+        key_type = evp_pkey.type
 
-        if type == self._lib.EVP_PKEY_RSA:
+        if key_type == self._lib.EVP_PKEY_RSA:
             rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
             assert rsa_cdata != self._ffi.NULL
             rsa_cdata = self._ffi.gc(rsa_cdata, self._lib.RSA_free)
             return _RSAPrivateKey(self, rsa_cdata)
-        elif type == self._lib.EVP_PKEY_DSA:
+        elif key_type == self._lib.EVP_PKEY_DSA:
             dsa_cdata = self._lib.EVP_PKEY_get1_DSA(evp_pkey)
             assert dsa_cdata != self._ffi.NULL
             dsa_cdata = self._ffi.gc(dsa_cdata, self._lib.DSA_free)
             return _DSAPrivateKey(self, dsa_cdata)
         elif (self._lib.Cryptography_HAS_EC == 1 and
-              type == self._lib.EVP_PKEY_EC):
+              key_type == self._lib.EVP_PKEY_EC):
             ec_cdata = self._lib.EVP_PKEY_get1_EC_KEY(evp_pkey)
             assert ec_cdata != self._ffi.NULL
             ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
@@ -502,20 +502,20 @@ class Backend(object):
         pointer.
         """
 
-        type = evp_pkey.type
+        key_type = evp_pkey.type
 
-        if type == self._lib.EVP_PKEY_RSA:
+        if key_type == self._lib.EVP_PKEY_RSA:
             rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
             assert rsa_cdata != self._ffi.NULL
             rsa_cdata = self._ffi.gc(rsa_cdata, self._lib.RSA_free)
             return _RSAPublicKey(self, rsa_cdata)
-        elif type == self._lib.EVP_PKEY_DSA:
+        elif key_type == self._lib.EVP_PKEY_DSA:
             dsa_cdata = self._lib.EVP_PKEY_get1_DSA(evp_pkey)
             assert dsa_cdata != self._ffi.NULL
             dsa_cdata = self._ffi.gc(dsa_cdata, self._lib.DSA_free)
             return _DSAPublicKey(self, dsa_cdata)
         elif (self._lib.Cryptography_HAS_EC == 1 and
-              type == self._lib.EVP_PKEY_EC):
+              key_type == self._lib.EVP_PKEY_EC):
             ec_cdata = self._lib.EVP_PKEY_get1_EC_KEY(evp_pkey)
             assert ec_cdata != self._ffi.NULL
             ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
@@ -1205,13 +1205,13 @@ class Backend(object):
         assert res == 1
         return self._read_mem_bio(bio)
 
-    def _private_key_bytes_traditional_der(self, type, cdata):
-        if type == self._lib.EVP_PKEY_RSA:
+    def _private_key_bytes_traditional_der(self, key_type, cdata):
+        if key_type == self._lib.EVP_PKEY_RSA:
             write_bio = self._lib.i2d_RSAPrivateKey_bio
         elif (self._lib.Cryptography_HAS_EC == 1 and
-              type == self._lib.EVP_PKEY_EC):
+              key_type == self._lib.EVP_PKEY_EC):
             write_bio = self._lib.i2d_ECPrivateKey_bio
-        elif type == self._lib.EVP_PKEY_DSA:
+        elif key_type == self._lib.EVP_PKEY_DSA:
             write_bio = self._lib.i2d_DSAPrivateKey_bio
 
         bio = self._create_mem_bio()

--- a/src/cryptography/hazmat/backends/openssl/utils.py
+++ b/src/cryptography/hazmat/backends/openssl/utils.py
@@ -16,7 +16,7 @@ def _truncate_digest(digest, order_bits):
 
     if 8 * digest_len > order_bits:
         rshift = 8 - (order_bits & 0x7)
-        assert rshift > 0 and rshift < 8
+        assert 0 < rshift < 8
 
         mask = 0xFF >> rshift << rshift
 

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -45,7 +45,7 @@ def _build_x509_name(backend, x509_name):
         assert res >= 0
         assert buf[0] != backend._ffi.NULL
         buf = backend._ffi.gc(
-            buf, lambda buf: backend._lib.OPENSSL_free(buf[0])
+            buf, lambda buffer: backend._lib.OPENSSL_free(buffer[0])
         )
         value = backend._ffi.buffer(buf[0], res)[:].decode('utf8')
         oid = _obj2txt(backend, obj)


### PR DESCRIPTION
Just a few cleanups and renamings.

Summary of changes:
- Remove redundant parentheses in `openssl/backend.py` 	
- Simplify chained comparison in `openssl/utils.py`
- Rename lambda argument in `openssl/x509.py`
- Rename 'type' variable which shadows built-in name 'type' in `openssl/backend.py`