### PR TITLE
Fix build with LibreSSL >= 2.2.2

### DIFF
--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -397,7 +397,7 @@ static const long Cryptography_HAS_EC2M = 1;
 #endif
 
 #if defined(OPENSSL_NO_EC) || OPENSSL_VERSION_NUMBER < 0x1000200f || \
-    defined(LIBRESSL_VERSION_NUMBER)
+    defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20020002L
 static const long Cryptography_HAS_EC_1_0_2 = 0;
 const char *(*EC_curve_nid2nist)(int) = NULL;
 #else


### PR DESCRIPTION
LIBRESSL_VERSION_NUMBER is now being incremented.

#2128 