### PR TITLE
enable ASLR and NX on windows builds (affects 2.x only)

### DIFF
--- a/src/_cffi_src/build_constant_time.py
+++ b/src/_cffi_src/build_constant_time.py
@@ -5,8 +5,9 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import sys
 
-from _cffi_src.utils import build_ffi
+from _cffi_src.utils import build_ffi, extra_link_args
 
 
 with open(os.path.join(
@@ -22,5 +23,6 @@ with open(os.path.join(
 ffi = build_ffi(
     module_name="_constant_time",
     cdef_source=types,
-    verify_source=functions
+    verify_source=functions,
+    extra_link_args=extra_link_args(sys.platform),
 )

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -7,9 +7,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
-from _cffi_src.utils import (
-    build_ffi_for_binding
-)
+from _cffi_src.utils import build_ffi_for_binding, extra_link_args
 
 
 def _get_openssl_libraries(platform):
@@ -94,5 +92,6 @@ ffi = build_ffi_for_binding(
     ],
     pre_include=_OSX_PRE_INCLUDE,
     post_include=_OSX_POST_INCLUDE,
-    libraries=_get_openssl_libraries(sys.platform)
+    libraries=_get_openssl_libraries(sys.platform),
+    extra_link_args=extra_link_args(sys.platform),
 )

--- a/src/_cffi_src/build_padding.py
+++ b/src/_cffi_src/build_padding.py
@@ -5,8 +5,9 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import sys
 
-from _cffi_src.utils import build_ffi
+from _cffi_src.utils import build_ffi, extra_link_args
 
 
 with open(os.path.join(
@@ -22,5 +23,6 @@ with open(os.path.join(
 ffi = build_ffi(
     module_name="_padding",
     cdef_source=types,
-    verify_source=functions
+    verify_source=functions,
+    extra_link_args=extra_link_args(sys.platform),
 )

--- a/src/_cffi_src/utils.py
+++ b/src/_cffi_src/utils.py
@@ -80,3 +80,12 @@ def build_ffi(module_name, cdef_source, verify_source, libraries=[],
         extra_link_args=extra_link_args,
     )
     return ffi
+
+
+def extra_link_args(platform):
+    if platform != "win32":
+        return []
+    else:
+        # Enable NX and ASLR for Windows builds. These are enabled by default
+        # on Python 3.3+ but not on 2.x.
+        return ["/NXCOMPAT", "/DYNAMICBASE"]


### PR DESCRIPTION
An experiment to fix #2021. Not sure if this is the right place to put the args yet.