### PR TITLE
move PublicKeyWithSerialization methods to PublicKey

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -153,21 +153,21 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization`
   and deprecated ``RSAPublicKeyWithNumbers``.
 * Added
-  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization.public_bytes`
+  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey.public_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization`
   and deprecated ``EllipticCurvePublicKeyWithNumbers``.
 * Added
-  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization.public_bytes`
+  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.public_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithSerialization`
   and deprecated ``DSAPublicKeyWithNumbers``.
 * Added
-  :meth:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithSerialization.public_bytes`
+  :meth:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey.public_bytes`
   to
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithSerialization`.
 * :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm` and

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -152,23 +152,17 @@ Changelog
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization`
   and deprecated ``RSAPublicKeyWithNumbers``.
-* Added
-  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey.public_bytes`
-  to
+* Added ``public_bytes`` to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization`
   and deprecated ``EllipticCurvePublicKeyWithNumbers``.
-* Added
-  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.public_bytes`
-  to
+* Added ``public_bytes`` to
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization`.
 * Added
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithSerialization`
   and deprecated ``DSAPublicKeyWithNumbers``.
-* Added
-  :meth:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey.public_bytes`
-  to
+* Added ``public_bytes`` to
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKeyWithSerialization`.
 * :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm` and
   :class:`~cryptography.hazmat.primitives.hashes.HashContext` were moved from

--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -367,13 +367,6 @@ Key interfaces
         :returns:
             :class:`~cryptography.hazmat.primitives.asymmetric.AsymmetricVerificationContext`
 
-
-.. class:: DSAPublicKeyWithSerialization
-
-    .. versionadded:: 0.8
-
-    Extends :class:`DSAPublicKey`.
-
     .. method:: public_numbers()
 
         Create a
@@ -400,6 +393,13 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.serialization.PublicFormat` enum.
 
         :return bytes: Serialized key.
+
+
+.. class:: DSAPublicKeyWithSerialization
+
+    .. versionadded:: 0.8
+
+    Alias of :class:`DSAPublicKey`.
 
 
 .. _`DSA`: https://en.wikipedia.org/wiki/Digital_Signature_Algorithm

--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -399,7 +399,7 @@ Key interfaces
 
     .. versionadded:: 0.8
 
-    Alias of :class:`DSAPublicKey`.
+    Alias for :class:`DSAPublicKey`.
 
 
 .. _`DSA`: https://en.wikipedia.org/wiki/Digital_Signature_Algorithm

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -414,7 +414,7 @@ Key Interfaces
 
     .. versionadded:: 0.6
 
-    Alias of :class:`EllipticCurvePublicKey`.
+    Alias for :class:`EllipticCurvePublicKey`.
 
 
 .. _`FIPS 186-3`: http://csrc.nist.gov/publications/fips/fips186-3/fips_186-3.pdf

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -386,13 +386,6 @@ Key Interfaces
 
         The elliptic curve for this key.
 
-
-.. class:: EllipticCurvePublicKeyWithSerialization
-
-    .. versionadded:: 0.6
-
-    Extends :class:`EllipticCurvePublicKey`.
-
     .. method:: public_numbers()
 
         Create a :class:`EllipticCurvePublicNumbers` object.
@@ -415,6 +408,13 @@ Key Interfaces
             :class:`~cryptography.hazmat.primitives.serialization.PublicFormat` enum.
 
         :return bytes: Serialized key.
+
+
+.. class:: EllipticCurvePublicKeyWithSerialization
+
+    .. versionadded:: 0.6
+
+    Alias of :class:`EllipticCurvePublicKey`.
 
 
 .. _`FIPS 186-3`: http://csrc.nist.gov/publications/fips/fips186-3/fips_186-3.pdf

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -113,10 +113,8 @@ It is also possible to serialize without encryption using
     >>> pem.splitlines()[0]
     '-----BEGIN RSA PRIVATE KEY-----'
 
-Similarly, if your public key implements
-:class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization`
-interface you can use
-:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization.public_bytes`
+For public keys you can use
+:meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey.public_bytes`
 to serialize the key.
 
 .. doctest::

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -608,13 +608,6 @@ Key interfaces
 
         The bit length of the modulus.
 
-
-.. class:: RSAPublicKeyWithSerialization
-
-    .. versionadded:: 0.8
-
-    Extends :class:`RSAPublicKey`.
-
     .. method:: public_numbers()
 
         Create a
@@ -643,6 +636,13 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.serialization.PublicFormat` enum.
 
         :return bytes: Serialized key.
+
+
+.. class:: RSAPublicKeyWithSerialization
+
+    .. versionadded:: 0.8
+
+    Alias of :class:`RSAPublicKey`.
 
 
 .. _`RSA`: https://en.wikipedia.org/wiki/RSA_(cryptosystem)

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -640,7 +640,7 @@ Key interfaces
 
     .. versionadded:: 0.8
 
-    Alias of :class:`RSAPublicKey`.
+    Alias for :class:`RSAPublicKey`.
 
 
 .. _`RSA`: https://en.wikipedia.org/wiki/RSA_(cryptosystem)

--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -91,9 +91,6 @@ class DSAPublicKey(object):
         Returns an AsymmetricVerificationContext used for signing data.
         """
 
-
-@six.add_metaclass(abc.ABCMeta)
-class DSAPublicKeyWithSerialization(DSAPublicKey):
     @abc.abstractmethod
     def public_numbers(self):
         """
@@ -105,6 +102,9 @@ class DSAPublicKeyWithSerialization(DSAPublicKey):
         """
         Returns the key serialized as bytes.
         """
+
+
+DSAPublicKeyWithSerialization = DSAPublicKey
 
 
 def generate_parameters(key_size, backend):

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -85,9 +85,6 @@ class EllipticCurvePublicKey(object):
         The EllipticCurve that this key is on.
         """
 
-
-@six.add_metaclass(abc.ABCMeta)
-class EllipticCurvePublicKeyWithSerialization(EllipticCurvePublicKey):
     @abc.abstractmethod
     def public_numbers(self):
         """
@@ -99,6 +96,9 @@ class EllipticCurvePublicKeyWithSerialization(EllipticCurvePublicKey):
         """
         Returns the key serialized as bytes.
         """
+
+
+EllipticCurvePublicKeyWithSerialization = EllipticCurvePublicKey
 
 
 @utils.register_interface(EllipticCurve)

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -76,9 +76,6 @@ class RSAPublicKey(object):
         The bit length of the public modulus.
         """
 
-
-@six.add_metaclass(abc.ABCMeta)
-class RSAPublicKeyWithSerialization(RSAPublicKey):
     @abc.abstractmethod
     def public_numbers(self):
         """
@@ -90,6 +87,9 @@ class RSAPublicKeyWithSerialization(RSAPublicKey):
         """
         Returns the key serialized as bytes.
         """
+
+
+RSAPublicKeyWithSerialization = RSAPublicKey
 
 
 def generate_private_key(public_exponent, key_size, backend):


### PR DESCRIPTION
Move the methods from *PublicKeyWithSerialization to PublicKey and make the *PublicKeyWithSerialization classes an alias. Fixes #1748 