### PR TITLE
Support AuthorityKeyIdentifier in CertificateBuilder

### DIFF
--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -1812,6 +1812,10 @@ class CertificateBuilder(object):
         """
         if isinstance(extension, BasicConstraints):
             extension = Extension(OID_BASIC_CONSTRAINTS, critical, extension)
+        elif isinstance(extension, AuthorityKeyIdentifier):
+            extension = Extension(
+                OID_AUTHORITY_KEY_IDENTIFIER, critical, extension
+            )
         elif isinstance(extension, KeyUsage):
             extension = Extension(OID_KEY_USAGE, critical, extension)
         elif isinstance(extension, ExtendedKeyUsage):


### PR DESCRIPTION
This depends on #2212 and #2210 so no need to review until then. I just wanted to get it up so all the extensions we're going to support for 1.0 have outstanding PRs.


refs #2192 