### PR TITLE
When encoding IP SANs, force packed values to be bytes()

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -194,8 +194,9 @@ def _encode_subject_alt_name(backend, san):
         elif isinstance(alt_name, x509.IPAddress):
             gn = backend._lib.GENERAL_NAME_new()
             assert gn != backend._ffi.NULL
+            address = bytes(alt_name.value.packed)
             ipaddr = _encode_asn1_str(
-                backend, alt_name.value.packed, len(alt_name.value.packed)
+                backend, address, len(address)
             )
             gn.type = backend._lib.GEN_IPADD
             gn.d.iPAddress = ipaddr


### PR DESCRIPTION
In Python 2, the ipaddress library returns a bytearray, which can't be
serialized by _encode_asn1_str.  This fixes the issue by casting to bytes.

No change in Python 3.4:

>>> a = ipaddress.ip_address('10.1.1.1').packed
>>> bytes(a) is a
True