### PR TITLE
notice_numbers are not optional in NoticeReference

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -959,13 +959,13 @@ These classes may be present within a :class:`CertificatePolicies` instance.
 
     .. attribute:: organization
 
-        :type: :term:`text` or None
+        :type: :term:`text`
 
     .. attribute:: notice_numbers
 
-        :type: list or None
+        :type: list
 
-        A list of integers or None.
+        A list of integers.
 
 Object Identifiers
 ~~~~~~~~~~~~~~~~~~

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -568,11 +568,11 @@ class UserNotice(object):
 class NoticeReference(object):
     def __init__(self, organization, notice_numbers):
         self._organization = organization
-        if notice_numbers and not all(
+        if not isinstance(notice_numbers, list) or not all(
             isinstance(x, int) for x in notice_numbers
         ):
             raise TypeError(
-                "notice_numbers must be a list of integers or None"
+                "notice_numbers must be a list of integers"
             )
 
         self._notice_numbers = notice_numbers

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -45,9 +45,8 @@ class TestNoticeReference(object):
             x509.NoticeReference("org", [1, 2, "three"])
 
     def test_notice_numbers_none(self):
-        nr = x509.NoticeReference("org", None)
-        assert nr.organization == "org"
-        assert nr.notice_numbers is None
+        with pytest.raises(TypeError):
+            x509.NoticeReference("org", None)
 
     def test_repr(self):
         nr = x509.NoticeReference(u"org", [1, 3, 4])
@@ -88,16 +87,16 @@ class TestUserNotice(object):
         assert un.explicit_text == "text"
 
     def test_repr(self):
-        un = x509.UserNotice(x509.NoticeReference(u"org", None), u"text")
+        un = x509.UserNotice(x509.NoticeReference(u"org", [1]), u"text")
         if six.PY3:
             assert repr(un) == (
                 "<UserNotice(notice_reference=<NoticeReference(organization='"
-                "org', notice_numbers=None)>, explicit_text='text')>"
+                "org', notice_numbers=[1])>, explicit_text='text')>"
             )
         else:
             assert repr(un) == (
                 "<UserNotice(notice_reference=<NoticeReference(organization=u"
-                "'org', notice_numbers=None)>, explicit_text=u'text')>"
+                "'org', notice_numbers=[1])>, explicit_text=u'text')>"
             )
 
     def test_eq(self):


### PR DESCRIPTION
I misread the RFC. Here's the definition:

```
NoticeReference ::= SEQUENCE {
     organization     DisplayText,
     noticeNumbers    SEQUENCE OF INTEGER }
```

Note the lack of "OPTIONAL".

refs #1743 