### PR TITLE
remove all mac 0.9.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,18 +108,6 @@ matrix:
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=0
         - language: generic
           os: osx
-          osx_image: xcode7
-          env: TOXENV=py26 OPENSSL=0.9.8
-        - language: generic
-          os: osx
-          osx_image: xcode7
-          env: TOXENV=py27 OPENSSL=0.9.8
-        - language: generic
-          os: osx
-          osx_image: xcode7
-          env: TOXENV=pypy OPENSSL=0.9.8
-        - language: generic
-          os: osx
           osx_image: osx10.11
           env: TOXENV=py26 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
@@ -129,7 +117,7 @@ matrix:
         - language: generic
           os: osx
           osx_image: xcode7
-          env: TOXENV=docs
+          env: TOXENV=docs CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
 
 install:
     - ./.travis/install.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -6,9 +6,7 @@ set -x
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew update || brew update
 
-    if [[ "${OPENSSL}" != "0.9.8" ]]; then
-        brew outdated openssl || brew upgrade openssl
-    fi
+    brew outdated openssl || brew upgrade openssl
 
     # install pyenv
     git clone https://github.com/yyuu/pyenv.git ~/.pyenv

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -9,22 +9,14 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
 
-    if [[ "${OPENSSL}" != "0.9.8" ]]; then
-        # set our flags to use homebrew openssl
-        export ARCHFLAGS="-arch x86_64"
-        # if the build is static we need different LDFLAGS
-        if [[ "${CRYPTOGRAPHY_OSX_NO_LINK_FLAGS}" == "1" ]]; then
-            export LDFLAGS="/usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a"
-        else
-            export LDFLAGS="-L/usr/local/opt/openssl/lib"
-        fi
-        export CFLAGS="-I/usr/local/opt/openssl/include"
-        # The Travis OS X jobs are run for two versions
-        # of OpenSSL, but we only need to run the
-        # CommonCrypto backend tests once. Exclude
-        # CommonCrypto when we test against brew OpenSSL
-        export TOX_FLAGS="--backend=openssl"
+    # set our flags to use homebrew openssl
+    # if the build is static we need different LDFLAGS
+    if [[ "${CRYPTOGRAPHY_OSX_NO_LINK_FLAGS}" == "1" ]]; then
+        export LDFLAGS="/usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a"
+    else
+        export LDFLAGS="-L/usr/local/opt/openssl/lib"
     fi
+    export CFLAGS="-I/usr/local/opt/openssl/include"
 else
     if [[ "${TOXENV}" == "pypy" ]]; then
         PYENV_ROOT="$HOME/.pyenv"

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,7 +26,6 @@ OpenSSL releases:
 
 * ``OpenSSL 0.9.8e-fips-rhel5`` (``RHEL/CentOS 5``)
 * ``OpenSSL 0.9.8k``
-* ``OpenSSL 0.9.8-latest`` (The most recent 0.9.8 release)
 * ``OpenSSL 1.0.0-fips`` (``RHEL/CentOS 6.4``)
 * ``OpenSSL 1.0.1``
 * ``OpenSSL 1.0.1e-fips`` (``RHEL/CentOS 7``)
@@ -194,6 +193,7 @@ This will install a compiler (clang) along with (most of) the required
 development headers.
 
 You'll also need OpenSSL, which you can obtain from `Homebrew`_ or `MacPorts`_.
+Cryptography does **not** support Apple's deprecated OpenSSL distribution.
 
 To build cryptography and dynamically link it:
 


### PR DESCRIPTION
This will probably slow down the test infrastructure as we're running far more CommonCrypto tests than before. We should figure out what to do there before merging this.

Fixes #2544 