### PR TITLE
Add --no-cache-dir when building static wheels.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -166,7 +166,7 @@ dependencies.
     ./config no-shared no-ssl2 -fPIC --prefix=${CWD}/openssl
     make && make install
     cd ..
-    CFLAGS="-I${CWD}/openssl/include" LDFLAGS="-L${CWD}/openssl/lib" pip wheel cryptography
+    CFLAGS="-I${CWD}/openssl/include" LDFLAGS="-L${CWD}/openssl/lib" pip wheel --no-use-wheel cryptography
 
 Building cryptography on OS X
 -----------------------------


### PR DESCRIPTION
Per @geradcoles suggestion in #2338 and certifi/python-certifi#26.