### PR TITLE
pypy 4 for travis mac builders

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -5,16 +5,16 @@ set -x
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew update || brew update
-    brew install pyenv
-    brew outdated pyenv || brew upgrade pyenv
 
     if [[ "${OPENSSL}" != "0.9.8" ]]; then
         brew outdated openssl || brew upgrade openssl
     fi
 
-    if which -s pyenv; then
-        eval "$(pyenv init -)"
-    fi
+    # install pyenv
+    git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
 
     case "${TOXENV}" in
         py26)

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -38,8 +38,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv global 3.5.0
             ;;
         pypy)
-            pyenv install pypy-c-jit-latest
-            pyenv global pypy-c-jit-latest
+            pyenv install pypy-4.0.0
+            pyenv global pypy-4.0.0
             ;;
         pypy3)
             pyenv install pypy3-2.4.0

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -4,7 +4,11 @@ set -e
 set -x
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
+    # initialize our pyenv
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
+
     if [[ "${OPENSSL}" != "0.9.8" ]]; then
         # set our flags to use homebrew openssl
         export ARCHFLAGS="-arch x86_64"


### PR DESCRIPTION
Switches from using pyenv on homebrew (which depends on a pyenv release) to directly cloning pyenv (like we do for our pypy linux builders).