### PR TITLE
Proof of Concept: Conditional CDEF

### DIFF
--- a/src/_cffi_src/openssl/aes.py
+++ b/src/_cffi_src/openssl/aes.py
@@ -23,13 +23,6 @@ int AES_set_decrypt_key(const unsigned char *, const int, AES_KEY *);
 """
 
 MACROS = """
-/* these can be moved back to FUNCTIONS once we drop support for 0.9.8h.
-   This should be when we drop RHEL/CentOS 5, which is on 0.9.8e. */
-int AES_wrap_key(AES_KEY *, const unsigned char *, unsigned char *,
-                 const unsigned char *, unsigned int);
-int AES_unwrap_key(AES_KEY *, const unsigned char *, unsigned char *,
-                   const unsigned char *, unsigned int);
-
 /* The ctr128_encrypt function is only useful in 0.9.8. You should use EVP for
    this in 1.0.0+. It is defined in macros because the function signature
    changed after 0.9.8 */
@@ -45,10 +38,6 @@ CUSTOMIZATIONS = """
 static const long Cryptography_HAS_AES_WRAP = 1;
 #else
 static const long Cryptography_HAS_AES_WRAP = 0;
-int (*AES_wrap_key)(AES_KEY *, const unsigned char *, unsigned char *,
-                    const unsigned char *, unsigned int) = NULL;
-int (*AES_unwrap_key)(AES_KEY *, const unsigned char *, unsigned char *,
-                      const unsigned char *, unsigned int) = NULL;
 #endif
 
 """
@@ -58,4 +47,25 @@ CONDITIONAL_NAMES = {
         "AES_wrap_key",
         "AES_unwrap_key",
     ],
+}
+
+
+CONDITIONAL_NAMES2 = {
+    "Cryptography_HAS_AES_WRAP": (
+        """
+/* OpenSSL 0.9.8h+ */
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER >= 0x0090808fL
+static const long Cryptography_HAS_AES_WRAP = 1;
+#else
+static const long Cryptography_HAS_AES_WRAP = 0;
+#endif
+        """,
+        """
+int AES_wrap_key(AES_KEY *, const unsigned char *, unsigned char *,
+                 const unsigned char *, unsigned int);
+int AES_unwrap_key(AES_KEY *, const unsigned char *, unsigned char *,
+                   const unsigned char *, unsigned int);
+        """,
+    ),
 }


### PR DESCRIPTION
This should not be merged! It is a proof of concept only.

This requires having CFFI installed from my fork on bitbucket (particularly [this commit](https://bitbucket.org/dstufft/cffi/commits/f7b3e65833d55c95fc1fe8d69c95f6c49fbf0d9f)).

This essentially works by modifying CFFI to give us a hook in the ``build_ext`` command when the FFI object exists but hasn't yet had it's C sources generated and we also have access to the ``build_ext`` command class so we can access things like libraries, include dirs, etc that were passed in via ``python setup.py build_ext ...``.

Essentially this inverts the old logic, instead of defining everything and then deleting some names from runtime, this only defines the unconditional names unconditionally and then defines a test and additional data to call ``ffi.cdef()`` with if that test passes. Then using the hook that I've modified CFFI to have we generate a small cffi module, compile it, check the value, and then conditionally add the items or not.

Some things I know this needs:

* It needs to pass all of the values in through ``set_source`` and not just libraries (like include dirs and such).
* We probably don't need to do the ``sys.path`` dance, just ensuring the tempdir is on there and then leaving it without cleaning up should be fine.
* Need to figure out what we want the data structure that defines conditional names should look like for real.
* Maybe all the ``#include`` statements should be added to each temporary module instead of needing to add them to each conditional test.
* Of course, actually move conditional names to this system.

I don't have the time right now to actually push this forward further, but hopefully this is enough that @reaperhulk or someone can pick up the mantle and take this forward.