### PR TITLE
PKCS7 signature, encryption and serialization bindings.

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/pem.py
+++ b/src/cryptography/hazmat/bindings/openssl/pem.py
@@ -32,7 +32,9 @@ int i2d_PKCS8PrivateKey_bio(BIO *, EVP_PKEY *, const EVP_CIPHER *,
 int i2d_PKCS8PrivateKey_nid_bio(BIO *, EVP_PKEY *, int,
                                 char *, int, pem_password_cb *, void *);
 
+int i2d_PKCS7_bio(BIO *, PKCS7 *);
 PKCS7 *d2i_PKCS7_bio(BIO *, PKCS7 **);
+
 EVP_PKEY *d2i_PKCS8PrivateKey_bio(BIO *, EVP_PKEY **, pem_password_cb *,
                                   void *);
 
@@ -45,6 +47,8 @@ X509_CRL *PEM_read_bio_X509_CRL(BIO *, X509_CRL **, pem_password_cb *, void *);
 int PEM_write_bio_X509_CRL(BIO *, X509_CRL *);
 
 PKCS7 *PEM_read_bio_PKCS7(BIO *, PKCS7 **, pem_password_cb *, void *);
+int PEM_write_bio_PKCS7(BIO *, PKCS7 *);
+
 DH *PEM_read_bio_DHparams(BIO *, DH **, pem_password_cb *, void *);
 
 DSA *PEM_read_bio_DSAPrivateKey(BIO *, DSA **, pem_password_cb *, void *);

--- a/src/cryptography/hazmat/bindings/openssl/pkcs7.py
+++ b/src/cryptography/hazmat/bindings/openssl/pkcs7.py
@@ -13,10 +13,39 @@ typedef struct {
     ASN1_OBJECT *type;
     ...;
 } PKCS7;
+
+static const int PKCS7_BINARY;
+static const int PKCS7_DETACHED;
+static const int PKCS7_NOATTR;
+static const int PKCS7_NOCERTS;
+static const int PKCS7_NOCHAIN;
+static const int PKCS7_NOINTERN;
+static const int PKCS7_NOSIGS;
+static const int PKCS7_NOVERIFY;
+static const int PKCS7_STREAM;
+static const int PKCS7_TEXT;
+
+static const int Cryptography_HAS_PKCS7_NOSMIMECAP;
+static const int PKCS7_NOSMIMECAP;
 """
 
 FUNCTIONS = """
+PKCS7 *SMIME_read_PKCS7(BIO *, BIO **);
+int SMIME_write_PKCS7(BIO *, PKCS7 *, BIO *, int);
+
 void PKCS7_free(PKCS7 *);
+
+PKCS7 *PKCS7_sign(X509 *, EVP_PKEY *, Cryptography_STACK_OF_X509 *,
+                  BIO *, int);
+int PKCS7_verify(PKCS7 *, Cryptography_STACK_OF_X509 *, X509_STORE *, BIO *,
+                 BIO *, int);
+Cryptography_STACK_OF_X509 *PKCS7_get0_signers(PKCS7 *,
+                                               Cryptography_STACK_OF_X509 *,
+                                               int);
+
+PKCS7 *PKCS7_encrypt(Cryptography_STACK_OF_X509 *certs, BIO *,
+                     const EVP_CIPHER *, int);
+int PKCS7_decrypt(PKCS7 *, EVP_PKEY *, X509 *, BIO *, int);
 """
 
 MACROS = """
@@ -27,6 +56,16 @@ int PKCS7_type_is_data(PKCS7 *);
 """
 
 CUSTOMIZATIONS = """
+#ifdef PKCS7_NOSMIMECAP
+static const int Cryptography_HAS_PKCS7_NOSMIMECAP = 1;
+#else
+static const int Cryptography_HAS_PKCS7_NOSMIMECAP = 0;
+static const int PKCS7_NOSMIMECAP = 0;
+#endif
 """
 
-CONDITIONAL_NAMES = {}
+CONDITIONAL_NAMES = {
+    'Cryptography_HAS_PKCS7_NOSMIMECAP': [
+        'PKCS7_NOSMIMECAP',
+    ]
+}

--- a/src/cryptography/hazmat/bindings/openssl/pkcs7.py
+++ b/src/cryptography/hazmat/bindings/openssl/pkcs7.py
@@ -43,7 +43,7 @@ Cryptography_STACK_OF_X509 *PKCS7_get0_signers(PKCS7 *,
                                                Cryptography_STACK_OF_X509 *,
                                                int);
 
-PKCS7 *PKCS7_encrypt(Cryptography_STACK_OF_X509 *certs, BIO *,
+PKCS7 *PKCS7_encrypt(Cryptography_STACK_OF_X509 *, BIO *,
                      const EVP_CIPHER *, int);
 int PKCS7_decrypt(PKCS7 *, EVP_PKEY *, X509 *, BIO *, int);
 """

--- a/src/cryptography/hazmat/bindings/openssl/pkcs7.py
+++ b/src/cryptography/hazmat/bindings/openssl/pkcs7.py
@@ -21,12 +21,10 @@ static const int PKCS7_NOCERTS;
 static const int PKCS7_NOCHAIN;
 static const int PKCS7_NOINTERN;
 static const int PKCS7_NOSIGS;
+static const int PKCS7_NOSMIMECAP;
 static const int PKCS7_NOVERIFY;
 static const int PKCS7_STREAM;
 static const int PKCS7_TEXT;
-
-static const int Cryptography_HAS_PKCS7_NOSMIMECAP;
-static const int PKCS7_NOSMIMECAP;
 """
 
 FUNCTIONS = """
@@ -55,17 +53,6 @@ int PKCS7_type_is_signedAndEnveloped(PKCS7 *);
 int PKCS7_type_is_data(PKCS7 *);
 """
 
-CUSTOMIZATIONS = """
-#ifdef PKCS7_NOSMIMECAP
-static const int Cryptography_HAS_PKCS7_NOSMIMECAP = 1;
-#else
-static const int Cryptography_HAS_PKCS7_NOSMIMECAP = 0;
-static const int PKCS7_NOSMIMECAP = 0;
-#endif
-"""
+CUSTOMIZATIONS = ""
 
-CONDITIONAL_NAMES = {
-    'Cryptography_HAS_PKCS7_NOSMIMECAP': [
-        'PKCS7_NOSMIMECAP',
-    ]
-}
+CONDITIONAL_NAMES = {}


### PR DESCRIPTION
The first of hopefully several pull requests in reference to #1828 (Adding and enhancing PKCS7 support). This one just adds all the PKCS7 bindings from OpenSSL that were sufficiently documented and seemed to be somewhat commonly used. These cover our use cases at eBay/PayPal, and we believe they'll be sufficient for the SMIME support mentioned in #1621.

We did not include bindings for OpenSSL's multiple signature support, such as `PKCS7_add_signer()` and `PKCS7_final()`. The documentation is virtually non existent; in many cases there isn't even anywhere appropriate to link to outside of the OpenSSL code itself. None of the API-level additions we have planned for future PyOpenSSL/cryptography pull requests depend on them, either.

These test fine on our systems, though I'm not sure our tests go as far back as the version of 0.9.8 used by Travis. There is one conditional include, for PKCS7_NOSMIMECAP, even though it's present in all our builds.

Let us (@mahmoud/@mwilliams3) know if there are any questions!