### PR TITLE
acquire a global lock to init the OpenSSL singleton locks

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -182,6 +182,8 @@ class Binding(object):
 # although it's still unclear what happens when a subinterpreter which
 # has registered the locks is destroyed. Do the callback functions still work
 # or are all the objects associated with that subinterpreter destroyed?
+# imp.acquire_lock() is global even in 3.4+ while import locks have moved to
+# per module granularity.
 try:
     imp.acquire_lock()
     Binding.init_static_locks()

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 import collections
+import imp
 import os
 import threading
 import types
@@ -171,3 +172,17 @@ class Binding(object):
                     mode, n, file, line
                 )
             )
+
+
+# https://github.com/pyca/cryptography/issues/2299 contains extensive
+# discussion about this workaround. In essence, we are acquiring a global lock
+# (including across all subinterpreters if we're in a mod_wsgi environment)
+# initializing some C level locks, then initializing the binding and adding the
+# OS random engine. This should prevent engine addition race conditions,
+# although it's still unclear what happens when a subinterpreter which
+# has registered the locks is destroyed. Do the callback functions still work
+# or are all the objects associated with that subinterpreter destroyed?
+imp.acquire_lock()
+Binding.init_static_locks()
+Binding._ensure_ffi_initialized()
+imp.release_lock()

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -182,7 +182,9 @@ class Binding(object):
 # although it's still unclear what happens when a subinterpreter which
 # has registered the locks is destroyed. Do the callback functions still work
 # or are all the objects associated with that subinterpreter destroyed?
-imp.acquire_lock()
-Binding.init_static_locks()
-Binding._ensure_ffi_initialized()
-imp.release_lock()
+try:
+    imp.acquire_lock()
+    Binding.init_static_locks()
+    Binding._ensure_ffi_initialized()
+finally:
+    imp.release_lock()


### PR DESCRIPTION
...then init the library since we really only want to do that once anyway

This approach was suggested in #2299. Of note, in a subinterpreter environment a "random" subinterpreter will register the static locks and engine. This means it will contain the Python callbacks for them. If the subinterpreter is subsequently destroyed, do the locks and random engine continue to function? If not, this solution will not work.

This should be considered WIP until we have a solid answer to the above.