### PR TITLE
X509_add_ext dupes the X509_EXTENSION when adding it. fix the leak

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1187,6 +1187,8 @@ class Backend(object):
                 1 if extension.critical else 0,
                 _encode_asn1_str_gc(self, pp[0], r)
             )
+            assert extension != self._ffi.NULL
+            extension = self._ffi.gc(extension, self._lib.X509_EXTENSION_free)
             res = self._lib.X509_add_ext(x509_cert, extension, i)
             assert res == 1
 


### PR DESCRIPTION
`X509_add_ext` calls `X509v3_add_ext` which duplicates the X509_EXTENSION before adding it.

```c
STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
					 X509_EXTENSION *ex, int loc)
	{
	X509_EXTENSION *new_ex=NULL;
	int n;
	STACK_OF(X509_EXTENSION) *sk=NULL;

	if (x == NULL)
		{
		X509err(X509_F_X509V3_ADD_EXT,ERR_R_PASSED_NULL_PARAMETER);
		goto err2;
		}

	if (*x == NULL)
		{
		if ((sk=sk_X509_EXTENSION_new_null()) == NULL)
			goto err;
		}
	else
		sk= *x;

	n=sk_X509_EXTENSION_num(sk);
	if (loc > n) loc=n;
	else if (loc < 0) loc=n;

	if ((new_ex=X509_EXTENSION_dup(ex)) == NULL)
		goto err2;
	if (!sk_X509_EXTENSION_insert(sk,new_ex,loc))
		goto err;
	if (*x == NULL)
		*x=sk;
	return(sk);
err:
	X509err(X509_F_X509V3_ADD_EXT,ERR_R_MALLOC_FAILURE);
err2:
	if (new_ex != NULL) X509_EXTENSION_free(new_ex);
	if (sk != NULL) sk_X509_EXTENSION_free(sk);
	return(NULL);
	}

```