### PR TITLE
SubjectKeyIdentifier classmethod

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1119,7 +1119,7 @@ X.509 Extensions
 
         The binary value of the identifier.
 
-    .. classmethod:: create_from_public_key(public_key)
+    .. classmethod:: from_public_key(public_key)
 
         .. versionadded:: 1.0
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1119,6 +1119,21 @@ X.509 Extensions
 
         The binary value of the identifier.
 
+    .. classmethod:: create_from_public_key(public_key)
+
+        .. versionadded:: 1.0
+
+        Creates a new SubjectKeyIdentifier instance using the public key
+        provided to generate the appropriate digest. This should be the public
+        key that is in the certificate.
+
+        :param public_key: One of
+            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`
+            ,
+            :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey`
+            , or
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey`.
+
 .. class:: SubjectAlternativeName
 
     .. versionadded:: 0.9

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1125,7 +1125,9 @@ X.509 Extensions
 
         Creates a new SubjectKeyIdentifier instance using the public key
         provided to generate the appropriate digest. This should be the public
-        key that is in the certificate.
+        key that is in the certificate. The generated digest is the SHA1 hash
+        of the ``subjectPublicKey`` ASN.1 bit string. This is the first
+        recommendation in :rfc:`5280` section 4.2.1.2.
 
         :param public_key: One of
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -47,16 +47,10 @@ else:
         return result
 
 
-if hasattr(int, "to_bytes"):
-    int_to_bytes = int.to_bytes
-else:
-    def int_to_bytes(integer, byteorder, signed=False):
-        assert byteorder == 'big'
-        assert not signed
-
-        hex_string = '%x' % integer
-        n = len(hex_string)
-        return binascii.unhexlify(hex_string.zfill(n + (n & 1)))
+def int_to_bytes(integer):
+    hex_string = '%x' % integer
+    n = len(hex_string)
+    return binascii.unhexlify(hex_string.zfill(n + (n & 1)))
 
 
 class InterfaceNotImplemented(Exception):

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 import abc
+import binascii
 import inspect
 import struct
 import sys
@@ -44,6 +45,18 @@ else:
             data = data[4:]
 
         return result
+
+
+if hasattr(int, "to_bytes"):
+    int_to_bytes = int.to_bytes
+else:
+    def int_to_bytes(integer, byteorder, signed=False):
+        assert byteorder == 'big'
+        assert not signed
+
+        hex_string = '%x' % integer
+        n = len(hex_string)
+        return binascii.unhexlify(hex_string.zfill(n + (n & 1)))
 
 
 class InterfaceNotImplemented(Exception):

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -682,7 +682,7 @@ class SubjectKeyIdentifier(object):
         self._digest = digest
 
     @classmethod
-    def create_from_public_key(cls, public_key):
+    def from_public_key(cls, public_key):
         # This is a very slow way to do this.
         serialized = public_key.public_bytes(
             serialization.Encoding.DER,

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function
 
 import abc
-import binascii
 import datetime
 import hashlib
 import ipaddress
@@ -699,10 +698,7 @@ class SubjectKeyIdentifier(object):
         for bit in spki.getComponentByName("subjectPublicKey"):
             bits = bits << 1 | bit
 
-        # convert the integer to bytes
-        hex_string = '%x' % bits
-        n = len(hex_string)
-        data = binascii.unhexlify(hex_string.zfill(n + (n & 1)))
+        data = utils.int_to_bytes(bits, "big")
         return cls(hashlib.sha1(data).digest())
 
     digest = utils.read_only_property("_digest")

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -698,7 +698,7 @@ class SubjectKeyIdentifier(object):
         for bit in spki.getComponentByName("subjectPublicKey"):
             bits = bits << 1 | bit
 
-        data = utils.int_to_bytes(bits, "big")
+        data = utils.int_to_bytes(bits)
         return cls(hashlib.sha1(data).digest())
 
     digest = utils.read_only_property("_digest")

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -691,6 +691,7 @@ class SubjectKeyIdentifier(object):
         spki, remaining = decoder.decode(
             serialized, asn1Spec=_SubjectPublicKeyInfo()
         )
+        assert not remaining
         # the univ.BitString object is a tuple of bits. We need bytes and
         # pyasn1 really doesn't want to give them to us. To get it we'll
         # build an integer, hex it, then decode the hex.

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -693,7 +693,7 @@ class SubjectKeyIdentifier(object):
         assert not remaining
         # the univ.BitString object is a tuple of bits. We need bytes and
         # pyasn1 really doesn't want to give them to us. To get it we'll
-        # build an integer, hex it, then decode the hex.
+        # build an integer and convert that to bytes.
         bits = 0
         for bit in spki.getComponentByName("subjectPublicKey"):
             bits = bits << 1 | bit

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -5,20 +5,32 @@
 from __future__ import absolute_import, division, print_function
 
 import abc
+import binascii
 import datetime
+import hashlib
 import ipaddress
 from email.utils import parseaddr
 from enum import Enum
 
 import idna
 
+from pyasn1.codec.der import decoder
+from pyasn1.type import namedtype, univ
+
 import six
 
 from six.moves import urllib_parse
 
 from cryptography import utils
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
+
+
+class _SubjectPublicKeyInfo(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('algorithm', univ.Sequence()),
+        namedtype.NamedType('subjectPublicKey', univ.BitString())
+    )
 
 
 _OID_NAMES = {
@@ -668,6 +680,29 @@ class NoticeReference(object):
 class SubjectKeyIdentifier(object):
     def __init__(self, digest):
         self._digest = digest
+
+    @classmethod
+    def create_from_public_key(cls, public_key):
+        # This is a very slow way to do this.
+        serialized = public_key.public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+        spki, remaining = decoder.decode(
+            serialized, asn1Spec=_SubjectPublicKeyInfo()
+        )
+        # the univ.BitString object is a tuple of bits. We need bytes and
+        # pyasn1 really doesn't want to give them to us. To get it we'll
+        # build an integer, hex it, then decode the hex.
+        bits = 0
+        for bit in spki.getComponentByName("subjectPublicKey"):
+            bits = bits << 1 | bit
+
+        # convert the integer to bytes
+        hex_string = '%x' % bits
+        n = len(hex_string)
+        data = binascii.unhexlify(hex_string.zfill(n + (n & 1)))
+        return cls(hashlib.sha1(data).digest())
 
     digest = utils.read_only_property("_digest")
 

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -13,8 +13,12 @@ import pytest
 import six
 
 from cryptography import x509
-from cryptography.hazmat.backends.interfaces import RSABackend, X509Backend
+from cryptography.hazmat.backends.interfaces import (
+    DSABackend, EllipticCurveBackend, RSABackend, X509Backend
+)
+from cryptography.hazmat.primitives.asymmetric import ec
 
+from .hazmat.primitives.test_ec import _skip_curve_unsupported
 from .test_x509 import _load_cert
 
 
@@ -917,9 +921,9 @@ class TestBasicConstraintsExtension(object):
         assert ext.value.ca is False
 
 
-@pytest.mark.requires_backend_interface(interface=RSABackend)
-@pytest.mark.requires_backend_interface(interface=X509Backend)
 class TestSubjectKeyIdentifierExtension(object):
+    @pytest.mark.requires_backend_interface(interface=RSABackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
     def test_subject_key_identifier(self, backend):
         cert = _load_cert(
             os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
@@ -936,6 +940,8 @@ class TestSubjectKeyIdentifierExtension(object):
             b"580184241bbc2b52944a3da510721451f5af3ac9"
         )
 
+    @pytest.mark.requires_backend_interface(interface=RSABackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
     def test_no_subject_key_identifier(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "bc_path_length_zero.pem"),
@@ -946,6 +952,57 @@ class TestSubjectKeyIdentifierExtension(object):
             cert.extensions.get_extension_for_oid(
                 x509.OID_SUBJECT_KEY_IDENTIFIER
             )
+
+    @pytest.mark.requires_backend_interface(interface=RSABackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
+    def test_create_from_rsa_public_key(self, backend):
+        cert = _load_cert(
+            os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
+            x509.load_der_x509_certificate,
+            backend
+        )
+        ext = cert.extensions.get_extension_for_oid(
+            x509.OID_SUBJECT_KEY_IDENTIFIER
+        )
+        ski = x509.SubjectKeyIdentifier.create_from_public_key(
+            cert.public_key()
+        )
+        assert ext.value == ski
+
+    @pytest.mark.requires_backend_interface(interface=DSABackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
+    def test_create_from_dsa_public_key(self, backend):
+        cert = _load_cert(
+            os.path.join("x509", "custom", "dsa_selfsigned_ca.pem"),
+            x509.load_pem_x509_certificate,
+            backend
+        )
+
+        ext = cert.extensions.get_extension_for_oid(
+            x509.OID_SUBJECT_KEY_IDENTIFIER
+        )
+        ski = x509.SubjectKeyIdentifier.create_from_public_key(
+            cert.public_key()
+        )
+        assert ext.value == ski
+
+    @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
+    def test_create_from_ec_public_key(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP384R1())
+        cert = _load_cert(
+            os.path.join("x509", "ecdsa_root.pem"),
+            x509.load_pem_x509_certificate,
+            backend
+        )
+
+        ext = cert.extensions.get_extension_for_oid(
+            x509.OID_SUBJECT_KEY_IDENTIFIER
+        )
+        ski = x509.SubjectKeyIdentifier.create_from_public_key(
+            cert.public_key()
+        )
+        assert ext.value == ski
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -955,7 +955,7 @@ class TestSubjectKeyIdentifierExtension(object):
 
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)
-    def test_create_from_rsa_public_key(self, backend):
+    def test_from_rsa_public_key(self, backend):
         cert = _load_cert(
             os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
             x509.load_der_x509_certificate,
@@ -964,14 +964,14 @@ class TestSubjectKeyIdentifierExtension(object):
         ext = cert.extensions.get_extension_for_oid(
             x509.OID_SUBJECT_KEY_IDENTIFIER
         )
-        ski = x509.SubjectKeyIdentifier.create_from_public_key(
+        ski = x509.SubjectKeyIdentifier.from_public_key(
             cert.public_key()
         )
         assert ext.value == ski
 
     @pytest.mark.requires_backend_interface(interface=DSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)
-    def test_create_from_dsa_public_key(self, backend):
+    def test_from_dsa_public_key(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "dsa_selfsigned_ca.pem"),
             x509.load_pem_x509_certificate,
@@ -981,14 +981,14 @@ class TestSubjectKeyIdentifierExtension(object):
         ext = cert.extensions.get_extension_for_oid(
             x509.OID_SUBJECT_KEY_IDENTIFIER
         )
-        ski = x509.SubjectKeyIdentifier.create_from_public_key(
+        ski = x509.SubjectKeyIdentifier.from_public_key(
             cert.public_key()
         )
         assert ext.value == ski
 
     @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)
-    def test_create_from_ec_public_key(self, backend):
+    def test_from_ec_public_key(self, backend):
         _skip_curve_unsupported(backend, ec.SECP384R1())
         cert = _load_cert(
             os.path.join("x509", "ecdsa_root.pem"),
@@ -999,7 +999,7 @@ class TestSubjectKeyIdentifierExtension(object):
         ext = cert.extensions.get_extension_for_oid(
             x509.OID_SUBJECT_KEY_IDENTIFIER
         )
-        ski = x509.SubjectKeyIdentifier.create_from_public_key(
+        ski = x509.SubjectKeyIdentifier.from_public_key(
             cert.public_key()
         )
         assert ext.value == ski


### PR DESCRIPTION
This class method is needed for creating the SKI extension that needs to be encoded when generating a certificate.

Unfortunately pyasn1 is not really geared towards giving us the data we need so the current solution is very inefficient. I'm not particularly worried about it from a performance perspective, but if there's an easy way to do this more efficiently (not by writing our own ASN.1 parser plz) I'm on board.

Longer term we could also look at the ASN1 lib mentioned in #2162.

refs #2192 