### PR TITLE
remove pypy3 from testing until a cffi 1.0 version is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,10 +91,6 @@ matrix:
         - language: generic
           os: osx
           osx_image: beta-xcode6.3
-          env: TOXENV=pypy3
-        - language: generic
-          os: osx
-          osx_image: beta-xcode6.3
           env: TOXENV=py26 OPENSSL=0.9.8
         - language: generic
           os: osx
@@ -112,10 +108,6 @@ matrix:
           os: osx
           osx_image: beta-xcode6.3
           env: TOXENV=pypy OPENSSL=0.9.8
-        - language: generic
-          os: osx
-          osx_image: beta-xcode6.3
-          env: TOXENV=pypy3 OPENSSL=0.9.8
         - language: generic
           os: osx
           osx_image: beta-xcode6.3


### PR DESCRIPTION
This is required by #1986 

We should re-add pypy3 ASAP.