### PR TITLE
expand RFC822Name to validate and (internally) IDNA encode

### DIFF
--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -906,10 +906,9 @@ class RFC822Name(object):
 
         name, address = parseaddr(value)
         parts = address.split(u"@")
-        if name or len(parts) > 2 or not address:
-            # parseaddr has found a name (e.g. Name <email>) or the split
-            # has found more than 2 parts (which means more than one @)
-            # or the entire value is an empty string.
+        if name or not address:
+            # parseaddr has found a name (e.g. Name <email>) or the entire
+            # value is an empty string.
             raise ValueError("Invalid rfc822name value")
         elif len(parts) == 1:
             # Single label email name. This is valid for local delivery.

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1087,6 +1087,24 @@ class TestDirectoryName(object):
         assert gn != object()
 
 
+class TestRFC822Name(object):
+    def test_invalid_email(self):
+        with pytest.raises(ValueError):
+            x509.RFC822Name(u"Name <email>")
+
+        with pytest.raises(ValueError):
+            x509.RFC822Name(u"")
+
+    def test_single_label(self):
+        gn = x509.RFC822Name(u"administrator")
+        assert gn.value == u"administrator"
+
+    def test_idna(self):
+        gn = x509.RFC822Name(u"email@em\xe5\xefl.com")
+        assert gn.value == u"email@em\xe5\xefl.com"
+        assert gn._encoded == b"email@xn--eml-vla4c.com"
+
+
 class TestRegisteredID(object):
     def test_not_oid(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
This will be used in the CSR builder. refs #2137 