### PR TITLE
enforce GCM AAD and ciphertext limits per NIST spec

### DIFF
--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -139,6 +139,8 @@ class CTR(object):
 @utils.register_interface(ModeWithAuthenticationTag)
 class GCM(object):
     name = "GCM"
+    _MAX_ENCRYPTED_BYTES = (2 ** 39 - 256) // 8
+    _MAX_AAD_BYTES = (2 ** 64) // 8
 
     def __init__(self, initialization_vector, tag=None, min_tag_length=16):
         # len(initialization_vector) must in [1, 2 ** 64), but it's impossible

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -253,3 +253,33 @@ class TestAESModeGCM(object):
         computed_ct = encryptor.update(pt) + encryptor.finalize()
         assert computed_ct == ct
         assert encryptor.tag == tag
+
+    def test_gcm_ciphertext_limit(self, backend):
+        encryptor = base.Cipher(
+            algorithms.AES(b"\x00" * 16),
+            modes.GCM(b"\x01" * 16),
+            backend=backend
+        ).encryptor()
+        # 16 bytes less than the encryption limit
+        near_limit_bytes = (2 ** 39 - 256 - 128) // 8
+        encryptor._ctx._bytes_processed = near_limit_bytes
+        encryptor.update(b"0" * 16)
+        assert (
+            encryptor._ctx._bytes_processed == modes.GCM._MAX_ENCRYPTED_BYTES
+        )
+        with pytest.raises(ValueError):
+            encryptor.update(b"0")
+
+    def test_gcm_aad_limit(self, backend):
+        encryptor = base.Cipher(
+            algorithms.AES(b"\x00" * 16),
+            modes.GCM(b"\x01" * 16),
+            backend=backend
+        ).encryptor()
+        # 16 bytes less than the AAD limit
+        near_limit_bytes = (2 ** 64 - 128) // 8
+        encryptor._ctx._aad_bytes_processed = near_limit_bytes
+        encryptor.authenticate_additional_data(b"0" * 16)
+        assert encryptor._ctx._aad_bytes_processed == modes.GCM._MAX_AAD_BYTES
+        with pytest.raises(ValueError):
+            encryptor.authenticate_additional_data(b"0")


### PR DESCRIPTION
fixes #1821 

This is a simplified approach to properly handle NIST limits for AAD and encrypted bytes.