### PR TITLE
fix a warning in cffi

### DIFF
--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -30,9 +30,10 @@ typedef struct {
     const char *comment;
 } EC_builtin_curve;
 typedef enum {
-    POINT_CONVERSION_COMPRESSED = 2,
-    POINT_CONVERSION_UNCOMPRESSED = 4,
-    POINT_CONVERSION_HYBRID = 6
+    POINT_CONVERSION_COMPRESSED,
+    POINT_CONVERSION_UNCOMPRESSED,
+    POINT_CONVERSION_HYBRID,
+    ...
 } point_conversion_form_t;
 """
 

--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -213,7 +213,11 @@ typedef struct {
     int nid;
     const char *comment;
 } EC_builtin_curve;
-typedef long point_conversion_form_t;
+typedef enum {
+    POINT_CONVERSION_COMPRESSED = 0,
+    POINT_CONVERSION_UNCOMPRESSED = 1,
+    POINT_CONVERSION_HYBRID = 2,
+} point_conversion_form_t;
 
 static const int OPENSSL_EC_NAMED_CURVE = 0;
 

--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -29,7 +29,11 @@ typedef struct {
     int nid;
     const char *comment;
 } EC_builtin_curve;
-typedef enum { ... } point_conversion_form_t;
+typedef enum {
+    POINT_CONVERSION_COMPRESSED = 2,
+    POINT_CONVERSION_UNCOMPRESSED = 4,
+    POINT_CONVERSION_HYBRID = 6
+} point_conversion_form_t;
 """
 
 FUNCTIONS = """

--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -214,9 +214,9 @@ typedef struct {
     const char *comment;
 } EC_builtin_curve;
 typedef enum {
-    POINT_CONVERSION_COMPRESSED = 0,
-    POINT_CONVERSION_UNCOMPRESSED = 1,
-    POINT_CONVERSION_HYBRID = 2,
+    POINT_CONVERSION_COMPRESSED,
+    POINT_CONVERSION_UNCOMPRESSED,
+    POINT_CONVERSION_HYBRID,
 } point_conversion_form_t;
 
 static const int OPENSSL_EC_NAMED_CURVE = 0;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -141,6 +141,9 @@ CONDITIONAL_NAMES = {
         "i2o_ECPublicKey",
         "o2i_ECPublicKey",
         "SSL_CTX_set_tmp_ecdh",
+        "POINT_CONVERSION_COMPRESSED",
+        "POINT_CONVERSION_UNCOMPRESSED",
+        "POINT_CONVERSION_HYBRID",
     ],
 
     "Cryptography_HAS_EC_1_0_1": [


### PR DESCRIPTION
cffi doesn't want to guess the type, so we'll deopaque the enum and strip the values out of the lib if EC is unavailable. Fixes https://github.com/pyca/pyopenssl/issues/392