### PR TITLE
skip the wheel if it's not from the latest build

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -47,7 +47,16 @@ def download_artifacts(session):
 
     paths = []
 
+    last_build_number = response.json()["number"]
     for run in response.json()["runs"]:
+        if run["number"] != last_build_number:
+            print(
+                "Skipping {0} as it is not from the latest build ({1})".format(
+                    run["url"], last_build_number
+                )
+            )
+            continue
+
         response = session.get(
             run["url"] + "api/json/",
             headers={


### PR DESCRIPTION
During the last release we dropped support for 3.2, but jenkins is like an elephant and remembers so it still shows 3.2 build configurations in the lastBuild JSON. This change will cause it to skip (but print information about) builds that are not the latest so we won't get twine upload errors from attempting to upload a mishmash of older wheels.