### PR TITLE
Added support for ssl_get_version

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/src/cryptography/hazmat/bindings/openssl/ssl.py
@@ -306,6 +306,7 @@ SSL_CTX *SSL_CTX_new(SSL_METHOD *);
 long SSL_CTX_get_timeout(const SSL_CTX *);
 
 const SSL_CIPHER *SSL_get_current_cipher(const SSL *);
+const char *SSL_get_version(const SSL *);
 int SSL_version(const SSL *);
 
 /* SNI APIs were introduced in OpenSSL 1.0.0.  To continue to support


### PR DESCRIPTION
This adds support for binding [SSL_get_version](https://www.openssl.org/docs/ssl/SSL_get_version.html) so that I can finish up pyca/pyopenssl#184.  SSL_get_version is supperior to SSL_version(already implemented), in that it returns a string(e.g. TLSv1) instead of hex(e.g. 0x769).

My first PR to cryptography and I'm new to the concepts of ffi, so please be extra skeptical.