### PR TITLE
IPAddress needs to support networks for nameconstraints

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -509,8 +509,9 @@ General Name Classes
 
     .. attribute:: value
 
-        :type: :class:`~ipaddress.IPv4Address` or
-            :class:`~ipaddress.IPv6Address`.
+        :type: :class:`~ipaddress.IPv4Address`,
+            :class:`~ipaddress.IPv6Address`,  :class:`~ipaddress.IPv4Network`,
+            or :class:`~ipaddress.IPv6Network`.
 
 .. class:: RegisteredID
 

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -909,11 +909,18 @@ class RegisteredID(object):
 class IPAddress(object):
     def __init__(self, value):
         if not isinstance(
-            value, (ipaddress.IPv4Address, ipaddress.IPv6Address)
+            value,
+            (
+                ipaddress.IPv4Address,
+                ipaddress.IPv6Address,
+                ipaddress.IPv4Network,
+                ipaddress.IPv6Network
+            )
         ):
             raise TypeError(
-                "value must be an instance of ipaddress.IPv4Address or "
-                "ipaddress.IPv6Address"
+                "value must be an instance of ipaddress.IPv4Address, "
+                "ipaddress.IPv6Address, ipaddress.IPv4Network, or "
+                "ipaddress.IPv6Network"
             )
 
         self._value = value

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1121,6 +1121,12 @@ class TestIPAddress(object):
         gn2 = x509.IPAddress(ipaddress.IPv6Address(u"ff::"))
         assert repr(gn2) == "<IPAddress(value=ff::)>"
 
+        gn3 = x509.IPAddress(ipaddress.IPv4Network(u"192.168.0.0/24"))
+        assert repr(gn3) == "<IPAddress(value=192.168.0.0/24)>"
+
+        gn4 = x509.IPAddress(ipaddress.IPv6Network(u"ff::/96"))
+        assert repr(gn4) == "<IPAddress(value=ff::/96)>"
+
     def test_eq(self):
         gn = x509.IPAddress(ipaddress.IPv4Address(u"127.0.0.1"))
         gn2 = x509.IPAddress(ipaddress.IPv4Address(u"127.0.0.1"))


### PR DESCRIPTION
The GeneralName IPAddress needs to allow network objects because NameConstraints will use netmasks. IPv4 is encoded as 8 octets, 4 for the IP, 4 for netmask. Similarly there are 32 octets for IPv6.