### PR TITLE
X509_set_subject_name and X509_set_issuer_name copy the object

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1372,7 +1372,7 @@ class Backend(object):
 
         # Set the subject's name.
         res = self._lib.X509_set_subject_name(
-            x509_cert, _encode_name(self, list(builder._subject_name))
+            x509_cert, _encode_name_gc(self, list(builder._subject_name))
         )
         self.openssl_assert(res == 1)
 
@@ -1423,7 +1423,7 @@ class Backend(object):
 
         # Set the issuer name.
         res = self._lib.X509_set_issuer_name(
-            x509_cert, _encode_name(self, list(builder._issuer_name))
+            x509_cert, _encode_name_gc(self, list(builder._issuer_name))
         )
         self.openssl_assert(res == 1)
 


### PR DESCRIPTION
So we need to register our own copy for gc. This fixes a memory leak reported by Wulf.