### PR TITLE
Add OIDs to extension types and add ExtensionType interface

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -922,8 +922,7 @@ X.509 Extensions
 
     The key usage extension defines the purpose of the key contained in the
     certificate.  The usage restriction might be employed when a key that could
-    be used for more than one operation is to be restricted. It corresponds to
-    :data:`OID_KEY_USAGE`.
+    be used for more than one operation is to be restricted.
 
     .. attribute:: oid
 
@@ -931,7 +930,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_KEY_USAGE`.
 
     .. attribute:: digital_signature
 
@@ -1022,8 +1021,7 @@ X.509 Extensions
 
     Basic constraints is an X.509 extension type that defines whether a given
     certificate is allowed to sign additional certificates and what path
-    length restrictions may exist. It corresponds to
-    :data:`OID_BASIC_CONSTRAINTS`.
+    length restrictions may exist.
 
     .. attribute:: oid
 
@@ -1031,7 +1029,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_BASIC_CONSTRAINTS`.
 
     .. attribute:: ca
 
@@ -1067,7 +1065,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_EXTENDED_KEY_USAGE`.
 
 
 .. class:: OCSPNoCheck
@@ -1106,7 +1104,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_NAME_CONSTRAINTS`.
 
     .. attribute:: permitted_subtrees
 
@@ -1141,7 +1139,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_AUTHORITY_KEY_IDENTIFIER`.
 
     .. attribute:: key_identifier
 
@@ -1175,7 +1173,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_SUBJECT_KEY_IDENTIFIER`.
 
     .. attribute:: digest
 
@@ -1198,7 +1196,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_SUBJECT_ALTERNATIVE_NAME`.
 
     .. method:: get_values_for_type(type)
 
@@ -1236,7 +1234,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_ISSUER_ALTERNATIVE_NAME`.
 
     .. method:: get_values_for_type(type)
 
@@ -1262,7 +1260,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_AUTHORITY_INFORMATION_ACCESS`.
 
 
 .. class:: AccessDescription
@@ -1300,7 +1298,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_CRL_DISTRIBUTION_POINTS`.
 
 .. class:: DistributionPoint
 
@@ -1406,7 +1404,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_INHIBIT_ANY_POLICY`.
 
     .. attribute:: skip_certs
 
@@ -1425,7 +1423,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_CERTIFICATE_POLICIES`.
 
 Certificate Policies Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1779,6 +1777,11 @@ Extension OIDs
 
     Corresponds to the dotted string ``"1.3.6.1.5.5.7.1.1"``. The identifier
     for the :class:`AuthorityInformationAccess` extension type.
+
+.. data:: OID_INHIBIT_ANY_POLICY
+
+    Corresponds to the dotted string ``"2.5.29.54"``. The identifier
+    for the :class:`InhibitAnyPolicy` extension type.
 
 .. data:: OID_OCSP_NO_CHECK
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1087,7 +1087,7 @@ X.509 Extensions
 
         :type: :class:`ObjectIdentifier`
 
-        The OID associated with this extension type.
+        Returns :data:`OID_OCSP_NO_CHECK`.
 
 .. class:: NameConstraints
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -918,6 +918,14 @@ X.509 Extensions
     be used for more than one operation is to be restricted. It corresponds to
     :data:`OID_KEY_USAGE`.
 
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
+
     .. attribute:: digital_signature
 
         :type: bool
@@ -1010,6 +1018,14 @@ X.509 Extensions
     length restrictions may exist. It corresponds to
     :data:`OID_BASIC_CONSTRAINTS`.
 
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
+
     .. attribute:: ca
 
         :type: bool
@@ -1038,6 +1054,15 @@ X.509 Extensions
     purposes indicated in the key usage extension. The object is
     iterable to obtain the list of :ref:`extended key usage OIDs <eku_oids>`.
 
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
+
+
 .. class:: OCSPNoCheck
 
     .. versionadded:: 1.0
@@ -1051,6 +1076,14 @@ X.509 Extensions
     extension is only relevant when the certificate is an authorized OCSP
     responder.
 
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
+
 .. class:: NameConstraints
 
     .. versionadded:: 1.0
@@ -1059,6 +1092,14 @@ X.509 Extensions
     defines a name space within which all subject names in certificates issued
     beneath the CA certificate must (or must not) be in. For specific details
     on the way this extension should be processed see :rfc:`5280`.
+
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
 
     .. attribute:: permitted_subtrees
 
@@ -1087,6 +1128,14 @@ X.509 Extensions
     certificate chain. For more information about generation and use of this
     extension see `RFC 5280 section 4.2.1.1`_.
 
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
+
     .. attribute:: key_identifier
 
         :type: bytes
@@ -1113,6 +1162,14 @@ X.509 Extensions
     The subject key identifier extension provides a means of identifying
     certificates that contain a particular public key.
 
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
+
     .. attribute:: digest
 
         :type: bytes
@@ -1127,6 +1184,14 @@ X.509 Extensions
     :ref:`general name <general_name_classes>` instances that provide a set
     of identities for which the certificate is valid. The object is iterable to
     get every element.
+
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
 
     .. method:: get_values_for_type(type)
 
@@ -1158,6 +1223,14 @@ X.509 Extensions
     of identities for the certificate issuer. The object is iterable to
     get every element.
 
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
+
     .. method:: get_values_for_type(type)
 
         :param type: A :class:`GeneralName` provider. This is one of the
@@ -1175,6 +1248,14 @@ X.509 Extensions
     the extension appears. Information and services may include online
     validation services (such as OCSP) and issuer data. It is an iterable,
     containing one or more :class:`AccessDescription` instances.
+
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
 
 
 .. class:: AccessDescription
@@ -1205,6 +1286,14 @@ X.509 Extensions
     The CRL distribution points extension identifies how CRL information is
     obtained. It is an iterable, containing one or more
     :class:`DistributionPoint` instances.
+
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
 
 .. class:: DistributionPoint
 
@@ -1304,6 +1393,14 @@ X.509 Extensions
     certificates issued by the subject of this certificate, but not in
     additional certificates in the path.
 
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
+
     .. attribute:: skip_certs
 
         :type: int
@@ -1314,6 +1411,14 @@ X.509 Extensions
 
     The certificate policies extension is an iterable, containing one or more
     :class:`PolicyInformation` instances.
+
+    .. attribute:: oid
+
+        .. versionadded:: 1.0
+
+        :type: :class:`ObjectIdentifier`
+
+        The OID associated with this extension type.
 
 Certificate Policies Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -909,6 +909,13 @@ X.509 Extensions
 
         Returns an instance of the extension type corresponding to the OID.
 
+.. class:: ExtensionType
+
+    .. versionadded:: 1.0
+
+    This is the interface against which all the following extension types are
+    registered.
+
 .. class:: KeyUsage
 
     .. versionadded:: 0.9

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -314,6 +314,8 @@ class Extension(object):
 
 
 class ExtendedKeyUsage(object):
+    oid = OID_EXTENDED_KEY_USAGE
+
     def __init__(self, usages):
         if not all(isinstance(x, ObjectIdentifier) for x in usages):
             raise TypeError(
@@ -342,10 +344,12 @@ class ExtendedKeyUsage(object):
 
 
 class OCSPNoCheck(object):
-    pass
+    oid = OID_OCSP_NO_CHECK
 
 
 class BasicConstraints(object):
+    oid = OID_BASIC_CONSTRAINTS
+
     def __init__(self, ca, path_length):
         if not isinstance(ca, bool):
             raise TypeError("ca must be a boolean value")
@@ -382,6 +386,8 @@ class BasicConstraints(object):
 
 
 class KeyUsage(object):
+    oid = OID_KEY_USAGE
+
     def __init__(self, digital_signature, content_commitment, key_encipherment,
                  data_encipherment, key_agreement, key_cert_sign, crl_sign,
                  encipher_only, decipher_only):
@@ -465,6 +471,8 @@ class KeyUsage(object):
 
 
 class AuthorityInformationAccess(object):
+    oid = OID_AUTHORITY_INFORMATION_ACCESS
+
     def __init__(self, descriptions):
         if not all(isinstance(x, AccessDescription) for x in descriptions):
             raise TypeError(
@@ -529,6 +537,8 @@ class AccessDescription(object):
 
 
 class CertificatePolicies(object):
+    oid = OID_CERTIFICATE_POLICIES
+
     def __init__(self, policies):
         if not all(isinstance(x, PolicyInformation) for x in policies):
             raise TypeError(
@@ -666,6 +676,8 @@ class NoticeReference(object):
 
 
 class SubjectKeyIdentifier(object):
+    oid = OID_SUBJECT_KEY_IDENTIFIER
+
     def __init__(self, digest):
         self._digest = digest
 
@@ -687,6 +699,8 @@ class SubjectKeyIdentifier(object):
 
 
 class NameConstraints(object):
+    oid = OID_NAME_CONSTRAINTS
+
     def __init__(self, permitted_subtrees, excluded_subtrees):
         if permitted_subtrees is not None:
             if not all(
@@ -751,6 +765,8 @@ class NameConstraints(object):
 
 
 class CRLDistributionPoints(object):
+    oid = OID_CRL_DISTRIBUTION_POINTS
+
     def __init__(self, distribution_points):
         if not all(
             isinstance(x, DistributionPoint) for x in distribution_points
@@ -871,6 +887,8 @@ class ReasonFlags(Enum):
 
 
 class InhibitAnyPolicy(object):
+    oid = OID_INHIBIT_ANY_POLICY
+
     def __init__(self, skip_certs):
         if not isinstance(skip_certs, six.integer_types):
             raise TypeError("skip_certs must be an integer")
@@ -1161,6 +1179,8 @@ class GeneralNames(object):
 
 
 class SubjectAlternativeName(object):
+    oid = OID_SUBJECT_ALTERNATIVE_NAME
+
     def __init__(self, general_names):
         self._general_names = GeneralNames(general_names)
 
@@ -1187,6 +1207,8 @@ class SubjectAlternativeName(object):
 
 
 class IssuerAlternativeName(object):
+    oid = OID_ISSUER_ALTERNATIVE_NAME
+
     def __init__(self, general_names):
         self._general_names = GeneralNames(general_names)
 
@@ -1213,6 +1235,8 @@ class IssuerAlternativeName(object):
 
 
 class AuthorityKeyIdentifier(object):
+    oid = OID_AUTHORITY_KEY_IDENTIFIER
+
     def __init__(self, key_identifier, authority_cert_issuer,
                  authority_cert_serial_number):
         if authority_cert_issuer or authority_cert_serial_number:

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -313,6 +313,16 @@ class Extension(object):
         return not self == other
 
 
+@six.add_metaclass(abc.ABCMeta)
+class ExtensionType(object):
+    @abc.abstractproperty
+    def oid(self):
+        """
+        Returns the oid associated with the given extension type.
+        """
+
+
+@utils.register_interface(ExtensionType)
 class ExtendedKeyUsage(object):
     oid = OID_EXTENDED_KEY_USAGE
 
@@ -343,10 +353,12 @@ class ExtendedKeyUsage(object):
         return not self == other
 
 
+@utils.register_interface(ExtensionType)
 class OCSPNoCheck(object):
     oid = OID_OCSP_NO_CHECK
 
 
+@utils.register_interface(ExtensionType)
 class BasicConstraints(object):
     oid = OID_BASIC_CONSTRAINTS
 
@@ -385,6 +397,7 @@ class BasicConstraints(object):
         return not self == other
 
 
+@utils.register_interface(ExtensionType)
 class KeyUsage(object):
     oid = OID_KEY_USAGE
 
@@ -470,6 +483,7 @@ class KeyUsage(object):
         return not self == other
 
 
+@utils.register_interface(ExtensionType)
 class AuthorityInformationAccess(object):
     oid = OID_AUTHORITY_INFORMATION_ACCESS
 
@@ -536,6 +550,7 @@ class AccessDescription(object):
     access_location = utils.read_only_property("_access_location")
 
 
+@utils.register_interface(ExtensionType)
 class CertificatePolicies(object):
     oid = OID_CERTIFICATE_POLICIES
 
@@ -675,6 +690,7 @@ class NoticeReference(object):
     notice_numbers = utils.read_only_property("_notice_numbers")
 
 
+@utils.register_interface(ExtensionType)
 class SubjectKeyIdentifier(object):
     oid = OID_SUBJECT_KEY_IDENTIFIER
 
@@ -698,6 +714,7 @@ class SubjectKeyIdentifier(object):
         return not self == other
 
 
+@utils.register_interface(ExtensionType)
 class NameConstraints(object):
     oid = OID_NAME_CONSTRAINTS
 
@@ -764,6 +781,7 @@ class NameConstraints(object):
     excluded_subtrees = utils.read_only_property("_excluded_subtrees")
 
 
+@utils.register_interface(ExtensionType)
 class CRLDistributionPoints(object):
     oid = OID_CRL_DISTRIBUTION_POINTS
 
@@ -886,6 +904,7 @@ class ReasonFlags(Enum):
     remove_from_crl = "removeFromCRL"
 
 
+@utils.register_interface(ExtensionType)
 class InhibitAnyPolicy(object):
     oid = OID_INHIBIT_ANY_POLICY
 
@@ -1178,6 +1197,7 @@ class GeneralNames(object):
         return not self == other
 
 
+@utils.register_interface(ExtensionType)
 class SubjectAlternativeName(object):
     oid = OID_SUBJECT_ALTERNATIVE_NAME
 
@@ -1206,6 +1226,7 @@ class SubjectAlternativeName(object):
         return not self == other
 
 
+@utils.register_interface(ExtensionType)
 class IssuerAlternativeName(object):
     oid = OID_ISSUER_ALTERNATIVE_NAME
 
@@ -1234,6 +1255,7 @@ class IssuerAlternativeName(object):
         return not self == other
 
 
+@utils.register_interface(ExtensionType)
 class AuthorityKeyIdentifier(object):
     oid = OID_AUTHORITY_KEY_IDENTIFIER
 


### PR DESCRIPTION
I'm putting up this PR to get some discussion going. Right now we have a set of extensions that have no common interface. Additionally, we don't directly associate the OID with them. Instead we create an extension object `Extension(oid, ext_class, critical)`. This is how the ASN.1 structure works, but I think there's significant value in attaching the OID as a property on the extension type class as well (BasicConstraints, SubjectAlternativeName, etc). At the moment our API requires you to know both the extension type class and the OID and the association between them is in the docs only. 

One improvement: `get_extension_by_oid` could now have a (far more friendly) `get_extension` that takes an extension type class. This does not actually require the oid attribute, but I wanted to mention it since I think we should add this in any case.

```python
ext = cert.get_extension(x509.BasicConstraints)
# instead of
ext = cert.get_extension_by_oid(x509.OID_BASIC_CONSTRAINTS)
```

We could also simplify some of our if/elif chains in CSRBuilder and CertificateBuilder:

```python
        if isinstance(extension, BasicConstraints):
            extension = Extension(OID_BASIC_CONSTRAINTS, critical, extension)
        elif isinstance(extension, ExtendedKeyUsage):
            extension = Extension(OID_EXTENDED_KEY_USAGE, critical, extension)
        elif isinstance(extension, SubjectAlternativeName):
            extension = Extension(
                OID_SUBJECT_ALTERNATIVE_NAME, critical, extension
            )
        elif isinstance(extension, KeyUsage):
            extension = Extension(OID_KEY_USAGE, critical, extension)
        elif isinstance(extension, InhibitAnyPolicy):
            extension = Extension(OID_INHIBIT_ANY_POLICY, critical, extension)
        else:
            raise NotImplementedError('Unsupported X.509 extension.')
```
becomes
```python
        ext = Extension(extension.oid, critical, extension)
        # NotImplementedError can be handled by the backend (which has that logic anyway)
```


This PR also proposes to have the extension type classes share a common interface. By doing so we get automatic testing for the presence of the `oid` attribute and we can use `isinstance` checks to give better errors out of code like the first example above. It will also help us by giving a common name for the extension type classes in the documentation.