### PR TITLE
[WIP] can't redefine SSLv2_ functions on Solaris

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -431,9 +431,9 @@ static const long Cryptography_HAS_SECURE_RENEGOTIATION = 1;
 #endif
 #ifdef OPENSSL_NO_SSL2
 static const long Cryptography_HAS_SSL2 = 0;
-SSL_METHOD* (*SSLv2_method)(void) = NULL;
-SSL_METHOD* (*SSLv2_client_method)(void) = NULL;
-SSL_METHOD* (*SSLv2_server_method)(void) = NULL;
+const SSL_METHOD *SSLv2_method(void);
+const SSL_METHOD *SSLv2_server_method(void);
+const SSL_METHOD *SSLv2_client_method(void);
 #else
 static const long Cryptography_HAS_SSL2 = 1;
 #endif


### PR DESCRIPTION
Trying to build cryptography on recent Solaris versions caused a problem with redefining SSLv2_ functions.

The cryptography code assumes, that if OPENSSL_NO_SSL2 is set, the following functions are not defined at all:
SSL_METHOD *SSLv2_method(void)
SSL_METHOD *SSLv2_client_method(void)
SSL_METHOD *SSLv2_server_method(void)

However, in Solaris the declarations have not been removed, just marked deprecated to not create linker issues with programs still looking for those.

This is a test to see if just putting in empty declarations instead of redefinitions will work for other platforms.