### PR TITLE
Add wrappers for STACK_OF(X509_CRL) manipulation

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/x509.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509.py
@@ -262,6 +262,12 @@ void sk_X509_EXTENSION_free(X509_EXTENSIONS *);
 int sk_X509_REVOKED_num(Cryptography_STACK_OF_X509_REVOKED *);
 X509_REVOKED *sk_X509_REVOKED_value(Cryptography_STACK_OF_X509_REVOKED *, int);
 
+Cryptography_STACK_OF_X509_CRL *sk_X509_CRL_new_null(void);
+void sk_X509_CRL_free(Cryptography_STACK_OF_X509_CRL *);
+int sk_X509_CRL_num(Cryptography_STACK_OF_X509_CRL *);
+int sk_X509_CRL_push(Cryptography_STACK_OF_X509_CRL *, X509_CRL *);
+X509_CRL *sk_X509_CRL_value(Cryptography_STACK_OF_X509_CRL *, int);
+
 int i2d_RSAPublicKey(RSA *, unsigned char **);
 int i2d_RSAPrivateKey(RSA *, unsigned char **);
 int i2d_DSAPublicKey(DSA *, unsigned char **);


### PR DESCRIPTION
This is useful for PyOpenssl to implement CRL checking
in the new X509StoreContext.verify_certificate() API to add
CRLs to the check via X509_STORE_CTX_set0_crls() which is already wrapped.

Not sure about tests needed, as i didn't see any tests for the other sk_* methods anywhere.

This helps with #1701, so one could write an app similar to `openssl verify` with the `-crlfile` option.