### PR TITLE
Add X509_delete_ext binding needed by Zorp

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/x509.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509.py
@@ -140,6 +140,7 @@ int X509_set_issuer_name(X509 *, X509_NAME *);
 
 int X509_get_ext_count(X509 *);
 int X509_add_ext(X509 *, X509_EXTENSION *, int);
+X509_EXTENSION *X509_delete_ext(X509 *, int);
 X509_EXTENSION *X509_EXTENSION_dup(X509_EXTENSION *);
 X509_EXTENSION *X509_get_ext(X509 *, int);
 int X509_get_ext_by_NID(X509 *, int, int);


### PR DESCRIPTION
[Balabit Zorp](https://github.com/balabit/zorp) application level firewall [relies on the del_extension function](https://github.com/balabit/zorp/blob/master/pylib/Zorp/Keybridge.py#L350) to remove attributes like CRL pathes from the mimicked  certificates when doing man-in-the-middle traffic filtering.