### PR TITLE
encode countryName with PrintableString

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+asn1crypto
 coverage
 flake8
 flake8-import-order

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-asn1crypto
 coverage
 flake8
 flake8-import-order
@@ -6,6 +5,7 @@ invoke
 iso8601
 pep8-naming
 pretend
+pyasn1_modules
 pytest
 requests
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ test_requirements = [
     "pretend",
     "iso8601",
     "hypothesis",
-    "asn1crypto",
+    "pyasn1_modules",
 ]
 
 # If there's no vectors locally that probably means we are in a tarball and

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ test_requirements = [
     "pretend",
     "iso8601",
     "hypothesis",
+    "asn1crypto",
 ]
 
 # If there's no vectors locally that probably means we are in a tarball and

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -120,8 +120,8 @@ def _encode_name(backend, attributes):
         value = attribute.value.encode('utf8')
         obj = _txt2obj_gc(backend, attribute.oid.dotted_string)
         if attribute.oid == NameOID.COUNTRY_NAME:
-            # Per RFC5280 countryName should be encoded as PrintableString,
-            # not UTF8String
+            # Per RFC5280 Appendix A.1 countryName should be encoded as
+            # PrintableString, not UTF8String
             type = backend._lib.MBSTRING_ASC
         else:
             type = backend._lib.MBSTRING_UTF8

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -872,8 +872,8 @@ class TestRSACertificateRequest(object):
         issuer = tbs_cert.getComponentByName('issuer')
         # \x13 is printable string. The first byte of the value of the
         # node corresponds to the ASN.1 string type.
-        assert subject[0][0][0][1][0] == "\x13"
-        assert issuer[0][0][0][1][0] == "\x13"
+        assert subject[0][0][0][1][0] == b"\x13"[0]
+        assert issuer[0][0][0][1][0] == b"\x13"[0]
 
 
 class TestCertificateBuilder(object):

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -872,8 +872,8 @@ class TestRSACertificateRequest(object):
         issuer = tbs_cert.getComponentByName('issuer')
         # \x13 is printable string. The first byte of the value of the
         # node corresponds to the ASN.1 string type.
-        assert str(subject[0][0][0][1])[0] == "\x13"
-        assert str(issuer[0][0][0][1])[0] == "\x13"
+        assert subject[0][0][0][1][0] == "\x13"
+        assert issuer[0][0][0][1][0] == "\x13"
 
 
 class TestCertificateBuilder(object):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pretend
     pytest
     hypothesis>=1.11.4
-    asn1crypto
+    pyasn1_modules
     ./vectors
 passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH USERNAME
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pretend
     pytest
     hypothesis>=1.11.4
+    asn1crypto
     ./vectors
 passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH USERNAME
 commands =


### PR DESCRIPTION
This commit adds a dependency on asn1crypto (thanks to wbond for pushing a release to pypi) for testing purposes to parse the certificate and confirm that countryName is encoded with PrintableString while other fields are UTF8String. This is a test only dep (but could eventually supplant pyasn1).

Fixes #2407 