### PR TITLE
handle RSA key too small and consume errors on CSR signature failure

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -230,6 +230,7 @@ static const int RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY;
 static const int RSA_R_BLOCK_TYPE_IS_NOT_01;
 static const int RSA_R_BLOCK_TYPE_IS_NOT_02;
 static const int RSA_R_PKCS_DECODING_ERROR;
+static const int RSA_F_RSA_SIGN;
 """
 
 FUNCTIONS = """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1057,12 +1057,12 @@ class Backend(object):
         )
         if res == 0:
             errors = self._consume_errors()
-            assert errors[0][1:] in (
+            assert errors[0][1:] == (
                 (
                     self._lib.ERR_LIB_RSA,
                     self._lib.RSA_F_RSA_SIGN,
                     self._lib.RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY
-                ),
+                )
             )
             raise ValueError("Digest too big for RSA key")
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1058,11 +1058,9 @@ class Backend(object):
         if res == 0:
             errors = self._consume_errors()
             assert errors[0][1:] == (
-                (
-                    self._lib.ERR_LIB_RSA,
-                    self._lib.RSA_F_RSA_SIGN,
-                    self._lib.RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY
-                )
+                self._lib.ERR_LIB_RSA,
+                self._lib.RSA_F_RSA_SIGN,
+                self._lib.RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY
             )
             raise ValueError("Digest too big for RSA key")
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1057,11 +1057,8 @@ class Backend(object):
         )
         if res == 0:
             errors = self._consume_errors()
-            assert errors[0][1:] == (
-                self._lib.ERR_LIB_RSA,
-                self._lib.RSA_F_RSA_SIGN,
-                self._lib.RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY
-            )
+            assert errors[0][1] == self._lib.ERR_LIB_RSA
+            assert errors[0][3] == self._lib.RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY
             raise ValueError("Digest too big for RSA key")
 
         return _CertificateSigningRequest(self, x509_req)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1055,7 +1055,16 @@ class Backend(object):
         res = self._lib.X509_REQ_sign(
             x509_req, private_key._evp_pkey, evp_md
         )
-        assert res > 0
+        if res == 0:
+            errors = self._consume_errors()
+            assert errors[0][1:] in (
+                (
+                    self._lib.ERR_LIB_RSA,
+                    self._lib.RSA_F_RSA_SIGN,
+                    self._lib.RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY
+                ),
+            )
+            raise ValueError("Digest too big for RSA key")
 
         return _CertificateSigningRequest(self, x509_req)
 

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1206,6 +1206,19 @@ class TestCertificateSigningRequestBuilder(object):
             x509.OID_CODE_SIGNING,
         ])
 
+    @pytest.mark.requires_backend_interface(interface=RSABackend)
+    def test_rsa_key_too_small(self, backend):
+        private_key = rsa.generate_private_key(65537, 512, backend)
+        builder = x509.CertificateSigningRequestBuilder()
+        builder = builder.subject_name(
+            x509.Name([x509.NameAttribute(x509.OID_COUNTRY_NAME, u'US')])
+        )
+
+        with pytest.raises(ValueError) as exc:
+            builder.sign(private_key, hashes.SHA512(), backend)
+
+        assert exc.value.message == "Digest too big for RSA key"
+
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1217,7 +1217,7 @@ class TestCertificateSigningRequestBuilder(object):
         with pytest.raises(ValueError) as exc:
             builder.sign(private_key, hashes.SHA512(), backend)
 
-        assert exc.value.message == "Digest too big for RSA key"
+        assert str(exc.value) == "Digest too big for RSA key"
 
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)


### PR DESCRIPTION
This PR is not ready for merge as I'm not sure how to trigger the generic failure case (e.g. signature failure that isn't RSA key too small). Suggestions?