### PR TITLE
add ocsp no check

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -699,6 +699,19 @@ X.509 Extensions
     purposes indicated in the key usage extension. The object is
     iterable to obtain the list of :ref:`extended key usage OIDs <eku_oids>`.
 
+.. class:: OCSPNoCheck
+
+    .. versionadded:: 0.10
+
+    This presence of this extension indicates that an OCSP client can trust a
+    responder for the lifetime of the responder's certificate. CAs issuing
+    such a certificate should realize that a compromise of the responder's key
+    is as serious as the compromise of a CA key used to sign CRLs, at least for
+    the validity period of this certificate. CA's may choose to issue this type
+    of certificate with a very short lifetime and renew it frequently. This
+    extension is only relevant when the certificate is an authorized OCSP
+    responder.
+
 .. class:: AuthorityKeyIdentifier
 
     .. versionadded:: 0.9
@@ -1234,6 +1247,11 @@ Extension OIDs
 
     Corresponds to the dotted string ``"1.3.6.1.5.5.7.1.1"``. The identifier
     for the :class:`AuthorityInformationAccess` extension type.
+
+.. data:: OID_OCSP_NO_CHECK
+
+    Corresponds to the dotted string ``"1.3.6.1.5.5.7.48.1.5"``. The identifier
+    for the :class:`OCSPNoCheck` extension type.
 
 Exceptions
 ~~~~~~~~~~

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -320,6 +320,10 @@ class ExtendedKeyUsage(object):
         return not self == other
 
 
+class OCSPNoCheck(object):
+    pass
+
+
 class BasicConstraints(object):
     def __init__(self, ca, path_length):
         if not isinstance(ca, bool):


### PR DESCRIPTION
OCSPNoCheck is a null-valued extension so it has no properties and is thus actually quite simple to define (hooray!).

refs #1947 