### PR TITLE
create evp_pkey in constructor for DSA/EC

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -508,17 +508,9 @@ class _RSAVerificationContext(object):
 
 @utils.register_interface(RSAPrivateKeyWithSerialization)
 class _RSAPrivateKey(object):
-    def __init__(self, backend, rsa_cdata):
+    def __init__(self, backend, rsa_cdata, evp_pkey):
         self._backend = backend
         self._rsa_cdata = rsa_cdata
-
-        evp_pkey = self._backend._lib.EVP_PKEY_new()
-        assert evp_pkey != self._backend._ffi.NULL
-        evp_pkey = self._backend._ffi.gc(
-            evp_pkey, self._backend._lib.EVP_PKEY_free
-        )
-        res = self._backend._lib.EVP_PKEY_set1_RSA(evp_pkey, rsa_cdata)
-        assert res == 1
         self._evp_pkey = evp_pkey
 
         self._key_size = self._backend._lib.BN_num_bits(self._rsa_cdata.n)
@@ -543,7 +535,8 @@ class _RSAPrivateKey(object):
         ctx.n = self._backend._lib.BN_dup(self._rsa_cdata.n)
         res = self._backend._lib.RSA_blinding_on(ctx, self._backend._ffi.NULL)
         assert res == 1
-        return _RSAPublicKey(self._backend, ctx)
+        evp_pkey = self._backend._rsa_cdata_to_evp_pkey(ctx)
+        return _RSAPublicKey(self._backend, ctx, evp_pkey)
 
     def private_numbers(self):
         return rsa.RSAPrivateNumbers(
@@ -571,17 +564,9 @@ class _RSAPrivateKey(object):
 
 @utils.register_interface(RSAPublicKeyWithSerialization)
 class _RSAPublicKey(object):
-    def __init__(self, backend, rsa_cdata):
+    def __init__(self, backend, rsa_cdata, evp_pkey):
         self._backend = backend
         self._rsa_cdata = rsa_cdata
-
-        evp_pkey = self._backend._lib.EVP_PKEY_new()
-        assert evp_pkey != self._backend._ffi.NULL
-        evp_pkey = self._backend._ffi.gc(
-            evp_pkey, self._backend._lib.EVP_PKEY_free
-        )
-        res = self._backend._lib.EVP_PKEY_set1_RSA(evp_pkey, rsa_cdata)
-        assert res == 1
         self._evp_pkey = evp_pkey
 
         self._key_size = self._backend._lib.BN_num_bits(self._rsa_cdata.n)


### PR DESCRIPTION
This relates to #1231 and #2045. It is an incremental step of instantiating a new evp_pkey inside the constructor rather than boiling the ocean of changing all invocations as is proposed in #1231.

We use `evp_pkey` objects for serialization and CSR generation (#2045).