### PR TITLE
Support Subject Alternative Name in the OpenSSL backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ with open(os.path.join(src_dir, "cryptography", "__about__.py")) as f:
 VECTORS_DEPENDENCY = "cryptography_vectors=={0}".format(about['__version__'])
 
 requirements = [
+    "idna",
     "pyasn1",
     "six>=1.4.1",
     "setuptools"

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -61,9 +61,7 @@ def _build_x509_name(backend, x509_name):
 
 def _build_general_name(backend, gn):
     if gn.type == backend._lib.GEN_DNS:
-        data = backend._ffi.buffer(
-            gn.d.dNSName.data, gn.d.dNSName.length
-        )[:].decode("ascii")
+        data = backend._ffi.buffer(gn.d.dNSName.data, gn.d.dNSName.length)[:]
         return x509.DNSName(idna.decode(data))
 
 
@@ -275,7 +273,7 @@ class _Certificate(object):
         num = self._backend._lib.sk_GENERAL_NAME_num(gns)
         general_names = []
 
-        for i in range(0, num):
+        for i in range(num):
             gn = self._backend._lib.sk_GENERAL_NAME_value(gns, i)
             assert gn != self._backend._ffi.NULL
             value = _build_general_name(self._backend, gn)

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -70,6 +70,19 @@ _OID_NAMES = {
 }
 
 
+_GENERAL_NAMES = {
+    0: "otherName",
+    1: "rfc822Name",
+    2: "dNSName",
+    3: "x400Address",
+    4: "directoryName",
+    5: "ediPartyName",
+    6: "uniformResourceIdentifier",
+    7: "iPAddress",
+    8: "registeredID",
+}
+
+
 class Version(Enum):
     v1 = 0
     v3 = 2
@@ -113,6 +126,10 @@ class ExtensionNotFound(Exception):
     def __init__(self, msg, oid):
         super(ExtensionNotFound, self).__init__(msg)
         self.oid = oid
+
+
+class UnsupportedGeneralNameType(Exception):
+    pass
 
 
 class NameAttribute(object):

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -70,19 +70,6 @@ _OID_NAMES = {
 }
 
 
-_GENERAL_NAMES = {
-    0: "otherName",
-    1: "rfc822Name",
-    2: "dNSName",
-    3: "x400Address",
-    4: "directoryName",
-    5: "ediPartyName",
-    6: "uniformResourceIdentifier",
-    7: "iPAddress",
-    8: "registeredID",
-}
-
-
 class Version(Enum):
     v1 = 0
     v3 = 2
@@ -126,10 +113,6 @@ class ExtensionNotFound(Exception):
     def __init__(self, msg, oid):
         super(ExtensionNotFound, self).__init__(msg)
         self.oid = oid
-
-
-class UnsupportedGeneralNameType(Exception):
-    pass
 
 
 class NameAttribute(object):

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -730,3 +730,24 @@ class TestSubjectAlternativeName(object):
         assert repr(san) == (
             "<SubjectAlternativeName([<DNSName(value=cryptography.io)>])>"
         )
+
+
+@pytest.mark.requires_backend_interface(interface=RSABackend)
+@pytest.mark.requires_backend_interface(interface=X509Backend)
+class TestRSASubjectAlternativeNameExtension(object):
+    def test_dns_name(self, backend):
+        cert = _load_cert(
+            os.path.join("x509", "cryptography.io.pem"),
+            x509.load_pem_x509_certificate,
+            backend
+        )
+        ext = cert.extensions.get_extension_for_oid(
+            x509.OID_SUBJECT_ALTERNATIVE_NAME
+        )
+        assert ext is not None
+        assert ext.critical is False
+
+        san = ext.value
+
+        dns = san.get_values_for_type(x509.DNSName)
+        assert dns == [u"www.cryptography.io", u"cryptography.io"]


### PR DESCRIPTION
This PR adds [idna](https://github.com/kjd/idna) as a dependency.

One item to discuss here is whether we want to actually represent UniformResourceIdentifiers as strings or if we should document the value as a ParseResult from urlparse.

requires #1854 
refs #1743 