### PR TITLE
fix a memory leak in certificate creation during extension creation

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1180,7 +1180,7 @@ class Backend(object):
             else:
                 raise NotImplementedError('Extension not yet supported.')
 
-            obj = _txt2obj(self, extension.oid.dotted_string)
+            obj = _txt2obj_gc(self, extension.oid.dotted_string)
             extension = self._lib.X509_EXTENSION_create_by_OBJ(
                 self._ffi.NULL,
                 obj,


### PR DESCRIPTION
When obj is passed to `X509_EXTENSION_create_by_OBJ` then `X509_EXTENSION_set_object` is called. This function duplicates the object, so we need to free the original.

```c
int X509_EXTENSION_set_object(X509_EXTENSION *ex, ASN1_OBJECT *obj)
   {
   if ((ex == NULL) || (obj == NULL))
      return(0);
   ASN1_OBJECT_free(ex->object);
   ex->object=OBJ_dup(obj);
   return(1);
   }
```