### PR TITLE
backport CMS binding fix

### DIFF
--- a/src/_cffi_src/openssl/cms.py
+++ b/src/_cffi_src/openssl/cms.py
@@ -17,6 +17,7 @@ INCLUDES = """
 
 TYPES = """
 static const long Cryptography_HAS_CMS;
+static const long Cryptography_HAS_CMS_BIO_FUNCTIONS;
 
 typedef ... CMS_ContentInfo;
 typedef ... CMS_SignerInfo;
@@ -71,8 +72,18 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *, X509 *, EVP_PKEY *,
 CUSTOMIZATIONS = """
 #if !defined(OPENSSL_NO_CMS) && OPENSSL_VERSION_NUMBER >= 0x0090808fL
 static const long Cryptography_HAS_CMS = 1;
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
+static const long Cryptography_HAS_CMS_BIO_FUNCTIONS = 0;
+/* These functions were added in 1.0.0 */
+BIO *(*BIO_new_CMS)(BIO *, CMS_ContentInfo *) = NULL;
+int (*i2d_CMS_bio_stream)(BIO *, CMS_ContentInfo *, BIO *, int) = NULL;
+int (*PEM_write_bio_CMS_stream)(BIO *, CMS_ContentInfo *, BIO *, int) = NULL;
+#else
+static const long Cryptography_HAS_CMS_BIO_FUNCTIONS = 1;
+#endif
 #else
 static const long Cryptography_HAS_CMS = 0;
+static const long Cryptography_HAS_CMS_BIO_FUNCTIONS = 0;
 typedef void CMS_ContentInfo;
 typedef void CMS_SignerInfo;
 typedef void CMS_CertificateChoices;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -52,6 +52,11 @@ CONDITIONAL_NAMES = {
         "CMS_USE_KEYID",
         "CMS_DEBUG_DECRYPT",
     ],
+    "Cryptography_HAS_CMS_BIO_FUNCTIONS": [
+        "BIO_new_CMS",
+        "i2d_CMS_bio_stream",
+        "PEM_write_bio_CMS_stream",
+    ],
     "Cryptography_HAS_EC": [
         "OPENSSL_EC_NAMED_CURVE",
         "EC_GROUP_new",


### PR DESCRIPTION
these functions were added in 1.0.0, while CMS was added in 0.9.8h. Backported to 1.1.x