### PR TITLE
add subjectkeyidentifier support

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -275,7 +275,7 @@ X.509 Certificate Object
 
             >>> for ext in cert.extensions:
             ...     print(ext)
-            <Extension(oid=<ObjectIdentifier(oid=2.5.29.14, name=subjectKeyIdentifier)>, critical=False, value=<SubjectKeyIdentifier(value=580184241bbc2b52944a3da510721451f5af3ac9)>)>
+            <Extension(oid=<ObjectIdentifier(oid=2.5.29.14, name=subjectKeyIdentifier)>, critical=False, value=<SubjectKeyIdentifier(digest='X\x01\x84$\x1b\xbc+R\x94J=\xa5\x10r\x14Q\xf5\xaf:\xc9')>)>
             <Extension(oid=<ObjectIdentifier(oid=2.5.29.19, name=basicConstraints)>, critical=True, value=<BasicConstraints(ca=True, path_length=None)>)>
 
 X.509 CSR (Certificate Signing Request) Object
@@ -589,12 +589,6 @@ X.509 Extensions
         :type: bytes
 
         The binary value of the identifier.
-
-    .. attribute:: hexdigest
-
-        :type: :term:`text`
-
-        The hexadecimal value of the identifier.
 
 
 Object Identifiers

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -275,6 +275,7 @@ X.509 Certificate Object
 
             >>> for ext in cert.extensions:
             ...     print(ext)
+            <Extension(oid=<ObjectIdentifier(oid=2.5.29.14, name=subjectKeyIdentifier)>, critical=False, value=<SubjectKeyIdentifier(value=580184241bbc2b52944a3da510721451f5af3ac9)>)>
             <Extension(oid=<ObjectIdentifier(oid=2.5.29.19, name=basicConstraints)>, critical=True, value=<BasicConstraints(ca=True, path_length=None)>)>
 
 X.509 CSR (Certificate Signing Request) Object
@@ -575,6 +576,25 @@ X.509 Extensions
     public key may be used, in addition to or in place of the basic
     purposes indicated in the key usage extension. The object is
     iterable to obtain the list of :ref:`extended key usage OIDs <eku_oids>`.
+
+.. class:: SubjectKeyIdentifier
+
+    .. versionadded:: 0.9
+
+    The subject key identifier extension provides a means of identifying
+    certificates that contain a particular public key.
+
+    .. attribute:: digest
+
+        :type: bytes
+
+        The binary value of the identifier.
+
+    .. attribute:: hexdigest
+
+        :type: :term:`text`
+
+        The hexadecimal value of the identifier.
 
 
 Object Identifiers

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -170,6 +170,8 @@ class _Certificate(object):
                 )
             elif oid == x509.OID_BASIC_CONSTRAINTS:
                 value = self._build_basic_constraints(ext)
+            elif oid == x509.OID_SUBJECT_KEY_IDENTIFIER:
+                value = self._build_subject_key_identifier(ext)
             elif oid == x509.OID_KEY_USAGE and critical:
                 # TODO: remove this obviously.
                 warnings.warn(
@@ -216,6 +218,16 @@ class _Certificate(object):
             path_length = self._backend._bn_to_int(bn)
 
         return x509.BasicConstraints(ca, path_length)
+
+    def _build_subject_key_identifier(self, ext):
+        asn1_string = self._backend._lib.X509V3_EXT_d2i(ext)
+        assert asn1_string != self._backend._ffi.NULL
+        asn1_string = self._backend._ffi.cast(
+            "ASN1_OCTET_STRING *", asn1_string
+        )
+        return x509.SubjectKeyIdentifier(
+            self._backend._ffi.buffer(asn1_string.data, asn1_string.length)[:]
+        )
 
 
 @utils.register_interface(x509.CertificateSigningRequest)

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -225,6 +225,9 @@ class _Certificate(object):
         asn1_string = self._backend._ffi.cast(
             "ASN1_OCTET_STRING *", asn1_string
         )
+        asn1_string = self._backend._ffi.gc(
+            asn1_string, self._backend._lib.ASN1_OCTET_STRING_free
+        )
         return x509.SubjectKeyIdentifier(
             self._backend._ffi.buffer(asn1_string.data, asn1_string.length)[:]
         )

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function
 
 import abc
-import binascii
 from enum import Enum
 
 import six

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -353,12 +353,8 @@ class SubjectKeyIdentifier(object):
 
     digest = utils.read_only_property("_digest")
 
-    @property
-    def hexdigest(self):
-        return binascii.hexlify(self.digest).decode("ascii")
-
     def __repr__(self):
-        return "<SubjectKeyIdentifier(value={0})>".format(self.hexdigest)
+        return "<SubjectKeyIdentifier(digest={0!r})>".format(self.digest)
 
     def __eq__(self, other):
         if not isinstance(other, SubjectKeyIdentifier):

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 import abc
+import binascii
 from enum import Enum
 
 import six
@@ -344,6 +345,31 @@ class KeyUsage(object):
             )
         else:
             return self._decipher_only
+
+
+class SubjectKeyIdentifier(object):
+    def __init__(self, digest):
+        self._digest = digest
+
+    digest = utils.read_only_property("_digest")
+
+    @property
+    def hexdigest(self):
+        return binascii.hexlify(self.digest).decode("ascii")
+
+    def __repr__(self):
+        return "<SubjectKeyIdentifier(value={0})>".format(self.hexdigest)
+
+    def __eq__(self, other):
+        if not isinstance(other, SubjectKeyIdentifier):
+            return NotImplemented
+
+        return (
+            self.digest == other.digest
+        )
+
+    def __ne__(self, other):
+        return not self == other
 
 
 OID_COMMON_NAME = ObjectIdentifier("2.5.4.3")

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -136,14 +136,14 @@ class TestKeyUsage(object):
 class TestSubjectKeyIdentifier(object):
     def test_properties(self):
         hexdigest = "092384932230498bc980aa8098456f6ff7ff3ac9"
-        value = binascii.unhexlify(hexdigest)
+        value = binascii.unhexlify(hexdigest.encode('ascii'))
         ski = x509.SubjectKeyIdentifier(value)
         assert ski.digest == value
         assert ski.hexdigest == hexdigest
 
     def test_repr(self):
         ski = x509.SubjectKeyIdentifier(
-            binascii.unhexlify("092384932230498bc980aa8098456f6ff7ff3ac9")
+            binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         )
         ext = x509.Extension(x509.OID_SUBJECT_KEY_IDENTIFIER, False, ski)
         assert repr(ext) == (
@@ -154,19 +154,19 @@ class TestSubjectKeyIdentifier(object):
 
     def test_eq(self):
         ski = x509.SubjectKeyIdentifier(
-            binascii.unhexlify("092384932230498bc980aa8098456f6ff7ff3ac9")
+            binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         )
         ski2 = x509.SubjectKeyIdentifier(
-            binascii.unhexlify("092384932230498bc980aa8098456f6ff7ff3ac9")
+            binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         )
         assert ski == ski2
 
     def test_ne(self):
         ski = x509.SubjectKeyIdentifier(
-            binascii.unhexlify("092384932230498bc980aa8098456f6ff7ff3ac9")
+            binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         )
         ski2 = x509.SubjectKeyIdentifier(
-            binascii.unhexlify("aa8098456f6ff7ff3ac9092384932230498bc980")
+            binascii.unhexlify(b"aa8098456f6ff7ff3ac9092384932230498bc980")
         )
         assert ski != ski2
         assert ski != object()
@@ -404,7 +404,7 @@ class TestSubjectKeyIdentifierExtension(object):
         assert ext.critical is False
         assert ski.hexdigest == "580184241bbc2b52944a3da510721451f5af3ac9"
         assert ski.digest == binascii.unhexlify(
-            "580184241bbc2b52944a3da510721451f5af3ac9"
+            b"580184241bbc2b52944a3da510721451f5af3ac9"
         )
 
     def test_no_subject_key_identifier(self, backend):

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import binascii
 import os
 
 import pytest
@@ -130,6 +131,45 @@ class TestKeyUsage(object):
 
         with pytest.raises(ValueError):
             ku.decipher_only
+
+
+class TestSubjectKeyIdentifier(object):
+    def test_properties(self):
+        hexdigest = "092384932230498bc980aa8098456f6ff7ff3ac9"
+        value = binascii.unhexlify(hexdigest)
+        ski = x509.SubjectKeyIdentifier(value)
+        assert ski.digest == value
+        assert ski.hexdigest == hexdigest
+
+    def test_repr(self):
+        ski = x509.SubjectKeyIdentifier(
+            binascii.unhexlify("092384932230498bc980aa8098456f6ff7ff3ac9")
+        )
+        ext = x509.Extension(x509.OID_SUBJECT_KEY_IDENTIFIER, False, ski)
+        assert repr(ext) == (
+            "<Extension(oid=<ObjectIdentifier(oid=2.5.29.14, name=subjectKey"
+            "Identifier)>, critical=False, value=<SubjectKeyIdentifier("
+            "value=092384932230498bc980aa8098456f6ff7ff3ac9)>)>"
+        )
+
+    def test_eq(self):
+        ski = x509.SubjectKeyIdentifier(
+            binascii.unhexlify("092384932230498bc980aa8098456f6ff7ff3ac9")
+        )
+        ski2 = x509.SubjectKeyIdentifier(
+            binascii.unhexlify("092384932230498bc980aa8098456f6ff7ff3ac9")
+        )
+        assert ski == ski2
+
+    def test_ne(self):
+        ski = x509.SubjectKeyIdentifier(
+            binascii.unhexlify("092384932230498bc980aa8098456f6ff7ff3ac9")
+        )
+        ski2 = x509.SubjectKeyIdentifier(
+            binascii.unhexlify("aa8098456f6ff7ff3ac9092384932230498bc980")
+        )
+        assert ski != ski2
+        assert ski != object()
 
 
 class TestBasicConstraints(object):
@@ -345,3 +385,35 @@ class TestBasicConstraintsExtension(object):
         assert ext is not None
         assert ext.critical is False
         assert ext.value.ca is False
+
+
+@pytest.mark.requires_backend_interface(interface=RSABackend)
+@pytest.mark.requires_backend_interface(interface=X509Backend)
+class TestSubjectKeyIdentifierExtension(object):
+    def test_subject_key_identifier(self, backend):
+        cert = _load_cert(
+            os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
+            x509.load_der_x509_certificate,
+            backend
+        )
+        ext = cert.extensions.get_extension_for_oid(
+            x509.OID_SUBJECT_KEY_IDENTIFIER
+        )
+        ski = ext.value
+        assert ext is not None
+        assert ext.critical is False
+        assert ski.hexdigest == "580184241bbc2b52944a3da510721451f5af3ac9"
+        assert ski.digest == binascii.unhexlify(
+            "580184241bbc2b52944a3da510721451f5af3ac9"
+        )
+
+    def test_no_subject_key_identifier(self, backend):
+        cert = _load_cert(
+            os.path.join("x509", "custom", "bc_path_length_zero.pem"),
+            x509.load_pem_x509_certificate,
+            backend
+        )
+        with pytest.raises(x509.ExtensionNotFound):
+            cert.extensions.get_extension_for_oid(
+                x509.OID_SUBJECT_KEY_IDENTIFIER
+            )

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -9,6 +9,8 @@ import os
 
 import pytest
 
+import six
+
 from cryptography import x509
 from cryptography.hazmat.backends.interfaces import RSABackend, X509Backend
 
@@ -135,22 +137,29 @@ class TestKeyUsage(object):
 
 class TestSubjectKeyIdentifier(object):
     def test_properties(self):
-        hexdigest = "092384932230498bc980aa8098456f6ff7ff3ac9"
-        value = binascii.unhexlify(hexdigest.encode('ascii'))
+        value = binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         ski = x509.SubjectKeyIdentifier(value)
         assert ski.digest == value
-        assert ski.hexdigest == hexdigest
 
     def test_repr(self):
         ski = x509.SubjectKeyIdentifier(
             binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         )
         ext = x509.Extension(x509.OID_SUBJECT_KEY_IDENTIFIER, False, ski)
-        assert repr(ext) == (
-            "<Extension(oid=<ObjectIdentifier(oid=2.5.29.14, name=subjectKey"
-            "Identifier)>, critical=False, value=<SubjectKeyIdentifier("
-            "value=092384932230498bc980aa8098456f6ff7ff3ac9)>)>"
-        )
+        if six.PY3:
+            assert repr(ext) == (
+                "<Extension(oid=<ObjectIdentifier(oid=2.5.29.14, name=subjectK"
+                "eyIdentifier)>, critical=False, value=<SubjectKeyIdentifier(d"
+                "igest=b\'\\t#\\x84\\x93\"0I\\x8b\\xc9\\x80\\xaa\\x80\\x98Eoo"
+                "\\xf7\\xff:\\xc9\')>)>"
+            )
+        else:
+            assert repr(ext) == (
+                "<Extension(oid=<ObjectIdentifier(oid=2.5.29.14, name=subjectK"
+                "eyIdentifier)>, critical=False, value=<SubjectKeyIdentifier(d"
+                "igest=\'\\t#\\x84\\x93\"0I\\x8b\\xc9\\x80\\xaa\\x80\\x98Eoo"
+                "\\xf7\\xff:\\xc9\')>)>"
+            )
 
     def test_eq(self):
         ski = x509.SubjectKeyIdentifier(
@@ -402,7 +411,6 @@ class TestSubjectKeyIdentifierExtension(object):
         ski = ext.value
         assert ext is not None
         assert ext.critical is False
-        assert ski.hexdigest == "580184241bbc2b52944a3da510721451f5af3ac9"
         assert ski.digest == binascii.unhexlify(
             b"580184241bbc2b52944a3da510721451f5af3ac9"
         )


### PR DESCRIPTION
When we originally discussed this the plan was to try using just a bytestring to represent the SKI extension. Unfortunately, we failed to consider that the Extension class repr will fail when a value that contains non-ascii characters is present. We could fix this by checking the Extension value to see if it's a bytestring and then hexadecimal encoding it or we could create a small extension class. I chose the latter approach as it gives us better consistency with our other extensions (as well as making documentation simpler since it's just another class to document).

refs #1743 