### PR TITLE
additional SSL bindings

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -242,19 +242,21 @@ void SSL_CTX_set_client_CA_list(SSL_CTX *, Cryptography_STACK_OF_X509_NAME *);
 
 /*  SSL_SESSION */
 void SSL_SESSION_free(SSL_SESSION *);
-int SSL_SESSION_print(BIO *, const SSL_SESSION *);
 
 /* Information about actually used cipher */
 const char *SSL_CIPHER_get_name(const SSL_CIPHER *);
 int SSL_CIPHER_get_bits(const SSL_CIPHER *, int *);
 char *SSL_CIPHER_get_version(const SSL_CIPHER *);
-char *SSL_CIPHER_description(const SSL_CIPHER *, char *, int);
 
 size_t SSL_get_finished(const SSL *, void *, size_t);
 size_t SSL_get_peer_finished(const SSL *, void *, size_t);
 """
 
 MACROS = """
+/* not a macro, but older OpenSSLs don't pass the args as const */
+char *SSL_CIPHER_description(const SSL_CIPHER *, char *, int);
+int SSL_SESSION_print(BIO *, const SSL_SESSION *);
+
 /* not macros, but will be conditionally bound so can't live in functions */
 const COMP_METHOD *SSL_get_current_compression(SSL *);
 const COMP_METHOD *SSL_get_current_expansion(SSL *);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -138,9 +138,6 @@ typedef struct {
     unsigned char session_id[...];
     unsigned int sid_ctx_length;
     unsigned char sid_ctx[...];
-    unsigned char *tlsext_tick;
-    size_t tlsext_ticklen;
-    long tlsext_tick_lifetime_hint;
     ...;
 } SSL_SESSION;
 
@@ -245,13 +242,13 @@ void SSL_CTX_set_client_CA_list(SSL_CTX *, Cryptography_STACK_OF_X509_NAME *);
 
 /*  SSL_SESSION */
 void SSL_SESSION_free(SSL_SESSION *);
-int SSL_SESSION_print(BIO *fp, const SSL_SESSION *ses);
+int SSL_SESSION_print(BIO *, const SSL_SESSION *);
 
 /* Information about actually used cipher */
 const char *SSL_CIPHER_get_name(const SSL_CIPHER *);
 int SSL_CIPHER_get_bits(const SSL_CIPHER *, int *);
 char *SSL_CIPHER_get_version(const SSL_CIPHER *);
-char *SSL_CIPHER_description(const SSL_CIPHER *, char *buf, int size);
+char *SSL_CIPHER_description(const SSL_CIPHER *, char *, int);
 
 size_t SSL_get_finished(const SSL *, void *, size_t);
 size_t SSL_get_peer_finished(const SSL *, void *, size_t);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -130,8 +130,6 @@ typedef ... SSL_METHOD;
 typedef ... SSL_CTX;
 
 typedef struct {
-    unsigned int key_arg_length;
-    unsigned char key_arg[...];
     int master_key_length;
     unsigned char master_key[...];
     unsigned int session_id_length;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -130,8 +130,17 @@ typedef ... SSL_METHOD;
 typedef ... SSL_CTX;
 
 typedef struct {
+    unsigned int key_arg_length;
+    unsigned char key_arg[...];
     int master_key_length;
     unsigned char master_key[...];
+    unsigned int session_id_length;
+    unsigned char session_id[...];
+    unsigned int sid_ctx_length;
+    unsigned char sid_ctx[...];
+    unsigned char *tlsext_tick;
+    size_t tlsext_ticklen;
+    long tlsext_tick_lifetime_hint;
     ...;
 } SSL_SESSION;
 
@@ -236,11 +245,13 @@ void SSL_CTX_set_client_CA_list(SSL_CTX *, Cryptography_STACK_OF_X509_NAME *);
 
 /*  SSL_SESSION */
 void SSL_SESSION_free(SSL_SESSION *);
+int SSL_SESSION_print(BIO *fp, const SSL_SESSION *ses);
 
 /* Information about actually used cipher */
 const char *SSL_CIPHER_get_name(const SSL_CIPHER *);
 int SSL_CIPHER_get_bits(const SSL_CIPHER *, int *);
 char *SSL_CIPHER_get_version(const SSL_CIPHER *);
+char *SSL_CIPHER_description(const SSL_CIPHER *, char *buf, int size);
 
 size_t SSL_get_finished(const SSL *, void *, size_t);
 size_t SSL_get_peer_finished(const SSL *, void *, size_t);


### PR DESCRIPTION
refs #2268 

This should steal the easy parts, but might still need a tweak or two.

One unfortunate thing about de-opaquing structs is that OpenSSL 1.1 will break this (as structs are all opaque and accessor functions exist). We'll cross that bridge when 1.1 comes out though...