### PR TITLE
rename sign_x509_certificate backend method to create_x509_certificate

### DIFF
--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -550,7 +550,7 @@ A specific ``backend`` may provide one or more of these interfaces.
         :returns: A new object with the
             :class:`~cryptography.x509.CertificateSigningRequest` interface.
 
-    .. method:: sign_x509_certificate(builder, private_key, algorithm)
+    .. method:: create_x509_certificate(builder, private_key, algorithm)
 
         .. versionadded:: 1.0
 

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -281,9 +281,9 @@ class X509Backend(object):
         """
 
     @abc.abstractmethod
-    def sign_x509_certificate(self, builder, private_key, algorithm):
+    def create_x509_certificate(self, builder, private_key, algorithm):
         """
-        Sign an X.509 Certificate from a CertificateBuilder object.
+        Create and sign an X.509 certificate from a CertificateBuilder object.
         """
 
 

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -352,9 +352,9 @@ class MultiBackend(object):
             _Reasons.UNSUPPORTED_X509
         )
 
-    def sign_x509_certificate(self, builder, private_key, algorithm):
+    def create_x509_certificate(self, builder, private_key, algorithm):
         for b in self._filtered_backends(X509Backend):
-            return b.sign_x509_certificate(builder, private_key, algorithm)
+            return b.create_x509_certificate(builder, private_key, algorithm)
 
         raise UnsupportedAlgorithm(
             "This backend does not support X.509.",

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1100,7 +1100,7 @@ class Backend(object):
 
         return _CertificateSigningRequest(self, x509_req)
 
-    def sign_x509_certificate(self, builder, private_key, algorithm):
+    def create_x509_certificate(self, builder, private_key, algorithm):
         if not isinstance(builder, x509.CertificateBuilder):
             raise TypeError('Builder type mismatch.')
         if not isinstance(algorithm, hashes.HashAlgorithm):

--- a/src/cryptography/x509.py
+++ b/src/cryptography/x509.py
@@ -1770,4 +1770,4 @@ class CertificateBuilder(object):
         if self._public_key is None:
             raise ValueError("A certificate must have a public key")
 
-        return backend.sign_x509_certificate(self, private_key, algorithm)
+        return backend.create_x509_certificate(self, private_key, algorithm)

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -206,7 +206,7 @@ class DummyX509Backend(object):
     def create_x509_csr(self, builder, private_key, algorithm):
         pass
 
-    def sign_x509_certificate(self, builder, private_key, algorithm):
+    def create_x509_certificate(self, builder, private_key, algorithm):
         pass
 
 
@@ -487,7 +487,7 @@ class TestMultiBackend(object):
         backend.load_pem_x509_csr(b"reqdata")
         backend.load_der_x509_csr(b"reqdata")
         backend.create_x509_csr(object(), b"privatekey", hashes.SHA1())
-        backend.sign_x509_certificate(object(), b"privatekey", hashes.SHA1())
+        backend.create_x509_certificate(object(), b"privatekey", hashes.SHA1())
 
         backend = MultiBackend([])
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
@@ -501,6 +501,6 @@ class TestMultiBackend(object):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
             backend.create_x509_csr(object(), b"privatekey", hashes.SHA1())
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
-            backend.sign_x509_certificate(
+            backend.create_x509_certificate(
                 object(), b"privatekey", hashes.SHA1()
             )

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -512,7 +512,7 @@ class TestOpenSSLSignX509Certificate(object):
         private_key = RSA_KEY_2048.private_key(backend)
 
         with pytest.raises(TypeError):
-            backend.sign_x509_certificate(object(), private_key, DummyHash())
+            backend.create_x509_certificate(object(), private_key, DummyHash())
 
     def test_checks_for_unsupported_extensions(self):
         private_key = RSA_KEY_2048.private_key(backend)


### PR DESCRIPTION
fixes #2218 