### PR TITLE
Branch fixes

### DIFF
--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -30,21 +30,6 @@ from ...utils import (
 )
 
 
-def _skip_if_no_serialization(key, backend):
-    if not isinstance(
-        key,
-        (dsa.DSAPrivateKeyWithSerialization, dsa.DSAPublicKeyWithSerialization)
-    ):
-        pytest.skip(
-            "{0} does not support DSA key serialization".format(backend)
-        )
-
-
-def test_skip_if_no_serialization():
-    with pytest.raises(pytest.skip.Exception):
-        _skip_if_no_serialization("notakeywithserialization", "backend")
-
-
 @utils.register_interface(serialization.KeySerializationEncryption)
 class DummyKeyEncryption(object):
     pass
@@ -75,35 +60,33 @@ class TestDSA(object):
             g=vector['g']
         ).parameters(backend)
         skey = parameters.generate_private_key()
-        if isinstance(skey, dsa.DSAPrivateKeyWithSerialization):
-            numbers = skey.private_numbers()
-            skey_parameters = numbers.public_numbers.parameter_numbers
-            pkey = skey.public_key()
-            parameters = pkey.parameters()
-            parameter_numbers = parameters.parameter_numbers()
-            assert parameter_numbers.p == skey_parameters.p
-            assert parameter_numbers.q == skey_parameters.q
-            assert parameter_numbers.g == skey_parameters.g
-            assert skey_parameters.p == vector['p']
-            assert skey_parameters.q == vector['q']
-            assert skey_parameters.g == vector['g']
-            assert skey.key_size == bit_length(vector['p'])
-            assert pkey.key_size == skey.key_size
-            public_numbers = pkey.public_numbers()
-            assert numbers.public_numbers.y == public_numbers.y
-            assert numbers.public_numbers.y == pow(
-                skey_parameters.g, numbers.x, skey_parameters.p
-            )
+        numbers = skey.private_numbers()
+        skey_parameters = numbers.public_numbers.parameter_numbers
+        pkey = skey.public_key()
+        parameters = pkey.parameters()
+        parameter_numbers = parameters.parameter_numbers()
+        assert parameter_numbers.p == skey_parameters.p
+        assert parameter_numbers.q == skey_parameters.q
+        assert parameter_numbers.g == skey_parameters.g
+        assert skey_parameters.p == vector['p']
+        assert skey_parameters.q == vector['q']
+        assert skey_parameters.g == vector['g']
+        assert skey.key_size == bit_length(vector['p'])
+        assert pkey.key_size == skey.key_size
+        public_numbers = pkey.public_numbers()
+        assert numbers.public_numbers.y == public_numbers.y
+        assert numbers.public_numbers.y == pow(
+            skey_parameters.g, numbers.x, skey_parameters.p
+        )
 
     def test_generate_dsa_private_key_and_parameters(self, backend):
         skey = dsa.generate_private_key(1024, backend)
         assert skey
-        if isinstance(skey, dsa.DSAPrivateKeyWithSerialization):
-            numbers = skey.private_numbers()
-            skey_parameters = numbers.public_numbers.parameter_numbers
-            assert numbers.public_numbers.y == pow(
-                skey_parameters.g, numbers.x, skey_parameters.p
-            )
+        numbers = skey.private_numbers()
+        skey_parameters = numbers.public_numbers.parameter_numbers
+        assert numbers.public_numbers.y == pow(
+            skey_parameters.g, numbers.x, skey_parameters.p
+        )
 
     def test_invalid_parameters_values(self, backend):
         # Test a p < 1024 bits in length
@@ -819,7 +802,6 @@ class TestDSASerialization(object):
             lambda pemfile: pemfile.read().encode()
         )
         key = serialization.load_pem_private_key(key_bytes, None, backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             serialization.Encoding.PEM,
             fmt,
@@ -847,7 +829,6 @@ class TestDSASerialization(object):
             lambda pemfile: pemfile.read().encode()
         )
         key = serialization.load_pem_private_key(key_bytes, None, backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             serialization.Encoding.DER,
             fmt,
@@ -888,7 +869,6 @@ class TestDSASerialization(object):
     def test_private_bytes_unencrypted(self, backend, encoding, fmt,
                                        loader_func):
         key = DSA_KEY_1024.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             encoding, fmt, serialization.NoEncryption()
         )
@@ -934,7 +914,6 @@ class TestDSASerialization(object):
 
     def test_private_bytes_traditional_der_encrypted_invalid(self, backend):
         key = DSA_KEY_1024.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.DER,
@@ -949,7 +928,6 @@ class TestDSASerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 "notencoding",
@@ -964,7 +942,6 @@ class TestDSASerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -979,7 +956,6 @@ class TestDSASerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -994,7 +970,6 @@ class TestDSASerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -1030,7 +1005,6 @@ class TestDSAPEMPublicKeySerialization(object):
             key_path, lambda pemfile: pemfile.read(), mode="rb"
         )
         key = loader_func(key_bytes, backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.public_bytes(
             encoding, serialization.PublicFormat.SubjectPublicKeyInfo,
         )
@@ -1038,7 +1012,6 @@ class TestDSAPEMPublicKeySerialization(object):
 
     def test_public_bytes_invalid_encoding(self, backend):
         key = DSA_KEY_2048.private_key(backend).public_key()
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.public_bytes(
                 "notencoding",
@@ -1047,13 +1020,11 @@ class TestDSAPEMPublicKeySerialization(object):
 
     def test_public_bytes_invalid_format(self, backend):
         key = DSA_KEY_2048.private_key(backend).public_key()
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.public_bytes(serialization.Encoding.PEM, "invalidformat")
 
     def test_public_bytes_pkcs1_unsupported(self, backend):
         key = DSA_KEY_2048.private_key(backend).public_key()
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
             key.public_bytes(
                 serialization.Encoding.PEM, serialization.PublicFormat.PKCS1

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -33,18 +33,6 @@ _HASH_TYPES = {
 }
 
 
-def _skip_if_no_serialization(key, backend):
-    if not isinstance(
-        key, (
-            ec.EllipticCurvePrivateKeyWithSerialization,
-            ec.EllipticCurvePublicKeyWithSerialization
-        )
-    ):
-        pytest.skip(
-            "{0} does not support EC key serialization".format(backend)
-        )
-
-
 def _skip_ecdsa_vector(backend, curve_type, hash_type):
     if not backend.elliptic_curve_signature_algorithm_supported(
         ec.ECDSA(hash_type()),
@@ -86,11 +74,6 @@ class DummyKeyEncryption(object):
 def test_skip_curve_unsupported(backend):
     with pytest.raises(pytest.skip.Exception):
         _skip_curve_unsupported(backend, DummyCurve())
-
-
-def test_skip_no_serialization():
-    with pytest.raises(pytest.skip.Exception):
-        _skip_if_no_serialization("fakebackend", "fakekey")
 
 
 def test_ec_numbers():
@@ -173,12 +156,11 @@ class TestECWithNumbers(object):
         ).private_key(backend)
         assert key
 
-        if isinstance(key, ec.EllipticCurvePrivateKeyWithSerialization):
-            priv_num = key.private_numbers()
-            assert priv_num.private_value == vector['d']
-            assert priv_num.public_numbers.x == vector['x']
-            assert priv_num.public_numbers.y == vector['y']
-            assert curve_type().name == priv_num.public_numbers.curve.name
+        priv_num = key.private_numbers()
+        assert priv_num.private_value == vector['d']
+        assert priv_num.public_numbers.x == vector['x']
+        assert priv_num.public_numbers.y == vector['y']
+        assert curve_type().name == priv_num.public_numbers.curve.name
 
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
@@ -437,7 +419,6 @@ class TestECSerialization(object):
             lambda pemfile: pemfile.read().encode()
         )
         key = serialization.load_pem_private_key(key_bytes, None, backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             serialization.Encoding.PEM,
             fmt,
@@ -467,7 +448,6 @@ class TestECSerialization(object):
             lambda pemfile: pemfile.read().encode()
         )
         key = serialization.load_pem_private_key(key_bytes, None, backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             serialization.Encoding.DER,
             fmt,
@@ -514,7 +494,6 @@ class TestECSerialization(object):
             lambda pemfile: pemfile.read().encode()
         )
         key = serialization.load_pem_private_key(key_bytes, None, backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             encoding, fmt, serialization.NoEncryption()
         )
@@ -566,7 +545,6 @@ class TestECSerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.DER,
@@ -583,7 +561,6 @@ class TestECSerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 "notencoding",
@@ -600,7 +577,6 @@ class TestECSerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -617,7 +593,6 @@ class TestECSerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -634,7 +609,6 @@ class TestECSerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -651,7 +625,6 @@ class TestECSerialization(object):
                 pemfile.read().encode(), None, backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         public = key.public_key()
         pem = public.public_bytes(
             serialization.Encoding.PEM,
@@ -689,7 +662,6 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             key_path, lambda pemfile: pemfile.read(), mode="rb"
         )
         key = loader_func(key_bytes, backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.public_bytes(
             encoding, serialization.PublicFormat.SubjectPublicKeyInfo,
         )
@@ -705,7 +677,6 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
                 pemfile.read().encode(), backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.public_bytes(
                 "notencoding",
@@ -722,7 +693,6 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
                 pemfile.read().encode(), backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.public_bytes(serialization.Encoding.PEM, "invalidformat")
 
@@ -736,7 +706,6 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
                 pemfile.read().encode(), backend
             )
         )
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
             key.public_bytes(
                 serialization.Encoding.PEM, serialization.PublicFormat.PKCS1

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -85,21 +85,6 @@ def test_modular_inverse():
     )
 
 
-def _skip_if_no_serialization(key, backend):
-    if not isinstance(
-        key,
-        (rsa.RSAPrivateKeyWithSerialization, rsa.RSAPublicKeyWithSerialization)
-    ):
-        pytest.skip(
-            "{0} does not support RSA key serialization".format(backend)
-        )
-
-
-def test_skip_if_no_serialization():
-    with pytest.raises(pytest.skip.Exception):
-        _skip_if_no_serialization("notakeywithserialization", "backend")
-
-
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 class TestRSA(object):
     @pytest.mark.parametrize(
@@ -113,10 +98,9 @@ class TestRSA(object):
         skey = rsa.generate_private_key(public_exponent, key_size, backend)
         assert skey.key_size == key_size
 
-        if isinstance(skey, rsa.RSAPrivateKeyWithSerialization):
-            _check_rsa_private_numbers(skey.private_numbers())
-            pkey = skey.public_key()
-            assert isinstance(pkey.public_numbers(), rsa.RSAPublicNumbers)
+        _check_rsa_private_numbers(skey.private_numbers())
+        pkey = skey.public_key()
+        assert isinstance(pkey.public_numbers(), rsa.RSAPublicNumbers)
 
     def test_generate_bad_public_exponent(self, backend):
         with pytest.raises(ValueError):
@@ -1769,7 +1753,6 @@ class TestRSAPrivateKeySerialization(object):
     )
     def test_private_bytes_encrypted_pem(self, backend, fmt, password):
         key = RSA_KEY_2048.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             serialization.Encoding.PEM,
             fmt,
@@ -1793,7 +1776,6 @@ class TestRSAPrivateKeySerialization(object):
     )
     def test_private_bytes_encrypted_der(self, backend, fmt, password):
         key = RSA_KEY_2048.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             serialization.Encoding.DER,
             fmt,
@@ -1834,7 +1816,6 @@ class TestRSAPrivateKeySerialization(object):
     def test_private_bytes_unencrypted(self, backend, encoding, fmt,
                                        loader_func):
         key = RSA_KEY_2048.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.private_bytes(
             encoding, fmt, serialization.NoEncryption()
         )
@@ -1878,7 +1859,6 @@ class TestRSAPrivateKeySerialization(object):
 
     def test_private_bytes_traditional_der_encrypted_invalid(self, backend):
         key = RSA_KEY_2048.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.DER,
@@ -1888,7 +1868,6 @@ class TestRSAPrivateKeySerialization(object):
 
     def test_private_bytes_invalid_encoding(self, backend):
         key = RSA_KEY_2048.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 "notencoding",
@@ -1898,7 +1877,6 @@ class TestRSAPrivateKeySerialization(object):
 
     def test_private_bytes_invalid_format(self, backend):
         key = RSA_KEY_2048.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -1908,7 +1886,6 @@ class TestRSAPrivateKeySerialization(object):
 
     def test_private_bytes_invalid_encryption_algorithm(self, backend):
         key = RSA_KEY_2048.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -1918,7 +1895,6 @@ class TestRSAPrivateKeySerialization(object):
 
     def test_private_bytes_unsupported_encryption_type(self, backend):
         key = RSA_KEY_2048.private_key(backend)
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.PEM,
@@ -1966,18 +1942,15 @@ class TestRSAPEMPublicKeySerialization(object):
             key_path, lambda pemfile: pemfile.read(), mode="rb"
         )
         key = loader_func(key_bytes, backend)
-        _skip_if_no_serialization(key, backend)
         serialized = key.public_bytes(encoding, format)
         assert serialized == key_bytes
 
     def test_public_bytes_invalid_encoding(self, backend):
         key = RSA_KEY_2048.private_key(backend).public_key()
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.public_bytes("notencoding", serialization.PublicFormat.PKCS1)
 
     def test_public_bytes_invalid_format(self, backend):
         key = RSA_KEY_2048.private_key(backend).public_key()
-        _skip_if_no_serialization(key, backend)
         with pytest.raises(TypeError):
             key.public_bytes(serialization.Encoding.PEM, "invalidformat")

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -53,8 +53,7 @@ class TestDERSerialization(object):
         )
         assert key
         assert isinstance(key, rsa.RSAPrivateKey)
-        if isinstance(key, rsa.RSAPrivateKeyWithSerialization):
-            _check_rsa_private_numbers(key.private_numbers())
+        _check_rsa_private_numbers(key.private_numbers())
 
     @pytest.mark.requires_backend_interface(interface=DSABackend)
     @pytest.mark.parametrize(
@@ -76,8 +75,7 @@ class TestDERSerialization(object):
         )
         assert key
         assert isinstance(key, dsa.DSAPrivateKey)
-        if isinstance(key, dsa.DSAPrivateKeyWithSerialization):
-            _check_dsa_private_numbers(key.private_numbers())
+        _check_dsa_private_numbers(key.private_numbers())
 
     @pytest.mark.parametrize(
         ("key_path", "password"),
@@ -247,9 +245,8 @@ class TestDERSerialization(object):
         )
         assert key
         assert isinstance(key, rsa.RSAPublicKey)
-        if isinstance(key, rsa.RSAPublicKeyWithSerialization):
-            numbers = key.public_numbers()
-            assert numbers.e == 65537
+        numbers = key.public_numbers()
+        assert numbers.e == 65537
 
     def test_load_der_invalid_public_key(self, backend):
         with pytest.raises(ValueError):
@@ -330,8 +327,7 @@ class TestPEMSerialization(object):
 
         assert key
         assert isinstance(key, rsa.RSAPrivateKey)
-        if isinstance(key, rsa.RSAPrivateKeyWithSerialization):
-            _check_rsa_private_numbers(key.private_numbers())
+        _check_rsa_private_numbers(key.private_numbers())
 
     @pytest.mark.parametrize(
         ("key_path", "password"),
@@ -352,8 +348,7 @@ class TestPEMSerialization(object):
         )
         assert key
         assert isinstance(key, dsa.DSAPrivateKey)
-        if isinstance(key, dsa.DSAPrivateKeyWithSerialization):
-            _check_dsa_private_numbers(key.private_numbers())
+        _check_dsa_private_numbers(key.private_numbers())
 
     @pytest.mark.parametrize(
         ("key_path", "password"),
@@ -397,9 +392,8 @@ class TestPEMSerialization(object):
         )
         assert key
         assert isinstance(key, rsa.RSAPublicKey)
-        if isinstance(key, rsa.RSAPublicKeyWithSerialization):
-            numbers = key.public_numbers()
-            assert numbers.e == 65537
+        numbers = key.public_numbers()
+        assert numbers.e == 65537
 
     @pytest.mark.parametrize(
         ("key_file"),
@@ -770,41 +764,40 @@ class TestPEMSerialization(object):
         params = key.parameters()
         assert isinstance(params, dsa.DSAParameters)
 
-        if isinstance(params, dsa.DSAParametersWithNumbers):
-            num = key.private_numbers()
-            pub = num.public_numbers
-            parameter_numbers = pub.parameter_numbers
-            assert num.x == int("00a535a8e1d0d91beafc8bee1d9b2a3a8de3311203",
-                                16)
-            assert pub.y == int(
-                "2b260ea97dc6a12ae932c640e7df3d8ff04a8a05a0324f8d5f1b23f15fa1"
-                "70ff3f42061124eff2586cb11b49a82dcdc1b90fc6a84fb10109cb67db5d"
-                "2da971aeaf17be5e37284563e4c64d9e5fc8480258b319f0de29d54d8350"
-                "70d9e287914d77df81491f4423b62da984eb3f45eb2a29fcea5dae525ac6"
-                "ab6bcce04bfdf5b6",
-                16
-            )
+        num = key.private_numbers()
+        pub = num.public_numbers
+        parameter_numbers = pub.parameter_numbers
+        assert num.x == int("00a535a8e1d0d91beafc8bee1d9b2a3a8de3311203",
+                            16)
+        assert pub.y == int(
+            "2b260ea97dc6a12ae932c640e7df3d8ff04a8a05a0324f8d5f1b23f15fa1"
+            "70ff3f42061124eff2586cb11b49a82dcdc1b90fc6a84fb10109cb67db5d"
+            "2da971aeaf17be5e37284563e4c64d9e5fc8480258b319f0de29d54d8350"
+            "70d9e287914d77df81491f4423b62da984eb3f45eb2a29fcea5dae525ac6"
+            "ab6bcce04bfdf5b6",
+            16
+        )
 
-            assert parameter_numbers.p == int(
-                "00aa0930cc145825221caffa28ac2894196a27833de5ec21270791689420"
-                "7774a2e7b238b0d36f1b2499a2c2585083eb01432924418d867faa212dd1"
-                "071d4dceb2782794ad393cc08a4d4ada7f68d6e839a5fcd34b4e402d82cb"
-                "8a8cb40fec31911bf9bd360b034caacb4c5e947992573c9e90099c1b0f05"
-                "940cabe5d2de49a167",
-                16
-            )
+        assert parameter_numbers.p == int(
+            "00aa0930cc145825221caffa28ac2894196a27833de5ec21270791689420"
+            "7774a2e7b238b0d36f1b2499a2c2585083eb01432924418d867faa212dd1"
+            "071d4dceb2782794ad393cc08a4d4ada7f68d6e839a5fcd34b4e402d82cb"
+            "8a8cb40fec31911bf9bd360b034caacb4c5e947992573c9e90099c1b0f05"
+            "940cabe5d2de49a167",
+            16
+        )
 
-            assert parameter_numbers.q == int(
-                "00adc0e869b36f0ac013a681fdf4d4899d69820451", 16)
+        assert parameter_numbers.q == int(
+            "00adc0e869b36f0ac013a681fdf4d4899d69820451", 16)
 
-            assert parameter_numbers.g == int(
-                "008c6b4589afa53a4d1048bfc346d1f386ca75521ccf72ddaa251286880e"
-                "e13201ff48890bbfc33d79bacaec71e7a778507bd5f1a66422e39415be03"
-                "e71141ba324f5b93131929182c88a9fa4062836066cebe74b5c6690c7d10"
-                "1106c240ab7ebd54e4e3301fd086ce6adac922fb2713a2b0887cba13b9bc"
-                "68ce5cfff241cd3246",
-                16
-            )
+        assert parameter_numbers.g == int(
+            "008c6b4589afa53a4d1048bfc346d1f386ca75521ccf72ddaa251286880e"
+            "e13201ff48890bbfc33d79bacaec71e7a778507bd5f1a66422e39415be03"
+            "e71141ba324f5b93131929182c88a9fa4062836066cebe74b5c6690c7d10"
+            "1106c240ab7ebd54e4e3301fd086ce6adac922fb2713a2b0887cba13b9bc"
+            "68ce5cfff241cd3246",
+            16
+        )
 
     @pytest.mark.parametrize(
         ("key_file", "password"),


### PR DESCRIPTION
This removes the skip logic for tests when serialization is not available. We do not currently have a backend that doesn't support serialization and there's a good argument that we should require all backends to have basic serialization for non-hardware keys.