### PR TITLE
[Discussion] Fernet: split `decrypt` into `verify` & `decrypt`

### DIFF
--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -70,7 +70,7 @@ class Fernet(object):
         hmac = h.finalize()
         return base64.urlsafe_b64encode(basic_parts + hmac)
 
-    def decrypt(self, token, ttl=None):
+    def verify(self, token, ttl=None):
         if not isinstance(token, bytes):
             raise TypeError("token must be bytes.")
 
@@ -99,6 +99,11 @@ class Fernet(object):
             h.verify(data[-32:])
         except InvalidSignature:
             raise InvalidToken
+
+        return data
+
+    def decrypt(self, token, ttl=None):
+        data = self.verify(token, ttl)
 
         iv = data[9:25]
         ciphertext = data[25:-32]


### PR DESCRIPTION
(This is not a complete pull request, it's just meant for discussion.)

Fernet offers encryption and authentication. I argue that it should offer an interface that offers de-/encryption and verification. Currently only the de-/encryption part is supported by the interface. The verification happens internally.

I just made the smallest change possible and split the decrypt function into `verify` & `decrypt` which makes it possible to authenticate/verify the message without encrypting. Currently `verify` returns the data. It raises an exception if the message is not valid (see [here](https://cryptography.io/en/latest/development/submitting-patches/#api-considerations)) but that can be changed.

Usecase: you have a a lot of fernet encrypted data and just want to make sure that it is what you think it is.

```python
fernet = Fernet(key)
for encrypted_msg in big_encrypted_data_repo():
    try:
        fernet.verify(encrypted_msg)
    except InvalidToken:
        print('Compromised')
```

What do you think? Is this a useful feature?
