### PR TITLE
Update URL for OpenSSL binaries

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -186,6 +186,6 @@ information, consult `Greg Wilson's blog post`_ on the subject.
 
 .. _`Homebrew`: http://brew.sh
 .. _`MacPorts`: http://www.macports.org
-.. _`pre-compiled binaries`: https://www.openssl.org/related/binaries.html
+.. _`pre-compiled binaries`: https://jenkins.cryptography.io/job/openssl-win32-release/
 .. _`bug in conda`: https://github.com/conda/conda-recipes/issues/110
 .. _`Greg Wilson's blog post`: http://software-carpentry.org/blog/2014/04/mr-biczo-was-right.html


### PR DESCRIPTION
The link for OpenSSL binaries should not point to the slproweb binaries anymore.

Maybe not the most beautiful fix, but after updating OpenSSL and then wasting a bit of time before I  discovered #2164, this may be worthwhile change for now.