### PR TITLE
Make Homebrew install instructions more generic

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -142,7 +142,7 @@ To link cryptography against a custom version of OpenSSL you'll need to set
 .. code-block:: console
 
     $ brew install openssl
-    $ env ARCHFLAGS="-arch x86_64" LDFLAGS="-L/usr/local/opt/openssl/lib" CFLAGS="-I/usr/local/opt/openssl/include" pip install cryptography
+    $ env ARCHFLAGS="-arch x86_64" LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install cryptography
 
 or `MacPorts`_:
 


### PR DESCRIPTION
Homebrew supports installing to locations other than /usr/local.