### PR TITLE
idempotent engine add

### DIFF
--- a/src/_cffi_src/openssl/engine.py
+++ b/src/_cffi_src/openssl/engine.py
@@ -44,6 +44,8 @@ static const unsigned int ENGINE_METHOD_DIGESTS;
 static const unsigned int ENGINE_METHOD_STORE;
 static const unsigned int ENGINE_METHOD_ALL;
 static const unsigned int ENGINE_METHOD_NONE;
+
+static const int ENGINE_R_CONFLICTING_ENGINE_ID;
 """
 
 FUNCTIONS = """

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -97,7 +97,6 @@ class Binding(object):
     @classmethod
     def _register_osrandom_engine(cls):
         _openssl_assert(cls.lib, cls.lib.ERR_peek_error() == 0)
-        cls.lib.ERR_clear_error()
 
         engine = cls.lib.ENGINE_new()
         _openssl_assert(cls.lib, engine != cls.ffi.NULL)
@@ -111,7 +110,8 @@ class Binding(object):
             result = cls.lib.ENGINE_add(engine)
             if result != 1:
                 errors = _consume_errors(cls.lib)
-                assert (
+                _openssl_assert(
+                    cls.lib,
                     errors[0].reason == cls.lib.ENGINE_R_CONFLICTING_ENGINE_ID
                 )
 
@@ -172,6 +172,3 @@ class Binding(object):
                     mode, n, file, line
                 )
             )
-
-# init the static locks so we have a locking callback in C for engine init
-Binding.init_static_locks()

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -89,8 +89,8 @@ class TestOpenSSL(object):
 
     def test_add_engine_more_than_once(self):
         b = Binding()
-        with pytest.raises(RuntimeError):
-            b._register_osrandom_engine()
+        b._register_osrandom_engine()
+        assert b.lib.ERR_get_error() == 0
 
     def test_ssl_ctx_options(self):
         # Test that we're properly handling 32-bit unsigned on all platforms.


### PR DESCRIPTION
Threading issues keep cropping up. ENGINE_add ideally acquires a lock at the C layer via CRYPTO_w_lock (provided you have registered the locking callbacks) so let's try to use that...

I don't think this is a real fix, but it should be an improvement over the current situation and may resolve the issues for some people. We should keep thinking about how to truly fix this.