### PR TITLE
Remove unneeded EC digest length check

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -973,13 +973,6 @@ class Backend(object):
         if not isinstance(signature_algorithm, ec.ECDSA):
             return False
 
-        # Before 0.9.8m OpenSSL can't cope with digests longer than the curve.
-        if (
-            self._lib.OPENSSL_VERSION_NUMBER < 0x009080df and
-            curve.key_size < signature_algorithm.algorithm.digest_size * 8
-        ):
-            return False
-
         return self.elliptic_curve_supported(curve)
 
     def generate_elliptic_curve_private_key(self, curve):

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -21,6 +21,9 @@ def _truncate_digest_for_ecdsa(ec_key_cdata, digest, backend):
     curve key's length so they can be signed. Since elliptic curve keys are
     much shorter than RSA keys many digests (e.g. SHA-512) may require
     truncation.
+
+    OpenSSL > 0.9.8m does this automatically and some day we can probably
+    remove this function.
     """
 
     _lib = backend._lib


### PR DESCRIPTION
We wrote truncation support for OpenSSL versions that don't support it automatically. So...I think this is safe. Jenkins/Travis will tell me if I'm right!