### PR TITLE
Added a repr() method to x509._Certificate

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,3 +24,4 @@ PGP key fingerprints are enclosed in parentheses.
 * Steven Buss <steven.buss@gmail.com> (1FB9 2EC1 CF93 DFD6 B47F F583 B1A5 6C22 290D A4C3)
 * Andre Caron <andre.l.caron@gmail.com>
 * Jiangge Zhang <tonyseek@gmail.com> (BBEC 782B 015F 71B1 5FF7  EACA 1A8C AA98 255F 5000)
+* Major Hayden <major@mhtx.net> (1BF9 9264 9596 0033 698C  252B 7370 51E0 C101 1FB1)

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -159,6 +159,9 @@ class _Certificate(object):
         self._backend = backend
         self._x509 = x509
 
+    def __repr__(self):
+        return "<Certificate(subject={0}, ...)>".format(self.subject)
+
     def __eq__(self, other):
         if not isinstance(other, x509.Certificate):
             return NotImplemented

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -450,6 +450,39 @@ class TestRSACertificate(object):
         serialized = cert.public_bytes(encoding)
         assert serialized == cert_bytes
 
+    def test_certificate_repr(self, backend):
+        cert = _load_cert(
+            os.path.join(
+                "x509", "cryptography.io.pem"
+            ),
+            x509.load_pem_x509_certificate,
+            backend
+        )
+        if six.PY3:
+            assert repr(cert) == (
+                "<Certificate(subject=<Name([<NameAttribute(oid=<ObjectIdentif"
+                "ier(oid=2.5.4.11, name=organizationalUnitName)>, value='GT487"
+                "42965')>, <NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.11, "
+                "name=organizationalUnitName)>, value='See www.rapidssl.com/re"
+                "sources/cps (c)14')>, <NameAttribute(oid=<ObjectIdentifier(oi"
+                "d=2.5.4.11, name=organizationalUnitName)>, value='Domain Cont"
+                "rol Validated - RapidSSL(R)')>, <NameAttribute(oid=<ObjectIde"
+                "ntifier(oid=2.5.4.3, name=commonName)>, value='www.cryptograp"
+                "hy.io')>])>, ...)>"
+            )
+        else:
+            assert repr(cert) == (
+                "<Certificate(subject=<Name([<NameAttribute(oid=<ObjectIdentif"
+                "ier(oid=2.5.4.11, name=organizationalUnitName)>, value=u'GT48"
+                "742965')>, <NameAttribute(oid=<ObjectIdentifier(oid=2.5.4.11,"
+                " name=organizationalUnitName)>, value=u'See www.rapidssl.com/"
+                "resources/cps (c)14')>, <NameAttribute(oid=<ObjectIdentifier("
+                "oid=2.5.4.11, name=organizationalUnitName)>, value=u'Domain C"
+                "ontrol Validated - RapidSSL(R)')>, <NameAttribute(oid=<Object"
+                "Identifier(oid=2.5.4.3, name=commonName)>, value=u'www.crypto"
+                "graphy.io')>])>, ...)>"
+            )
+
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)


### PR DESCRIPTION
This should make it easier to get a quick representation of the _Certificate object using print() or pprint().  I considered using something like:

    cert.subject.get_attributes_for_oid(x509.OID_COMMON_NAME)

But I wasn't sure if every certificate would have data in the commonName OID field.