### PR TITLE
Ensure early exeption on non-bytes signature

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/dsa.py
+++ b/src/cryptography/hazmat/backends/openssl/dsa.py
@@ -29,6 +29,9 @@ def _truncate_digest_for_dsa(dsa_cdata, digest, backend):
 @utils.register_interface(AsymmetricVerificationContext)
 class _DSAVerificationContext(object):
     def __init__(self, backend, public_key, signature, algorithm):
+        if not isinstance(signature, bytes):
+            raise TypeError("signature must be bytes.")
+
         self._backend = backend
         self._public_key = public_key
         self._signature = signature

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -119,6 +119,8 @@ class _ECDSASignatureContext(object):
 @utils.register_interface(AsymmetricVerificationContext)
 class _ECDSAVerificationContext(object):
     def __init__(self, backend, public_key, signature, algorithm):
+        if not isinstance(signature, bytes):
+            raise TypeError("signature must be bytes.")
         self._backend = backend
         self._public_key = public_key
         self._signature = signature

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -337,6 +337,9 @@ class _RSASignatureContext(object):
 @utils.register_interface(AsymmetricVerificationContext)
 class _RSAVerificationContext(object):
     def __init__(self, backend, public_key, signature, padding, algorithm):
+        if not isinstance(signature, bytes):
+            raise TypeError("signature must be bytes.")
+
         self._backend = backend
         self._public_key = public_key
         self._signature = signature

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -583,6 +583,11 @@ class TestDSAVerification(object):
         with pytest.raises(InvalidSignature):
             verifier.verify()
 
+    def test_signature_not_bytes(self, backend):
+        public_key = DSA_KEY_1024.public_numbers.public_key(backend)
+        with pytest.raises(TypeError):
+            public_key.verifier(1234, hashes.SHA1())
+
     def test_use_after_finalize(self, backend):
         public_key = DSA_KEY_1024.public_numbers.public_key(backend)
         verifier = public_key.verifier(b'fakesig', hashes.SHA1())

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -710,3 +710,12 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             key.public_bytes(
                 serialization.Encoding.PEM, serialization.PublicFormat.PKCS1
             )
+
+
+@pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
+class TestECDSAVerification(object):
+    def test_signature_not_bytes(self, backend):
+        key = ec.generate_private_key(ec.SECP192R1(), backend)
+        public_key = key.public_key()
+        with pytest.raises(TypeError):
+            public_key.verifier(1234, ec.ECDSA(hashes.SHA256()))

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -679,6 +679,23 @@ class TestRSAVerification(object):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
             public_key.verifier(b"sig", DummyPadding(), hashes.SHA1())
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.rsa_padding_supported(
+            padding.PKCS1v15()
+        ),
+        skip_message="Does not support PKCS1v1.5."
+    )
+    def test_signature_not_bytes(self, backend):
+        public_key = RSA_KEY_512.public_numbers.public_key(backend)
+        signature = 1234
+
+        with pytest.raises(TypeError):
+            public_key.verifier(
+                signature,
+                padding.PKCS1v15(),
+                hashes.SHA1()
+            )
+
     def test_padding_incorrect_type(self, backend):
         private_key = RSA_KEY_512.private_key(backend)
         public_key = private_key.public_key()


### PR DESCRIPTION
Signature must be in bytes. If the check is skipped, verify() can
explode later in cffi call in _verify_pkey_ctx() for example.