### PR TITLE
[WIP] Add GcmSizeValidator and a few tests.

### DIFF
--- a/src/cryptography/hazmat/backends/commoncrypto/ciphers.py
+++ b/src/cryptography/hazmat/backends/commoncrypto/ciphers.py
@@ -8,7 +8,7 @@ from cryptography import utils
 from cryptography.exceptions import (
     InvalidTag, UnsupportedAlgorithm, _Reasons
 )
-from cryptography.hazmat.backends.utils import GcmSizeValidator
+from cryptography.hazmat.backends.utils import _GCMSizeValidator
 from cryptography.hazmat.primitives import ciphers, constant_time
 from cryptography.hazmat.primitives.ciphers import modes
 from cryptography.hazmat.primitives.ciphers.modes import (
@@ -112,7 +112,7 @@ class _GCMCipherContext(object):
         self._mode = mode
         self._operation = operation
         self._tag = None
-        self._gcm_size_validator = GcmSizeValidator()
+        self._gcm_size_validator = _GCMSizeValidator()
 
         registry = self._backend._cipher_registry
         try:

--- a/src/cryptography/hazmat/backends/commoncrypto/ciphers.py
+++ b/src/cryptography/hazmat/backends/commoncrypto/ciphers.py
@@ -8,6 +8,7 @@ from cryptography import utils
 from cryptography.exceptions import (
     InvalidTag, UnsupportedAlgorithm, _Reasons
 )
+from cryptography.hazmat.backends.utils import GcmSizeValidator
 from cryptography.hazmat.primitives import ciphers, constant_time
 from cryptography.hazmat.primitives.ciphers import modes
 from cryptography.hazmat.primitives.ciphers.modes import (
@@ -111,6 +112,7 @@ class _GCMCipherContext(object):
         self._mode = mode
         self._operation = operation
         self._tag = None
+        self._gcm_size_validator = GcmSizeValidator()
 
         registry = self._backend._cipher_registry
         try:
@@ -151,6 +153,7 @@ class _GCMCipherContext(object):
         self.authenticate_additional_data(b"")
 
     def update(self, data):
+        self._gcm_size_validator.update_and_validate_plaintext(data)
         buf = self._backend._ffi.new("unsigned char[]", len(data))
         args = (self._ctx[0], data, len(data), buf)
         if self._operation == self._backend._lib.kCCEncrypt:
@@ -185,6 +188,7 @@ class _GCMCipherContext(object):
         return b""
 
     def authenticate_additional_data(self, data):
+        self._gcm_size_validator.validate_aad(data)
         res = self._backend._lib.CCCryptorGCMAddAAD(
             self._ctx[0], data, len(data)
         )

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from cryptography import utils
 from cryptography.exceptions import InvalidTag, UnsupportedAlgorithm, _Reasons
-from cryptography.hazmat.backends.utils import GcmSizeValidator
+from cryptography.hazmat.backends.utils import _GCMSizeValidator
 from cryptography.hazmat.primitives import ciphers
 from cryptography.hazmat.primitives.ciphers import modes
 
@@ -24,7 +24,7 @@ class _CipherContext(object):
         self._mode = mode
         self._operation = operation
         self._tag = None
-        self._gcm_size_validator = GcmSizeValidator()
+        self._gcm_size_validator = _GCMSizeValidator()
 
         if isinstance(self._cipher, ciphers.BlockCipherAlgorithm):
             self._block_size = self._cipher.block_size

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from cryptography import utils
 from cryptography.exceptions import InvalidTag, UnsupportedAlgorithm, _Reasons
+from cryptography.hazmat.backends.utils import GcmSizeValidator
 from cryptography.hazmat.primitives import ciphers
 from cryptography.hazmat.primitives.ciphers import modes
 
@@ -23,6 +24,7 @@ class _CipherContext(object):
         self._mode = mode
         self._operation = operation
         self._tag = None
+        self._gcm_size_validator = GcmSizeValidator()
 
         if isinstance(self._cipher, ciphers.BlockCipherAlgorithm):
             self._block_size = self._cipher.block_size
@@ -110,6 +112,12 @@ class _CipherContext(object):
         if len(data) == 0 and not isinstance(self._mode, modes.GCM):
             return b""
 
+        # OpenSSL does not properly handle the case when encrypting plaintext
+        # in GCM mode when the byte limit of 2**39 - 256 bits is reached.
+        # See #1821
+        if isinstance(self._mode, modes.GCM):
+            self._gcm_size_validator.update_and_validate_plaintext(data)
+
         buf = self._backend._ffi.new("unsigned char[]",
                                      len(data) + self._block_size - 1)
         outlen = self._backend._ffi.new("int *")
@@ -172,6 +180,9 @@ class _CipherContext(object):
         return self._backend._ffi.buffer(buf)[:outlen[0]]
 
     def authenticate_additional_data(self, data):
+        if isinstance(self._mode, modes.GCM):
+            self._gcm_size_validator.validate_aad(data)
+
         outlen = self._backend._ffi.new("int *")
         res = self._backend._lib.EVP_CipherUpdate(
             self._ctx, self._backend._ffi.NULL, outlen, data, len(data)

--- a/src/cryptography/hazmat/backends/utils.py
+++ b/src/cryptography/hazmat/backends/utils.py
@@ -10,8 +10,8 @@ class _GCMSizeValidator(object):
     GCM may only encrypt up to 2**39 - 256 bits of plaintext, so we
     must track the number of bytes we see.
     """
-    _PLAINTEXT_BYTE_LIMIT = (2 ** 39 - 256) / 8
-    _AAD_BYTE_LIMIT = (2 ** 64) / 8
+    _PLAINTEXT_BYTE_LIMIT = int((2 ** 39 - 256) / 8)
+    _AAD_BYTE_LIMIT = int((2 ** 64) / 8)
 
     def __init__(self):
         self._plaintext_len = 0

--- a/src/cryptography/hazmat/backends/utils.py
+++ b/src/cryptography/hazmat/backends/utils.py
@@ -10,14 +10,14 @@ class _GCMSizeValidator(object):
     GCM may only encrypt up to 2**39 - 256 bits of plaintext, so we
     must track the number of bytes we see.
     """
-    _PLAINTEXT_BIT_LIMIT = 2 ** 39 - 256
-    _AAD_BIT_LIMIT = 2 ** 64 - 1
+    _PLAINTEXT_BYTE_LIMIT = (2 ** 39 - 256) / 8
+    _AAD_BYTE_LIMIT = (2 ** 64) / 8
 
     def __init__(self):
         self._plaintext_len = 0
 
     def update_and_validate_plaintext(self, data):
-        self._plaintext_len += len(data) * 8
+        self._plaintext_len += len(data)
         self.validate_plaintext_len()
 
     def validate_plaintext_len(self):
@@ -27,12 +27,12 @@ class _GCMSizeValidator(object):
         # Also size 0 plaintext shouldn't produce any output so I don't
         # think we need to worry about it.
         if (self._plaintext_len < 0 or
-                self._plaintext_len > self._PLAINTEXT_BIT_LIMIT):
-            raise ValueError("Exceeded GCM mode plaintext bit limit.")
+                self._plaintext_len > self._PLAINTEXT_BYTE_LIMIT):
+            raise ValueError("Exceeded GCM mode plaintext byte limit.")
 
     def validate_aad(self, data):
-        return self.validate_aad_len(len(data) * 8)
+        return self.validate_aad_len(len(data))
 
     def validate_aad_len(self, datalen):
-        if datalen < 0 or datalen > self._AAD_BIT_LIMIT:
-            raise ValueError("Exceeded GCM mode AAD bit limit.")
+        if datalen < 0 or datalen > self._AAD_BYTE_LIMIT:
+            raise ValueError("Exceeded GCM mode AAD byte limit.")

--- a/src/cryptography/hazmat/backends/utils.py
+++ b/src/cryptography/hazmat/backends/utils.py
@@ -1,0 +1,38 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+
+class GcmSizeValidator(object):
+    """
+    GCM may only encrypt up to 2**39 - 256 bits of plaintext, so we
+    must track the number of bytes we see.
+    """
+    _PLAINTEXT_BIT_LIMIT = 2 ** 39 - 256
+    _AAD_BIT_LIMIT = 2 ** 64 - 1
+
+    def __init__(self):
+        self._plaintext_len = 0
+
+    def update_and_validate_plaintext(self, data):
+        self._plaintext_len += len(data) * 8
+        self.validate_plaintext_len()
+
+    def validate_plaintext_len(self):
+        # Technically a size of 0 is invalid, but there are a couple hacks
+        # around some things that call update(b"") on a newly initialized
+        # CipherContext, and we can't interfere with that.
+        # Also size 0 plaintext shouldn't produce any output so I don't
+        # think we need to worry about it.
+        if (self._plaintext_len < 0 or
+                self._plaintext_len > self._PLAINTEXT_BIT_LIMIT):
+            raise ValueError("Exceeded GCM mode plaintext bit limit.")
+
+    def validate_aad(self, data):
+        return self.validate_aad_len(len(data) * 8)
+
+    def validate_aad_len(self, datalen):
+        if datalen < 0 or datalen > self._AAD_BIT_LIMIT:
+            raise ValueError("Exceeded GCM mode AAD bit limit.")

--- a/src/cryptography/hazmat/backends/utils.py
+++ b/src/cryptography/hazmat/backends/utils.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 
-class GcmSizeValidator(object):
+class _GCMSizeValidator(object):
     """
     GCM may only encrypt up to 2**39 - 256 bits of plaintext, so we
     must track the number of bytes we see.

--- a/tests/hazmat/backends/test_utils.py
+++ b/tests/hazmat/backends/test_utils.py
@@ -1,0 +1,45 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from cryptography.hazmat.backends.utils import GcmSizeValidator
+
+
+class TestGcmSizeValidator(object):
+    def test_validate_plaintext_len_valid(self):
+        gcm_size_validator = GcmSizeValidator()
+        assert gcm_size_validator.validate_plaintext_len() is None
+        gcm_size_validator._plaintext_len = 1024
+        assert gcm_size_validator.validate_plaintext_len() is None
+        gcm_size_validator._plaintext_len = (
+            GcmSizeValidator._PLAINTEXT_BIT_LIMIT)
+        assert gcm_size_validator.validate_plaintext_len() is None
+
+    def test_validate_plaintext_len_invalid(self):
+        gcm_size_validator = GcmSizeValidator()
+        gcm_size_validator._plaintext_len = (
+            GcmSizeValidator._PLAINTEXT_BIT_LIMIT + 1)
+        with pytest.raises(ValueError):
+            gcm_size_validator.validate_plaintext_len()
+        gcm_size_validator._plaintext_len = -1
+        with pytest.raises(ValueError):
+            gcm_size_validator.validate_plaintext_len()
+
+    def test_validate_aad_len_valid(self):
+        gcm_size_validator = GcmSizeValidator()
+        assert gcm_size_validator.validate_aad_len(0) is None
+        assert gcm_size_validator.validate_aad_len(1024) is None
+        assert gcm_size_validator.validate_aad_len(
+            GcmSizeValidator._AAD_BIT_LIMIT) is None
+
+    def test_validate_aad_len_invalid(self):
+        gcm_size_validator = GcmSizeValidator()
+        with pytest.raises(ValueError):
+            gcm_size_validator.validate_aad_len(
+                GcmSizeValidator._AAD_BIT_LIMIT + 1)
+        with pytest.raises(ValueError):
+            gcm_size_validator.validate_aad_len(-1)

--- a/tests/hazmat/backends/test_utils.py
+++ b/tests/hazmat/backends/test_utils.py
@@ -6,23 +6,23 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from cryptography.hazmat.backends.utils import GcmSizeValidator
+from cryptography.hazmat.backends.utils import _GCMSizeValidator
 
 
 class TestGcmSizeValidator(object):
     def test_validate_plaintext_len_valid(self):
-        gcm_size_validator = GcmSizeValidator()
+        gcm_size_validator = _GCMSizeValidator()
         assert gcm_size_validator.validate_plaintext_len() is None
         gcm_size_validator._plaintext_len = 1024
         assert gcm_size_validator.validate_plaintext_len() is None
         gcm_size_validator._plaintext_len = (
-            GcmSizeValidator._PLAINTEXT_BIT_LIMIT)
+            _GCMSizeValidator._PLAINTEXT_BIT_LIMIT)
         assert gcm_size_validator.validate_plaintext_len() is None
 
     def test_validate_plaintext_len_invalid(self):
-        gcm_size_validator = GcmSizeValidator()
+        gcm_size_validator = _GCMSizeValidator()
         gcm_size_validator._plaintext_len = (
-            GcmSizeValidator._PLAINTEXT_BIT_LIMIT + 1)
+            _GCMSizeValidator._PLAINTEXT_BIT_LIMIT + 1)
         with pytest.raises(ValueError):
             gcm_size_validator.validate_plaintext_len()
         gcm_size_validator._plaintext_len = -1
@@ -30,16 +30,16 @@ class TestGcmSizeValidator(object):
             gcm_size_validator.validate_plaintext_len()
 
     def test_validate_aad_len_valid(self):
-        gcm_size_validator = GcmSizeValidator()
+        gcm_size_validator = _GCMSizeValidator()
         assert gcm_size_validator.validate_aad_len(0) is None
         assert gcm_size_validator.validate_aad_len(1024) is None
         assert gcm_size_validator.validate_aad_len(
-            GcmSizeValidator._AAD_BIT_LIMIT) is None
+            _GCMSizeValidator._AAD_BIT_LIMIT) is None
 
     def test_validate_aad_len_invalid(self):
-        gcm_size_validator = GcmSizeValidator()
+        gcm_size_validator = _GCMSizeValidator()
         with pytest.raises(ValueError):
             gcm_size_validator.validate_aad_len(
-                GcmSizeValidator._AAD_BIT_LIMIT + 1)
+                _GCMSizeValidator._AAD_BIT_LIMIT + 1)
         with pytest.raises(ValueError):
             gcm_size_validator.validate_aad_len(-1)

--- a/tests/hazmat/backends/test_utils.py
+++ b/tests/hazmat/backends/test_utils.py
@@ -10,6 +10,21 @@ from cryptography.hazmat.backends.utils import _GCMSizeValidator
 
 
 class TestGcmSizeValidator(object):
+    def test_update_and_validate_valid(self):
+        gcm_size_validator = _GCMSizeValidator()
+        assert gcm_size_validator.update_and_validate_plaintext(b"") is None
+        assert gcm_size_validator.update_and_validate_plaintext(b"0") is None
+        gcm_size_validator._plaintext_len = (
+            _GCMSizeValidator._PLAINTEXT_BIT_LIMIT)
+        assert gcm_size_validator.update_and_validate_plaintext(b"") is None
+
+    def test_update_and_validate_invalid(self):
+        gcm_size_validator = _GCMSizeValidator()
+        gcm_size_validator._plaintext_len = (
+            _GCMSizeValidator._PLAINTEXT_BIT_LIMIT)
+        with pytest.raises(ValueError):
+            gcm_size_validator.update_and_validate_plaintext(b"0")
+
     def test_validate_plaintext_len_valid(self):
         gcm_size_validator = _GCMSizeValidator()
         assert gcm_size_validator.validate_plaintext_len() is None

--- a/tests/hazmat/backends/test_utils.py
+++ b/tests/hazmat/backends/test_utils.py
@@ -15,13 +15,13 @@ class TestGcmSizeValidator(object):
         assert gcm_size_validator.update_and_validate_plaintext(b"") is None
         assert gcm_size_validator.update_and_validate_plaintext(b"0") is None
         gcm_size_validator._plaintext_len = (
-            _GCMSizeValidator._PLAINTEXT_BIT_LIMIT)
+            _GCMSizeValidator._PLAINTEXT_BYTE_LIMIT)
         assert gcm_size_validator.update_and_validate_plaintext(b"") is None
 
     def test_update_and_validate_invalid(self):
         gcm_size_validator = _GCMSizeValidator()
         gcm_size_validator._plaintext_len = (
-            _GCMSizeValidator._PLAINTEXT_BIT_LIMIT)
+            _GCMSizeValidator._PLAINTEXT_BYTE_LIMIT)
         with pytest.raises(ValueError):
             gcm_size_validator.update_and_validate_plaintext(b"0")
 
@@ -31,13 +31,13 @@ class TestGcmSizeValidator(object):
         gcm_size_validator._plaintext_len = 1024
         assert gcm_size_validator.validate_plaintext_len() is None
         gcm_size_validator._plaintext_len = (
-            _GCMSizeValidator._PLAINTEXT_BIT_LIMIT)
+            _GCMSizeValidator._PLAINTEXT_BYTE_LIMIT)
         assert gcm_size_validator.validate_plaintext_len() is None
 
     def test_validate_plaintext_len_invalid(self):
         gcm_size_validator = _GCMSizeValidator()
         gcm_size_validator._plaintext_len = (
-            _GCMSizeValidator._PLAINTEXT_BIT_LIMIT + 1)
+            _GCMSizeValidator._PLAINTEXT_BYTE_LIMIT + 1)
         with pytest.raises(ValueError):
             gcm_size_validator.validate_plaintext_len()
         gcm_size_validator._plaintext_len = -1
@@ -49,12 +49,12 @@ class TestGcmSizeValidator(object):
         assert gcm_size_validator.validate_aad_len(0) is None
         assert gcm_size_validator.validate_aad_len(1024) is None
         assert gcm_size_validator.validate_aad_len(
-            _GCMSizeValidator._AAD_BIT_LIMIT) is None
+            _GCMSizeValidator._AAD_BYTE_LIMIT) is None
 
     def test_validate_aad_len_invalid(self):
         gcm_size_validator = _GCMSizeValidator()
         with pytest.raises(ValueError):
             gcm_size_validator.validate_aad_len(
-                _GCMSizeValidator._AAD_BIT_LIMIT + 1)
+                _GCMSizeValidator._AAD_BYTE_LIMIT + 1)
         with pytest.raises(ValueError):
             gcm_size_validator.validate_aad_len(-1)


### PR DESCRIPTION
Please advise on my design here. I think this is super weird and kind of ugly. I'm out of my normal skillset with the object composition used in `cryptography`, so I'm sure I made some problems.

I'd also like a tip on testing the `update_and_validate_plaintext` and `update_aad`, since they can only trigger the `ValueError` when given extremely large bytestrings as input.

CC @reaperhulk & thanks for the help with this today at the PyCon2015 sprint.

Potential solution for #1821