### PR TITLE
Resolve an unusual test bug related to initializing the bindings

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -529,13 +529,6 @@ class Backend(object):
 
         self._binding.init_static_locks()
 
-        # adds all ciphers/digests for EVP
-        self._lib.OpenSSL_add_all_algorithms()
-        # registers available SSL/TLS ciphers and digests
-        self._lib.SSL_library_init()
-        # loads error strings for libcrypto and libssl functions
-        self._lib.SSL_load_error_strings()
-
         self._cipher_registry = {}
         self._register_default_ciphers()
         self.activate_osrandom_engine()

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -92,6 +92,12 @@ class Binding(object):
             if not cls._lib_loaded:
                 cls.lib = build_conditional_library(lib, CONDITIONAL_NAMES)
                 cls._lib_loaded = True
+                # initialize the SSL library
+                cls.lib.SSL_library_init()
+                # adds all ciphers/digests for EVP
+                cls.lib.OpenSSL_add_all_algorithms()
+                # loads error strings for libcrypto and libssl functions
+                cls.lib.SSL_load_error_strings()
                 cls._register_osrandom_engine()
 
     @classmethod


### PR DESCRIPTION
To make calls against the "SSL" parts of OpenSSL you need to call
SSL_library_init. There are multiple ways this can be called:

* If you're using the same OpenSSL in cryptography as you are in your
  Python then Python will call it for you.
* If you import the openssl backend.

These tests need SSL_library_init to be called. When run in our CI
SSL_library_init is called because during the parametrization step
the OpenSSL backend is imported (thus triggering it). However, you
can also run tests directly via py.test and without this change

py.test tests/hazmat/bindings/test_openssl.py

would crash if you had cryptography linked against a different OpenSSL
than your Python used.