### PR TITLE
backport pypy error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,13 @@ if sys.version_info < (3, 4):
 if sys.version_info < (3, 3):
     requirements.append("ipaddress")
 
-if platform.python_implementation() != "PyPy":
+if platform.python_implementation() == "PyPy":
+    if sys.pypy_version_info < (2, 6):
+        raise RuntimeError(
+            "cryptography 1.0 is not compatible with PyPy < 2.6. Please "
+            "upgrade PyPy to use this library."
+        )
+else:
     requirements.append("cffi>=1.1.0")
     setup_requirements.append("cffi>=1.1.0")
 


### PR DESCRIPTION
raise an error if trying to install on PyPy < 2.6