### PR TITLE
move lock initialization to during binding import

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -524,8 +524,6 @@ class Backend(object):
         res = self._lib.ASN1_STRING_set_default_mask_asc(b"utf8only")
         self.openssl_assert(res == 1)
 
-        self._binding.init_static_locks()
-
         self._cipher_registry = {}
         self._register_default_ciphers()
         self.activate_osrandom_engine()

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -172,3 +172,7 @@ class Binding(object):
                     mode, n, file, line
                 )
             )
+
+
+# OpenSSL is not thread safe until the locks are initialized.
+Binding.init_static_locks()

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -174,5 +174,7 @@ class Binding(object):
             )
 
 
-# OpenSSL is not thread safe until the locks are initialized.
+# OpenSSL is not thread safe until the locks are initialized. We initialize in
+# module scope to cause initialization whenever this module is imported (and
+# try to get some benefit from the import lock).
 Binding.init_static_locks()

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -174,7 +174,9 @@ class Binding(object):
             )
 
 
-# OpenSSL is not thread safe until the locks are initialized. We initialize in
-# module scope to cause initialization whenever this module is imported (and
-# try to get some benefit from the import lock).
+# OpenSSL is not thread safe until the locks are initialized. We call this
+# method in module scope so that it executes with the import lock. On
+# Pythons < 3.4 this import lock is a global lock, which can prevent a race
+# condition registering the OpenSSL locks. On Python 3.4+ the import lock
+# is per module so this approach will not work.
 Binding.init_static_locks()


### PR DESCRIPTION
Previously we attempted to register our openssl locks only if the backend was initialized, but we should really just do it immediately. Consumers like PyOpenSSL already call init_static_locks after importing the binding and if a library wants to replace the locks with something else they can do so themselves.