### PR TITLE
Twofactor invalid token

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -37,9 +37,3 @@ Exceptions
 
     This is raised when the verify method of a key derivation function's
     computed key does not match the expected key.
-
-
-.. class:: InvalidToken
-
-    This is raised when the verify method of a one time password function's
-    computed token does not match the expected token.

--- a/docs/hazmat/primitives/twofactor.rst
+++ b/docs/hazmat/primitives/twofactor.rst
@@ -11,6 +11,11 @@ Currently, it contains an algorithm for generating and verifying
 one time password values based on Hash-based message authentication
 codes (HMAC).
 
+.. class:: InvalidToken
+
+    This is raised when the verify method of a one time password function's
+    computed token does not match the expected token.
+
 .. currentmodule:: cryptography.hazmat.primitives.twofactor.hotp
 
 .. class:: HOTP(key, length, algorithm, backend)
@@ -66,8 +71,8 @@ codes (HMAC).
 
         :param bytes hotp: The one time password value to validate.
         :param int counter: The counter value to validate against.
-        :raises cryptography.exceptions.InvalidToken: This is raised when the
-            supplied HOTP does not match the expected HOTP.
+        :raises cryptography.hazmat.primitives.twofactor.InvalidToken: This
+             is raised when the supplied HOTP does not match the expected HOTP.
 
 Throttling
 ~~~~~~~~~~
@@ -164,5 +169,5 @@ similar to the following code.
 
         :param bytes totp: The one time password value to validate.
         :param int time: The time value to validate against.
-        :raises cryptography.exceptions.InvalidToken: This is raised when the
-            supplied TOTP does not match the expected TOTP.
+        :raises cryptography.hazmat.primitives.twofactor.InvalidToken: This
+             is raised when the supplied TOTP does not match the expected TOTP.

--- a/src/cryptography/exceptions.py
+++ b/src/cryptography/exceptions.py
@@ -6,6 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 from enum import Enum
 
+from cryptography import utils
+from cryptography.hazmat.primitives import twofactor
+
 
 class _Reasons(Enum):
     BACKEND_MISSING_INTERFACE = 0
@@ -53,5 +56,12 @@ class InvalidKey(Exception):
     pass
 
 
-class InvalidToken(Exception):
-    pass
+InvalidToken = utils.deprecated(
+    twofactor.InvalidToken,
+    __name__,
+    (
+        "The InvalidToken exception has moved to the "
+        "cryptography.hazmat.primitives.twofactor module"
+    ),
+    utils.DeprecatedIn08
+)

--- a/src/cryptography/exceptions.py
+++ b/src/cryptography/exceptions.py
@@ -63,5 +63,5 @@ InvalidToken = utils.deprecated(
         "The InvalidToken exception has moved to the "
         "cryptography.hazmat.primitives.twofactor module"
     ),
-    utils.DeprecatedIn08
+    utils.DeprecatedIn09
 )

--- a/src/cryptography/hazmat/primitives/twofactor/__init__.py
+++ b/src/cryptography/hazmat/primitives/twofactor/__init__.py
@@ -3,3 +3,7 @@
 # for complete details.
 
 from __future__ import absolute_import, division, print_function
+
+
+class InvalidToken(Exception):
+    pass

--- a/src/cryptography/hazmat/primitives/twofactor/hotp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/hotp.py
@@ -9,11 +9,12 @@ import struct
 import six
 
 from cryptography.exceptions import (
-    InvalidToken, UnsupportedAlgorithm, _Reasons
+    UnsupportedAlgorithm, _Reasons
 )
 from cryptography.hazmat.backends.interfaces import HMACBackend
 from cryptography.hazmat.primitives import constant_time, hmac
 from cryptography.hazmat.primitives.hashes import SHA1, SHA256, SHA512
+from cryptography.hazmat.primitives.twofactor import InvalidToken
 
 
 class HOTP(object):

--- a/src/cryptography/hazmat/primitives/twofactor/totp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/totp.py
@@ -5,10 +5,11 @@
 from __future__ import absolute_import, division, print_function
 
 from cryptography.exceptions import (
-    InvalidToken, UnsupportedAlgorithm, _Reasons
+    UnsupportedAlgorithm, _Reasons
 )
 from cryptography.hazmat.backends.interfaces import HMACBackend
 from cryptography.hazmat.primitives import constant_time
+from cryptography.hazmat.primitives.twofactor import InvalidToken
 from cryptography.hazmat.primitives.twofactor.hotp import HOTP
 
 

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -11,6 +11,7 @@ import warnings
 
 
 DeprecatedIn08 = DeprecationWarning
+DeprecatedIn09 = DeprecationWarning
 
 
 def read_only_property(name):

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -8,10 +8,11 @@ import os
 
 import pytest
 
-from cryptography.exceptions import InvalidToken, _Reasons
+from cryptography.exceptions import _Reasons
 from cryptography.hazmat.backends.interfaces import HMACBackend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.hashes import MD5, SHA1
+from cryptography.hazmat.primitives.twofactor import InvalidToken
 from cryptography.hazmat.primitives.twofactor.hotp import HOTP
 
 from ....utils import (

--- a/tests/hazmat/primitives/twofactor/test_totp.py
+++ b/tests/hazmat/primitives/twofactor/test_totp.py
@@ -6,9 +6,10 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from cryptography.exceptions import InvalidToken, _Reasons
+from cryptography.exceptions import _Reasons
 from cryptography.hazmat.backends.interfaces import HMACBackend
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.twofactor import InvalidToken
 from cryptography.hazmat.primitives.twofactor.totp import TOTP
 
 from ....utils import (


### PR DESCRIPTION
Fixes #1818

This moves `cryptography.exceptions.InvalidToken` to `cryptography.hazmat.primitives.twofactor.InvalidToken`, since that exception is intended for (and only used by) the twofactor module. The previous location now uses `utils.deprecated` for backwards compatibility.

@reaperhulk wrote:

> `The cryptography.exceptions.InvalidToken` is meant for HOTP/TOTP, but since it's the same class name as `cryptography.fernet.InvalidToken` this is super confusing [...] maybe we need to move this (and consider renaming it?) and deprecate the old location.

I think keeping the name the same is ok since we're now namespacing it properly, though it does remain slightly confusing.