### PR TITLE
issue-2524

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -239,7 +239,7 @@ class AuthorityInformationAccess(object):
 class AccessDescription(object):
     def __init__(self, access_method, access_location):
         if not isinstance(access_method, ObjectIdentifier):
-          raise TypeError("access_method must be an ObjectIdentifier")
+            raise TypeError("access_method must be an ObjectIdentifier")
 
         if not isinstance(access_location, GeneralName):
             raise TypeError("access_location must be a GeneralName")

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -238,11 +238,8 @@ class AuthorityInformationAccess(object):
 
 class AccessDescription(object):
     def __init__(self, access_method, access_location):
-        if not (access_method == AuthorityInformationAccessOID.OCSP or
-                access_method == AuthorityInformationAccessOID.CA_ISSUERS):
-            raise ValueError(
-                "access_method must be OID_OCSP or OID_CA_ISSUERS"
-            )
+        if not isinstance(access_method, ObjectIdentifier):
+          raise TypeError("access_method must be an ObjectIdentifier")
 
         if not isinstance(access_location, GeneralName):
             raise TypeError("access_location must be a GeneralName")

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -18,9 +18,7 @@ from cryptography import utils
 from cryptography.hazmat.primitives import constant_time, serialization
 from cryptography.x509.general_name import GeneralName, IPAddress, OtherName
 from cryptography.x509.name import Name
-from cryptography.x509.oid import (
-    AuthorityInformationAccessOID, ExtensionOID, ObjectIdentifier
-)
+from cryptography.x509.oid import ExtensionOID, ObjectIdentifier
 
 
 class _SubjectPublicKeyInfo(univ.Sequence):

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1293,7 +1293,6 @@ class TestCertificateBuilder(object):
         with pytest.raises(NotImplementedError):
             builder.sign(private_key, hashes.SHA1(), backend)
 
-
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)
     def test_encode_nonstandard_aia(self, backend):
@@ -1323,7 +1322,6 @@ class TestCertificateBuilder(object):
         )
 
         builder.sign(private_key, hashes.SHA256(), backend)
-
 
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1293,6 +1293,38 @@ class TestCertificateBuilder(object):
         with pytest.raises(NotImplementedError):
             builder.sign(private_key, hashes.SHA1(), backend)
 
+
+    @pytest.mark.requires_backend_interface(interface=RSABackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
+    def test_encode_nonstandard_aia(self, backend):
+        private_key = RSA_KEY_2048.private_key(backend)
+
+        aia = x509.AuthorityInformationAccess([
+            x509.AccessDescription(
+                x509.ObjectIdentifier("2.999.7"),
+                x509.UniformResourceIdentifier(u"http://example.com")
+            ),
+        ])
+
+        builder = x509.CertificateBuilder().subject_name(x509.Name([
+            x509.NameAttribute(NameOID.COUNTRY_NAME, u'US'),
+        ])).issuer_name(x509.Name([
+            x509.NameAttribute(NameOID.COUNTRY_NAME, u'US'),
+        ])).public_key(
+            private_key.public_key()
+        ).serial_number(
+            777
+        ).not_valid_before(
+            datetime.datetime(1999, 1, 1)
+        ).not_valid_after(
+            datetime.datetime(2020, 1, 1)
+        ).add_extension(
+            aia, False
+        )
+
+        builder.sign(private_key, hashes.SHA256(), backend)
+
+
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)
     def test_no_subject_name(self, backend):

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1861,7 +1861,8 @@ class TestExtendedKeyUsageExtension(object):
 
 class TestAccessDescription(object):
     def test_invalid_access_method(self):
-        with pytest.raises(ValueError):
+        # access_method can be *any* valid OID
+        with pytest.raises(TypeError):
             x509.AccessDescription("notanoid", x509.DNSName(u"test"))
 
     def test_invalid_access_location(self):

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -18,8 +18,8 @@ from cryptography.hazmat.backends.interfaces import (
 )
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import (
-    AuthorityInformationAccessOID, ExtendedKeyUsageOID,
-    ExtensionOID, NameOID
+    AuthorityInformationAccessOID, ExtendedKeyUsageOID, ExtensionOID,
+    NameOID, ObjectIdentifier
 )
 
 from .hazmat.primitives.test_ec import _skip_curve_unsupported
@@ -1872,7 +1872,10 @@ class TestAccessDescription(object):
             )
 
     def test_valid_nonstandard_method (self):
-        ad = x509.AccessDescription("2.999.1", x509.UniformResourceIdentifier(u"http://example.com"))
+        ad = x509.AccessDescription(
+            ObjectIdentifier("2.999.1"),
+            x509.UniformResourceIdentifier(u"http://example.com")
+        )
         assert ad is not None
 
     def test_repr(self):

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1861,7 +1861,6 @@ class TestExtendedKeyUsageExtension(object):
 
 class TestAccessDescription(object):
     def test_invalid_access_method(self):
-        # access_method can be *any* valid OID
         with pytest.raises(TypeError):
             x509.AccessDescription("notanoid", x509.DNSName(u"test"))
 

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1871,6 +1871,10 @@ class TestAccessDescription(object):
                 AuthorityInformationAccessOID.CA_ISSUERS, "invalid"
             )
 
+    def test_valid_nonstandard_method (self):
+        ad = x509.AccessDescription("2.999.1", x509.UniformResourceIdentifier(u"http://example.com"))
+        assert ad is not None
+
     def test_repr(self):
         ad = x509.AccessDescription(
             AuthorityInformationAccessOID.OCSP,

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1870,7 +1870,7 @@ class TestAccessDescription(object):
                 AuthorityInformationAccessOID.CA_ISSUERS, "invalid"
             )
 
-    def test_valid_nonstandard_method (self):
+    def test_valid_nonstandard_method(self):
         ad = x509.AccessDescription(
             ObjectIdentifier("2.999.1"),
             x509.UniformResourceIdentifier(u"http://example.com")


### PR DESCRIPTION
- Allows for any OID in access_method
- Validates OIDs at creation time
- Cleaned up all tests which used illegal OID values (other than those that should)
- Added a test for arbitrary access_method OIDs