### PR TITLE
unpin pytest now that 2.8.2 is released

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ invoke
 iso8601
 pep8-naming
 pretend
-pytest<2.8
+pytest
 requests
 sphinx
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ else:
 
 # If you add a new dep here you probably need to add it in the tox.ini as well
 test_requirements = [
-    "pytest<2.8",
+    "pytest",
     "pretend",
     "iso8601",
     "hypothesis",

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     coverage
     iso8601
     pretend
-    pytest<2.8
+    pytest
     hypothesis>=1.11.4
     ./vectors
 passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH USERNAME


### PR DESCRIPTION
The recent broken versions are 2.8, 2.8.1, and 2.7.2. We've had other pytests break us in the past though and we haven't tried to set up exclusions in the dependency, so I think we should probably just fully unpin again (and if people have problems running the tests tell them to upgrade to latest).