### PR TITLE
remove the bindings for these x86_64 specific EC functions

### DIFF
--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -15,7 +15,6 @@ INCLUDES = """
 TYPES = """
 static const int Cryptography_HAS_EC;
 static const int Cryptography_HAS_EC_1_0_1;
-static const int Cryptography_HAS_EC_NISTP_64_GCC_128;
 static const int Cryptography_HAS_EC2M;
 static const int Cryptography_HAS_EC_1_0_2;
 
@@ -184,10 +183,6 @@ int EC_GROUP_have_precompute_mult(const EC_GROUP *);
 const EC_METHOD *EC_GFp_simple_method();
 const EC_METHOD *EC_GFp_mont_method();
 const EC_METHOD *EC_GFp_nist_method();
-
-const EC_METHOD *EC_GFp_nistp224_method();
-const EC_METHOD *EC_GFp_nistp256_method();
-const EC_METHOD *EC_GFp_nistp521_method();
 
 const EC_METHOD *EC_GF2m_simple_method();
 
@@ -358,17 +353,6 @@ int (*EC_KEY_set_public_key_affine_coordinates)(
 static const long Cryptography_HAS_EC_1_0_1 = 1;
 #endif
 
-
-#if defined(OPENSSL_NO_EC) || OPENSSL_VERSION_NUMBER < 0x1000100f || \
-    defined(OPENSSL_NO_EC_NISTP_64_GCC_128)
-static const long Cryptography_HAS_EC_NISTP_64_GCC_128 = 0;
-
-const EC_METHOD *(*EC_GFp_nistp224_method)(void) = NULL;
-const EC_METHOD *(*EC_GFp_nistp256_method)(void) = NULL;
-const EC_METHOD *(*EC_GFp_nistp521_method)(void) = NULL;
-#else
-static const long Cryptography_HAS_EC_NISTP_64_GCC_128 = 1;
-#endif
 
 #if defined(OPENSSL_NO_EC) || defined(OPENSSL_NO_EC2M)
 static const long Cryptography_HAS_EC2M = 0;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -150,12 +150,6 @@ CONDITIONAL_NAMES = {
         "EC_KEY_set_public_key_affine_coordinates",
     ],
 
-    "Cryptography_HAS_EC_NISTP_64_GCC_128": [
-        "EC_GFp_nistp224_method",
-        "EC_GFp_nistp256_method",
-        "EC_GFp_nistp521_method",
-    ],
-
     "Cryptography_HAS_EC2M": [
         "EC_GF2m_simple_method",
         "EC_POINT_set_affine_coordinates_GF2m",


### PR DESCRIPTION
We have no need to invoke them directly and their presence triggers a bug related to Fedora 23's hobbling of openssl EC functions (uugh)

This also fixes the SIGBUS issue in #2503, although that is more appropriately resolved via header fixes for universal libraries on OS X.