### PR TITLE
Expose SSL_CTX_set_cert_verify_callback

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/ssl.py
+++ b/src/cryptography/hazmat/bindings/openssl/ssl.py
@@ -211,6 +211,9 @@ int SSL_CTX_use_certificate_chain_file(SSL_CTX *, const char *);
 int SSL_CTX_use_PrivateKey(SSL_CTX *, EVP_PKEY *);
 int SSL_CTX_use_PrivateKey_file(SSL_CTX *, const char *, int);
 int SSL_CTX_check_private_key(const SSL_CTX *);
+void SSL_CTX_set_cert_verify_callback(SSL_CTX *,
+                                      int (*)(X509_STORE_CTX *,void *),
+                                      void *);
 
 void SSL_CTX_set_cert_store(SSL_CTX *, X509_STORE *);
 X509_STORE *SSL_CTX_get_cert_store(const SSL_CTX *);


### PR DESCRIPTION
This is for use with HPKP, as discussed in shazow/urllib3#607.

It's my belief that this change is sufficient to move forward in PyOpenSSL, but I'm not 100% confident of that fact yet. We'll see.