### PR TITLE
add CRLDistributionPoints and associated classes

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -835,7 +835,7 @@ X.509 Extensions
 
     .. attribute:: reasons
 
-        :type: list of :class:`ReasonFlags` or None
+        :type: frozenset of :class:`ReasonFlags` or None
 
         The reasons a given distribution point may be used for when performing
         revocation checks.

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -781,6 +781,8 @@ X.509 Extensions
 
 .. class:: AccessDescription
 
+    .. versionadded:: 0.9
+
     .. attribute:: access_method
 
         :type: :class:`ObjectIdentifier`
@@ -797,6 +799,76 @@ X.509 Extensions
         :type: :class:`GeneralName`
 
         Where to access the information defined by the access method.
+
+.. class:: CRLDistributionPoints
+
+    .. versionadded:: 0.9
+
+    The CRL distribution points extension identifies how CRL information is
+    obtained. It is an iterable, containing one or more
+    :class:`DistributionPoint` instances.
+
+.. class:: DistributionPoint
+
+    .. versionadded:: 0.9
+
+    .. attribute:: distribution_point
+
+        :type: list of :class:`GeneralName` instances, :class:`Name`, or None
+
+        This field describes methods to retrieve the CRL.
+
+    .. attribute:: crl_issuer
+
+        :type: list of :class:`GeneralName` instances or None
+
+        Information about the issuer of the CRL.
+
+    .. attribute:: reasons
+
+        :type: :class:`ReasonFlags` or None
+
+        The reasons a given distribution point may be used for when performing
+        revocation checks.
+
+.. class:: ReasonFlags
+
+    .. versionadded:: 0.9
+
+    This class holds reasons a distribution point may be used for when
+    performing revocation checks.
+
+    .. attribute:: key_compromise
+
+        :type: bool
+
+    .. attribute:: ca_compromise
+
+        :type: bool
+
+    .. attribute:: affiliation_changed
+
+        :type: bool
+
+    .. attribute:: superseded
+
+        :type: bool
+
+    .. attribute:: cessation_of_operation
+
+        :type: bool
+
+    .. attribute:: certificate_hold
+
+        :type: bool
+
+    .. attribute:: privilege_withdrawn
+
+        :type: bool
+
+    .. attribute:: aa_compromise
+
+        :type: bool
 
 Object Identifiers
 ~~~~~~~~~~~~~~~~~~

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -812,11 +812,19 @@ X.509 Extensions
 
     .. versionadded:: 0.9
 
-    .. attribute:: distribution_point
+    .. attribute:: full_name
 
-        :type: list of :class:`GeneralName` instances, :class:`Name`, or None
+        :type: list of :class:`GeneralName` instances or None
 
-        This field describes methods to retrieve the CRL.
+        This field describes methods to retrieve the CRL. If this is not None
+        then ``relative_name`` must be None.
+
+    .. attribute:: relative_name
+
+        :type: :class:`Name` or None
+
+        This field describes methods to retrieve the CRL relative to the CRL
+        issuer. If this is not None then ``full_name`` must be None.
 
     .. attribute:: crl_issuer
 
@@ -826,7 +834,7 @@ X.509 Extensions
 
     .. attribute:: reasons
 
-        :type: :class:`ReasonFlags` or None
+        :type: list of :class:`ReasonFlags` or None
 
         The reasons a given distribution point may be used for when performing
         revocation checks.
@@ -835,40 +843,53 @@ X.509 Extensions
 
     .. versionadded:: 0.9
 
-    This class holds reasons a distribution point may be used for when
-    performing revocation checks.
+    An enumeration for CRL reasons.
+
+    .. attribute:: unspecified
+
+        It is unspecified why the certificate was revoked. This reason cannot
+        be used as a reason flag in a :class:`DistributionPoint`.
 
     .. attribute:: key_compromise
 
-        :type: bool
+        This reason indicates that the private key was compromised.
 
     .. attribute:: ca_compromise
 
-        :type: bool
+        This reason indicates that the CA issuing the certificate was
+        compromised.
 
     .. attribute:: affiliation_changed
 
-        :type: bool
+        This reason indicates that the subject's name or other information has
+        changed.
 
     .. attribute:: superseded
 
-        :type: bool
+        This reason indicates that a certificate has been superseded.
 
     .. attribute:: cessation_of_operation
 
-        :type: bool
+        This reason indicates that the certificate is no longer required.
 
     .. attribute:: certificate_hold
 
-        :type: bool
+        This reason indicates that the certificate is on hold.
 
     .. attribute:: privilege_withdrawn
 
-        :type: bool
+        This reason indicates that the privilege granted by this certificate
+        have been withdrawn.
 
     .. attribute:: aa_compromise
 
-        :type: bool
+        When an attribute authority has been compromised.
+
+    .. attribute:: remove_from_crl
+
+        This reason indicates that the certificate was on hold and should be
+        removed from the CRL. This reason cannot be used as a reason flag
+        in a :class:`DistributionPoint`.
 
 Object Identifiers
 ~~~~~~~~~~~~~~~~~~

--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -816,15 +816,16 @@ X.509 Extensions
 
         :type: list of :class:`GeneralName` instances or None
 
-        This field describes methods to retrieve the CRL. If this is not None
-        then ``relative_name`` must be None.
+        This field describes methods to retrieve the CRL. At most one of
+        ``full_name`` or ``relative_name`` will be non-None.
 
     .. attribute:: relative_name
 
         :type: :class:`Name` or None
 
         This field describes methods to retrieve the CRL relative to the CRL
-        issuer. If this is not None then ``full_name`` must be None.
+        issuer. At most one of ``full_name`` or ``relative_name`` will be
+        non-None.
 
     .. attribute:: crl_issuer
 

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -536,10 +536,10 @@ class DistributionPoint(object):
                 "crl_issuer must be None or a list of general names"
             )
 
-        if reasons and not all(
+        if reasons and (not isinstance(reasons, frozenset) or not all(
             isinstance(x, ReasonFlags) for x in reasons
-        ):
-            raise TypeError("reasons must be None or list of ReasonFlags")
+        )):
+            raise TypeError("reasons must be None or frozenset of ReasonFlags")
 
         if reasons and (
             ReasonFlags.unspecified in reasons or

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -513,20 +513,21 @@ class CRLDistributionPoints(object):
 
 
 class DistributionPoint(object):
-    def __init__(self, distribution_point, reasons, crl_issuer):
-        if distribution_point:
-            if (
-                (
-                    isinstance(distribution_point, list) and
-                    not all(
-                        isinstance(x, GeneralName) for x in distribution_point
-                    )
-                ) or not isinstance(distribution_point, (list, Name))
-            ):
-                raise TypeError(
-                    "distribution_point must be None, a list of general names"
-                    ", or a Name"
-                )
+    def __init__(self, full_name, relative_name, reasons, crl_issuer):
+        if full_name and relative_name:
+            raise ValueError(
+                "At least one of full_name and relative_name must be None"
+            )
+
+        if full_name and not all(
+            isinstance(x, GeneralName) for x in full_name
+        ):
+            raise TypeError(
+                "full_name must be a list of GeneralName objects"
+            )
+
+        if relative_name and not isinstance(relative_name, Name):
+            raise TypeError("relative_name must be a Name")
 
         if crl_issuer and not all(
             isinstance(x, GeneralName) for x in crl_issuer
@@ -535,23 +536,36 @@ class DistributionPoint(object):
                 "crl_issuer must be None or a list of general names"
             )
 
-        if reasons and not isinstance(reasons, ReasonFlags):
-            raise TypeError("reasons must be None or ReasonFlags")
+        if reasons and not all(
+            isinstance(x, ReasonFlags) for x in reasons
+        ):
+            raise TypeError("reasons must be None or list of ReasonFlags")
 
-        if reasons and not crl_issuer and not distribution_point:
+        if reasons and (
+            ReasonFlags.unspecified in reasons or
+            ReasonFlags.remove_from_crl in reasons
+        ):
             raise ValueError(
-                "You must supply crl_issuer or distribution_point when "
+                "unspecified and remove_from_crl are not valid reasons in a "
+                "DistributionPoint"
+            )
+
+        if reasons and not crl_issuer and not (full_name or relative_name):
+            raise ValueError(
+                "You must supply crl_issuer, full_name, or relative_name when "
                 "reasons is not None"
             )
 
-        self._distribution_point = distribution_point
+        self._full_name = full_name
+        self._relative_name = relative_name
         self._reasons = reasons
         self._crl_issuer = crl_issuer
 
     def __repr__(self):
         return (
-            "<DistributionPoint(distribution_point={0.distribution_point}, rea"
-            "sons={0.reasons}, crl_issuer={0.crl_issuer})>".format(self)
+            "<DistributionPoint(full_name={0.full_name}, relative_name={0.rela"
+            "tive_name}, reasons={0.reasons}, crl_issuer={0.crl_is"
+            "suer})>".format(self)
         )
 
     def __eq__(self, other):
@@ -559,7 +573,8 @@ class DistributionPoint(object):
             return NotImplemented
 
         return (
-            self.distribution_point == other.distribution_point and
+            self.full_name == other.full_name and
+            self.relative_name == other.relative_name and
             self.reasons == other.reasons and
             self.crl_issuer == other.crl_issuer
         )
@@ -567,62 +582,23 @@ class DistributionPoint(object):
     def __ne__(self, other):
         return not self == other
 
-    distribution_point = utils.read_only_property("_distribution_point")
+    full_name = utils.read_only_property("_full_name")
+    relative_name = utils.read_only_property("_relative_name")
     reasons = utils.read_only_property("_reasons")
     crl_issuer = utils.read_only_property("_crl_issuer")
 
 
-class ReasonFlags(object):
-    def __init__(self, key_compromise, ca_compromise, affiliation_changed,
-                 superseded, cessation_of_operation, certificate_hold,
-                 privilege_withdrawn, aa_compromise):
-        self._key_compromise = key_compromise
-        self._ca_compromise = ca_compromise
-        self._affiliation_changed = affiliation_changed
-        self._superseded = superseded
-        self._cessation_of_operation = cessation_of_operation
-        self._certificate_hold = certificate_hold
-        self._privilege_withdrawn = privilege_withdrawn
-        self._aa_compromise = aa_compromise
-
-    def __repr__(self):
-        return (
-            "<ReasonFlags(key_compromise={0.key_compromise}, ca_compromise"
-            "={0.ca_compromise}, affiliation_changed={0.affiliation_changed},"
-            "superseded={0.superseded}, cessation_of_operation={0.cessation_o"
-            "f_operation}, certificate_hold={0.certificate_hold}, privilege_w"
-            "ithdrawn={0.privilege_withdrawn}, aa_compromise={0.aa_compromise"
-            "})>".format(self)
-        )
-
-    def __eq__(self, other):
-        if not isinstance(other, ReasonFlags):
-            return NotImplemented
-
-        return (
-            self.key_compromise == other.key_compromise and
-            self.ca_compromise == other.ca_compromise and
-            self.affiliation_changed == other.affiliation_changed and
-            self.superseded == other.superseded and
-            self.cessation_of_operation == other.cessation_of_operation and
-            self.certificate_hold == other.certificate_hold and
-            self.privilege_withdrawn == other.privilege_withdrawn and
-            self.aa_compromise == other.aa_compromise
-        )
-
-    def __ne__(self, other):
-        return not self == other
-
-    key_compromise = utils.read_only_property("_key_compromise")
-    ca_compromise = utils.read_only_property("_ca_compromise")
-    affiliation_changed = utils.read_only_property("_affiliation_changed")
-    superseded = utils.read_only_property("_superseded")
-    cessation_of_operation = utils.read_only_property(
-        "_cessation_of_operation"
-    )
-    certificate_hold = utils.read_only_property("_certificate_hold")
-    privilege_withdrawn = utils.read_only_property("_privilege_withdrawn")
-    aa_compromise = utils.read_only_property("_aa_compromise")
+class ReasonFlags(Enum):
+    unspecified = "unspecified"
+    key_compromise = "keyCompromise"
+    ca_compromise = "cACompromise"
+    affiliation_changed = "affiliationChanged"
+    superseded = "superseded"
+    cessation_of_operation = "cessationOfOperation"
+    certificate_hold = "certificateHold"
+    privilege_withdrawn = "privilegeWithdrawn"
+    aa_compromise = "aACompromise"
+    remove_from_crl = "removeFromCRL"
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -481,6 +481,150 @@ class SubjectKeyIdentifier(object):
         return not self == other
 
 
+class CRLDistributionPoints(object):
+    def __init__(self, distribution_points):
+        if not all(
+            isinstance(x, DistributionPoint) for x in distribution_points
+        ):
+            raise TypeError(
+                "distribution_points must be a list of DistributionPoint "
+                "objects"
+            )
+
+        self._distribution_points = distribution_points
+
+    def __iter__(self):
+        return iter(self._distribution_points)
+
+    def __len__(self):
+        return len(self._distribution_points)
+
+    def __repr__(self):
+        return "<CRLDistributionPoints({0})>".format(self._distribution_points)
+
+    def __eq__(self, other):
+        if not isinstance(other, CRLDistributionPoints):
+            return NotImplemented
+
+        return self._distribution_points == other._distribution_points
+
+    def __ne__(self, other):
+        return not self == other
+
+
+class DistributionPoint(object):
+    def __init__(self, distribution_point, reasons, crl_issuer):
+        if distribution_point:
+            if (
+                (
+                    isinstance(distribution_point, list) and
+                    not all(
+                        isinstance(x, GeneralName) for x in distribution_point
+                    )
+                ) or not isinstance(distribution_point, (list, Name))
+            ):
+                raise TypeError(
+                    "distribution_point must be None, a list of general names"
+                    ", or a Name"
+                )
+
+        if crl_issuer and not all(
+            isinstance(x, GeneralName) for x in crl_issuer
+        ):
+            raise TypeError(
+                "crl_issuer must be None or a list of general names"
+            )
+
+        if reasons and not isinstance(reasons, ReasonFlags):
+            raise TypeError("reasons must be None or ReasonFlags")
+
+        if reasons and not crl_issuer and not distribution_point:
+            raise ValueError(
+                "You must supply crl_issuer or distribution_point when "
+                "reasons is not None"
+            )
+
+        self._distribution_point = distribution_point
+        self._reasons = reasons
+        self._crl_issuer = crl_issuer
+
+    def __repr__(self):
+        return (
+            "<DistributionPoint(distribution_point={0.distribution_point}, rea"
+            "sons={0.reasons}, crl_issuer={0.crl_issuer})>".format(self)
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, DistributionPoint):
+            return NotImplemented
+
+        return (
+            self.distribution_point == other.distribution_point and
+            self.reasons == other.reasons and
+            self.crl_issuer == other.crl_issuer
+        )
+
+    def __ne__(self, other):
+        return not self == other
+
+    distribution_point = utils.read_only_property("_distribution_point")
+    reasons = utils.read_only_property("_reasons")
+    crl_issuer = utils.read_only_property("_crl_issuer")
+
+
+class ReasonFlags(object):
+    def __init__(self, key_compromise, ca_compromise, affiliation_changed,
+                 superseded, cessation_of_operation, certificate_hold,
+                 privilege_withdrawn, aa_compromise):
+        self._key_compromise = key_compromise
+        self._ca_compromise = ca_compromise
+        self._affiliation_changed = affiliation_changed
+        self._superseded = superseded
+        self._cessation_of_operation = cessation_of_operation
+        self._certificate_hold = certificate_hold
+        self._privilege_withdrawn = privilege_withdrawn
+        self._aa_compromise = aa_compromise
+
+    def __repr__(self):
+        return (
+            "<ReasonFlags(key_compromise={0.key_compromise}, ca_compromise"
+            "={0.ca_compromise}, affiliation_changed={0.affiliation_changed},"
+            "superseded={0.superseded}, cessation_of_operation={0.cessation_o"
+            "f_operation}, certificate_hold={0.certificate_hold}, privilege_w"
+            "ithdrawn={0.privilege_withdrawn}, aa_compromise={0.aa_compromise"
+            "})>".format(self)
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, ReasonFlags):
+            return NotImplemented
+
+        return (
+            self.key_compromise == other.key_compromise and
+            self.ca_compromise == other.ca_compromise and
+            self.affiliation_changed == other.affiliation_changed and
+            self.superseded == other.superseded and
+            self.cessation_of_operation == other.cessation_of_operation and
+            self.certificate_hold == other.certificate_hold and
+            self.privilege_withdrawn == other.privilege_withdrawn and
+            self.aa_compromise == other.aa_compromise
+        )
+
+    def __ne__(self, other):
+        return not self == other
+
+    key_compromise = utils.read_only_property("_key_compromise")
+    ca_compromise = utils.read_only_property("_ca_compromise")
+    affiliation_changed = utils.read_only_property("_affiliation_changed")
+    superseded = utils.read_only_property("_superseded")
+    cessation_of_operation = utils.read_only_property(
+        "_cessation_of_operation"
+    )
+    certificate_hold = utils.read_only_property("_certificate_hold")
+    privilege_withdrawn = utils.read_only_property("_privilege_withdrawn")
+    aa_compromise = utils.read_only_property("_aa_compromise")
+
+
 @six.add_metaclass(abc.ABCMeta)
 class GeneralName(object):
     @abc.abstractproperty

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1442,10 +1442,7 @@ class TestDistributionPoint(object):
             x509.Name([
                 x509.NameAttribute(x509.OID_COMMON_NAME, "myCN")
             ]),
-            frozenset([
-                x509.ReasonFlags.key_compromise,
-                x509.ReasonFlags.ca_compromise,
-            ]),
+            frozenset([x509.ReasonFlags.ca_compromise]),
             [
                 x509.DirectoryName(
                     x509.Name([
@@ -1459,11 +1456,10 @@ class TestDistributionPoint(object):
         assert repr(dp) == (
             "<DistributionPoint(full_name=None, relative_name=<Name([<NameAtt"
             "ribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)>, val"
-            "ue='myCN')>])>, reasons=frozenset([<ReasonFlags.key_compromise: "
-            "'keyCompromise'>, <ReasonFlags.ca_compromise: 'cACompromise'>]),"
-            " crl_issuer=[<DirectoryName(value=<Name([<NameAttribute(oid=<Obj"
-            "ectIdentifier(oid=2.5.4.3, name=commonName)>, value='Important C"
-            "A')>])>)>])>"
+            "ue='myCN')>])>, reasons=frozenset([<ReasonFlags.ca_compromise: '"
+            "cACompromise'>]), crl_issuer=[<DirectoryName(value=<Name([<NameA"
+            "ttribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)>, v"
+            "alue='Important CA')>])>)>])>"
         )
 
 
@@ -1514,18 +1510,15 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                frozenset([
-                    x509.ReasonFlags.key_compromise,
-                    x509.ReasonFlags.ca_compromise,
-                ]),
+                frozenset([x509.ReasonFlags.key_compromise]),
                 None
             ),
         ])
         assert repr(cdp) == (
             "<CRLDistributionPoints([<DistributionPoint(full_name=[<UniformRes"
             "ourceIdentifier(value=ftp://domain)>], relative_name=None, reason"
-            "s=frozenset([<ReasonFlags.key_compromise: 'keyCompromise'>, <Reas"
-            "onFlags.ca_compromise: 'cACompromise'>]), crl_issuer=None)>])>"
+            "s=frozenset([<ReasonFlags.key_compromise: 'keyCompromise'>]), crl"
+            "_issuer=None)>])>"
         )
 
     def test_eq(self):

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1342,7 +1342,16 @@ class TestDistributionPoint(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"http://crypt.og/crl")],
                 None,
-                ["notreasonflags"],
+                frozenset(["notreasonflags"]),
+                None
+            )
+
+    def test_reason_not_frozenset(self):
+        with pytest.raises(TypeError):
+            x509.DistributionPoint(
+                [x509.UniformResourceIdentifier(u"http://crypt.og/crl")],
+                None,
+                [x509.ReasonFlags.ca_compromise],
                 None
             )
 
@@ -1351,7 +1360,7 @@ class TestDistributionPoint(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"http://crypt.og/crl")],
                 None,
-                [x509.ReasonFlags.unspecified],
+                frozenset([x509.ReasonFlags.unspecified]),
                 None
             )
 
@@ -1359,7 +1368,7 @@ class TestDistributionPoint(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"http://crypt.og/crl")],
                 None,
-                [x509.ReasonFlags.remove_from_crl],
+                frozenset([x509.ReasonFlags.remove_from_crl]),
                 None
             )
 
@@ -1368,7 +1377,7 @@ class TestDistributionPoint(object):
             x509.DistributionPoint(
                 None,
                 None,
-                [x509.ReasonFlags.aa_compromise],
+                frozenset([x509.ReasonFlags.aa_compromise]),
                 None
             )
 
@@ -1376,7 +1385,7 @@ class TestDistributionPoint(object):
         dp = x509.DistributionPoint(
             [x509.UniformResourceIdentifier(u"http://crypt.og/crl")],
             None,
-            [x509.ReasonFlags.superseded],
+            frozenset([x509.ReasonFlags.superseded]),
             [
                 x509.DirectoryName(
                     x509.Name([
@@ -1390,7 +1399,7 @@ class TestDistributionPoint(object):
         dp2 = x509.DistributionPoint(
             [x509.UniformResourceIdentifier(u"http://crypt.og/crl")],
             None,
-            [x509.ReasonFlags.superseded],
+            frozenset([x509.ReasonFlags.superseded]),
             [
                 x509.DirectoryName(
                     x509.Name([
@@ -1407,9 +1416,7 @@ class TestDistributionPoint(object):
         dp = x509.DistributionPoint(
             [x509.UniformResourceIdentifier(u"http://crypt.og/crl")],
             None,
-            [
-                x509.ReasonFlags.superseded,
-            ],
+            frozenset([x509.ReasonFlags.superseded]),
             [
                 x509.DirectoryName(
                     x509.Name([
@@ -1435,10 +1442,10 @@ class TestDistributionPoint(object):
             x509.Name([
                 x509.NameAttribute(x509.OID_COMMON_NAME, "myCN")
             ]),
-            [
+            frozenset([
                 x509.ReasonFlags.key_compromise,
                 x509.ReasonFlags.ca_compromise,
-            ],
+            ]),
             [
                 x509.DirectoryName(
                     x509.Name([
@@ -1452,10 +1459,11 @@ class TestDistributionPoint(object):
         assert repr(dp) == (
             "<DistributionPoint(full_name=None, relative_name=<Name([<NameAtt"
             "ribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)>, val"
-            "ue='myCN')>])>, reasons=[<ReasonFlags.key_compromise: 'keyCompro"
-            "mise'>, <ReasonFlags.ca_compromise: 'cACompromise'>], crl_issuer"
-            "=[<DirectoryName(value=<Name([<NameAttribute(oid=<ObjectIdentifi"
-            "er(oid=2.5.4.3, name=commonName)>, value='Important CA')>])>)>])>"
+            "ue='myCN')>])>, reasons=frozenset([<ReasonFlags.key_compromise: "
+            "'keyCompromise'>, <ReasonFlags.ca_compromise: 'cACompromise'>]),"
+            " crl_issuer=[<DirectoryName(value=<Name([<NameAttribute(oid=<Obj"
+            "ectIdentifier(oid=2.5.4.3, name=commonName)>, value='Important C"
+            "A')>])>)>])>"
         )
 
 
@@ -1475,10 +1483,10 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                [
+                frozenset([
                     x509.ReasonFlags.key_compromise,
                     x509.ReasonFlags.ca_compromise,
-                ],
+                ]),
                 None
             ),
         ])
@@ -1493,10 +1501,10 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                [
+                frozenset([
                     x509.ReasonFlags.key_compromise,
                     x509.ReasonFlags.ca_compromise,
-                ],
+                ]),
                 None
             ),
         ]
@@ -1506,18 +1514,18 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                [
+                frozenset([
                     x509.ReasonFlags.key_compromise,
                     x509.ReasonFlags.ca_compromise,
-                ],
+                ]),
                 None
             ),
         ])
         assert repr(cdp) == (
             "<CRLDistributionPoints([<DistributionPoint(full_name=[<UniformRes"
             "ourceIdentifier(value=ftp://domain)>], relative_name=None, reason"
-            "s=[<ReasonFlags.key_compromise: 'keyCompromise'>, <ReasonFlags.ca"
-            "_compromise: 'cACompromise'>], crl_issuer=None)>])>"
+            "s=frozenset([<ReasonFlags.key_compromise: 'keyCompromise'>, <Reas"
+            "onFlags.ca_compromise: 'cACompromise'>]), crl_issuer=None)>])>"
         )
 
     def test_eq(self):
@@ -1525,10 +1533,10 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                [
+                frozenset([
                     x509.ReasonFlags.key_compromise,
                     x509.ReasonFlags.ca_compromise,
-                ],
+                ]),
                 [x509.UniformResourceIdentifier(u"uri://thing")],
             ),
         ])
@@ -1536,10 +1544,10 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                [
+                frozenset([
                     x509.ReasonFlags.key_compromise,
                     x509.ReasonFlags.ca_compromise,
-                ],
+                ]),
                 [x509.UniformResourceIdentifier(u"uri://thing")],
             ),
         ])
@@ -1550,10 +1558,10 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                [
+                frozenset([
                     x509.ReasonFlags.key_compromise,
                     x509.ReasonFlags.ca_compromise,
-                ],
+                ]),
                 [x509.UniformResourceIdentifier(u"uri://thing")],
             ),
         ])
@@ -1561,10 +1569,10 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain2")],
                 None,
-                [
+                frozenset([
                     x509.ReasonFlags.key_compromise,
                     x509.ReasonFlags.ca_compromise,
-                ],
+                ]),
                 [x509.UniformResourceIdentifier(u"uri://thing")],
             ),
         ])
@@ -1572,9 +1580,7 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                [
-                    x509.ReasonFlags.key_compromise,
-                ],
+                frozenset([x509.ReasonFlags.key_compromise]),
                 [x509.UniformResourceIdentifier(u"uri://thing")],
             ),
         ])
@@ -1582,10 +1588,10 @@ class TestCRLDistributionPoints(object):
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier(u"ftp://domain")],
                 None,
-                [
+                frozenset([
                     x509.ReasonFlags.key_compromise,
                     x509.ReasonFlags.ca_compromise,
-                ],
+                ]),
                 [x509.UniformResourceIdentifier(u"uri://thing2")],
             ),
         ])

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1453,14 +1453,24 @@ class TestDistributionPoint(object):
                 )
             ],
         )
-        assert repr(dp) == (
-            "<DistributionPoint(full_name=None, relative_name=<Name([<NameAtt"
-            "ribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)>, val"
-            "ue='myCN')>])>, reasons=frozenset([<ReasonFlags.ca_compromise: '"
-            "cACompromise'>]), crl_issuer=[<DirectoryName(value=<Name([<NameA"
-            "ttribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)>, v"
-            "alue='Important CA')>])>)>])>"
-        )
+        if six.PY3:
+            assert repr(dp) == (
+                "<DistributionPoint(full_name=None, relative_name=<Name([<Name"
+                "Attribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)"
+                ">, value='myCN')>])>, reasons=frozenset({<ReasonFlags.ca_comp"
+                "romise: 'cACompromise'>}), crl_issuer=[<DirectoryName(value=<"
+                "Name([<NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.3, name="
+                "commonName)>, value='Important CA')>])>)>])>"
+            )
+        else:
+            assert repr(dp) == (
+                "<DistributionPoint(full_name=None, relative_name=<Name([<Name"
+                "Attribute(oid=<ObjectIdentifier(oid=2.5.4.3, name=commonName)"
+                ">, value='myCN')>])>, reasons=frozenset([<ReasonFlags.ca_comp"
+                "romise: 'cACompromise'>]), crl_issuer=[<DirectoryName(value=<"
+                "Name([<NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.3, name="
+                "commonName)>, value='Important CA')>])>)>])>"
+            )
 
 
 class TestCRLDistributionPoints(object):
@@ -1514,12 +1524,20 @@ class TestCRLDistributionPoints(object):
                 None
             ),
         ])
-        assert repr(cdp) == (
-            "<CRLDistributionPoints([<DistributionPoint(full_name=[<UniformRes"
-            "ourceIdentifier(value=ftp://domain)>], relative_name=None, reason"
-            "s=frozenset([<ReasonFlags.key_compromise: 'keyCompromise'>]), crl"
-            "_issuer=None)>])>"
-        )
+        if six.PY3:
+            assert repr(cdp) == (
+                "<CRLDistributionPoints([<DistributionPoint(full_name=[<Unifo"
+                "rmResourceIdentifier(value=ftp://domain)>], relative_name=No"
+                "ne, reasons=frozenset({<ReasonFlags.key_compromise: 'keyComp"
+                "romise'>}), crl_issuer=None)>])>"
+            )
+        else:
+            assert repr(cdp) == (
+                "<CRLDistributionPoints([<DistributionPoint(full_name=[<Unifo"
+                "rmResourceIdentifier(value=ftp://domain)>], relative_name=No"
+                "ne, reasons=frozenset([<ReasonFlags.key_compromise: 'keyComp"
+                "romise'>]), crl_issuer=None)>])>"
+            )
 
     def test_eq(self):
         cdp = x509.CRLDistributionPoints([


### PR DESCRIPTION
Much like certificate policies, this has one property (distribution_point on DistributionPoint) that can be 2 different types. If we decide to do this another way (suggestions?) we can change it on both PRs.

refs #1743 