### PR TITLE
fix ec_cdata_to_evp_pkey bug

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1073,6 +1073,7 @@ class Backend(object):
         evp_pkey = self._ffi.gc(evp_pkey, self._lib.EVP_PKEY_free)
         res = self._lib.EVP_PKEY_set1_EC_KEY(evp_pkey, ec_cdata)
         assert res == 1
+        return evp_pkey
 
     def _elliptic_curve_to_nid(self, curve):
         """

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -642,6 +642,24 @@ class TestECSerialization(object):
                 DummyKeyEncryption()
             )
 
+    def test_public_bytes_from_derived_public_key(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+        key = load_vectors_from_file(
+            os.path.join(
+                "asymmetric", "PKCS8", "ec_private_key.pem"),
+            lambda pemfile: serialization.load_pem_private_key(
+                pemfile.read().encode(), None, backend
+            )
+        )
+        _skip_if_no_serialization(key, backend)
+        public = key.public_key()
+        pem = public.public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+        parsed_public = serialization.load_pem_public_key(pem, backend)
+        assert parsed_public
+
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)


### PR DESCRIPTION
We weren't actually returning the object and the tests weren't catching it because we didn't try to use the evp_pkey property in the tests (except for serialization, where it wasn't using this code path). The added test confirms it actually works. I'm not making a very strong assertion, but we don't have `__eq__` on public/private keys yet (maybe that's a good idea?).

We should probably add the same sort of test to RSA and DSA, but I didn't want to do that in this bug fix PR.

refs #2045 