### PR TITLE
Add more CRYPTO_EX_DATA functions

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -251,6 +251,15 @@ char *SSL_CIPHER_get_version(const SSL_CIPHER *);
 
 size_t SSL_get_finished(const SSL *, void *, size_t);
 size_t SSL_get_peer_finished(const SSL *, void *, size_t);
+
+/* CRYPTO_EX_DATA */
+int SSL_get_ex_new_index(long, void *, CRYPTO_EX_new *, CRYPTO_EX_dup *,
+                         CRYPTO_EX_free *);
+int SSL_set_ex_data(SSL *, int, void *);
+
+int SSL_CTX_get_ex_new_index(long, void *, CRYPTO_EX_new *, CRYPTO_EX_dup *,
+                             CRYPTO_EX_free *);
+int SSL_CTX_set_ex_data(SSL_CTX *, int, void *);
 """
 
 MACROS = """
@@ -336,6 +345,9 @@ long SSL_CTX_get_timeout(const SSL_CTX *);
 const SSL_CIPHER *SSL_get_current_cipher(const SSL *);
 const char *SSL_get_version(const SSL *);
 int SSL_version(const SSL *);
+
+void *SSL_CTX_get_ex_data(const SSL_CTX *, int);
+void *SSL_get_ex_data(const SSL *, int);
 
 /* SNI APIs were introduced in OpenSSL 1.0.0.  To continue to support
  * earlier versions some special handling of these is necessary.

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -149,6 +149,12 @@ X509_EXTENSION *X509_EXTENSION_dup(X509_EXTENSION *);
 X509_EXTENSION *X509_get_ext(X509 *, int);
 int X509_get_ext_by_NID(X509 *, int, int);
 
+/* CRYPTO_EX_DATA */
+int X509_get_ex_new_index(long, void *, CRYPTO_EX_new *, CRYPTO_EX_dup *,
+                          CRYPTO_EX_free *);
+int X509_set_ex_data(X509 *, int, void *);
+void *X509_get_ex_data(X509 *, int);
+
 int X509_EXTENSION_get_critical(X509_EXTENSION *);
 ASN1_OBJECT *X509_EXTENSION_get_object(X509_EXTENSION *);
 void X509_EXTENSION_free(X509_EXTENSION *);

--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -173,6 +173,8 @@ int X509_STORE_CTX_get_error(X509_STORE_CTX *);
 void X509_STORE_CTX_set_error(X509_STORE_CTX *, int);
 int X509_STORE_CTX_get_error_depth(X509_STORE_CTX *);
 X509 *X509_STORE_CTX_get_current_cert(X509_STORE_CTX *);
+int X509_STORE_CTX_get_ex_new_index(long, void *, CRYPTO_EX_new *,
+                                    CRYPTO_EX_dup *, CRYPTO_EX_free *);
 int X509_STORE_CTX_set_ex_data(X509_STORE_CTX *, int, void *);
 void *X509_STORE_CTX_get_ex_data(X509_STORE_CTX *, int);
 


### PR DESCRIPTION
The patch adds a couple of additional functions to create, store and
retrieve ex_data on SSL, SSL_CTX and X509 objects. It also adds the
missing get_ex_new_index function for X509_STORE_CTX.

Signed-off-by: Christian Heimes <cheimes@redhat.com>