### PR TITLE
Adds ASN1 time binding for OpenSSL.

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/asn1.py
+++ b/src/cryptography/hazmat/bindings/openssl/asn1.py
@@ -98,7 +98,7 @@ ASN1_TIME *ASN1_TIME_new(void);
 void ASN1_TIME_free(ASN1_TIME *);
 ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *,
                                                    ASN1_GENERALIZEDTIME **);
-ASN1_TIME *ASN1_TIME_set(ASN1_TIME *s, time_t t);
+ASN1_TIME *ASN1_TIME_set(ASN1_TIME *, time_t);
 
 /*  ASN1 UTCTIME */
 ASN1_UTCTIME *ASN1_UTCTIME_new(void);

--- a/src/cryptography/hazmat/bindings/openssl/asn1.py
+++ b/src/cryptography/hazmat/bindings/openssl/asn1.py
@@ -98,6 +98,7 @@ ASN1_TIME *ASN1_TIME_new(void);
 void ASN1_TIME_free(ASN1_TIME *);
 ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *,
                                                    ASN1_GENERALIZEDTIME **);
+ASN1_TIME *ASN1_TIME_set(ASN1_TIME *s, time_t t);
 
 /*  ASN1 UTCTIME */
 ASN1_UTCTIME *ASN1_UTCTIME_new(void);


### PR DESCRIPTION
This OpenSSL function can be used to convert a UNIX timestamp to an `ASN1_TIME` OpenSSL object.  This will be used for the certificate builder to set the "not before" and "not after times" using Python `datetime` objects.