### PR TITLE
when building a CSR adding > 1 extension would trigger a bug

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -976,7 +976,7 @@ class Backend(object):
             )
             assert extension != self._ffi.NULL
             res = self._lib.sk_X509_EXTENSION_push(extensions, extension)
-            assert res == 1
+            assert res >= 1
         res = self._lib.X509_REQ_add_extensions(x509_req, extensions)
         assert res == 1
 


### PR DESCRIPTION
We were checking sk_X509_EXTENSION_push for a value == 1, but in reality it returns the number of extensions on the stack.