### PR TITLE
Adjusted the README to reflect that only PyPy 2.6 and above is supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Cryptography
 
 ``cryptography`` is a package which provides cryptographic recipes and
 primitives to Python developers.  Our goal is for it to be your "cryptographic
-standard library". It supports Python 2.6-2.7, Python 3.3+, and PyPy.
+standard library". It supports Python 2.6-2.7, Python 3.3+, and PyPy 2.6+. For support of PyPy versions below 2.6 use cryptography 0.9.x.
 
 ``cryptography`` includes both high level recipes, and low level interfaces to
 common cryptographic algorithms such as symmetric ciphers, message digests and


### PR DESCRIPTION
Since version 1.0 cryptography only installs on PyPy 2.6 and above. I changed the readme file to reflect that.