### PR TITLE
add some el capitan to our travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,16 +132,16 @@ matrix:
           env: TOXENV=pypy OPENSSL=0.9.8
         - language: generic
           os: osx
-          osx_image: xcode7
-          env: TOXENV=docs
-        - language: generic
-          os: osx
           osx_image: osx10.11
           env: TOXENV=py26 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx
           osx_image: osx10.11
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+        - language: generic
+          os: osx
+          osx_image: xcode7
+          env: TOXENV=docs
 
 install:
     - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,14 @@ matrix:
           os: osx
           osx_image: xcode7
           env: TOXENV=docs
+        - language: generic
+          os: osx
+          osx_image: osx10.11
+          env: TOXENV=py26 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+        - language: generic
+          os: osx
+          osx_image: osx10.11
+          env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
 
 install:
     - ./.travis/install.sh


### PR DESCRIPTION
I think we may want to revisit what our OS X build matrix looks like to try to trim it down if we can, but for the moment let's add system Python from El Capitan (10.11).