### PR TITLE
add conditional removal for SET_CERT_CB

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -410,5 +410,9 @@ CONDITIONAL_NAMES = {
     ],
     "Cryptography_HAS_X509_V_FLAG_CHECK_SS_SIGNATURE": [
         "X509_V_FLAG_CHECK_SS_SIGNATURE",
-    ]
+    ],
+    "Cryptography_HAS_SET_CERT_CB": [
+        "SSL_CTX_set_cert_cb",
+        "SSL_set_cert_cb",
+    ],
 }


### PR DESCRIPTION
Adds conditional I didn't notice was missing in #2295 

A followup PR could be done to add a test that imports the dictionary in `_conditional` and loops over it to verify that anything not present has been removed. That would have caught this mistake.