### PR TITLE
Added teh OID for ECDSA with SHA1.

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -1267,6 +1267,11 @@ Signature Algorithm OIDs
     Corresponds to the dotted string ``"1.2.840.113549.1.1.13"``. This is
     a SHA512 digest signed by an RSA key.
 
+.. data:: OID_ECDSA_WITH_SHA1
+
+    Corresponds to the dotted string ``"1.2.840.10045.4.1"``. This is a SHA1
+    digest signed by an ECDSA key.
+
 .. data:: OID_ECDSA_WITH_SHA224
 
     Corresponds to the dotted string ``"1.2.840.10045.4.3.1"``. This is

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -36,6 +36,7 @@ _OID_NAMES = {
     "1.2.840.113549.1.1.11": "sha256WithRSAEncryption",
     "1.2.840.113549.1.1.12": "sha384WithRSAEncryption",
     "1.2.840.113549.1.1.13": "sha512WithRSAEncryption",
+    "1.2.840.10045.4.1": "ecdsa-with-SHA1",
     "1.2.840.10045.4.3.1": "ecdsa-with-SHA224",
     "1.2.840.10045.4.3.2": "ecdsa-with-SHA256",
     "1.2.840.10045.4.3.3": "ecdsa-with-SHA384",
@@ -1206,6 +1207,7 @@ OID_RSA_WITH_SHA224 = ObjectIdentifier("1.2.840.113549.1.1.14")
 OID_RSA_WITH_SHA256 = ObjectIdentifier("1.2.840.113549.1.1.11")
 OID_RSA_WITH_SHA384 = ObjectIdentifier("1.2.840.113549.1.1.12")
 OID_RSA_WITH_SHA512 = ObjectIdentifier("1.2.840.113549.1.1.13")
+OID_ECDSA_WITH_SHA1 = ObjectIdentifier("1.2.840.10045.4.1")
 OID_ECDSA_WITH_SHA224 = ObjectIdentifier("1.2.840.10045.4.3.1")
 OID_ECDSA_WITH_SHA256 = ObjectIdentifier("1.2.840.10045.4.3.2")
 OID_ECDSA_WITH_SHA384 = ObjectIdentifier("1.2.840.10045.4.3.3")
@@ -1221,6 +1223,7 @@ _SIG_OIDS_TO_HASH = {
     OID_RSA_WITH_SHA256.dotted_string: hashes.SHA256(),
     OID_RSA_WITH_SHA384.dotted_string: hashes.SHA384(),
     OID_RSA_WITH_SHA512.dotted_string: hashes.SHA512(),
+    OID_ECDSA_WITH_SHA1.dotted_string: hashes.SHA1(),
     OID_ECDSA_WITH_SHA224.dotted_string: hashes.SHA224(),
     OID_ECDSA_WITH_SHA256.dotted_string: hashes.SHA256(),
     OID_ECDSA_WITH_SHA384.dotted_string: hashes.SHA384(),


### PR DESCRIPTION
In practice this is rare because the BR requires ECDSA signatures to use SHA256+ (or maybe the requirements for SHA256 just came at the same time as ECDSA, idk)