### PR TITLE
Add support for RSA_R_OAEP_DECODING_ERROR error flag.

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -14,6 +14,7 @@ static const int Cryptography_HAS_098H_ERROR_CODES;
 static const int Cryptography_HAS_098C_CAMELLIA_CODES;
 static const int Cryptography_HAS_EC_CODES;
 static const int Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR;
+static const int Cryptography_HAS_RSA_R_OAEP_DECODING_ERROR;
 
 struct ERR_string_data_st {
     unsigned long error;
@@ -230,6 +231,7 @@ static const int RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY;
 static const int RSA_R_BLOCK_TYPE_IS_NOT_01;
 static const int RSA_R_BLOCK_TYPE_IS_NOT_02;
 static const int RSA_R_PKCS_DECODING_ERROR;
+static const int RSA_R_OAEP_DECODING_ERROR;
 static const int RSA_F_RSA_SIGN;
 """
 
@@ -333,5 +335,12 @@ static const long Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR = 1;
 #else
 static const long Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR = 0;
 static const long RSA_R_PKCS_DECODING_ERROR = 0;
+#endif
+
+#ifdef RSA_R_OAEP_DECODING_ERROR
+static const long Cryptography_HAS_RSA_R_OAEP_DECODING_ERROR = 1;
+#else
+static const long Cryptography_HAS_RSA_R_OAEP_DECODING_ERROR = 0;
+static const long RSA_R_OAEP_DECODING_ERROR = 0;
 #endif
 """

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -142,6 +142,9 @@ def _handle_rsa_enc_dec_error(backend, key):
         if backend._lib.Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR:
             decoding_errors.append(backend._lib.RSA_R_PKCS_DECODING_ERROR)
 
+        if backend._lib.Cryptography_HAS_RSA_R_OAEP_DECODING_ERROR:
+            decoding_errors.append(backend._lib.RSA_R_OAEP_DECODING_ERROR)
+
         assert errors[0].reason in decoding_errors
         raise ValueError("Decryption failed.")
 

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -217,6 +217,9 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR": [
         "RSA_R_PKCS_DECODING_ERROR"
     ],
+    "Cryptography_HAS_RSA_R_OAEP_DECODING_ERROR": [
+        "RSA_R_OAEP_DECODING_ERROR"
+    ],
     "Cryptography_HAS_GCM": [
         "EVP_CTRL_GCM_GET_TAG",
         "EVP_CTRL_GCM_SET_TAG",

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -479,16 +479,15 @@ class TestOpenSSLRSA(object):
             )
         )
 
-        decrypted = RSA_KEY_512_ALT.private_key(backend).decrypt(
-            ciphertext,
-            padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA1()),
-                algorithm=hashes.SHA1(),
-                label=None
+        with pytest.raises(ValueError):
+            RSA_KEY_512_ALT.private_key(backend).decrypt(
+                ciphertext,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.SHA1()),
+                    algorithm=hashes.SHA1(),
+                    label=None
+                )
             )
-        )
-
-        assert decrypted == b'secure data'
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -29,7 +29,7 @@ from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.modes import CBC, CTR, Mode
 
 from ..primitives.fixtures_dsa import DSA_KEY_2048
-from ..primitives.fixtures_rsa import RSA_KEY_2048, RSA_KEY_512
+from ..primitives.fixtures_rsa import RSA_KEY_2048, RSA_KEY_512, RSA_KEY_512_ALT
 from ..primitives.test_ec import _skip_curve_unsupported
 from ...utils import load_vectors_from_file, raises_unsupported_algorithm
 
@@ -479,7 +479,7 @@ class TestOpenSSLRSA(object):
             )
         )
 
-        decrypted = private_key.decrypt(
+        decrypted = RSA_KEY_512_ALT.private_key(backend).decrypt(
             ciphertext,
             padding.OAEP(
                 mgf=padding.MGF1(algorithm=hashes.SHA1()),

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -467,6 +467,29 @@ class TestOpenSSLRSA(object):
                 )
             )
 
+    def test_supported_oaep_decrypt(self):
+        private_key = RSA_KEY_512.private_key(backend)
+
+        ciphertext = private_key.public_key().encrypt(
+            b'secure data',
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA1()),
+                algorithm=hashes.SHA1(),
+                label=None
+            )
+        )
+
+        decrypted = private_key.decrypt(
+            ciphertext,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA1()),
+                algorithm=hashes.SHA1(),
+                label=None
+            )
+        )
+
+        assert decrypted == b'secure data'
+
 
 @pytest.mark.skipif(
     backend._lib.OPENSSL_VERSION_NUMBER <= 0x10001000,

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -479,8 +479,10 @@ class TestOpenSSLRSA(object):
             )
         )
 
+        private_key_alt = RSA_KEY_512_ALT.private_key(backend)
+
         with pytest.raises(ValueError):
-            RSA_KEY_512_ALT.private_key(backend).decrypt(
+            private_key_alt.decrypt(
                 ciphertext,
                 padding.OAEP(
                     mgf=padding.MGF1(algorithm=hashes.SHA1()),


### PR DESCRIPTION
This pull request adds support for the ``RSA_R_OAEP_DECODING_ERROR`` error flag referenced here: https://github.com/openssl/openssl/blob/master/include/openssl/rsa.h#L626

This error code is being raised on error condition (e.g wrong private key) for this code: https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/#decryption

I actually didn't see any tests for ``RSA_R_PKCS_DECODING_ERROR`` flag and don't really know how to test such flags. Please let me know if you need any, I'd be happy for any guidance here :smiley: 