### PR TITLE
workaround for pytest 2.7.3's expectation of USERNAME on windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pretend
     pytest
     ./vectors
-passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH
+passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH USERNAME
 commands =
     pip list
     python -c "from cryptography.hazmat.backends.openssl.backend import backend; print(backend.openssl_version_text())"


### PR DESCRIPTION
We should remove this when a pytest that resolves https://github.com/pytest-dev/pytest/issues/1010 is released