### PR TITLE
Add binding for CommonCrypto SecTrustCopyAnchorCertificates

### DIFF
--- a/src/_cffi_src/build_commoncrypto.py
+++ b/src/_cffi_src/build_commoncrypto.py
@@ -22,6 +22,7 @@ ffi = build_ffi_for_binding(
         "seckey",
         "seckeychain",
         "sectransform",
+        "sectrust",
     ],
     extra_link_args=[
         "-framework", "Security", "-framework", "CoreFoundation"

--- a/src/_cffi_src/commoncrypto/sectrust.py
+++ b/src/_cffi_src/commoncrypto/sectrust.py
@@ -12,7 +12,7 @@ TYPES = """
 """
 
 FUNCTIONS = """
-OSStatus SecTrustCopyAnchorCertificates ( CFArrayRef *anchors );
+OSStatus SecTrustCopyAnchorCertificates(CFArrayRef *);
 """
 
 MACROS = """

--- a/src/_cffi_src/commoncrypto/sectrust.py
+++ b/src/_cffi_src/commoncrypto/sectrust.py
@@ -1,0 +1,22 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+INCLUDES = """
+#include <Security/SecTrust.h>
+"""
+
+TYPES = """
+"""
+
+FUNCTIONS = """
+OSStatus SecTrustCopyAnchorCertificates ( CFArrayRef *anchors );
+"""
+
+MACROS = """
+"""
+
+CUSTOMIZATIONS = """
+"""


### PR DESCRIPTION
I'm going to use this for building my OS X to OpenSSL trust store conversion tool. This was the only binding we appeared to be missing.