### PR TITLE
issuer alternative name support

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -885,6 +885,23 @@ X.509 Extensions
             [u'www.cryptography.io', u'cryptography.io']
 
 
+.. class:: IssuerAlternativeName
+
+    .. versionadded:: 1.0
+
+    Issuer alternative name is an X.509 extension that provides a list of
+    :ref:`general name <general_name_classes>` instances that provide a set
+    of identities for the certificate issuer. The object is iterable to
+    get every element.
+
+    .. method:: get_values_for_type(type)
+
+        :param type: A :class:`GeneralName` provider. This is one of the
+            :ref:`general name classes <general_name_classes>`.
+
+        :returns: A list of values extracted from the matched general names.
+
+
 .. class:: AuthorityInformationAccess
 
     .. versionadded:: 0.9
@@ -1341,6 +1358,11 @@ Extension OIDs
 
     Corresponds to the dotted string ``"2.5.29.17"``. The identifier for the
     :class:`SubjectAlternativeName` extension type.
+
+.. data:: OID_ISSUER_ALTERNATIVE_NAME
+
+    Corresponds to the dotted string ``"2.5.29.18"``. The identifier for the
+    :class:`IssuerAlternativeName` extension type.
 
 .. data:: OID_SUBJECT_KEY_IDENTIFIER
 

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -1033,6 +1033,32 @@ class SubjectAlternativeName(object):
         return not self == other
 
 
+class IssuerAlternativeName(object):
+    def __init__(self, general_names):
+        self._general_names = GeneralNames(general_names)
+
+    def __iter__(self):
+        return iter(self._general_names)
+
+    def __len__(self):
+        return len(self._general_names)
+
+    def get_values_for_type(self, type):
+        return self._general_names.get_values_for_type(type)
+
+    def __repr__(self):
+        return "<IssuerAlternativeName({0})>".format(self._general_names)
+
+    def __eq__(self, other):
+        if not isinstance(other, IssuerAlternativeName):
+            return NotImplemented
+
+        return self._general_names == other._general_names
+
+    def __ne__(self, other):
+        return not self == other
+
+
 class AuthorityKeyIdentifier(object):
     def __init__(self, key_identifier, authority_cert_issuer,
                  authority_cert_serial_number):

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1194,6 +1194,62 @@ class TestGeneralNames(object):
         assert gns != object()
 
 
+class TestIssuerAlternativeName(object):
+    def test_get_values_for_type(self):
+        san = x509.IssuerAlternativeName(
+            [x509.DNSName(u"cryptography.io")]
+        )
+        names = san.get_values_for_type(x509.DNSName)
+        assert names == [u"cryptography.io"]
+
+    def test_iter_names(self):
+        san = x509.IssuerAlternativeName([
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
+        ])
+        assert len(san) == 2
+        assert list(san) == [
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
+        ]
+
+    def test_invalid_general_names(self):
+        with pytest.raises(TypeError):
+            x509.IssuerAlternativeName(
+                [x509.DNSName(u"cryptography.io"), "invalid"]
+            )
+
+    def test_repr(self):
+        san = x509.IssuerAlternativeName(
+            [
+                x509.DNSName(u"cryptography.io")
+            ]
+        )
+        assert repr(san) == (
+            "<IssuerAlternativeName("
+            "<GeneralNames([<DNSName(value=cryptography.io)>])>)>"
+        )
+
+    def test_eq(self):
+        san = x509.IssuerAlternativeName(
+            [x509.DNSName(u"cryptography.io")]
+        )
+        san2 = x509.IssuerAlternativeName(
+            [x509.DNSName(u"cryptography.io")]
+        )
+        assert san == san2
+
+    def test_ne(self):
+        san = x509.IssuerAlternativeName(
+            [x509.DNSName(u"cryptography.io")]
+        )
+        san2 = x509.IssuerAlternativeName(
+            [x509.RFC822Name(u"admin@cryptography.io")]
+        )
+        assert san != san2
+        assert san != object()
+
+
 class TestSubjectAlternativeName(object):
     def test_get_values_for_type(self):
         san = x509.SubjectAlternativeName(


### PR DESCRIPTION
This extension is identical to SubjectAlternativeName but is for the issuer. This is essentially a straight copy of the SAN extension renamed (bleh).

refs #1947 