### PR TITLE
Refs #1870 - replace six.u with the u prefix in tests/hazmat/primitives

### DIFF
--- a/tests/hazmat/primitives/test_cmac.py
+++ b/tests/hazmat/primitives/test_cmac.py
@@ -10,8 +10,6 @@ import pretend
 
 import pytest
 
-import six
-
 from cryptography.exceptions import (
     AlreadyFinalized, InvalidSignature, _Reasons
 )
@@ -170,10 +168,10 @@ class TestCMAC(object):
         cmac = CMAC(AES(key), backend)
 
         with pytest.raises(TypeError):
-            cmac.update(six.u(''))
+            cmac.update(u'')
 
         with pytest.raises(TypeError):
-            cmac.verify(six.u(''))
+            cmac.verify(u'')
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.cmac_algorithm_supported(

--- a/tests/hazmat/primitives/test_constant_time.py
+++ b/tests/hazmat/primitives/test_constant_time.py
@@ -6,21 +6,19 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-import six
-
 from cryptography.hazmat.primitives import constant_time
 
 
 class TestConstantTimeBytesEq(object):
     def test_reject_unicode(self):
         with pytest.raises(TypeError):
-            constant_time.bytes_eq(b"foo", six.u("foo"))
+            constant_time.bytes_eq(b"foo", u"foo")
 
         with pytest.raises(TypeError):
-            constant_time.bytes_eq(six.u("foo"), b"foo")
+            constant_time.bytes_eq(u"foo", b"foo")
 
         with pytest.raises(TypeError):
-            constant_time.bytes_eq(six.u("foo"), six.u("foo"))
+            constant_time.bytes_eq(u"foo", u"foo")
 
     def test_compares(self):
         assert constant_time.bytes_eq(b"foo", b"foo") is True

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -8,8 +8,6 @@ import pretend
 
 import pytest
 
-import six
-
 from cryptography import utils
 from cryptography.exceptions import AlreadyFinalized, _Reasons
 from cryptography.hazmat.backends.interfaces import HashBackend
@@ -32,7 +30,7 @@ class TestHashContext(object):
     def test_hash_reject_unicode(self, backend):
         m = hashes.Hash(hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):
-            m.update(six.u("\u00FC"))
+            m.update(u"\u00FC")
 
     def test_copy_backend_object(self):
         backend = DummyHashBackend([hashes.SHA1])

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -8,8 +8,6 @@ import binascii
 
 import pytest
 
-import six
-
 from cryptography.exceptions import (
     AlreadyFinalized, InvalidKey, _Reasons
 )
@@ -97,7 +95,7 @@ class TestHKDF(object):
             HKDF(
                 hashes.SHA256(),
                 16,
-                salt=six.u("foo"),
+                salt=u"foo",
                 info=None,
                 backend=backend
             )
@@ -107,7 +105,7 @@ class TestHKDF(object):
                 hashes.SHA256(),
                 16,
                 salt=None,
-                info=six.u("foo"),
+                info=u"foo",
                 backend=backend
             )
 
@@ -120,7 +118,7 @@ class TestHKDF(object):
                 backend=backend
             )
 
-            hkdf.derive(six.u("foo"))
+            hkdf.derive(u"foo")
 
         with pytest.raises(TypeError):
             hkdf = HKDF(
@@ -131,7 +129,7 @@ class TestHKDF(object):
                 backend=backend
             )
 
-            hkdf.verify(six.u("foo"), b"bar")
+            hkdf.verify(u"foo", b"bar")
 
         with pytest.raises(TypeError):
             hkdf = HKDF(
@@ -142,7 +140,7 @@ class TestHKDF(object):
                 backend=backend
             )
 
-            hkdf.verify(b"foo", six.u("bar"))
+            hkdf.verify(b"foo", u"bar")
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
@@ -198,7 +196,7 @@ class TestHKDFExpand(object):
         hkdf = HKDFExpand(hashes.SHA256(), 42, info, backend)
 
         with pytest.raises(TypeError):
-            hkdf.derive(six.u("first"))
+            hkdf.derive(u"first")
 
 
 def test_invalid_backend():

--- a/tests/hazmat/primitives/test_hmac.py
+++ b/tests/hazmat/primitives/test_hmac.py
@@ -8,8 +8,6 @@ import pretend
 
 import pytest
 
-import six
-
 from cryptography import utils
 from cryptography.exceptions import (
     AlreadyFinalized, InvalidSignature, _Reasons
@@ -45,7 +43,7 @@ class TestHMAC(object):
     def test_hmac_reject_unicode(self, backend):
         h = hmac.HMAC(b"mykey", hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):
-            h.update(six.u("\u00FC"))
+            h.update(u"\u00FC")
 
     def test_copy_backend_object(self):
         backend = DummyHMACBackend([hashes.SHA1])
@@ -93,7 +91,7 @@ class TestHMAC(object):
     def test_verify_reject_unicode(self, backend):
         h = hmac.HMAC(b'', hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):
-            h.verify(six.u(''))
+            h.verify(u'')
 
     def test_unsupported_hash(self, backend):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-import six
-
 from cryptography.exceptions import AlreadyFinalized
 from cryptography.hazmat.primitives import padding
 
@@ -35,10 +33,10 @@ class TestPKCS7(object):
     def test_non_bytes(self):
         padder = padding.PKCS7(128).padder()
         with pytest.raises(TypeError):
-            padder.update(six.u("abc"))
+            padder.update(u"abc")
         unpadder = padding.PKCS7(128).unpadder()
         with pytest.raises(TypeError):
-            unpadder.update(six.u("abc"))
+            unpadder.update(u"abc")
 
     @pytest.mark.parametrize(("size", "unpadded", "padded"), [
         (

--- a/tests/hazmat/primitives/test_pbkdf2hmac.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-import six
-
 from cryptography import utils
 from cryptography.exceptions import (
     AlreadyFinalized, InvalidKey, _Reasons
@@ -57,12 +55,12 @@ class TestPBKDF2HMAC(object):
 
     def test_unicode_error_with_salt(self):
         with pytest.raises(TypeError):
-            PBKDF2HMAC(hashes.SHA1(), 20, six.u("salt"), 10, default_backend())
+            PBKDF2HMAC(hashes.SHA1(), 20, u"salt", 10, default_backend())
 
     def test_unicode_error_with_key_material(self):
         kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, default_backend())
         with pytest.raises(TypeError):
-            kdf.derive(six.u("unicode here"))
+            kdf.derive(u"unicode here")
 
 
 def test_invalid_backend():


### PR DESCRIPTION
This PR only replaces the uses of six.u with the u prefix in tests/hazmat/primitives. The remaining occurrences of six.u will be addressed in another PR (I am working on it right now, just wanted to keep the diff small so I divided it into two pull requests), which will close the issue. :-)

Thanks,
Eeshan