### PR TITLE
add a check to require that the list passed to SAN is all general names

### DIFF
--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -542,6 +542,12 @@ class IPAddress(object):
 
 class SubjectAlternativeName(object):
     def __init__(self, general_names):
+        if not all(isinstance(x, GeneralName) for x in general_names):
+            raise TypeError(
+                "Every item in the general_names list must be an "
+                "object conforming to the GeneralName interface"
+            )
+
         self._general_names = general_names
 
     def __iter__(self):

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -721,6 +721,12 @@ class TestSubjectAlternativeName(object):
             x509.DNSName(six.u("crypto.local")),
         ]
 
+    def test_invalid_general_names(self):
+        with pytest.raises(TypeError):
+            x509.SubjectAlternativeName(
+                [x509.DNSName(six.u("cryptography.io")), "invalid"]
+            )
+
     def test_repr(self):
         san = x509.SubjectAlternativeName(
             [


### PR DESCRIPTION
Quick improvement to do a type check we do on many of our other x509 extension objects.