### PR TITLE
support the EKU OIDs specified in RFC 5280 section 4.2.1.12

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -633,6 +633,39 @@ Signature Algorithm OIDs
     Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.2"``. This is
     a SHA256 digest signed by a DSA key.
 
+Extended Key Usage OIDs
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. data:: OID_SERVER_AUTH
+
+    Corresponds to the dotted string ``"1.3.6.1.5.5.7.3.1"``. This is used to
+    denote that a certificate may be used for TLS web server authentication.
+
+.. data:: OID_CLIENT_AUTH
+
+    Corresponds to the dotted string ``"1.3.6.1.5.5.7.3.2"``. This is used to
+    denote that a certificate may be used for TLS web client authentication.
+
+.. data:: OID_CODE_SIGNING
+
+    Corresponds to the dotted string ``"1.3.6.1.5.5.7.3.3"``. This is used to
+    denote that a certificate may be used for code signing.
+
+.. data:: OID_EMAIL_PROTECTION
+
+    Corresponds to the dotted string ``"1.3.6.1.5.5.7.3.4"``. This is used to
+    denote that a certificate may be used for email protection.
+
+.. data:: OID_TIME_STAMPING
+
+    Corresponds to the dotted string ``"1.3.6.1.5.5.7.3.8"``. This is used to
+    denote that a certificate may be used for time stamping.
+
+.. data:: OID_OCSP_SIGNING
+
+    Corresponds to the dotted string ``"1.3.6.1.5.5.7.3.9"``. This is used to
+    denote that a certificate may be used for signing OCSP responses.
+
 .. _extension_oids:
 
 Extension OIDs

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -42,8 +42,15 @@ _OID_NAMES = {
     "1.2.840.10040.4.3": "dsa-with-sha1",
     "2.16.840.1.101.3.4.3.1": "dsa-with-sha224",
     "2.16.840.1.101.3.4.3.2": "dsa-with-sha256",
+    "1.3.6.1.5.5.7.3.1": "serverAuth",
+    "1.3.6.1.5.5.7.3.2": "clientAuth",
+    "1.3.6.1.5.5.7.3.3": "codeSigning",
+    "1.3.6.1.5.5.7.3.4": "emailProtection",
+    "1.3.6.1.5.5.7.3.8": "timeStamping",
+    "1.3.6.1.5.5.7.3.9": "OCSPSigning",
     "2.5.29.19": "basicConstraints",
     "2.5.29.15": "keyUsage",
+    "2.5.29.37": "extendedKeyUsage",
 }
 
 
@@ -170,6 +177,7 @@ class Name(object):
 
 
 OID_KEY_USAGE = ObjectIdentifier("2.5.29.15")
+OID_EXTENDED_KEY_USAGE = ObjectIdentifier("2.5.29.37")
 OID_BASIC_CONSTRAINTS = ObjectIdentifier("2.5.29.19")
 
 
@@ -286,6 +294,13 @@ _SIG_OIDS_TO_HASH = {
     OID_DSA_WITH_SHA224.dotted_string: hashes.SHA224(),
     OID_DSA_WITH_SHA256.dotted_string: hashes.SHA256()
 }
+
+OID_SERVER_AUTH = ObjectIdentifier("1.3.6.1.5.5.7.3.1")
+OID_CLIENT_AUTH = ObjectIdentifier("1.3.6.1.5.5.7.3.2")
+OID_CODE_SIGNING = ObjectIdentifier("1.3.6.1.5.5.7.3.3")
+OID_EMAIL_PROTECTION = ObjectIdentifier("1.3.6.1.5.5.7.3.4")
+OID_TIME_STAMPING = ObjectIdentifier("1.3.6.1.5.5.7.3.8")
+OID_OCSP_SIGNING = ObjectIdentifier("1.3.6.1.5.5.7.3.9")
 
 
 @six.add_metaclass(abc.ABCMeta)


### PR DESCRIPTION
These OIDs will be used in the extended key usage extension implementation. They are the set defined here: http://tools.ietf.org/html/rfc5280#section-4.2.1.12

refs #1743