### PR TITLE
pin sphinx to 1.3.1 while we sort out the bytes repr issue with 1.3.2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ pretend
 pyasn1_modules
 pytest
 requests
-sphinx
+sphinx==1.3.1
 sphinx_rtd_theme
 sphinxcontrib-spelling
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     doc8
     pyenchant
     readme>=0.5.1
-    sphinx
+    sphinx==1.3.1
     sphinx_rtd_theme
     sphinxcontrib-spelling
 basepython = python2.7


### PR DESCRIPTION
Obviously we should unpin once sphinx is fixed.