### PR TITLE
add create_x509_crl interface

### DIFF
--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -570,6 +570,26 @@ A specific ``backend`` may provide one or more of these interfaces.
         :returns: A new object with the
             :class:`~cryptography.x509.Certificate` interface.
 
+    .. method:: create_x509_crl(builder, private_key, algorithm)
+
+        .. versionadded:: 1.2
+
+        :param builder: An instance of
+            CertificateRevocationListBuilder.
+
+        :param private_key: The
+            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`,
+            :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey` or
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKey`
+            that will be used to sign the CRL.
+
+        :param algorithm: The
+            :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+            that will be used to generate the CRL signature.
+
+        :returns: A new object with the
+            :class:`~cryptography.x509.CertificateRevocationList` interface.
+
 
 .. class:: DHBackend
 

--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -587,8 +587,8 @@ A specific ``backend`` may provide one or more of these interfaces.
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
             that will be used to generate the CRL signature.
 
-        :returns: A new object with the
-            :class:`~cryptography.x509.CertificateRevocationList` interface.
+        :returns: A new instance of
+            :class:`~cryptography.x509.CertificateRevocationList`.
 
 
 .. class:: DHBackend

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -292,6 +292,13 @@ class X509Backend(object):
         Create and sign an X.509 certificate from a CertificateBuilder object.
         """
 
+    @abc.abstractmethod
+    def create_x509_crl(self, builder, private_key, algorithm):
+        """
+        Create and sign an X.509 CertificateRevocationList from a
+        CertificateRevocationListBuilder object.
+        """
+
 
 @six.add_metaclass(abc.ABCMeta)
 class DHBackend(object):

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -384,3 +384,12 @@ class MultiBackend(object):
             "This backend does not support X.509.",
             _Reasons.UNSUPPORTED_X509
         )
+
+    def create_x509_crl(self, builder, private_key, algorithm):
+        for b in self._filtered_backends(X509Backend):
+            return b.create_x509_crl(builder, private_key, algorithm)
+
+        raise UnsupportedAlgorithm(
+            "This backend does not support X.509.",
+            _Reasons.UNSUPPORTED_X509
+        )

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1455,6 +1455,9 @@ class Backend(object):
 
         return _Certificate(self, x509_cert)
 
+    def create_x509_crl(self, builder, private_key, algorithm):
+        pass
+
     def load_pem_private_key(self, data, password):
         return self._load_key(
             self._lib.PEM_read_bio_PrivateKey,

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1456,7 +1456,7 @@ class Backend(object):
         return _Certificate(self, x509_cert)
 
     def create_x509_crl(self, builder, private_key, algorithm):
-        pass
+        raise NotImplementedError
 
     def load_pem_private_key(self, data, password):
         return self._load_key(

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -218,6 +218,9 @@ class DummyX509Backend(object):
     def create_x509_certificate(self, builder, private_key, algorithm):
         pass
 
+    def create_x509_crl(self, builder, private_key, algorithm):
+        pass
+
 
 class TestMultiBackend(object):
     def test_ciphers(self):
@@ -514,6 +517,7 @@ class TestMultiBackend(object):
         backend.load_der_x509_csr(b"reqdata")
         backend.create_x509_csr(object(), b"privatekey", hashes.SHA1())
         backend.create_x509_certificate(object(), b"privatekey", hashes.SHA1())
+        backend.create_x509_crl(object(), b"privatekey", hashes.SHA1())
 
         backend = MultiBackend([])
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
@@ -532,5 +536,9 @@ class TestMultiBackend(object):
             backend.create_x509_csr(object(), b"privatekey", hashes.SHA1())
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
             backend.create_x509_certificate(
+                object(), b"privatekey", hashes.SHA1()
+            )
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
+            backend.create_x509_crl(
                 object(), b"privatekey", hashes.SHA1()
             )

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -501,6 +501,11 @@ class TestOpenSSLSignX509Certificate(object):
             backend.create_x509_certificate(object(), private_key, DummyHash())
 
 
+def test_crl_creation_not_implemented():
+    with pytest.raises(NotImplementedError):
+        backend.create_x509_crl("", "", "")
+
+
 class TestOpenSSLSerialisationWithOpenSSL(object):
     def test_pem_password_cb_buffer_too_small(self):
         ffi_cb, userdata = backend._pem_password_cb(b"aa")


### PR DESCRIPTION
Since we enforce interfaces we need a dummy implementation in the OpenSSL backend to make this possible. Implementation remains in #2559.