### PR TITLE
remove pep8/py3pep8 from travis because we can run those in jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,6 @@ matrix:
               apt:
                   packages:
                       - libenchant-dev
-        - python: 2.7
-          env: TOXENV=pep8
-        - python: 3.3
-          env: TOXENV=py3pep8
         - language: generic
           os: osx
           osx_image: beta-xcode6.3


### PR DESCRIPTION
Just added a new jenkins PR builder with status API to give faster feedback on pep8 problems.