### PR TITLE
Remove ext_package from setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,6 @@ setup(
 
     # for cffi
     zip_safe=False,
-    ext_package="cryptography.hazmat.bindings",
     entry_points={
         "cryptography.backends": backends,
     },


### PR DESCRIPTION
Looking at the CFFI 1.0 docs I don't think this is actually needed anymore.