### PR TITLE
SubjectKeyIdentifier equality now uses constant-time digest comparison.

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -15,7 +15,7 @@ from pyasn1.type import namedtype, univ
 import six
 
 from cryptography import utils
-from cryptography.hazmat.primitives import serialization, constant_time
+from cryptography.hazmat.primitives import constant_time, serialization
 from cryptography.x509.general_name import GeneralName, IPAddress, OtherName
 from cryptography.x509.name import Name
 from cryptography.x509.oid import (

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -15,7 +15,7 @@ from pyasn1.type import namedtype, univ
 import six
 
 from cryptography import utils
-from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import serialization, constant_time
 from cryptography.x509.general_name import GeneralName, IPAddress, OtherName
 from cryptography.x509.name import Name
 from cryptography.x509.oid import (
@@ -193,9 +193,7 @@ class SubjectKeyIdentifier(object):
         if not isinstance(other, SubjectKeyIdentifier):
             return NotImplemented
 
-        return (
-            self.digest == other.digest
-        )
+        return constant_time.bytes_eq(self.digest, other.digest)
 
     def __ne__(self, other):
         return not self == other


### PR DESCRIPTION
This hardens SubjectKeyIdentifier against potential timing attacks, despite the fact that there is no immediately obvious advantage an adversary could gain by executing such an attack.