### PR TITLE
[WIP] ECPrivateKey from private_value

### DIFF
--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -215,6 +215,12 @@ class EllipticCurveBackend(object):
         Return an EllipticCurvePublicKey provider using the given numbers.
         """
 
+    @abc.abstractmethod
+    def derive_elliptic_curve_public_point(self, private_value, curve):
+        """
+        Compute the public key point (x, y) given the private value and curve.
+        """
+
 
 @six.add_metaclass(abc.ABCMeta)
 class PEMSerializationBackend(object):

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -271,6 +271,18 @@ class MultiBackend(object):
             _Reasons.UNSUPPORTED_ELLIPTIC_CURVE
         )
 
+    def derive_elliptic_curve_public_point(self, private_value, curve):
+        for b in self._filtered_backends(EllipticCurveBackend):
+            try:
+                return b.derive_elliptic_curve_public_point(private_value, curve)
+            except UnsupportedAlgorithm:
+                continue
+
+        raise UnsupportedAlgorithm(
+            "This backend does not support this elliptic curve.",
+            _Reasons.UNSUPPORTED_ELLIPTIC_CURVE
+        )
+
     def load_pem_private_key(self, data, password):
         for b in self._filtered_backends(PEMSerializationBackend):
             return b.load_pem_private_key(data, password)

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -274,7 +274,8 @@ class MultiBackend(object):
     def derive_elliptic_curve_public_point(self, private_value, curve):
         for b in self._filtered_backends(EllipticCurveBackend):
             try:
-                return b.derive_elliptic_curve_public_point(private_value, curve)
+                return b.derive_elliptic_curve_public_point(private_value,
+                                                            curve)
             except UnsupportedAlgorithm:
                 continue
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1042,6 +1042,7 @@ class Backend(object):
 
         ec_cdata = self._lib.EC_KEY_new_by_curve_name(curve_nid)
         assert ec_cdata != self._ffi.NULL
+        ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
 
         set_func, get_func, group = (
             self._ec_key_determine_group_get_set_funcs(ec_cdata)
@@ -1049,8 +1050,10 @@ class Backend(object):
 
         point = self._lib.EC_POINT_new(group)
         assert point != self._ffi.NULL
+        point = self._ffi.gc(point, self._lib.EC_POINT_free)
 
         value = self._int_to_bn(private_value)
+        value = self._ffi.gc(value, self._lib.BN_free)
 
         with self._tmp_bn_ctx() as bn_ctx:
             res = self._lib.EC_POINT_mul(group, point, value, self._ffi.NULL,
@@ -1065,10 +1068,6 @@ class Backend(object):
 
             point_x = self._bn_to_int(bn_x)
             point_y = self._bn_to_int(bn_y)
-
-        self._lib.BN_free(value)
-        self._lib.EC_POINT_free(point)
-        self._lib.EC_KEY_free(ec_cdata)
 
         return point_x, point_y
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -285,6 +285,18 @@ class EllipticCurvePrivateNumbers(object):
         self._private_value = private_value
         self._public_numbers = public_numbers
 
+    @classmethod
+    def from_private_value_and_curve(cls, private_value, curve, backend):
+        if not isinstance(private_value, six.integer_types):
+            raise TypeError("private_value must be an integer.")
+
+        if not isinstance(curve, EllipticCurve):
+            raise TypeError("curve must provide the EllipticCurve interface.")
+
+        x, y = backend.derive_elliptic_curve_public_point(private_value, curve)
+        public_numbers = EllipticCurvePublicNumbers(x, y, curve)
+        return cls(private_value, public_numbers)
+
     def private_key(self, backend):
         return backend.load_elliptic_curve_private_numbers(self)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -234,6 +234,17 @@ def generate_private_key(curve, backend):
     return backend.generate_elliptic_curve_private_key(curve)
 
 
+def derive_from_private_value_and_curve(cls, private_value, curve, backend):
+    if not isinstance(private_value, six.integer_types):
+        raise TypeError("private_value must be an integer.")
+
+    if not isinstance(curve, EllipticCurve):
+        raise TypeError("curve must provide the EllipticCurve interface.")
+
+    x, y = backend.derive_elliptic_curve_public_point(private_value, curve)
+    return EllipticCurvePublicNumbers(x, y, curve)
+
+
 class EllipticCurvePublicNumbers(object):
     def __init__(self, x, y, curve):
         if (
@@ -284,18 +295,6 @@ class EllipticCurvePrivateNumbers(object):
 
         self._private_value = private_value
         self._public_numbers = public_numbers
-
-    @classmethod
-    def from_private_value_and_curve(cls, private_value, curve, backend):
-        if not isinstance(private_value, six.integer_types):
-            raise TypeError("private_value must be an integer.")
-
-        if not isinstance(curve, EllipticCurve):
-            raise TypeError("curve must provide the EllipticCurve interface.")
-
-        x, y = backend.derive_elliptic_curve_public_point(private_value, curve)
-        public_numbers = EllipticCurvePublicNumbers(x, y, curve)
-        return cls(private_value, public_numbers)
 
     def private_key(self, backend):
         return backend.load_elliptic_curve_private_numbers(self)

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -170,6 +170,10 @@ class DummyEllipticCurveBackend(object):
         if not self.elliptic_curve_supported(numbers.curve):
             raise UnsupportedAlgorithm(_Reasons.UNSUPPORTED_ELLIPTIC_CURVE)
 
+    def derive_elliptic_curve_public_point(self, private_value, curve):
+        if not self.elliptic_curve_supported(curve):
+            raise UnsupportedAlgorithm(_Reasons.UNSUPPORTED_ELLIPTIC_CURVE)
+
 
 @utils.register_interface(PEMSerializationBackend)
 class DummyPEMSerializationBackend(object):


### PR DESCRIPTION
This PR adds the class method `EllipticCurvePrivateNumbers.from_private_value_and_curve` to be able to build an `ECPrivateKey` from a given private value.

This functionality is needed to implement some private key encodings specific to Bitcoin (e.g. WIF).