### PR TITLE
print the version of openssl loaded by cryptography in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     ./vectors
 passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH
 commands =
+    python -c "from cryptography.hazmat.backends.openssl.backend import backend; print(backend.openssl_version_text())"
     # We use parallel mode and then combine here so that coverage.py will take
     # the paths like .tox/py34/lib/python3.4/site-packages/cryptography/__init__.py
     # and collapse them into src/cryptography/__init__.py.
@@ -46,12 +47,14 @@ commands =
 # coverage.py on pypy.
 [testenv:pypy]
 commands =
+    python -c "from cryptography.hazmat.backends.openssl.backend import backend; print(backend.openssl_version_text())"
     py.test --capture=no --strict {posargs}
 
 # Temporarily disable coverage on pypy3 because of performance problems with
 # coverage.py on pypy3.
 [testenv:pypy3]
 commands =
+    python -c "from cryptography.hazmat.backends.openssl.backend import backend; print(backend.openssl_version_text())"
     py.test --capture=no --strict {posargs}
 
 [testenv:pep8]


### PR DESCRIPTION
This is sometimes useful, especially in CI when debugging.