### PR TITLE
Add PEM_write_bio_DHparams binding

### DIFF
--- a/src/_cffi_src/openssl/pem.py
+++ b/src/_cffi_src/openssl/pem.py
@@ -79,6 +79,7 @@ MACROS = """
 int PEM_write_bio_ECPrivateKey(BIO *, EC_KEY *, const EVP_CIPHER *,
                                unsigned char *, int, pem_password_cb *,
                                void *);
+int PEM_write_bio_DHparams(BIO *, DH *);
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
This pull request simply add PEM_write_bio_DHparams binding.

Adding this binding would be really valuable in order to make possible to generate DH parameters from the application and save them on a the filesystem using the PEM format.