### PR TITLE
pytest 2.8.1 resolves the deprecation check bug

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ invoke
 iso8601
 pep8-naming
 pretend
-pytest<2.8
+pytest>=2.8.1
 requests
 sphinx
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ else:
 
 # If you add a new dep here you probably need to add it in the tox.ini as well
 test_requirements = [
-    "pytest<2.8",
+    "pytest>=2.8.1",
     "pretend",
     "iso8601",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     coverage
     iso8601
     pretend
-    pytest<2.8
+    pytest>=2.8.1
     ./vectors
 passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH USERNAME
 commands =


### PR DESCRIPTION
fixes #2354 