### PR TITLE
remove docs for WithNumbers classes that are removed in 1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -130,48 +130,42 @@ Changelog
   SubjectPublicKeyInfo format for RSA, EC, and DSA).
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization`
-  and deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithNumbers`.
+  and deprecated ``EllipticCurvePrivateKeyWithNumbers``.
 * Added
   :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization.private_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`
-  and deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithNumbers`.
+  and deprecated ``RSAPrivateKeyWithNumbers``.
 * Added
   :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization.private_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithSerialization`
-  and deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithNumbers`.
+  and deprecated ``DSAPrivateKeyWithNumbers``.
 * Added
   :meth:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithSerialization.private_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization`
-  and deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithNumbers`.
+  and deprecated ``RSAPublicKeyWithNumbers``.
 * Added
   :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization.public_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization`
-  and deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithNumbers`.
+  and deprecated ``EllipticCurvePublicKeyWithNumbers``.
 * Added
   :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization.public_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithSerialization`
-  and deprecated
-  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithNumbers`.
+  and deprecated ``DSAPublicKeyWithNumbers``.
 * Added
   :meth:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithSerialization.public_bytes`
   to
@@ -209,25 +203,24 @@ Changelog
 * :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAParameters`,
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAParametersWithNumbers`,
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`,
-  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithNumbers`,
+  ``DSAPrivateKeyWithNumbers``,
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey` and
-  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithNumbers`
-  were moved from :mod:`~cryptography.hazmat.primitives.interfaces` to
+  ``DSAPublicKeyWithNumbers`` were moved from
+  :mod:`~cryptography.hazmat.primitives.interfaces` to
   :mod:`~cryptography.hazmat.primitives.asymmetric.dsa`
 * :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`,
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurveSignatureAlgorithm`,
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKey`,
-  :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithNumbers`,
+  ``EllipticCurvePrivateKeyWithNumbers``,
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey`,
-  and
-  :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithNumbers`
+  and ``EllipticCurvePublicKeyWithNumbers``
   were moved from :mod:`~cryptography.hazmat.primitives.interfaces` to
   :mod:`~cryptography.hazmat.primitives.asymmetric.ec`.
 * :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`,
-  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithNumbers`,
+  ``RSAPrivateKeyWithNumbers``,
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey` and
-  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithNumbers`
-  were moved from :mod:`~cryptography.hazmat.primitives.interfaces` to
+  ``RSAPublicKeyWithNumbers`` were moved from
+  :mod:`~cryptography.hazmat.primitives.interfaces` to
   :mod:`~cryptography.hazmat.primitives.asymmetric.rsa`.
 
 0.7.2 - 2015-01-16

--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -284,23 +284,6 @@ Key interfaces
         The bit length of the modulus.
 
 
-.. class:: DSAPrivateKeyWithNumbers
-
-    .. versionadded:: 0.5
-
-    Extends :class:`DSAPrivateKey`.
-
-    .. method:: private_numbers()
-
-        Create a
-        :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateNumbers`
-        object.
-
-        :returns: A
-            :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateNumbers`
-            instance.
-
-
 .. class:: DSAPrivateKeyWithSerialization
 
     .. versionadded:: 0.8
@@ -384,22 +367,6 @@ Key interfaces
         :returns:
             :class:`~cryptography.hazmat.primitives.asymmetric.AsymmetricVerificationContext`
 
-
-.. class:: DSAPublicKeyWithNumbers
-
-    .. versionadded:: 0.5
-
-    Extends :class:`DSAPublicKey`.
-
-    .. method:: public_numbers()
-
-        Create a
-        :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicNumbers`
-        object.
-
-        :returns: A
-            :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicNumbers`
-            instance.
 
 .. class:: DSAPublicKeyWithSerialization
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -321,19 +321,6 @@ Key Interfaces
         The EllipticCurvePublicKey object for this private key.
 
 
-.. class:: EllipticCurvePrivateKeyWithNumbers
-
-    .. versionadded:: 0.6
-
-    Extends :class:`EllipticCurvePrivateKey`.
-
-    .. method:: private_numbers()
-
-        Create a :class:`EllipticCurvePrivateNumbers` object.
-
-        :returns: An :class:`EllipticCurvePrivateNumbers` instance.
-
-
 .. class:: EllipticCurvePrivateKeyWithSerialization
 
     .. versionadded:: 0.8
@@ -398,19 +385,6 @@ Key Interfaces
         :type: :class:`EllipticCurve`
 
         The elliptic curve for this key.
-
-
-.. class:: EllipticCurvePublicKeyWithNumbers
-
-    .. versionadded:: 0.6
-
-    Extends :class:`EllipticCurvePublicKey`.
-
-    .. method:: public_numbers()
-
-        Create a :class:`EllipticCurvePublicNumbers` object.
-
-        :returns: An :class:`EllipticCurvePublicNumbers` instance.
 
 
 .. class:: EllipticCurvePublicKeyWithSerialization

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -518,23 +518,6 @@ Key interfaces
         The bit length of the modulus.
 
 
-.. class:: RSAPrivateKeyWithNumbers
-
-    .. versionadded:: 0.5
-
-    Extends :class:`RSAPrivateKey`.
-
-    .. method:: private_numbers()
-
-        Create a
-        :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
-        object.
-
-        :returns: An
-            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
-            instance.
-
-
 .. class:: RSAPrivateKeyWithSerialization
 
     .. versionadded:: 0.8
@@ -624,23 +607,6 @@ Key interfaces
         :type: int
 
         The bit length of the modulus.
-
-
-.. class:: RSAPublicKeyWithNumbers
-
-    .. versionadded:: 0.5
-
-    Extends :class:`RSAPublicKey`.
-
-    .. method:: public_numbers()
-
-        Create a
-        :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicNumbers`
-        object.
-
-        :returns: An
-            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicNumbers`
-            instance.
 
 
 .. class:: RSAPublicKeyWithSerialization


### PR DESCRIPTION
We deprecated these in 0.8 and removed them at the start of the 1.0 development cycle.