### PR TITLE
temporarily pin ipaddress to 1.0.7 to avoid a pypy bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.version_info < (3, 4):
     requirements.append("enum34")
 
 if sys.version_info < (3, 3):
-    requirements.append("ipaddress")
+    requirements.append("ipaddress==1.0.7")
 
 if platform.python_implementation() != "PyPy":
     requirements.append("cffi>=1.1.0")


### PR DESCRIPTION
This will unblock our CI while we get this fixed upstream.