### PR TITLE
Adds support for CSR extensions

### DIFF
--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -1177,3 +1177,9 @@ class CertificateSigningRequest(object):
         Returns a HashAlgorithm corresponding to the type of the digest signed
         in the certificate.
         """
+
+    @abc.abstractproperty
+    def extensions(self):
+        """
+        Returns the extensions in the signing request.
+        """


### PR DESCRIPTION
For now, I only added the basic constraints extension to get the new CSR interface implemented on the OpenSSL backend.

I'll probably be adding support for more extensions in follow-up PRs.