### PR TITLE
add ellipticcurvepublicnumbers repr

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -302,6 +302,12 @@ class EllipticCurvePublicNumbers(object):
     def __ne__(self, other):
         return not self == other
 
+    def __repr__(self):
+        return (
+            "<EllipticCurvePublicNumbers(curve={0.curve.name}, x={0.x}, "
+            "y={0.y}>".format(self)
+        )
+
 
 class EllipticCurvePrivateNumbers(object):
     def __init__(self, private_value, public_numbers):

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -215,6 +215,11 @@ def test_from_encoded_point_not_a_curve():
         )
 
 
+def test_ec_public_numbers_repr():
+    pn = ec.EllipticCurvePublicNumbers(2, 3, ec.SECP256R1())
+    assert repr(pn) == "<EllipticCurvePublicNumbers(curve=secp256r1, x=2, y=3>"
+
+
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 class TestECWithNumbers(object):
     @pytest.mark.parametrize(


### PR DESCRIPTION
No private numbers repr because we don't actually want to output the private key. We could implement the repr without displaying that info, but this is consistent with what we've done with RSAPublicNumbers (vs RSAPrivateNumbers) for now.

fixes #2448 