### PR TITLE
Port callbacks to new static callback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ if platform.python_implementation() == "PyPy":
             "upgrade PyPy to use this library."
         )
 else:
-    requirements.append("cffi>=1.1.0")
-    setup_requirements.append("cffi>=1.1.0")
+    requirements.append("cffi>=1.4.1")
+    setup_requirements.append("cffi>=1.4.1")
 
 # If you add a new dep here you probably need to add it in the tox.ini as well
 test_requirements = [

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -90,6 +90,7 @@ ffi = build_ffi_for_binding(
         "x509v3",
         "x509_vfy",
         "pkcs7",
+        "callbacks",
     ],
     pre_include=_OSX_PRE_INCLUDE,
     post_include=_OSX_POST_INCLUDE,

--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -1,0 +1,111 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import cffi
+
+INCLUDES = """
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
+"""
+
+TYPES = """
+static const long Cryptography_STATIC_CALLBACKS;
+
+/* crypto.h
+ * CRYPTO_set_locking_callback
+ * void (*cb)(int mode, int type, const char *file, int line)
+ */
+extern "Python" void Cryptography_locking_cb(int, int, const char *, int);
+
+/* pem.h
+ * int pem_password_cb(char *buf, int size, int rwflag, void *userdata);
+ */
+extern "Python" int Cryptography_pem_password_cb(char *, int, int, void *);
+
+/* rand.h
+ * int (*bytes)(unsigned char *buf, int num);
+ * int (*status)(void);
+ */
+extern "Python" int Cryptography_rand_bytes(unsigned char *, int);
+extern "Python" int Cryptography_rand_status(void);
+
+/* ssl.h
+ *
+ * SSL_CTX_set_cert_verify_callback
+ * int (*cert_verify_callback)(X509_STORE_CTX *ctx, void *userdata)
+ */
+extern "Python" int Cryptography_cert_verify_cb(
+    X509_STORE_CTX *, void *);
+
+/* SSL_CTX_set_info_callback
+ * void (*info_callback)(const SSL *ssl, int type, int val)
+ */
+extern "Python" void Cryptography_ssl_info_cb(
+    const SSL *, int, int);
+
+/* SSL_CTX_set_msg_callback
+ * void (*info_callback)(int write_p, int version, int content_type,
+ *                       const void *buf, size_t len, SSL *ssl, void *arg)
+ */
+extern "Python" void Cryptography_msg_cb(
+    int, int, int, const void *, size_t, SSL *, void *);
+
+/* SSL_CTX_set_client_cert_cb
+ * int (*client_cert_cb) (SSL *ssl, X509 **x509, EVP_PKEY **pkey)
+ */
+extern "Python" int Cryptography_client_cert_cb(
+    SSL *, X509 **, EVP_PKEY **);
+
+/* SSL_CTX_set_next_protos_advertised_cb
+ * int (*cb)(SSL *ssl, const unsigned char **out, unsigned int *outlen,
+ *           void *arg
+ */
+extern "Python" int Cryptography_next_proto_advertised_cb(
+    SSL *, const unsigned char **, unsigned int *, void *);
+
+/* SSL_CTX_set_next_proto_select_cb
+ * int (*cb) (SSL *ssl, unsigned char **out, unsigned char *outlen,
+ *            const unsigned char *in, unsigned int inlen, void *arg)
+ */
+extern "Python" int Cryptography_next_proto_select_cb(
+    SSL *, unsigned char **, unsigned char *, const unsigned char *,
+    unsigned int, void *);
+
+/* SSL_CTX_set_alpn_select_cb
+ * int (*cb) (SSL *ssl, const unsigned char **out, unsigned char *outlen,
+              const unsigned char *in, unsigned int inlen, void *arg)
+ */
+extern "Python" int Cryptography_alpn_select_cb(
+    SSL *, const unsigned char **, unsigned char *, const unsigned char *,
+    unsigned int, void *arg);
+
+/* tls1.h
+ * SSL_CTX_set_tlsext_servername_callback
+ */
+extern "Python" int Cryptography_tlsext_servername_cb(
+    const SSL *, int *, void *);
+
+/* x509_vfy.h
+ * int (*verify_cb)(int ok, X509_STORE_CTX *ctx)
+ */
+extern "Python" int Cryptography_verify_cb(int, X509_STORE_CTX *);
+"""
+
+FUNCTIONS = """
+"""
+
+MACROS = """
+"""
+
+CUSTOMIZATIONS = """
+static const long Cryptography_STATIC_CALLBACKS = 1;
+"""
+
+if cffi.__version_info__ < (1, 4, 0):
+    # backwards compatibility for old cffi version on PyPy
+    TYPES = "static const long Cryptography_STATIC_CALLBACKS;"
+    CUSTOMIZATIONS = "static const long Cryptography_STATIC_CALLBACKS = 0;"

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -43,6 +43,7 @@ from cryptography.hazmat.backends.openssl.x509 import (
 )
 from cryptography.hazmat.bindings._openssl import ffi as _ffi
 from cryptography.hazmat.bindings.openssl import binding
+from cryptography.hazmat.bindings._openssl import ffi as _ffi
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from cryptography.hazmat.primitives.asymmetric.padding import (


### PR DESCRIPTION
cffi 1.3.1 will introduce a new API to create static callbacks. Contrary to
the old callback API, static callbacks no longer depend on libffi's
dynamic code generation for closures. Static code has some benefits over
dynamic generation. For example the code is faster. Also it doesn't need
writeable and executable memory mappings, which makes it compatible with
SELinux's deny execmem policy.

https://bitbucket.org/cffi/cffi/issues/232/static-callbacks

Closes: #2477
Signed-off-by: Christian Heimes <cheimes@redhat.com>