### PR TITLE
Revert "pin pytest to disallow 2.8.4 which breaks tests"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ iso8601
 pep8-naming
 pretend
 pyasn1_modules
-pytest!=2.8.4
+pytest
 requests
 sphinx==1.3.1
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ else:
 
 # If you add a new dep here you probably need to add it in the tox.ini as well
 test_requirements = [
-    "pytest!=2.8.4",
+    "pytest",
     "pretend",
     "iso8601",
     "hypothesis",

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     coverage
     iso8601
     pretend
-    pytest!=2.8.4
+    pytest
     hypothesis>=1.11.4
     pyasn1_modules
     ./vectors


### PR DESCRIPTION
This reverts commit ed48066a3f8e58af58926a17906540213e57f88e.

Closes #2514 

(While leaving the != pin is technically safe, it introduces significant cruft for us long term and I'd prefer to remove it. There are at least 2 other 2.8.x releases that also don't work and we don't have exclusions for them)