### PR TITLE
Fix AKI authority_cert_issuer type

### DIFF
--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -666,8 +666,13 @@ class AuthorityKeyIdentifier(object):
                     "must both be present or both None"
                 )
 
-            if not isinstance(authority_cert_issuer, Name):
-                raise TypeError("authority_cert_issuer must be a Name")
+            if not all(
+                isinstance(x, GeneralName) for x in authority_cert_issuer
+            ):
+                raise TypeError(
+                    "authority_cert_issuer must be a list of GeneralName "
+                    "objects"
+                )
 
             if not isinstance(authority_cert_serial_number, six.integer_types):
                 raise TypeError(

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -221,29 +221,33 @@ class TestSubjectKeyIdentifier(object):
 
 
 class TestAuthorityKeyIdentifier(object):
-    def test_authority_cert_issuer_not_name(self):
+    def test_authority_cert_issuer_not_generalname(self):
         with pytest.raises(TypeError):
-            x509.AuthorityKeyIdentifier(b"identifier", "notname", 3)
+            x509.AuthorityKeyIdentifier(b"identifier", ["notname"], 3)
 
     def test_authority_cert_serial_number_not_integer(self):
-        name = x509.Name([
-            x509.NameAttribute(x509.ObjectIdentifier('oid'), 'value1'),
-            x509.NameAttribute(x509.ObjectIdentifier('oid2'), 'value2'),
-        ])
+        dirname = x509.DirectoryName(
+            x509.Name([
+                x509.NameAttribute(x509.ObjectIdentifier('oid'), 'value1'),
+                x509.NameAttribute(x509.ObjectIdentifier('oid2'), 'value2'),
+            ])
+        )
         with pytest.raises(TypeError):
-            x509.AuthorityKeyIdentifier(b"identifier", name, "notanint")
+            x509.AuthorityKeyIdentifier(b"identifier", [dirname], "notanint")
 
     def test_authority_issuer_none_serial_not_none(self):
         with pytest.raises(ValueError):
             x509.AuthorityKeyIdentifier(b"identifier", None, 3)
 
     def test_authority_issuer_not_none_serial_none(self):
-        name = x509.Name([
-            x509.NameAttribute(x509.ObjectIdentifier('oid'), 'value1'),
-            x509.NameAttribute(x509.ObjectIdentifier('oid2'), 'value2'),
-        ])
+        dirname = x509.DirectoryName(
+            x509.Name([
+                x509.NameAttribute(x509.ObjectIdentifier('oid'), 'value1'),
+                x509.NameAttribute(x509.ObjectIdentifier('oid2'), 'value2'),
+            ])
+        )
         with pytest.raises(ValueError):
-            x509.AuthorityKeyIdentifier(b"identifier", name, None)
+            x509.AuthorityKeyIdentifier(b"identifier", [dirname], None)
 
     def test_authority_cert_serial_and_issuer_none(self):
         aki = x509.AuthorityKeyIdentifier(b"id", None, None)
@@ -252,22 +256,24 @@ class TestAuthorityKeyIdentifier(object):
         assert aki.authority_cert_serial_number is None
 
     def test_repr(self):
-        name = x509.Name([x509.NameAttribute(x509.OID_COMMON_NAME, 'myCN')])
-        aki = x509.AuthorityKeyIdentifier(b"digest", name, 1234)
+        dirname = x509.DirectoryName(
+            x509.Name([x509.NameAttribute(x509.OID_COMMON_NAME, 'myCN')])
+        )
+        aki = x509.AuthorityKeyIdentifier(b"digest", [dirname], 1234)
 
         if six.PY3:
             assert repr(aki) == (
                 "<AuthorityKeyIdentifier(key_identifier=b'digest', authority_"
-                "cert_issuer=<Name([<NameAttribute(oid=<ObjectIdentifier(oid="
-                "2.5.4.3, name=commonName)>, value='myCN')>])>, authority_cer"
-                "t_serial_number=1234)>"
+                "cert_issuer=[<DirectoryName(value=<Name([<NameAttribute(oid="
+                "<ObjectIdentifier(oid=2.5.4.3, name=commonName)>, value='myC"
+                "N')>])>)>], authority_cert_serial_number=1234)>"
             )
         else:
             assert repr(aki) == (
                 "<AuthorityKeyIdentifier(key_identifier='digest', authority_ce"
-                "rt_issuer=<Name([<NameAttribute(oid=<ObjectIdentifier(oid=2.5"
-                ".4.3, name=commonName)>, value='myCN')>])>, authority_cert_se"
-                "rial_number=1234)>"
+                "rt_issuer=[<DirectoryName(value=<Name([<NameAttribute(oid=<Ob"
+                "jectIdentifier(oid=2.5.4.3, name=commonName)>, value='myCN')>"
+                "])>)>], authority_cert_serial_number=1234)>"
             )
 
 


### PR DESCRIPTION
It was originally defined as an X509 Name, but in reality it is a list of GeneralName objects (albeit typically a list of one DirectoryName).