### PR TITLE
Fix comparison between pyasn1 objects introduced in #1843

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/utils.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/utils.py
@@ -32,7 +32,7 @@ def decode_rfc6979_signature(signature):
     # pyasn1 can erroneously return this from top-level DER decoding.
     # It's intended as a sentinel in recursive BER decoding, so it's
     # returned even though an asn1Spec is provided.
-    if data == eoo.endOfOctets:
+    if eoo.endOfOctets.isSameTypeWith(data) and data == eoo.endOfOctets:
         raise ValueError("Invalid signature data. Unable to decode ASN.1")
 
     r = int(data.getComponentByName('r'))


### PR DESCRIPTION
`__eq__` compares values, so e.g. `univ.Integer(0) == eoo.endOfOctets`. I believe this isn't a logic error for what we're doing now, but keep the code right in case it gets reused. This is the pattern used by pyasn1 internally.