### PR TITLE
remove malloc_debug_init as it has occasionally caused compile issues

### DIFF
--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -49,7 +49,6 @@ void OPENSSL_free(void *);
 MACROS = """
 void CRYPTO_add(int *, int, int);
 void CRYPTO_malloc_init(void);
-void CRYPTO_malloc_debug_init(void);
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
We also don't use it in our backend (and neither does pyOpenSSL)

This should help resolve https://github.com/letsencrypt/letsencrypt/issues/1332