### PR TITLE
Switch to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ script:
     - ./.travis/run.sh
 
 after_success:
-    - source ~/.venv/bin/activate && codecov --env TRAVIS_OS_NAME TOXENV OPENSSL
+    - source ~/.venv/bin/activate && bash <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/coveragepy/codecov) -e TRAVIS_OS_NAME,TOXENV,OPENSSL
 
 notifications:
     irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ script:
     - ./.travis/run.sh
 
 after_success:
-    - source ~/.venv/bin/activate && coveralls
+    - source ~/.venv/bin/activate && codecov --env TRAVIS_OS_NAME TOXENV OPENSSL
 
 notifications:
     irc:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -65,4 +65,4 @@ fi
 
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
-pip install tox coveralls
+pip install tox codecov

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Cryptography
 .. image:: https://travis-ci.org/pyca/cryptography.svg?branch=master
     :target: https://travis-ci.org/pyca/cryptography
 
-.. image:: https://img.shields.io/coveralls/pyca/cryptography/master.svg
-    :target: https://coveralls.io/r/pyca/cryptography?branch=master
+.. image:: https://codecov.io/github/pyca/cryptography/coverage.svg?branch=master
+    :target: https://codecov.io/github/pyca/cryptography?branch=master
 
 
 ``cryptography`` is a package which provides cryptographic recipes and


### PR DESCRIPTION
codecov is now fully working thanks to @stevepeak's hard work. Let's switch over!

Note: Since codecov has branch coverage we can now see that we are **not at 100%**. This means we can't set the status API to fail at 100% only right now. Fortunately, codecov supports a coverage on diff'd lines measurement so we can setting that to 100% while we work on covering the missed branches.

This supersedes #2070 