### PR TITLE
Make py3pep8 tox target use a general python3.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ commands =
     flake8 .
 
 [testenv:py3pep8]
-basepython = python3.4
+basepython = python3
 deps =
     flake8
     flake8-import-order


### PR DESCRIPTION
This saves us the effort from updating this file with every Python release. I don't think a specific Python 3 version matters when it comes to pep8 linting.