### PR TITLE
remove py3 mac 0.9.8 jobs from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,18 +117,6 @@ matrix:
         - language: generic
           os: osx
           osx_image: xcode7
-          env: TOXENV=py33 OPENSSL=0.9.8
-        - language: generic
-          os: osx
-          osx_image: xcode7
-          env: TOXENV=py34 OPENSSL=0.9.8
-        - language: generic
-          os: osx
-          osx_image: xcode7
-          env: TOXENV=py35 OPENSSL=0.9.8
-        - language: generic
-          os: osx
-          osx_image: xcode7
           env: TOXENV=pypy OPENSSL=0.9.8
         - language: generic
           os: osx


### PR DESCRIPTION
pyenv now compiles against homebrew and this makes it difficult to link against the system openssl. You should be using homebrew or macports to get a recent OpenSSL anyway (and we continue to test it
against system Python for now).