### PR TITLE
Remove SSLv2 bindings.

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -433,6 +433,10 @@ const long SSL_OP_LEGACY_SERVER_CONNECT = 0;
 static const long Cryptography_HAS_SECURE_RENEGOTIATION = 1;
 #endif
 
+/* Cryptography now compiles out all SSLv2 bindings. This exists to allow
+ * clients that use it to check for SSLv2 support to keep functioning as
+ * expected.
+ */
 static const long Cryptography_HAS_SSL2 = 0;
 
 #ifdef OPENSSL_NO_SSL3_METHOD

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -301,15 +301,6 @@ unsigned long SSL_CTX_add_extra_chain_cert(SSL_CTX *, X509 *);
 
 /*  methods */
 
-/* SSLv2 support is compiled out of some versions of OpenSSL.  These will
- * get special support when we generate the bindings so that if they are
- * available they will be wrapped, but if they are not they won't cause
- * problems (like link errors).
- */
-const SSL_METHOD *SSLv2_method(void);
-const SSL_METHOD *SSLv2_server_method(void);
-const SSL_METHOD *SSLv2_client_method(void);
-
 /*
  * TLSv1_1 and TLSv1_2 are recent additions.  Only sufficiently new versions of
  * OpenSSL support them.
@@ -441,14 +432,8 @@ const long SSL_OP_LEGACY_SERVER_CONNECT = 0;
 #else
 static const long Cryptography_HAS_SECURE_RENEGOTIATION = 1;
 #endif
-#ifdef OPENSSL_NO_SSL2
+
 static const long Cryptography_HAS_SSL2 = 0;
-SSL_METHOD* (*SSLv2_method)(void) = NULL;
-SSL_METHOD* (*SSLv2_client_method)(void) = NULL;
-SSL_METHOD* (*SSLv2_server_method)(void) = NULL;
-#else
-static const long Cryptography_HAS_SSL2 = 1;
-#endif
 
 #ifdef OPENSSL_NO_SSL3_METHOD
 static const long Cryptography_HAS_SSL3_METHOD = 0;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -276,12 +276,6 @@ CONDITIONAL_NAMES = {
         "TLSv1_2_client_method",
     ],
 
-    "Cryptography_HAS_SSL2": [
-        "SSLv2_method",
-        "SSLv2_client_method",
-        "SSLv2_server_method",
-    ],
-
     "Cryptography_HAS_SSL3_METHOD": [
         "SSLv3_method",
         "SSLv3_client_method",


### PR DESCRIPTION
Resolves #2527. Not sure how well this will test.

BTW, I left in OP_NO_SSLv2 and OP_MSIE_SSLV2_RSA_PADDING. I did that because compiling out these bindings does not actually remove SSLv2 from OpenSSL, and so it still needs options that control its behaviour (or, you know, to disable it: I bloody hope no-one is setting OP_MSIE_SSLV2_RSA_PADDING).

I'll confirm that PyOpenSSL behaves appropriately under this patch.