### PR TITLE
[WIP] cffi init_once (1.4+) support in the openssl backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ if platform.python_implementation() == "PyPy":
             "upgrade PyPy to use this library."
         )
 else:
-    requirements.append("cffi>=1.1.0")
-    setup_requirements.append("cffi>=1.1.0")
+    requirements.append("cffi>=1.4.0")
+    setup_requirements.append("cffi>=1.4.0")
 
 # If you add a new dep here you probably need to add it in the tox.ini as well
 test_requirements = [

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -9,6 +9,8 @@ import os
 import threading
 import types
 
+import cffi
+
 from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings._openssl import ffi, lib
 from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
@@ -16,6 +18,9 @@ from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
 
 _OpenSSLError = collections.namedtuple("_OpenSSLError",
                                        ["code", "lib", "func", "reason"])
+
+
+_init_once = True if cffi.__version__ >= '1.4.0' else False
 
 
 def _consume_errors(lib):
@@ -82,7 +87,6 @@ class Binding(object):
     _lock_cb_handle = None
     _init_lock = threading.Lock()
     _lock_init_lock = threading.Lock()
-
     _osrandom_engine_id = ffi.new("const char[]", b"osrandom")
     _osrandom_engine_name = ffi.new("const char[]", b"osrandom_engine")
     _osrandom_method = ffi.new(
@@ -95,43 +99,14 @@ class Binding(object):
         self._ensure_ffi_initialized()
 
     @classmethod
-    def _register_osrandom_engine(cls):
-        _openssl_assert(cls.lib, cls.lib.ERR_peek_error() == 0)
-
-        engine = cls.lib.ENGINE_new()
-        _openssl_assert(cls.lib, engine != cls.ffi.NULL)
-        try:
-            result = cls.lib.ENGINE_set_id(engine, cls._osrandom_engine_id)
-            _openssl_assert(cls.lib, result == 1)
-            result = cls.lib.ENGINE_set_name(engine, cls._osrandom_engine_name)
-            _openssl_assert(cls.lib, result == 1)
-            result = cls.lib.ENGINE_set_RAND(engine, cls._osrandom_method)
-            _openssl_assert(cls.lib, result == 1)
-            result = cls.lib.ENGINE_add(engine)
-            if result != 1:
-                errors = _consume_errors(cls.lib)
-                _openssl_assert(
-                    cls.lib,
-                    errors[0].reason == cls.lib.ENGINE_R_CONFLICTING_ENGINE_ID
-                )
-
-        finally:
-            result = cls.lib.ENGINE_free(engine)
-            _openssl_assert(cls.lib, result == 1)
-
-    @classmethod
     def _ensure_ffi_initialized(cls):
         with cls._init_lock:
             if not cls._lib_loaded:
+                if not _init_once:
+                    _init_openssl()
+
                 cls.lib = build_conditional_library(lib, CONDITIONAL_NAMES)
                 cls._lib_loaded = True
-                # initialize the SSL library
-                cls.lib.SSL_library_init()
-                # adds all ciphers/digests for EVP
-                cls.lib.OpenSSL_add_all_algorithms()
-                # loads error strings for libcrypto and libssl functions
-                cls.lib.SSL_load_error_strings()
-                cls._register_osrandom_engine()
 
     @classmethod
     def init_static_locks(cls):
@@ -174,9 +149,50 @@ class Binding(object):
             )
 
 
-# OpenSSL is not thread safe until the locks are initialized. We call this
-# method in module scope so that it executes with the import lock. On
-# Pythons < 3.4 this import lock is a global lock, which can prevent a race
-# condition registering the OpenSSL locks. On Python 3.4+ the import lock
-# is per module so this approach will not work.
-Binding.init_static_locks()
+def _init_openssl():
+    # initialize the SSL library
+    lib.SSL_library_init()
+    # adds all ciphers/digests for EVP
+    lib.OpenSSL_add_all_algorithms()
+    # loads error strings for libcrypto and libssl functions
+    lib.SSL_load_error_strings()
+    _openssl_assert(lib, lib.ERR_peek_error() == 0)
+
+    engine = lib.ENGINE_new()
+    _openssl_assert(lib, engine != ffi.NULL)
+    try:
+        result = lib.ENGINE_set_id(engine, Binding._osrandom_engine_id)
+        _openssl_assert(lib, result == 1)
+        result = lib.ENGINE_set_name(engine, Binding._osrandom_engine_name)
+        _openssl_assert(lib, result == 1)
+        result = lib.ENGINE_set_RAND(engine, Binding._osrandom_method)
+        _openssl_assert(lib, result == 1)
+        result = lib.ENGINE_add(engine)
+        if result != 1:
+            errors = _consume_errors(lib)
+            _openssl_assert(
+                lib,
+                errors[0].reason == lib.ENGINE_R_CONFLICTING_ENGINE_ID
+            )
+
+    finally:
+        result = lib.ENGINE_free(engine)
+        _openssl_assert(lib, result == 1)
+
+
+# cffi 1.4+ has a new feature where we can guarantee a call only occurs once.
+# This is exactly what we want for initializing the OpenSSL library + adding
+# the osrandom engine since that is a shared global. However, we don't want
+# to reprise the cffi 1.0 transition where we broke PyPy < 2.6, so for now
+# we'll support both initialization methods. PyPy 4.1 should add init_once and
+# we can eventually require that as a minimum version.
+if _init_once:
+    ffi.init_once(_init_openssl, "init_openssl")
+    ffi.init_once(Binding.init_static_locks, "init_locks")
+else:
+    # OpenSSL is not thread safe until the locks are initialized. We call this
+    # method in module scope so that it executes with the import lock. On
+    # Pythons < 3.4 this import lock is a global lock, which can prevent a race
+    # condition registering the OpenSSL locks. On Python 3.4+ the import lock
+    # is per module so this approach will not work.
+    Binding.init_static_locks()

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from cryptography.hazmat.bindings.openssl.binding import _init_openssl, Binding
+from cryptography.hazmat.bindings.openssl.binding import Binding, _init_openssl
 
 
 class TestOpenSSL(object):

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from cryptography.hazmat.bindings.openssl.binding import Binding
+from cryptography.hazmat.bindings.openssl.binding import _init_openssl, Binding
 
 
 class TestOpenSSL(object):
@@ -87,9 +87,9 @@ class TestOpenSSL(object):
         assert lock.acquire(False)
         lock.release()
 
-    def test_add_engine_more_than_once(self):
+    def test_init_more_than_once(self):
         b = Binding()
-        b._register_osrandom_engine()
+        _init_openssl()
         assert b.lib.ERR_get_error() == 0
 
     def test_ssl_ctx_options(self):


### PR DESCRIPTION
cffi added `init_once` support in version 1.4. This can alleviate a race for us around the registration of the osrandom engine, but since we don't want to bump our PyPy minimum version beyond 2.6 we need to support both code paths. I am far from confident that the current PR represents the right approach, but it should serve as a starting point to figure out what we want to do.