### PR TITLE
add shebang for setup.py scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/vectors/setup.py
+++ b/vectors/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.


### PR DESCRIPTION
Minor patch to add a shebang to the `setup.py` scripts, this seems to be done by other packages such as `Twisted` and `setuptools`.