### PR TITLE
support registeredID general name encoding

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -162,8 +162,19 @@ def _encode_subject_alt_name(backend, san):
             res = backend._lib.ASN1_STRING_set(ia5, value, len(value))
             assert res == 1
             gn.d.dNSName = ia5
+        elif isinstance(alt_name, x509.RegisteredID):
+            gn = backend._lib.GENERAL_NAME_new()
+            assert gn != backend._ffi.NULL
+            gn.type = backend._lib.GEN_RID
+            obj = backend._lib.OBJ_txt2obj(
+                alt_name.value.dotted_string.encode('ascii'), 1
+            )
+            assert obj != backend._ffi.NULL
+            gn.d.registeredID = obj
         else:
-            raise NotImplementedError("Only DNSNames are supported right now")
+            raise NotImplementedError(
+                "Only DNSName and RegisteredID supported right now"
+            )
 
         res = backend._lib.sk_GENERAL_NAME_push(general_names, gn)
         assert res != 0

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -922,6 +922,7 @@ class TestCertificateSigningRequestBuilder(object):
             x509.SubjectAlternativeName([
                 x509.DNSName(u"example.com"),
                 x509.DNSName(u"*.example.com"),
+                x509.RegisteredID(x509.ObjectIdentifier("1.2.3.4.5.6.7")),
             ]),
             critical=False,
         ).sign(private_key, hashes.SHA256(), backend)
@@ -935,6 +936,7 @@ class TestCertificateSigningRequestBuilder(object):
         assert list(ext.value) == [
             x509.DNSName(u"example.com"),
             x509.DNSName(u"*.example.com"),
+            x509.RegisteredID(x509.ObjectIdentifier("1.2.3.4.5.6.7")),
         ]
 
     def test_subject_alt_name_unsupported_general_name(self, backend):


### PR DESCRIPTION
refs #2117 

This PR does not use the `_txt2obj` function because we don't want to GC the resulting ASN1_OBJECT.