### PR TITLE
Handling path_length when ca is True

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -235,7 +235,7 @@ def _encode_basic_constraints(backend, basic_constraints):
         constraints, backend._lib.BASIC_CONSTRAINTS_free
     )
     constraints.ca = 255 if basic_constraints.ca else 0
-    if basic_constraints.ca:
+    if basic_constraints.ca and basic_constraints.path_length != None:
         constraints.pathlen = _encode_asn1_int(
             backend, basic_constraints.path_length
         )

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -235,7 +235,7 @@ def _encode_basic_constraints(backend, basic_constraints):
         constraints, backend._lib.BASIC_CONSTRAINTS_free
     )
     constraints.ca = 255 if basic_constraints.ca else 0
-    if basic_constraints.ca and basic_constraints.path_length != None:
+    if basic_constraints.ca and basic_constraints.path_length is not None:
         constraints.pathlen = _encode_asn1_int(
             backend, basic_constraints.path_length
         )


### PR DESCRIPTION
Using CertificateBuilder:
`builder = builder.add_extension(x509.BasicConstraints(ca=True,path_length=None), critical=True)` return TypeError in line 792 because None can't be converted to hex.

```
  File ".../lib/python2.7/site-packages/cryptography/x509/base.py", line 465, in sign
    return backend.create_x509_certificate(self, private_key, algorithm)
  File ".../lib/python2.7/site-packages/cryptography/hazmat/backends/multibackend.py", line 357, in create_x509_certificate
    return b.create_x509_certificate(builder, private_key, algorithm)
  File ".../lib/python2.7/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 1290, in create_x509_certificate
    pp, r = encode(self, extension.value)
  File ".../lib/python2.7/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 239, in _encode_basic_constraints
    backend, basic_constraints.path_length
  File ".../lib/python2.7/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 71, in _encode_asn1_int
    i = backend._int_to_bn(x)
  File ".../lib/python2.7/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 792, in _int_to_bn
    hex_num = hex(num).rstrip("L").lstrip("0x").encode("ascii") or b"0"
TypeError: hex() argument can't be converted to hex
```

In https://tools.ietf.org/html/rfc5280.html#section-4.2.1.9: CAs MUST NOT include the pathLenConstraint field unless the cA boolean is asserted and the key usage extension asserts the keyCertSign bit.