### PR TITLE
Move validation code into CertificateBuilder constructor

### DIFF
--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -313,7 +313,8 @@ class CertificateSigningRequestBuilder(object):
 class CertificateBuilder(object):
     def __init__(self, issuer_name=None, subject_name=None,
                  public_key=None, serial_number=None,
-                 not_valid_before=None, not_valid_after=None):
+                 not_valid_before=None, not_valid_after=None,
+                 optional_extensions=[], critical_extensions=[]):
         self._version = Version.v3
         self._issuer_name = None
         self._subject_name = None
@@ -340,6 +341,12 @@ class CertificateBuilder(object):
 
         if not_valid_after is not None:
             self._set_not_valid_after(not_valid_after)
+
+        for extension in optional_extensions:
+            self._add_extension(extension, critical=False)
+
+        for extension in critical_extensions:
+            self._add_extension(extension, critical=True)
 
     def _clone(self):
         clone = self.__class__()

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -311,7 +311,9 @@ class CertificateSigningRequestBuilder(object):
 
 
 class CertificateBuilder(object):
-    def __init__(self, **kwargs):
+    def __init__(self, issuer_name=None, subject_name=None,
+                 public_key=None, serial_number=None,
+                 not_valid_before=None, not_valid_after=None):
         self._version = Version.v3
         self._issuer_name = None
         self._subject_name = None
@@ -321,7 +323,23 @@ class CertificateBuilder(object):
         self._not_valid_after = None
         self._extensions = []
 
-        self._apply_updates(**kwargs)
+        if issuer_name is not None:
+            self._set_issuer_name(issuer_name)
+
+        if subject_name is not None:
+            self._set_subject_name(subject_name)
+
+        if public_key is not None:
+            self._set_public_key(public_key)
+
+        if serial_number is not None:
+            self._set_serial_number(serial_number)
+
+        if not_valid_before is not None:
+            self._set_not_valid_before(not_valid_before)
+
+        if not_valid_after is not None:
+            self._set_not_valid_after(not_valid_after)
 
     def _clone(self):
         clone = self.__class__()
@@ -334,72 +352,112 @@ class CertificateBuilder(object):
         clone._extensions = list(self._extensions)
         return clone
 
-    def _with_updates(self, **kwargs):
+    def _set_issuer_name(self, issuer_name):
+        if not isinstance(issuer_name, Name):
+            raise TypeError('Expecting x509.Name object for issuer name.')
+        if self._issuer_name is not None:
+            raise ValueError('The issuer name may only be set once.')
+        self._issuer_name = issuer_name
+
+    def issuer_name(self, name):
+        """
+        Sets the CA's distinguished name.
+        """
         clone = self._clone()
-        clone._apply_updates(**kwargs)
+        clone._set_issuer_name(name)
         return clone
 
-    def _apply_updates(self, issuer_name=None, subject_name=None,
-                       public_key=None, serial_number=None,
-                       not_valid_before=None, not_valid_after=None):
-        if issuer_name is not None:
-            if not isinstance(issuer_name, Name):
-                raise TypeError('Expecting x509.Name object for issuer name.')
-            if self._issuer_name is not None:
-                raise ValueError('The issuer name may only be set once.')
-            self._issuer_name = issuer_name
+    def _set_subject_name(self, subject_name):
+        if not isinstance(subject_name, Name):
+            raise TypeError('Expecting x509.Name object for subject name.')
+        if self._subject_name is not None:
+            raise ValueError('The subject name may only be set once.')
+        self._subject_name = subject_name
 
-        if subject_name is not None:
-            if not isinstance(subject_name, Name):
-                raise TypeError('Expecting x509.Name object for subject name.')
-            if self._subject_name is not None:
-                raise ValueError('The subject name may only be set once.')
-            self._subject_name = subject_name
+    def subject_name(self, name):
+        """
+        Sets the requestor's distinguished name.
+        """
+        clone = self._clone()
+        clone._set_subject_name(name)
+        return clone
 
-        if public_key is not None:
-            if not isinstance(public_key, (dsa.DSAPublicKey, rsa.RSAPublicKey,
-                                           ec.EllipticCurvePublicKey)):
-                raise TypeError('Expecting one of DSAPublicKey, RSAPublicKey,'
-                                ' or EllipticCurvePublicKey.')
-            if self._public_key is not None:
-                raise ValueError('The public key may only be set once.')
-            self._public_key = public_key
+    def _set_public_key(self, public_key):
+        if not isinstance(public_key, (dsa.DSAPublicKey, rsa.RSAPublicKey,
+                                       ec.EllipticCurvePublicKey)):
+            raise TypeError('Expecting one of DSAPublicKey, RSAPublicKey,'
+                            ' or EllipticCurvePublicKey.')
+        if self._public_key is not None:
+            raise ValueError('The public key may only be set once.')
+        self._public_key = public_key
 
-        if serial_number is not None:
-            if not isinstance(serial_number, six.integer_types):
-                raise TypeError('Serial number must be of integral type.')
-            if self._serial_number is not None:
-                raise ValueError('The serial number may only be set once.')
-            if serial_number < 0:
-                raise ValueError('The serial number should be non-negative.')
-            if utils.bit_length(serial_number) > 160:  # As defined in RFC 5280
-                raise ValueError('The serial number should not be more than '
-                                 '160 bits.')
-            self._serial_number = serial_number
+    def public_key(self, key):
+        """
+        Sets the requestor's public key (as found in the signing request).
+        """
+        clone = self._clone()
+        clone._set_public_key(key)
+        return clone
 
-        if not_valid_before is not None:
-            if not isinstance(not_valid_before, datetime.datetime):
-                raise TypeError('Expecting datetime object.')
-            if self._not_valid_before is not None:
-                raise ValueError('The not valid before may only be set once.')
-            if not_valid_before <= _UNIX_EPOCH:
-                raise ValueError('The not valid before date must be after the '
-                                 'unix epoch (1970 January 1).')
-            self._not_valid_before = not_valid_before
+    def _set_serial_number(self, serial_number):
+        if not isinstance(serial_number, six.integer_types):
+            raise TypeError('Serial number must be of integral type.')
+        if self._serial_number is not None:
+            raise ValueError('The serial number may only be set once.')
+        if serial_number < 0:
+            raise ValueError('The serial number should be non-negative.')
+        if utils.bit_length(serial_number) > 160:  # As defined in RFC 5280
+            raise ValueError('The serial number should not be more than '
+                             '160 bits.')
+        self._serial_number = serial_number
 
-        if not_valid_after is not None:
-            if not isinstance(not_valid_after, datetime.datetime):
-                raise TypeError('Expecting datetime object.')
-            if self._not_valid_after is not None:
-                raise ValueError('The not valid after may only be set once.')
-            if not_valid_after <= _UNIX_EPOCH:
-                raise ValueError('The not valid after date must be after the '
-                                 'unix epoch (1970 January 1).')
-            self._not_valid_after = not_valid_after
+    def serial_number(self, number):
+        """
+        Sets the certificate serial number.
+        """
+        clone = self._clone()
+        clone._set_serial_number(number)
+        return clone
+
+    def _set_not_valid_before(self, not_valid_before):
+        if not isinstance(not_valid_before, datetime.datetime):
+            raise TypeError('Expecting datetime object.')
+        if self._not_valid_before is not None:
+            raise ValueError('The not valid before may only be set once.')
+        if not_valid_before <= _UNIX_EPOCH:
+            raise ValueError('The not valid before date must be after the '
+                             'unix epoch (1970 January 1).')
+        self._not_valid_before = not_valid_before
+
+    def not_valid_before(self, time):
+        """
+        Sets the certificate activation time.
+        """
+        clone = self._clone()
+        clone._set_not_valid_before(time)
+        return clone
+
+    def _set_not_valid_after(self, not_valid_after):
+        if not isinstance(not_valid_after, datetime.datetime):
+            raise TypeError('Expecting datetime object.')
+        if self._not_valid_after is not None:
+            raise ValueError('The not valid after may only be set once.')
+        if not_valid_after <= _UNIX_EPOCH:
+            raise ValueError('The not valid after date must be after the '
+                             'unix epoch (1970 January 1).')
+        self._not_valid_after = not_valid_after
+
+    def not_valid_after(self, time):
+        """
+        Sets the certificate expiration time.
+        """
+        clone = self._clone()
+        clone._set_not_valid_after(time)
+        return clone
 
     def _add_extension(self, extension, critical):
         """
-        Adds an X.509 extension to the certificate.
+        Adds an X.509 extension to the certificate in-place.
         """
         if not isinstance(extension, ExtensionType):
             raise TypeError("extension must be an ExtensionType")
@@ -412,42 +470,6 @@ class CertificateBuilder(object):
                 raise ValueError('This extension has already been set.')
 
         self._extensions.append(extension)
-
-    def issuer_name(self, name):
-        """
-        Sets the CA's distinguished name.
-        """
-        return self._with_updates(issuer_name=name)
-
-    def subject_name(self, name):
-        """
-        Sets the requestor's distinguished name.
-        """
-        return self._with_updates(subject_name=name)
-
-    def public_key(self, key):
-        """
-        Sets the requestor's public key (as found in the signing request).
-        """
-        return self._with_updates(public_key=key)
-
-    def serial_number(self, number):
-        """
-        Sets the certificate serial number.
-        """
-        return self._with_updates(serial_number=number)
-
-    def not_valid_before(self, time):
-        """
-        Sets the certificate activation time.
-        """
-        return self._with_updates(not_valid_before=time)
-
-    def not_valid_after(self, time):
-        """
-        Sets the certificate expiration time.
-        """
-        return self._with_updates(not_valid_after=time)
 
     def add_extension(self, extension, critical):
         """

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -976,11 +976,17 @@ class TestCertificateBuilder(object):
         with pytest.raises(TypeError):
             builder.issuer_name(object)
 
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(issuer_name="subject")
+
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(issuer_name=object)
+
     def test_issuer_name_may_only_be_set_once(self):
         name = x509.Name([
             x509.NameAttribute(NameOID.COUNTRY_NAME, u'US'),
         ])
-        builder = x509.CertificateBuilder().issuer_name(name)
+        builder = x509.CertificateBuilder(issuer_name=name)
 
         with pytest.raises(ValueError):
             builder.issuer_name(name)
@@ -994,11 +1000,17 @@ class TestCertificateBuilder(object):
         with pytest.raises(TypeError):
             builder.subject_name(object)
 
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(subject_name="subject")
+
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(subject_name=object)
+
     def test_subject_name_may_only_be_set_once(self):
         name = x509.Name([
             x509.NameAttribute(NameOID.COUNTRY_NAME, u'US'),
         ])
-        builder = x509.CertificateBuilder().subject_name(name)
+        builder = x509.CertificateBuilder(subject_name=name)
 
         with pytest.raises(ValueError):
             builder.subject_name(name)
@@ -1017,7 +1029,7 @@ class TestCertificateBuilder(object):
     def test_public_key_may_only_be_set_once(self, backend):
         private_key = RSA_KEY_2048.private_key(backend)
         public_key = private_key.public_key()
-        builder = x509.CertificateBuilder().public_key(public_key)
+        builder = x509.CertificateBuilder(public_key=public_key)
 
         with pytest.raises(ValueError):
             builder.public_key(public_key)
@@ -1026,17 +1038,26 @@ class TestCertificateBuilder(object):
         with pytest.raises(TypeError):
             x509.CertificateBuilder().serial_number(10.0)
 
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(serial_number=10.0)
+
     def test_serial_number_must_be_non_negative(self):
         with pytest.raises(ValueError):
             x509.CertificateBuilder().serial_number(-10)
+
+        with pytest.raises(ValueError):
+            x509.CertificateBuilder(serial_number=-10)
 
     def test_serial_number_must_be_less_than_160_bits_long(self):
         with pytest.raises(ValueError):
             # 2 raised to the 160th power is actually 161 bits
             x509.CertificateBuilder().serial_number(2 ** 160)
 
+        with pytest.raises(ValueError):
+            x509.CertificateBuilder(serial_number=2 ** 160)
+
     def test_serial_number_may_only_be_set_once(self):
-        builder = x509.CertificateBuilder().serial_number(10)
+        builder = x509.CertificateBuilder(serial_number=10)
 
         with pytest.raises(ValueError):
             builder.serial_number(20)
@@ -1053,9 +1074,20 @@ class TestCertificateBuilder(object):
                 datetime.datetime(1960, 8, 10)
             )
 
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(not_valid_after=104204304504)
+
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(not_valid_after=datetime.time())
+
+        with pytest.raises(ValueError):
+            x509.CertificateBuilder(
+                not_valid_after=datetime.datetime(1960, 8, 10)
+            )
+
     def test_not_valid_after_may_only_be_set_once(self):
-        builder = x509.CertificateBuilder().not_valid_after(
-            datetime.datetime.now()
+        builder = x509.CertificateBuilder(
+            not_valid_after=datetime.datetime.now()
         )
 
         with pytest.raises(ValueError):
@@ -1075,9 +1107,20 @@ class TestCertificateBuilder(object):
                 datetime.datetime(1960, 8, 10)
             )
 
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(not_valid_before=104204304504)
+
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(not_valid_before=datetime.time())
+
+        with pytest.raises(ValueError):
+            x509.CertificateBuilder(
+                not_valid_before=datetime.datetime(1960, 8, 10)
+            )
+
     def test_not_valid_before_may_only_be_set_once(self):
-        builder = x509.CertificateBuilder().not_valid_before(
-            datetime.datetime.now()
+        builder = x509.CertificateBuilder(
+            not_valid_before=datetime.datetime.now()
         )
 
         with pytest.raises(ValueError):

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1138,11 +1138,31 @@ class TestCertificateBuilder(object):
                 x509.BasicConstraints(ca=False, path_length=None), True,
             )
 
+        with pytest.raises(ValueError):
+            x509.CertificateBuilder(
+                critical_extensions=[
+                    x509.BasicConstraints(ca=False, path_length=None),
+                    x509.BasicConstraints(ca=False, path_length=None),
+                ]
+            )
+
+        with pytest.raises(ValueError):
+            x509.CertificateBuilder(
+                critical_extensions=[
+                    x509.BasicConstraints(ca=False, path_length=None),
+                ],
+                optional_extensions=[
+                    x509.BasicConstraints(ca=False, path_length=None),
+                ]
+            )
+
     def test_add_invalid_extension_type(self):
-        builder = x509.CertificateBuilder()
 
         with pytest.raises(TypeError):
-            builder.add_extension(object(), False)
+            x509.CertificateBuilder().add_extension(object(), False)
+
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder(critical_extensions=[object()])
 
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)


### PR DESCRIPTION
Realised earlier that values passed into the constructor of the CertificateBuilder (and other builders) are not validated.  This pull requests just shifts the validation code out of the chaining methods and into `__init__`.

If you call multiple methods in succession then validation code for earlier attributes will be called multiple times.  I think fixing this would be a premature optimisation though.

There is also a problem with `add_extension` taking an object which gets turned into an `Extension` and `__init__` taking a list of `Extensions`.  I think neither should accept `Extension`s but to achieve that, the original list of objects needs to be saved as well as the list of `Extension` objects.  I've split my idea of how to go about it into a second commit but would I am not currently very happy with it.  In particular I'm not sure what to do with the `critical` argument (for now have bundled it into a tuple, could we add it to the extension objects or possible have two arguments taking lists of critical and non-critical extensions?) and I'm not sure `_base_extensions` is the best name.  I would really appreciate some advice.

Will be happy to repeat the work on the other builder classes if everyone thinks it would be a good idea.