### PR TITLE
support parsing CRL extensions in the OpenSSL backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Changelog
 * Support serialization of certificate revocation lists using the
   :meth:`~cryptography.x509.CertificateRevocationList.public_bytes` method of
   :class:`~cryptography.x509.CertificateRevocationList`.
+* Add support for parsing :class:`~cryptography.x509.CertificateRevocationList`
+  :meth:`~cryptography.x509.CertificateRevocationList.extensions` in the
+  OpenSSL backend.
 
 1.1.2 - 2015-12-10
 ~~~~~~~~~~~~~~~~~~

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -2097,6 +2097,12 @@ instances. The following common OIDs are available as constants.
         identifier for the :class:`~cryptography.x509.OCSPNoCheck` extension
         type.
 
+    .. attribute:: CRL_NUMBER
+
+        Corresponds to the dotted string ``"2.5.29.20"``. The identifier for
+        the ``CRLNumber`` extension type. This extension only has meaning
+        for certificate revocation lists.
+
 Exceptions
 ~~~~~~~~~~
 .. currentmodule:: cryptography.x509

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -85,6 +85,7 @@ class ExtensionOID(object):
     AUTHORITY_INFORMATION_ACCESS = ObjectIdentifier("1.3.6.1.5.5.7.1.1")
     SUBJECT_INFORMATION_ACCESS = ObjectIdentifier("1.3.6.1.5.5.7.1.11")
     OCSP_NO_CHECK = ObjectIdentifier("1.3.6.1.5.5.7.48.1.5")
+    CRL_NUMBER = ObjectIdentifier("2.5.29.20")
 
 
 class CRLExtensionOID(object):
@@ -234,6 +235,7 @@ _OID_NAMES = {
     ExtensionOID.AUTHORITY_INFORMATION_ACCESS: "authorityInfoAccess",
     ExtensionOID.SUBJECT_INFORMATION_ACCESS: "subjectInfoAccess",
     ExtensionOID.OCSP_NO_CHECK: "OCSPNoCheck",
+    ExtensionOID.CRL_NUMBER: "CRLNumber",
     AuthorityInformationAccessOID.OCSP: "OCSP",
     AuthorityInformationAccessOID.CA_ISSUERS: "caIssuers",
     CertificatePoliciesOID.CPS_QUALIFIER: "id-qt-cps",

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -235,7 +235,7 @@ _OID_NAMES = {
     ExtensionOID.AUTHORITY_INFORMATION_ACCESS: "authorityInfoAccess",
     ExtensionOID.SUBJECT_INFORMATION_ACCESS: "subjectInfoAccess",
     ExtensionOID.OCSP_NO_CHECK: "OCSPNoCheck",
-    ExtensionOID.CRL_NUMBER: "CRLNumber",
+    ExtensionOID.CRL_NUMBER: "cRLNumber",
     AuthorityInformationAccessOID.OCSP: "OCSP",
     AuthorityInformationAccessOID.CA_ISSUERS: "caIssuers",
     CertificatePoliciesOID.CPS_QUALIFIER: "id-qt-cps",

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -175,14 +175,26 @@ class TestCertificateRevocationList(object):
 
     def test_extensions(self, backend):
         crl = _load_cert(
-            os.path.join("x509", "custom", "crl_all_reasons.pem"),
-            x509.load_pem_x509_crl,
+            os.path.join("x509", "PKITS_data", "crls", "GoodCACRL.crl"),
+            x509.load_der_x509_crl,
             backend
         )
 
-        # CRL extensions are currently not supported in the OpenSSL backend.
-        with pytest.raises(NotImplementedError):
-            crl.extensions
+        crl_number = crl.extensions.get_extension_for_oid(
+            ExtensionOID.CRL_NUMBER
+        )
+        aki = crl.extensions.get_extension_for_class(
+            x509.AuthorityKeyIdentifier
+        )
+        assert crl_number.value == 1
+        assert crl_number.critical is False
+        assert aki.value == x509.AuthorityKeyIdentifier(
+            key_identifier=(
+                b'X\x01\x84$\x1b\xbc+R\x94J=\xa5\x10r\x14Q\xf5\xaf:\xc9'
+            ),
+            authority_cert_issuer=None,
+            authority_cert_serial_number=None
+        )
 
     def test_signature(self, backend):
         crl = _load_cert(


### PR DESCRIPTION
Unrecognized non-critical extensions will be ignored (the same as our current cert/csr parsing). Supporting arbitrary extensions more robustly is filed as #2288.

Fixes #2539 