### PR TITLE
Fixed #2121 -- added __eq__ and __ne__ to CSRs

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -701,6 +701,14 @@ class _CertificateSigningRequest(object):
         self._backend = backend
         self._x509_req = x509_req
 
+    def __eq__(self, other):
+        if not isinstance(other, _CertificateSigningRequest):
+            return NotImplemented
+
+        self_bytes = self.public_bytes(serialization.Encoding.DER)
+        other_bytes = other.public_bytes(serialization.Encoding.DER)
+        return self_bytes == other_bytes
+
     def public_key(self):
         pkey = self._backend._lib.X509_REQ_get_pubkey(self._x509_req)
         assert pkey != self._backend._ffi.NULL

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -709,6 +709,9 @@ class _CertificateSigningRequest(object):
         other_bytes = other.public_bytes(serialization.Encoding.DER)
         return self_bytes == other_bytes
 
+    def __ne__(self, other):
+        return not self == other
+
     def public_key(self):
         pkey = self._backend._lib.X509_REQ_get_pubkey(self._x509_req)
         assert pkey != self._backend._ffi.NULL

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -1391,6 +1391,18 @@ class CertificateRevocationList(object):
 
 @six.add_metaclass(abc.ABCMeta)
 class CertificateSigningRequest(object):
+    @abc.abstracmethod
+    def __eq__(self, other):
+        """
+        Checks equality.
+        """
+
+    @abc.abstractmethod
+    def __ne__(self, other):
+        """
+        Checks not equal.
+        """
+
     @abc.abstractmethod
     def public_key(self):
         """

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -1391,7 +1391,7 @@ class CertificateRevocationList(object):
 
 @six.add_metaclass(abc.ABCMeta)
 class CertificateSigningRequest(object):
-    @abc.abstracmethod
+    @abc.abstractmethod
     def __eq__(self, other):
         """
         Checks equality.

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -715,7 +715,7 @@ class TestRSACertificateRequest(object):
             backend
         )
         request2 = _load_cert(
-            os.path.join("x509", "requests", "rsa_sha1.pem"),
+            os.path.join("x509", "requests", "san_rsa_sha1.pem"),
             x509.load_pem_x509_csr,
             backend
         )

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -694,6 +694,35 @@ class TestRSACertificateRequest(object):
         serialized = request.public_bytes(encoding)
         assert serialized == request_bytes
 
+    def test_eq(self, backend):
+        request1 = _load_cert(
+            os.path.join("x509", "requests", "rsa_sha1.pem"),
+            x509.load_pem_x509_csr,
+            backend
+        )
+        request2 = _load_cert(
+            os.path.join("x509", "requests", "rsa_sha1.pem"),
+            x509.load_pem_x509_csr,
+            backend
+        )
+
+        assert request1 == request2
+
+    def test_ne(self, backend):
+        request1 = _load_cert(
+            os.path.join("x509", "requests", "rsa_sha1.pem"),
+            x509.load_pem_x509_csr,
+            backend
+        )
+        request2 = _load_cert(
+            os.path.join("x509", "requests", "rsa_sha1.pem"),
+            x509.load_pem_x509_csr,
+            backend
+        )
+
+        assert request1 != request2
+        assert request1 != object()
+
 
 @pytest.mark.requires_backend_interface(interface=X509Backend)
 class TestCertificateSigningRequestBuilder(object):


### PR DESCRIPTION
OpenSSL doesn't have X509_REQ_cmp, so I went with just comparing the DER bytes, is there a better way?