### PR TITLE
Adds basic CA support functions.

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -4,13 +4,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+import calendar
 import collections
 import itertools
 from contextlib import contextmanager
 
 import six
 
-from cryptography import utils
+from cryptography import utils, x509
 from cryptography.exceptions import (
     InternalError, UnsupportedAlgorithm, _Reasons
 )
@@ -36,9 +37,7 @@ from cryptography.hazmat.backends.openssl.rsa import (
 )
 from cryptography.hazmat.backends.openssl.x509 import (
     _Certificate, _CertificateSigningRequest,
-    _CertificateSigningRequestBuilder,
-    _CertificateBuilder,
-    _CertificateRevocationListBuilder,
+    _CertificateRevocationList,
 )
 from cryptography.hazmat.bindings.openssl.binding import Binding
 from cryptography.hazmat.primitives import hashes, serialization
@@ -57,6 +56,89 @@ from cryptography.hazmat.primitives.ciphers.modes import (
 _MemoryBIO = collections.namedtuple("_MemoryBIO", ["bio", "char_ptr"])
 _OpenSSLError = collections.namedtuple("_OpenSSLError",
                                        ["code", "lib", "func", "reason"])
+
+
+def _make_asn1_int(backend, x):
+    i = backend._lib.ASN1_INTEGER_new()
+    #i = backend._ffi.gc(i, backend._lib.ASN1_INTEGER_free)
+    backend._lib.ASN1_INTEGER_set(i, x)
+    return i
+
+
+def _make_asn1_str(backend, x, n):
+    s = backend._lib.ASN1_OCTET_STRING_new()
+    #s = backend._ffi.gc(s, backend._lib.ASN1_OCTET_STRING_free)
+    backend._lib.ASN1_OCTET_STRING_set(s, x, n)
+    return s
+
+
+def _make_name(backend, attributes):
+    resolve = {
+        x509.OID_COMMON_NAME: 'CN',
+        x509.OID_COUNTRY_NAME: 'C',
+        x509.OID_STATE_OR_PROVINCE_NAME: 'ST',
+        x509.OID_LOCALITY_NAME: 'L',
+        x509.OID_ORGANIZATION_NAME: 'O',
+        x509.OID_ORGANIZATIONAL_UNIT_NAME: 'OU',
+    }
+    subject = backend._lib.X509_NAME_new()
+    subject = backend._ffi.gc(subject, backend._lib.X509_NAME_free)
+    for attribute in attributes:
+        value = attribute.value
+        if isinstance(value, unicode):
+            value = value.encode('ascii')
+        res = backend._lib.X509_NAME_add_entry_by_txt(
+            subject,
+            resolve[attribute.oid],
+            backend._lib.MBSTRING_ASC,
+            value,
+            -1, -1, 0,
+        )
+        assert res == 1
+    return subject
+
+
+def _txt2obj(backend, name):
+    if isinstance(name, unicode):
+        name = name.encode('ascii')
+    obj = backend._lib.OBJ_txt2obj(name, 1)
+    if obj == backend._ffi.NULL:
+        raise ValueError('Unknown ASN.1 object "%s".' % name)
+    # NOTE: not sure if we should GC...
+    return obj
+
+
+def _make_basic_constraints(backend, ca=False, pathlen=0):
+    obj = _txt2obj(backend, x509.OID_BASIC_CONSTRAINTS.dotted_string)
+    assert obj != None
+    constraints = backend._lib.BASIC_CONSTRAINTS_new()
+    constraints.ca = 255 if ca else 0
+    if ca:
+        constraints.pathlen = _make_asn1_int(backend, pathlen)
+
+    # Allocate a buffer for encoded payload.
+    cdata = backend._ffi.new(
+        'unsigned char[]',
+        2048,  # TODO: shrink to fit!
+    )
+    assert cdata != backend._ffi.NULL
+
+    # Fetch the encoded payload.
+    p = backend._ffi.new('unsigned char*[1]')
+    assert p != backend._ffi.NULL
+    p[0] = cdata
+    r = backend._lib.i2d_BASIC_CONSTRAINTS(constraints, p)
+    assert r > 0
+
+    # Wrap that in an X509 extension object.
+    extension = backend._lib.X509_EXTENSION_create_by_OBJ(
+        backend._ffi.NULL,
+        obj,
+        1,
+        _make_asn1_str(backend, cdata, r),
+    )
+    assert extension != backend._ffi.NULL
+    return extension
 
 
 @utils.register_interface(CipherBackend)
@@ -689,14 +771,209 @@ class Backend(object):
     def create_cmac_ctx(self, algorithm):
         return _CMACContext(self, algorithm)
 
-    def new_x509_csr(self):
-        return _CertificateSigningRequestBuilder(self)
+    def sign_x509_request(self, builder, private_key, algorithm):
+        # TODO: check type of private key parameter.
+        if not isinstance(builder, x509.CertificateSigningRequestBuilder):
+            raise TypeError('Builder type mismatch.')
+        if not isinstance(algorithm, hashes.HashAlgorithm):
+            raise TypeError('Algorithm must be a registered hash algorithm.')
 
-    def new_x509_cert(self):
-        return _CertificateBuilder(self)
+        # Resolve the signature algorithm.
+        evp_md = self._lib.EVP_get_digestbyname(
+            algorithm.name.encode('ascii')
+        )
+        assert evp_md != self._ffi.NULL
 
-    def new_x509_crl(self):
-        return _CertificateRevocationListBuilder(self)
+        # Create an empty request.
+        x509_req = self._lib.X509_REQ_new()
+        assert x509_req != self._ffi.NULL
+
+        # Set x509 version.
+        res = self._lib.X509_REQ_set_version(x509_req, builder._version.value)
+        assert res == 1
+
+        # Set subject name.
+        res = self._lib.X509_REQ_set_subject_name(
+            x509_req, _make_name(self, list(builder._subject_name))
+        )
+        assert res == 1
+
+        # Set subject public key.
+        public_key = private_key.public_key()
+        res = self._lib.X509_REQ_set_pubkey(
+            x509_req, public_key._evp_pkey
+        )
+        assert res == 1
+
+        # Add extensions.
+        extensions = self._lib.sk_X509_EXTENSION_new_null()
+        extensions = self._ffi.gc(
+            extensions,
+            self._lib.sk_X509_EXTENSION_free,
+        )
+        for extension in builder._extensions:
+            if isinstance(extension.value, x509.BasicConstraints):
+                extension = _make_basic_constraints(
+                    self,
+                    extension.value.ca,
+                    extension.value.path_length
+                )
+            else:
+                raise ValueError('Extension not yet supported.')
+            res = self._lib.sk_X509_EXTENSION_push(extensions, extension)
+            assert res == 1
+        res = self._lib.X509_REQ_add_extensions(x509_req, extensions)
+        assert res == 1
+
+        # Sign the request using the requester's private key.
+        res = self._lib.X509_REQ_sign(
+            x509_req, private_key._evp_pkey, evp_md
+        )
+        assert res > 0
+
+        return _CertificateSigningRequest(self, x509_req)
+
+    def sign_x509_certificate(self, builder, private_key, algorithm):
+        # TODO: check type of private key parameter.
+        if not isinstance(builder, x509.CertificateBuilder):
+            raise TypeError('Builder type mismatch.')
+        if not isinstance(algorithm, hashes.HashAlgorithm):
+            raise TypeError('Algorithm must be a registered hash algorithm.')
+
+        # Resolve the signature algorithm.
+        evp_md = self._lib.EVP_get_digestbyname(
+            algorithm.name.encode('ascii')
+        )
+        assert evp_md != self._ffi.NULL
+
+        # Create an empty certificate.
+        x509_cert = self._lib.X509_new()
+        x509_cert = self._ffi.gc(x509_cert, backend._lib.X509_free)
+
+        # Set the x509 version.
+        res = self._lib.X509_set_version(x509_cert, builder._version.value)
+        assert res == 1
+
+        # Set the subject's name.
+        res = self._lib.X509_set_subject_name(
+            x509_cert, _make_name(self, list(builder._subject_name))
+        )
+        assert res == 1
+
+        # Set the subject's public key.
+        res = self._lib.X509_set_pubkey(
+            x509_cert, builder._public_key._evp_pkey
+        )
+        assert res == 1
+
+        # Set the certificate serial number.
+        serial_number = _make_asn1_int(self, builder._serial_number)
+        self._lib.X509_set_serialNumber(x509_cert, serial_number)
+
+        # Set the "not before" time.
+        res = self._lib.ASN1_TIME_set(
+            self._lib.X509_get_notBefore(x509_cert),
+            calendar.timegm(builder._not_valid_before.timetuple())
+        )
+        assert res != self._ffi.NULL
+
+        # Set the "not after" time.
+        res = self._lib.ASN1_TIME_set(
+            self._lib.X509_get_notAfter(x509_cert),
+            calendar.timegm(builder._not_valid_after.timetuple())
+        )
+        assert res != self._ffi.NULL
+
+        # Add extensions.
+        for extension in builder._extensions:
+            if isinstance(extension.value, x509.BasicConstraints):
+                extension = _make_basic_constraints(
+                    self,
+                    extension.value.ca,
+                    extension.value.path_length
+                )
+            else:
+                raise ValueError('Extension not yet supported.')
+            res = self._lib.X509_add_ext(x509_cert, extension, 0)
+            assert res == 1
+
+        # Set the issuer name.
+        res = self._lib.X509_set_issuer_name(
+            x509_cert, _make_name(self, list(builder._issuer_name))
+        )
+        assert res == 1
+
+        # Sign the certificate with the issuer's private key.
+        res = self._lib.X509_sign(
+            x509_cert, private_key._evp_pkey, evp_md
+        )
+        assert res > 0
+
+        return _Certificate(self, x509_cert)
+
+    def sign_x509_revocation_list(self, builder, private_key, algorithm):
+        if not isinstance(algorithm, hashes.HashAlgorithm):
+            raise TypeError('Algorithm must be a registered hash algorithm.')
+
+        evp_md = self._lib.EVP_get_digestbyname(
+            algorithm.name.encode('ascii')
+        )
+        assert evp_md != self._ffi.NULL
+
+        # Create an empty CRL.
+        x509_crl = self._lib.X509_CRL_new()
+        assert x509_crl != self._ffi.NULL
+        x509_crl = self._ffi.gc(
+            x509_crl, self._lib.X509_CRL_free
+        )
+
+        # Set issuer name.
+        res = self._lib.X509_CRL_set_issuer_name(
+            x509_crl,
+            _make_name(self, list(builder._issuer_name))
+        )
+        assert res == 1
+
+        # Set last update time.
+        res = self._lib.ASN1_UTCTIME_set(
+            x509_crl.crl.lastUpdate,
+            calendar.timegm(builder._last_update.timetuple())
+        )
+        assert res != self._ffi.NULL
+
+        # Set next update time.
+        x509_crl.crl.nextUpdate = self._lib.ASN1_UTCTIME_set(
+            self._ffi.NULL,
+            calendar.timegm(builder._next_update.timetuple())
+        )
+        assert x509_crl.crl.nextUpdate != self._ffi.NULL
+
+        # Add revoked certificates.
+        for serial_number, revocation_date in builder._certificates:
+            # NOTE: don't GC (adding to CRL will consume reference count).
+            x509_rev = self._lib.X509_REVOKED_new()
+            res = self._lib.X509_REVOKED_set_serialNumber(
+                x509_rev,
+                _make_asn1_int(self, serial_number)
+            )
+            assert res == 1
+            res = self._lib.ASN1_TIME_set(
+                x509_rev.revocationDate,
+                calendar.timegm(revocation_date.timetuple())
+            )
+            assert res != self._ffi.NULL
+            res = self._lib.X509_CRL_add0_revoked(
+                x509_crl, x509_rev
+            )
+            assert res == 1
+
+        # Sign the CRL using the issuer's private key.
+        res = self._lib.X509_CRL_sign(
+            x509_crl, private_key._evp_pkey, evp_md
+        )
+        assert res > 0
+
+        return _CertificateRevocationList(self, x509_crl)
 
     def load_pem_private_key(self, data, password):
         return self._load_key(

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1133,6 +1133,28 @@ class Backend(object):
         x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)
         return _CertificateSigningRequest(self, x509_req)
 
+    def load_pem_x509_crl(self, data):
+        mem_bio = self._bytes_to_bio(data)
+        x509_crl = self._lib.PEM_read_bio_X509_CRL(
+            mem_bio.bio, self._ffi.NULL, self._ffi.NULL, self._ffi.NULL
+        )
+        if x509_crl == self._ffi.NULL:
+            self._consume_errors()
+            raise ValueError("Unable to load certificate")
+
+        x509_crl = self._ffi.gc(x509_crl, self._lib.X509_free)
+        return _CertificateRevocationList(self, x509_crl)
+
+    def load_der_x509_crl(self, data):
+        mem_bio = self._bytes_to_bio(data)
+        x509_crl = self._lib.d2i_X509_CRL_bio(mem_bio.bio, self._ffi.NULL)
+        if x509_crl == self._ffi.NULL:
+            self._consume_errors()
+            raise ValueError("Unable to load certificate")
+
+        x509_crl = self._ffi.gc(x509_crl, self._lib.X509_free)
+        return _CertificateRevocationList(self, x509_crl)
+
     def create_x509_csr(self):
         x509_req = self._lib.X509_REQ_new()
         if x509_req == self._ffi.NULL:

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -140,6 +140,34 @@ def _build_general_name(backend, gn):
         )
 
 
+def _parse_asn1_time(backend, asn1_time):
+    assert asn1_time != backend._ffi.NULL
+    generalized_time = backend._lib.ASN1_TIME_to_generalizedtime(
+        asn1_time, backend._ffi.NULL
+    )
+    assert generalized_time != backend._ffi.NULL
+    generalized_time = backend._ffi.gc(
+        generalized_time, backend._lib.ASN1_GENERALIZEDTIME_free
+    )
+    time = backend._ffi.string(
+        backend._lib.ASN1_STRING_data(
+            backend._ffi.cast("ASN1_STRING *", generalized_time)
+        )
+    ).decode("ascii")
+    return datetime.datetime.strptime(time, "%Y%m%d%H%M%SZ")
+
+
+def _parse_asn1_utctime(backend, asn1_time):
+    assert asn1_time != backend._ffi.NULL
+    time = backend._ffi.string(
+        backend._lib.ASN1_STRING_data(
+            backend._ffi.cast("ASN1_STRING *", asn1_time)
+        )
+    ).decode("ascii")
+    print('TIME: %r.' % time)
+    return datetime.datetime.strptime(time, "%y%m%d%H%M%SZ")
+
+
 @utils.register_interface(x509.Certificate)
 class _Certificate(object):
     def __init__(self, backend, x509):
@@ -208,20 +236,7 @@ class _Certificate(object):
         return self._parse_asn1_time(asn1_time)
 
     def _parse_asn1_time(self, asn1_time):
-        assert asn1_time != self._backend._ffi.NULL
-        generalized_time = self._backend._lib.ASN1_TIME_to_generalizedtime(
-            asn1_time, self._backend._ffi.NULL
-        )
-        assert generalized_time != self._backend._ffi.NULL
-        generalized_time = self._backend._ffi.gc(
-            generalized_time, self._backend._lib.ASN1_GENERALIZEDTIME_free
-        )
-        time = self._backend._ffi.string(
-            self._backend._lib.ASN1_STRING_data(
-                self._backend._ffi.cast("ASN1_STRING *", generalized_time)
-            )
-        ).decode("ascii")
-        return datetime.datetime.strptime(time, "%Y%m%d%H%M%SZ")
+        return _parse_asn1_time(self._backend, asn1_time)
 
     @property
     def issuer(self):
@@ -283,6 +298,22 @@ class _Certificate(object):
             extensions.append(x509.Extension(oid, critical, value))
 
         return x509.Extensions(extensions)
+
+
+    def public_bytes(self, encoding):
+        if not isinstance(encoding, serialization.Encoding):
+            raise TypeError("encoding must be an item from the Encoding enum")
+
+        # TODO: make text prelude optional.
+        bio = self._backend._create_mem_bio()
+        res = self._backend._lib.X509_print(bio, self._x509)
+        assert res == 1
+        if encoding is serialization.Encoding.PEM:
+            res = self._backend._lib.PEM_write_bio_X509(bio, self._x509)
+        elif encoding is serialization.Encoding.DER:
+            res = self._backend._lib.i2d_X509_bio(bio, self._x509)
+        assert res == 1
+        return self._backend._read_mem_bio(bio)
 
     def _build_basic_constraints(self, ext):
         bc_st = self._backend._lib.X509V3_EXT_d2i(ext)
@@ -416,162 +447,9 @@ class _CertificateSigningRequest(object):
                 "Signature algorithm OID:{0} not recognized".format(oid)
             )
 
-
-def _make_asn1_int(backend, x):
-    i = backend._lib.ASN1_INTEGER_new()
-    #i = backend._ffi.gc(i, backend._lib.ASN1_INTEGER_free)
-    backend._lib.ASN1_INTEGER_set(i, x)
-    return i
-
-
-def _make_asn1_str(backend, x, n):
-    s = backend._lib.ASN1_OCTET_STRING_new()
-    #s = backend._ffi.gc(s, backend._lib.ASN1_OCTET_STRING_free)
-    backend._lib.ASN1_OCTET_STRING_set(s, x, n)
-    return s
-
-
-def _make_name(backend, attributes):
-    resolve = {
-        x509.OID_COMMON_NAME: 'CN',
-        x509.OID_COUNTRY_NAME: 'C',
-        x509.OID_STATE_OR_PROVINCE_NAME: 'ST',
-        x509.OID_LOCALITY_NAME: 'L',
-        x509.OID_ORGANIZATION_NAME: 'O',
-        x509.OID_ORGANIZATIONAL_UNIT_NAME: 'OU',
-    }
-    subject = backend._lib.X509_NAME_new()
-    subject = backend._ffi.gc(subject, backend._lib.X509_NAME_free)
-    for attribute in attributes:
-        value = attribute.value
-        if isinstance(value, unicode):
-            value = value.encode('ascii')
-        res = backend._lib.X509_NAME_add_entry_by_txt(
-            subject,
-            resolve[attribute.oid],
-            backend._lib.MBSTRING_ASC,
-            value,
-            -1, -1, 0,
-        )
-        assert res == 1
-    return subject
-
-
-def _txt2obj(backend, name):
-    if isinstance(name, unicode):
-        name = name.encode('ascii')
-    obj = backend._lib.OBJ_txt2obj(name, 1)
-    if obj == backend._ffi.NULL:
-        raise ValueError('Unknown ASN.1 object "%s".' % name)
-    # NOTE: not sure if we should GC...
-    return obj
-
-
-def _make_basic_constraints(backend, ca=False, pathlen=0):
-    obj = _txt2obj(backend, x509.OID_BASIC_CONSTRAINTS.dotted_string)
-    assert obj != None
-    constraints = backend._lib.BASIC_CONSTRAINTS_new()
-    constraints.ca = 255 if ca else 0
-    if ca:
-        constraints.pathlen = _make_asn1_int(backend, pathlen)
-
-    # Allocate a buffer for encoded payload.
-    cdata = backend._ffi.new(
-        'unsigned char[]',
-        2048,  # TODO: shrink to fit!
-    )
-    assert cdata != backend._ffi.NULL
-
-    # Fetch the encoded payload.
-    p = backend._ffi.new('unsigned char*[1]')
-    assert p != backend._ffi.NULL
-    p[0] = cdata
-    r = backend._lib.i2d_BASIC_CONSTRAINTS(constraints, p)
-    assert r > 0
-
-    # Wrap that in an X509 extension object.
-    extension = backend._lib.X509_EXTENSION_create_by_OBJ(
-        backend._ffi.NULL,
-        obj,
-        1,
-        _make_asn1_str(backend, cdata, r),
-    )
-    assert extension != backend._ffi.NULL
-    return extension
-
-
-@utils.register_interface(x509.CertificateSigningRequestBuilder)
-class _CertificateSigningRequestBuilder(object):
-    def __init__(self, backend):
-        self._backend = backend
-        self._x509_csr = self._backend._lib.X509_REQ_new()
-        assert self._x509_csr != self._backend._ffi.NULL
-        self._extensions = self._backend._lib.sk_X509_EXTENSION_new_null()
-        self._extensions = self._backend._ffi.gc(
-            self._extensions,
-            self._backend._lib.sk_X509_EXTENSION_free,
-        )
-
-    # TODO: accept {v1, v3} enum instead of {0, 2} int?
-    def set_version(self, version):
-        if version not in (0, 2):
-            raise ValueError('Version must be 0 (v1) or 2 (v3).')
-        res = self._backend._lib.X509_REQ_set_version(self._x509_csr, version)
-        assert res == 1
-        return self
-
-    def set_subject_name(self, attributes):
-        name = _make_name(self._backend, attributes)
-        res = self._backend._lib.X509_REQ_set_subject_name(
-            self._x509_csr, name
-        )
-        assert res == 1
-        return self
-
-    def add_extension(self, extension):
-        if not isinstance(extension, x509.Extension):
-            raise TypeError('Expecting an x509 extension.')
-
-        if isinstance(extension.value, x509.BasicConstraints):
-            extension = _make_basic_constraints(
-                self._backend,
-                extension.value.ca,
-                extension.value.path_length
-            )
-        else:
-            raise ValueError('Extension not yet supported.')
-
-        res = self._backend._lib.sk_X509_EXTENSION_push(
-            self._extensions, extension
-        )
-        assert res == 1
-        return self
-
-    def sign(self, private_key, algorithm):
-        if not isinstance(algorithm, hashes.HashAlgorithm):
-            raise TypeError('Algorithm must be a registered hash algorithm.')
-
-        evp_md = self._backend._lib.EVP_get_digestbyname(
-            algorithm.name.encode('ascii')
-        )
-        assert evp_md != self._backend._ffi.NULL
-
-        res = self._backend._lib.X509_REQ_add_extensions(
-            self._x509_csr, self._extensions
-        )
-        assert res == 1
-
-        public_key = private_key.public_key()
-        res = self._backend._lib.X509_REQ_set_pubkey(
-            self._x509_csr, public_key._evp_pkey
-        )
-        assert res == 1
-
-        res = self._backend._lib.X509_REQ_sign(
-            self._x509_csr, private_key._evp_pkey, evp_md
-        )
-        assert res > 0
-        return self
+    @property
+    def extensions(self):
+        return None
 
     def public_bytes(self, encoding):
         if not isinstance(encoding, serialization.Encoding):
@@ -579,195 +457,66 @@ class _CertificateSigningRequestBuilder(object):
 
         # TODO: make text prelude optional.
         bio = self._backend._create_mem_bio()
-        res = self._backend._lib.X509_REQ_print(bio, self._x509_csr)
+        res = self._backend._lib.X509_REQ_print(bio, self._x509_req)
         assert res == 1
         if encoding is serialization.Encoding.PEM:
             res = self._backend._lib.PEM_write_bio_X509_REQ(
-                bio, self._x509_csr
+                bio, self._x509_req
             )
         elif encoding is serialization.Encoding.DER:
-            res = self._backend._lib.i2d_X509_REQ_bio(bio, self._x509_csr)
+            res = self._backend._lib.i2d_X509_REQ_bio(bio, self._x509_req)
         assert res == 1
         return self._backend._read_mem_bio(bio)
 
 
-@utils.register_interface(x509.CertificateBuilder)
-class _CertificateBuilder(object):
-    def __init__(self, backend):
+class _CertificateRevocationList(object):
+    def __init__(self, backend, x509_crl):
         self._backend = backend
-        self._x509 = self._backend._lib.X509_new()
-        self._x509 = self._backend._ffi.gc(self._x509, backend._lib.X509_free)
+        self._x509_crl = x509_crl
 
-    def set_version(self, version):
-        res = self._backend._lib.X509_set_version(self._x509, 2)
-        assert res == 1
-        return self
+    @property
+    def issuer(self):
+        issuer = self._backend._lib.X509_CRL_get_issuer(self._x509_crl)
+        assert issuer != self._backend._ffi.NULL
+        return _build_x509_name(self._backend, issuer)
 
-    def set_issuer_name(self, attributes):
-        res = self._backend._lib.X509_set_issuer_name(
-            self._x509, _make_name(self._backend, attributes)
-        )
-        assert res == 1
-        return self
+    @property
+    def last_update(self):
+        time = self._x509_crl.crl.lastUpdate
+        if time == self._backend._ffi.NULL:
+            return None
+        return _parse_asn1_utctime(self._backend, time)
 
-    def set_subject_name(self, attributes):
-        res = self._backend._lib.X509_set_subject_name(
-            self._x509, _make_name(self._backend, attributes)
-        )
-        assert res == 1
-        return self
+    @property
+    def next_update(self):
+        time = self._x509_crl.crl.nextUpdate
+        if time == self._backend._ffi.NULL:
+            return None
+        return _parse_asn1_utctime(self._backend, time)
 
-    def set_public_key(self, public_key):
-        res = self._backend._lib.X509_set_pubkey(
-            self._x509, public_key._evp_pkey
-        )
-        assert res == 1
-        return self
-
-    def set_serial_number(self, serial_number):
-        serial_number = _make_asn1_int(self._backend, serial_number)
-        self._backend._lib.X509_set_serialNumber(self._x509, serial_number)
-        return self
-
-    # NOTE: this is totally incorrect!
-    def set_not_valid_before(self, time):
-        res = self._backend._lib.ASN1_TIME_set(
-            self._backend._lib.X509_get_notBefore(self._x509),
-            calendar.timegm(time.timetuple())
-        )
-        assert res != self._backend._ffi.NULL
-        return self
-
-    # NOTE: this is totally incorrect!
-    def set_not_valid_after(self, time):
-        res = self._backend._lib.ASN1_TIME_set(
-            self._backend._lib.X509_get_notAfter(self._x509),
-            calendar.timegm(time.timetuple())
-        )
-        assert res != self._backend._ffi.NULL
-        return self
-
-    def add_extension(self, extension):
-        if not isinstance(extension, x509.Extension):
-            raise TypeError('Expecting an x509 extension.')
-
-        if isinstance(extension.value, x509.BasicConstraints):
-            extension = _make_basic_constraints(
-                self._backend,
-                extension.value.ca,
-                extension.value.path_length
+    @property
+    def certificates(self):
+        certs = []
+        num = self._backend._lib.sk_X509_REVOKED_num(self._x509_crl.crl.revoked)
+        for i in range(0, num):
+            x509_rev = self._backend._lib.sk_X509_REVOKED_value(
+                self._x509_crl.crl.revoked, i
             )
-        else:
-            raise ValueError('Extension not yet supported.')
-
-        res = self._backend._lib.X509_add_ext(self._x509, extension, 0)
-        assert res == 1
-        return self
-
-    def sign(self, private_key, algorithm):
-        if not isinstance(algorithm, hashes.HashAlgorithm):
-            raise TypeError('Algorithm must be a registered hash algorithm.')
-
-        evp_md = self._backend._lib.EVP_get_digestbyname(
-            algorithm.name.encode('ascii')
-        )
-        assert evp_md != self._backend._ffi.NULL
-
-        res = self._backend._lib.X509_sign(
-            self._x509, private_key._evp_pkey, evp_md
-        )
-        assert res > 0
-        return self
-
-    def public_bytes(self, encoding):
-        if not isinstance(encoding, serialization.Encoding):
-            raise TypeError("encoding must be an item from the Encoding enum")
-
-        # TODO: make text prelude optional.
-        bio = self._backend._create_mem_bio()
-        res = self._backend._lib.X509_print(bio, self._x509)
-        assert res == 1
-        if encoding is serialization.Encoding.PEM:
-            res = self._backend._lib.PEM_write_bio_X509(bio, self._x509)
-        elif encoding is serialization.Encoding.DER:
-            res = self._backend._lib.i2d_X509_bio(bio, self._x509)
-        assert res == 1
-        return self._backend._read_mem_bio(bio)
-
-
-@utils.register_interface(x509.CertificateRevocationListBuilder)
-class _CertificateRevocationListBuilder(object):
-    def __init__(self, backend):
-        self._backend = backend
-        self._x509_crl = self._backend._lib.X509_CRL_new()
-        assert self._x509_crl != self._backend._ffi.NULL
-        self._x509_crl = self._backend._ffi.gc(
-            self._x509_crl, self._backend._lib.X509_CRL_free
-        )
-
-    def set_version(self, version):
-        return self
-
-    def set_issuer_name(self, attributes):
-        res = self._backend._lib.X509_CRL_set_issuer_name(
-            self._x509_crl,
-            _make_name(self._backend, attributes)
-        )
-        assert res == 1
-        return self
-
-    def set_last_update(self, time):
-        res = self._backend._lib.ASN1_UTCTIME_set(
-            self._x509_crl.crl.lastUpdate,
-            calendar.timegm(time.timetuple())
-        )
-        assert res != self._backend._ffi.NULL
-        return self
-
-    def set_next_update(self, time):
-        res = self._backend._lib.ASN1_UTCTIME_set(
-            self._x509_crl.crl.nextUpdate,
-            calendar.timegm(time.timetuple())
-        )
-        assert res != self._backend._ffi.NULL
-        return self
-
-    def add_extension(self, extension):
-        return self
-
-    def add_certificate(self, serial_number, revocation_date):
-        # NOTE: don't GC (adding to CRL will consume reference count).
-        x509_rev = self._backend._lib.X509_REVOKED_new()
-        res = self._backend._lib.X509_REVOKED_set_serialNumber(
-            x509_rev,
-            _make_asn1_int(self._backend, serial_number)
-        )
-        assert res == 1
-        res = self._backend._lib.ASN1_TIME_set(
-            x509_rev.revocationDate,
-            calendar.timegm(revocation_date.timetuple())
-        )
-        assert res != self._backend._ffi.NULL
-        res = self._backend._lib.X509_CRL_add0_revoked(
-            self._x509_crl, x509_rev
-        )
-        assert res == 1
-        return self
-
-    def sign(self, private_key, algorithm):
-        if not isinstance(algorithm, hashes.HashAlgorithm):
-            raise TypeError('Algorithm must be a registered hash algorithm.')
-
-        evp_md = self._backend._lib.EVP_get_digestbyname(
-            algorithm.name.encode('ascii')
-        )
-        assert evp_md != self._backend._ffi.NULL
-
-        res = self._backend._lib.X509_CRL_sign(
-            self._x509_crl, private_key._evp_pkey, evp_md
-        )
-        assert res > 0
-        return self
+            assert x509_rev != self._backend._ffi.NULL
+            # Decode serial number.
+            bn = self._backend._lib.ASN1_INTEGER_to_BN(
+                x509_rev.serialNumber, self._backend._ffi.NULL
+            )
+            assert bn != self._backend._ffi.NULL
+            bn = self._backend._ffi.gc(bn, self._backend._lib.BN_free)
+            serial_number = self._backend._bn_to_int(bn)
+            # Decode revocation date.
+            revocation_date = _parse_asn1_time(
+                self._backend, x509_rev.revocationDate
+            )
+            certs.append((serial_number, revocation_date))
+            
+        return certs
 
     def public_bytes(self, encoding):
         if not isinstance(encoding, serialization.Encoding):

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -13,6 +13,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import calendar
 import datetime
 import ipaddress
 from email.utils import parseaddr
@@ -25,7 +26,7 @@ from six.moves import urllib_parse
 
 from cryptography import utils, x509
 from cryptography.exceptions import UnsupportedAlgorithm
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 
 
 def _obj2txt(backend, obj):
@@ -414,3 +415,373 @@ class _CertificateSigningRequest(object):
             raise UnsupportedAlgorithm(
                 "Signature algorithm OID:{0} not recognized".format(oid)
             )
+
+
+def _make_asn1_int(backend, x):
+    i = backend._lib.ASN1_INTEGER_new()
+    #i = backend._ffi.gc(i, backend._lib.ASN1_INTEGER_free)
+    backend._lib.ASN1_INTEGER_set(i, x)
+    return i
+
+
+def _make_asn1_str(backend, x, n):
+    s = backend._lib.ASN1_OCTET_STRING_new()
+    #s = backend._ffi.gc(s, backend._lib.ASN1_OCTET_STRING_free)
+    backend._lib.ASN1_OCTET_STRING_set(s, x, n)
+    return s
+
+
+def _make_name(backend, attributes):
+    resolve = {
+        x509.OID_COMMON_NAME: 'CN',
+        x509.OID_COUNTRY_NAME: 'C',
+        x509.OID_STATE_OR_PROVINCE_NAME: 'ST',
+        x509.OID_LOCALITY_NAME: 'L',
+        x509.OID_ORGANIZATION_NAME: 'O',
+        x509.OID_ORGANIZATIONAL_UNIT_NAME: 'OU',
+    }
+    subject = backend._lib.X509_NAME_new()
+    subject = backend._ffi.gc(subject, backend._lib.X509_NAME_free)
+    for attribute in attributes:
+        value = attribute.value
+        if isinstance(value, unicode):
+            value = value.encode('ascii')
+        res = backend._lib.X509_NAME_add_entry_by_txt(
+            subject,
+            resolve[attribute.oid],
+            backend._lib.MBSTRING_ASC,
+            value,
+            -1, -1, 0,
+        )
+        assert res == 1
+    return subject
+
+
+def _txt2obj(backend, name):
+    if isinstance(name, unicode):
+        name = name.encode('ascii')
+    obj = backend._lib.OBJ_txt2obj(name, 1)
+    if obj == backend._ffi.NULL:
+        raise ValueError('Unknown ASN.1 object "%s".' % name)
+    # NOTE: not sure if we should GC...
+    return obj
+
+
+def _make_basic_constraints(backend, ca=False, pathlen=0):
+    obj = _txt2obj(backend, x509.OID_BASIC_CONSTRAINTS.dotted_string)
+    assert obj != None
+    constraints = backend._lib.BASIC_CONSTRAINTS_new()
+    constraints.ca = 255 if ca else 0
+    if ca:
+        constraints.pathlen = _make_asn1_int(backend, pathlen)
+
+    # Allocate a buffer for encoded payload.
+    cdata = backend._ffi.new(
+        'unsigned char[]',
+        2048,  # TODO: shrink to fit!
+    )
+    assert cdata != backend._ffi.NULL
+
+    # Fetch the encoded payload.
+    p = backend._ffi.new('unsigned char*[1]')
+    assert p != backend._ffi.NULL
+    p[0] = cdata
+    r = backend._lib.i2d_BASIC_CONSTRAINTS(constraints, p)
+    assert r > 0
+
+    # Wrap that in an X509 extension object.
+    extension = backend._lib.X509_EXTENSION_create_by_OBJ(
+        backend._ffi.NULL,
+        obj,
+        1,
+        _make_asn1_str(backend, cdata, r),
+    )
+    assert extension != backend._ffi.NULL
+    return extension
+
+
+@utils.register_interface(x509.CertificateSigningRequestBuilder)
+class _CertificateSigningRequestBuilder(object):
+    def __init__(self, backend):
+        self._backend = backend
+        self._x509_csr = self._backend._lib.X509_REQ_new()
+        assert self._x509_csr != self._backend._ffi.NULL
+        self._extensions = self._backend._lib.sk_X509_EXTENSION_new_null()
+        self._extensions = self._backend._ffi.gc(
+            self._extensions,
+            self._backend._lib.sk_X509_EXTENSION_free,
+        )
+
+    # TODO: accept {v1, v3} enum instead of {0, 2} int?
+    def set_version(self, version):
+        if version not in (0, 2):
+            raise ValueError('Version must be 0 (v1) or 2 (v3).')
+        res = self._backend._lib.X509_REQ_set_version(self._x509_csr, version)
+        assert res == 1
+        return self
+
+    def set_subject_name(self, attributes):
+        name = _make_name(self._backend, attributes)
+        res = self._backend._lib.X509_REQ_set_subject_name(
+            self._x509_csr, name
+        )
+        assert res == 1
+        return self
+
+    def add_extension(self, extension):
+        if not isinstance(extension, x509.Extension):
+            raise TypeError('Expecting an x509 extension.')
+
+        if isinstance(extension.value, x509.BasicConstraints):
+            extension = _make_basic_constraints(
+                self._backend,
+                extension.value.ca,
+                extension.value.path_length
+            )
+        else:
+            raise ValueError('Extension not yet supported.')
+
+        res = self._backend._lib.sk_X509_EXTENSION_push(
+            self._extensions, extension
+        )
+        assert res == 1
+        return self
+
+    def sign(self, private_key, algorithm):
+        if not isinstance(algorithm, hashes.HashAlgorithm):
+            raise TypeError('Algorithm must be a registered hash algorithm.')
+
+        evp_md = self._backend._lib.EVP_get_digestbyname(
+            algorithm.name.encode('ascii')
+        )
+        assert evp_md != self._backend._ffi.NULL
+
+        res = self._backend._lib.X509_REQ_add_extensions(
+            self._x509_csr, self._extensions
+        )
+        assert res == 1
+
+        public_key = private_key.public_key()
+        res = self._backend._lib.X509_REQ_set_pubkey(
+            self._x509_csr, public_key._evp_pkey
+        )
+        assert res == 1
+
+        res = self._backend._lib.X509_REQ_sign(
+            self._x509_csr, private_key._evp_pkey, evp_md
+        )
+        assert res > 0
+        return self
+
+    def public_bytes(self, encoding):
+        if not isinstance(encoding, serialization.Encoding):
+            raise TypeError("encoding must be an item from the Encoding enum")
+
+        # TODO: make text prelude optional.
+        bio = self._backend._create_mem_bio()
+        res = self._backend._lib.X509_REQ_print(bio, self._x509_csr)
+        assert res == 1
+        if encoding is serialization.Encoding.PEM:
+            res = self._backend._lib.PEM_write_bio_X509_REQ(
+                bio, self._x509_csr
+            )
+        elif encoding is serialization.Encoding.DER:
+            res = self._backend._lib.i2d_X509_REQ_bio(bio, self._x509_csr)
+        assert res == 1
+        return self._backend._read_mem_bio(bio)
+
+
+@utils.register_interface(x509.CertificateBuilder)
+class _CertificateBuilder(object):
+    def __init__(self, backend):
+        self._backend = backend
+        self._x509 = self._backend._lib.X509_new()
+        self._x509 = self._backend._ffi.gc(self._x509, backend._lib.X509_free)
+
+    def set_version(self, version):
+        res = self._backend._lib.X509_set_version(self._x509, 2)
+        assert res == 1
+        return self
+
+    def set_issuer_name(self, attributes):
+        res = self._backend._lib.X509_set_issuer_name(
+            self._x509, _make_name(self._backend, attributes)
+        )
+        assert res == 1
+        return self
+
+    def set_subject_name(self, attributes):
+        res = self._backend._lib.X509_set_subject_name(
+            self._x509, _make_name(self._backend, attributes)
+        )
+        assert res == 1
+        return self
+
+    def set_public_key(self, public_key):
+        res = self._backend._lib.X509_set_pubkey(
+            self._x509, public_key._evp_pkey
+        )
+        assert res == 1
+        return self
+
+    def set_serial_number(self, serial_number):
+        serial_number = _make_asn1_int(self._backend, serial_number)
+        self._backend._lib.X509_set_serialNumber(self._x509, serial_number)
+        return self
+
+    # NOTE: this is totally incorrect!
+    def set_not_valid_before(self, time):
+        res = self._backend._lib.ASN1_TIME_set(
+            self._backend._lib.X509_get_notBefore(self._x509),
+            calendar.timegm(time.timetuple())
+        )
+        assert res != self._backend._ffi.NULL
+        return self
+
+    # NOTE: this is totally incorrect!
+    def set_not_valid_after(self, time):
+        res = self._backend._lib.ASN1_TIME_set(
+            self._backend._lib.X509_get_notAfter(self._x509),
+            calendar.timegm(time.timetuple())
+        )
+        assert res != self._backend._ffi.NULL
+        return self
+
+    def add_extension(self, extension):
+        if not isinstance(extension, x509.Extension):
+            raise TypeError('Expecting an x509 extension.')
+
+        if isinstance(extension.value, x509.BasicConstraints):
+            extension = _make_basic_constraints(
+                self._backend,
+                extension.value.ca,
+                extension.value.path_length
+            )
+        else:
+            raise ValueError('Extension not yet supported.')
+
+        res = self._backend._lib.X509_add_ext(self._x509, extension, 0)
+        assert res == 1
+        return self
+
+    def sign(self, private_key, algorithm):
+        if not isinstance(algorithm, hashes.HashAlgorithm):
+            raise TypeError('Algorithm must be a registered hash algorithm.')
+
+        evp_md = self._backend._lib.EVP_get_digestbyname(
+            algorithm.name.encode('ascii')
+        )
+        assert evp_md != self._backend._ffi.NULL
+
+        res = self._backend._lib.X509_sign(
+            self._x509, private_key._evp_pkey, evp_md
+        )
+        assert res > 0
+        return self
+
+    def public_bytes(self, encoding):
+        if not isinstance(encoding, serialization.Encoding):
+            raise TypeError("encoding must be an item from the Encoding enum")
+
+        # TODO: make text prelude optional.
+        bio = self._backend._create_mem_bio()
+        res = self._backend._lib.X509_print(bio, self._x509)
+        assert res == 1
+        if encoding is serialization.Encoding.PEM:
+            res = self._backend._lib.PEM_write_bio_X509(bio, self._x509)
+        elif encoding is serialization.Encoding.DER:
+            res = self._backend._lib.i2d_X509_bio(bio, self._x509)
+        assert res == 1
+        return self._backend._read_mem_bio(bio)
+
+
+@utils.register_interface(x509.CertificateRevocationListBuilder)
+class _CertificateRevocationListBuilder(object):
+    def __init__(self, backend):
+        self._backend = backend
+        self._x509_crl = self._backend._lib.X509_CRL_new()
+        assert self._x509_crl != self._backend._ffi.NULL
+        self._x509_crl = self._backend._ffi.gc(
+            self._x509_crl, self._backend._lib.X509_CRL_free
+        )
+
+    def set_version(self, version):
+        return self
+
+    def set_issuer_name(self, attributes):
+        res = self._backend._lib.X509_CRL_set_issuer_name(
+            self._x509_crl,
+            _make_name(self._backend, attributes)
+        )
+        assert res == 1
+        return self
+
+    def set_last_update(self, time):
+        res = self._backend._lib.ASN1_UTCTIME_set(
+            self._x509_crl.crl.lastUpdate,
+            calendar.timegm(time.timetuple())
+        )
+        assert res != self._backend._ffi.NULL
+        return self
+
+    def set_next_update(self, time):
+        res = self._backend._lib.ASN1_UTCTIME_set(
+            self._x509_crl.crl.nextUpdate,
+            calendar.timegm(time.timetuple())
+        )
+        assert res != self._backend._ffi.NULL
+        return self
+
+    def add_extension(self, extension):
+        return self
+
+    def add_certificate(self, serial_number, revocation_date):
+        # NOTE: don't GC (adding to CRL will consume reference count).
+        x509_rev = self._backend._lib.X509_REVOKED_new()
+        res = self._backend._lib.X509_REVOKED_set_serialNumber(
+            x509_rev,
+            _make_asn1_int(self._backend, serial_number)
+        )
+        assert res == 1
+        res = self._backend._lib.ASN1_TIME_set(
+            x509_rev.revocationDate,
+            calendar.timegm(revocation_date.timetuple())
+        )
+        assert res != self._backend._ffi.NULL
+        res = self._backend._lib.X509_CRL_add0_revoked(
+            self._x509_crl, x509_rev
+        )
+        assert res == 1
+        return self
+
+    def sign(self, private_key, algorithm):
+        if not isinstance(algorithm, hashes.HashAlgorithm):
+            raise TypeError('Algorithm must be a registered hash algorithm.')
+
+        evp_md = self._backend._lib.EVP_get_digestbyname(
+            algorithm.name.encode('ascii')
+        )
+        assert evp_md != self._backend._ffi.NULL
+
+        res = self._backend._lib.X509_CRL_sign(
+            self._x509_crl, private_key._evp_pkey, evp_md
+        )
+        assert res > 0
+        return self
+
+    def public_bytes(self, encoding):
+        if not isinstance(encoding, serialization.Encoding):
+            raise TypeError("encoding must be an item from the Encoding enum")
+
+        # TODO: make text prelude optional.
+        bio = self._backend._create_mem_bio()
+        res = self._backend._lib.X509_CRL_print(bio, self._x509_crl)
+        assert res == 1
+        if encoding is serialization.Encoding.PEM:
+            res = self._backend._lib.PEM_write_bio_X509_CRL(
+                bio, self._x509_crl
+            )
+        elif encoding is serialization.Encoding.DER:
+            res = self._backend._lib.i2d_X509_CRL_bio(bio, self._x509_crl)
+        assert res == 1
+        return self._backend._read_mem_bio(bio)

--- a/src/cryptography/hazmat/bindings/openssl/asn1.py
+++ b/src/cryptography/hazmat/bindings/openssl/asn1.py
@@ -98,6 +98,7 @@ ASN1_TIME *ASN1_TIME_new(void);
 void ASN1_TIME_free(ASN1_TIME *);
 ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *,
                                                    ASN1_GENERALIZEDTIME **);
+ASN1_TIME *ASN1_TIME_set(ASN1_TIME *s, time_t t);
 
 /*  ASN1 UTCTIME */
 ASN1_UTCTIME *ASN1_UTCTIME_new(void);

--- a/src/cryptography/hazmat/bindings/openssl/x509.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509.py
@@ -17,19 +17,24 @@ INCLUDES = """
 typedef STACK_OF(X509) Cryptography_STACK_OF_X509;
 typedef STACK_OF(X509_CRL) Cryptography_STACK_OF_X509_CRL;
 typedef STACK_OF(X509_REVOKED) Cryptography_STACK_OF_X509_REVOKED;
+typedef STACK_OF(X509_ATTRIBUTE) Cryptography_STACK_OF_X509_ATTRIBUTE;
 """
 
 TYPES = """
 typedef ... Cryptography_STACK_OF_X509;
 typedef ... Cryptography_STACK_OF_X509_CRL;
 typedef ... Cryptography_STACK_OF_X509_REVOKED;
+typedef ... Cryptography_STACK_OF_X509_ATTRIBUTE;
 
 typedef struct {
     ASN1_OBJECT *algorithm;
     ...;
 } X509_ALGOR;
 
-typedef ... X509_ATTRIBUTE;
+typedef struct {
+    ASN1_OBJECT *object;
+    ...;
+} X509_ATTRIBUTE;
 
 typedef struct {
     X509_ALGOR *signature;
@@ -58,6 +63,8 @@ typedef struct {
 } X509_REVOKED;
 
 typedef struct {
+    ASN1_UTCTIME *lastUpdate;
+    ASN1_UTCTIME *nextUpdate;
     Cryptography_STACK_OF_X509_REVOKED *revoked;
     ...;
 } X509_CRL_INFO;
@@ -117,6 +124,7 @@ void X509_free(X509 *);
 X509 *X509_dup(X509 *);
 int X509_cmp(const X509 *, const X509 *);
 
+int X509_print(BIO *, X509 *);
 int X509_print_ex(BIO *, X509 *, unsigned long, unsigned long);
 
 int X509_set_version(X509 *, long);
@@ -138,6 +146,8 @@ int X509_set_subject_name(X509 *, X509_NAME *);
 
 X509_NAME *X509_get_issuer_name(X509 *);
 int X509_set_issuer_name(X509 *, X509_NAME *);
+
+X509_EXTENSION *X509_EXTENSION_create_by_OBJ(X509_EXTENSION **, ASN1_OBJECT *, int, ASN1_OCTET_STRING *);
 
 int X509_get_ext_count(X509 *);
 int X509_add_ext(X509 *, X509_EXTENSION *, int);
@@ -161,6 +171,7 @@ int X509_REQ_digest(const X509_REQ *, const EVP_MD *,
                     unsigned char *, unsigned int *);
 EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *);
 int X509_REQ_print_ex(BIO *, X509_REQ *, unsigned long, unsigned long);
+int X509_REQ_print(BIO *, X509_REQ *);
 
 int X509V3_EXT_print(BIO *, X509_EXTENSION *, unsigned long, int);
 ASN1_OCTET_STRING *X509_EXTENSION_get_data(X509_EXTENSION *);
@@ -186,6 +197,10 @@ int X509_CRL_sign(X509_CRL *, EVP_PKEY *, const EVP_MD *);
 int X509_CRL_get_ext_count(X509_CRL *);
 X509_EXTENSION *X509_CRL_get_ext(X509_CRL *, int);
 int X509_CRL_add_ext(X509_CRL *, X509_EXTENSION *, int);
+
+X509_ATTRIBUTE *X509_ATTRIBUTE_new(void);
+void X509_ATTRIBUTE_free(X509_ATTRIBUTE *);
+int X509_REQ_add1_attr(X509_REQ *, X509_ATTRIBUTE *);
 
 int NETSCAPE_SPKI_verify(NETSCAPE_SPKI *, EVP_PKEY *);
 int NETSCAPE_SPKI_sign(NETSCAPE_SPKI *, EVP_PKEY *, const EVP_MD *);
@@ -253,6 +268,7 @@ ASN1_TIME *X509_get_notAfter(X509 *);
 
 long X509_REQ_get_version(X509_REQ *);
 X509_NAME *X509_REQ_get_subject_name(X509_REQ *);
+int X509_REQ_set_subject_name(X509_REQ *, X509_NAME *);
 
 Cryptography_STACK_OF_X509 *sk_X509_new_null(void);
 void sk_X509_free(Cryptography_STACK_OF_X509 *);

--- a/src/cryptography/hazmat/bindings/openssl/x509_vfy.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509_vfy.py
@@ -171,6 +171,8 @@ int X509_VERIFY_PARAM_set1_policies(X509_VERIFY_PARAM *,
                                     Cryptography_STACK_OF_ASN1_OBJECT *);
 void X509_VERIFY_PARAM_set_depth(X509_VERIFY_PARAM *, int);
 int X509_VERIFY_PARAM_get_depth(const X509_VERIFY_PARAM *);
+
+ASN1_TIME* X509_time_adj(ASN1_TIME *, long, time_t *);
 """
 
 MACROS = """

--- a/src/cryptography/hazmat/bindings/openssl/x509v3.py
+++ b/src/cryptography/hazmat/bindings/openssl/x509v3.py
@@ -106,9 +106,12 @@ void *X509V3_EXT_d2i(X509_EXTENSION *);
 """
 
 MACROS = """
+int i2d_BASIC_CONSTRAINTS(BASIC_CONSTRAINTS *a, unsigned char **pp);
+BASIC_CONSTRAINTS *BASIC_CONSTRAINTS_new(void);
 /* This is a macro defined by a call to DECLARE_ASN1_FUNCTIONS in the
    x509v3.h header. */
 void BASIC_CONSTRAINTS_free(BASIC_CONSTRAINTS *);
+
 void *X509V3_set_ctx_nodb(X509V3_CTX *);
 int sk_GENERAL_NAME_num(struct stack_st_GENERAL_NAME *);
 int sk_GENERAL_NAME_push(struct stack_st_GENERAL_NAME *, GENERAL_NAME *);
@@ -121,9 +124,14 @@ X509_EXTENSION *X509V3_EXT_conf_nid(Cryptography_LHASH_OF_CONF_VALUE *,
 const X509V3_EXT_METHOD *X509V3_EXT_get(X509_EXTENSION *);
 const X509V3_EXT_METHOD *X509V3_EXT_get_nid(int);
 
+int __i2d_BASIC_CONSTRAINTS(BASIC_CONSTRAINTS *a, unsigned char **pp);
 """
 
 CUSTOMIZATIONS = """
+int __i2d_BASIC_CONSTRAINTS(BASIC_CONSTRAINTS *a, unsigned char **pp)
+{
+    return i2d_BASIC_CONSTRAINTS(a, pp);
+}
 """
 
 CONDITIONAL_NAMES = {}

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -106,6 +106,18 @@ def load_der_x509_csr(data, backend):
     return backend.load_der_x509_csr(data)
 
 
+def new_x509_csr(backend):
+    return backend.new_x509_csr()
+
+
+def new_x509_cert(backend):
+    return backend.new_x509_cert()
+
+
+def new_x509_crl(backend):
+    return backend.new_x509_crl()
+
+
 class InvalidVersion(Exception):
     def __init__(self, msg, parsed_version):
         super(InvalidVersion, self).__init__(msg)
@@ -844,4 +856,119 @@ class CertificateSigningRequest(object):
         """
         Returns a HashAlgorithm corresponding to the type of the digest signed
         in the certificate.
+        """
+
+    # TODO: extensions!
+
+
+@six.add_metaclass(abc.ABCMeta)
+class CertificateBuilder(object):
+    @abc.abstractmethod
+    def set_version(self, version):
+        """."""
+
+    @abc.abstractmethod
+    def set_issuer_name(self, attributes):
+        """."""
+
+    @abc.abstractmethod
+    def set_subject_name(self, attributes):
+        """."""
+
+    @abc.abstractmethod
+    def set_public_key(self, public_key):
+        """."""
+
+    @abc.abstractmethod
+    def set_serial_number(self, serial_number):
+        """."""
+
+    @abc.abstractmethod
+    def set_not_valid_before(self, time):
+        """."""
+
+    @abc.abstractmethod
+    def set_not_valid_after(self, time):
+        """."""
+
+    @abc.abstractmethod
+    def add_extension(self, extension):
+        """."""
+
+    @abc.abstractmethod
+    def sign(self, private_key, algorithm):
+        """
+        Signs the certificate using the CA's private key.
+        """
+
+    @abc.abstractmethod
+    def public_bytes(self, encoding):
+        """
+        Encodes the certificate to PEM or DER format.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class CertificateSigningRequestBuilder(object):
+    @abc.abstractmethod
+    def set_version(self, version):
+        """."""
+
+    @abc.abstractmethod
+    def set_subject_name(self, attributes):
+        """."""
+
+    @abc.abstractmethod
+    def add_extension(self, extension):
+        """."""
+
+    @abc.abstractmethod
+    def sign(self, private_key, algorithm):
+        """
+        Signs the request using the requestor's private key.
+        """
+
+    @abc.abstractmethod
+    def public_bytes(self, encoding):
+        """
+        Encodes the request to PEM or DER format.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class CertificateRevocationListBuilder(object):
+    @abc.abstractmethod
+    def set_version(self, version):
+        """."""
+
+    @abc.abstractmethod
+    def set_issuer_name(self, attributes):
+        """."""
+
+    @abc.abstractmethod
+    def set_last_update(self, time):
+        """."""
+
+    @abc.abstractmethod
+    def set_next_update(self, time):
+        """."""
+
+    @abc.abstractmethod
+    def add_extension(self, extension):
+        """."""
+
+    @abc.abstractmethod
+    def add_certificate(self, serial_number, revocation_date):
+        """."""
+
+    @abc.abstractmethod
+    def sign(self, private_key, algorithm):
+        """
+        Signs the revocation list using the CA's private key.
+        """
+
+    @abc.abstractmethod
+    def public_bytes(self, encoding):
+        """
+        Encodes the revocation list to PEM or DER format.
         """

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -107,6 +107,14 @@ def load_der_x509_csr(data, backend):
     return backend.load_der_x509_csr(data)
 
 
+def load_pem_x509_crl(data, backend):
+    return backend.load_pem_x509_crl(data)
+
+
+def load_der_x509_crl(data, backend):
+    return backend.load_der_x509_crl(data)
+
+
 class InvalidVersion(Exception):
     def __init__(self, msg, parsed_version):
         super(InvalidVersion, self).__init__(msg)

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -453,11 +453,11 @@ class TestRSACertificate(object):
             x509.NameAttribute(x509.OID_ORGANIZATION_NAME, 'PyCA'),
             x509.NameAttribute(x509.OID_COMMON_NAME, 'cryptography.io'),
         ]
-#        basic_constraints = request.extensions.get_extension_for_oid(
-#            x509.OID_BASIC_CONSTRAINTS
-#        )
-#        assert basic_constraints.value.ca is True
-#        assert basic_constraints.value.path_length == 2
+        basic_constraints = request.extensions.get_extension_for_oid(
+            x509.OID_BASIC_CONSTRAINTS
+        )
+        assert basic_constraints.value.ca is True
+        assert basic_constraints.value.path_length == 2
 
     def test_build_cert(self, backend):
         issuer_private_key = rsa.generate_private_key(

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -537,9 +537,9 @@ class TestRSACertificate(object):
         revocation_list = builder.sign(backend, private_key, hashes.SHA1())
 
         # Encode to PEM then load it back.
-#        print(revocation_list.public_bytes(
-#            encoding=serialization.Encoding.PEM,
-#        ))
+        revocation_list = x509.load_pem_x509_crl(revocation_list.public_bytes(
+            encoding=serialization.Encoding.PEM,
+        ), backend)
 
         # Check contents.
         assert revocation_list.issuer == x509.Name([


### PR DESCRIPTION
This PR is definitely _NOT_ final.  It's a draft implementation of issue #1911.  I'm hoping that this can be used as a basis for discussion about the CA support API.

The builder interfaces are based on a suggestion by Alex in the [Concern over x509 interface design](https://mail.python.org/pipermail/cryptography-dev/2015-May/000443.html) thread on the mailing list.  I've tried to be consistent with the rest of the code elsewhere.

I only have basic support for CSRs, certificate signing and CRLs, but I think it's worth getting this reviewed before I put more effort into it.

So, lemme know what you think :-)