### PR TITLE
add create_x509_revoked_certificate to x509backend interface

### DIFF
--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -589,6 +589,15 @@ A specific ``backend`` may provide one or more of these interfaces.
         :returns: A new instance of
             :class:`~cryptography.x509.CertificateRevocationList`.
 
+    .. method:: create_x509_revoked_certificate(builder)
+
+        .. versionadded:: 1.2
+
+        :param builder: An instance of RevokedCertificateBuilder.
+
+        :returns: A new instance of
+            :class:`~cryptography.x509.RevokedCertificate`.
+
 .. class:: DHBackend
 
     .. versionadded:: 0.9

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -299,6 +299,13 @@ class X509Backend(object):
         CertificateRevocationListBuilder object.
         """
 
+    @abc.abstractmethod
+    def create_x509_revoked_certificate(self, builder):
+        """
+        Create a RevokedCertificate object from a RevokedCertificateBuilder
+        object.
+        """
+
 
 @six.add_metaclass(abc.ABCMeta)
 class DHBackend(object):

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -393,3 +393,12 @@ class MultiBackend(object):
             "This backend does not support X.509.",
             _Reasons.UNSUPPORTED_X509
         )
+
+    def create_x509_revoked_certificate(self, builder):
+        for b in self._filtered_backends(X509Backend):
+            return b.create_x509_revoked_certificate(builder)
+
+        raise UnsupportedAlgorithm(
+            "This backend does not support X.509.",
+            _Reasons.UNSUPPORTED_X509
+        )

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1558,6 +1558,9 @@ class Backend(object):
             res = add_func(x509_obj, x509_extension, i)
             self.openssl_assert(res >= 1)
 
+    def create_x509_revoked_certificate(self, builder):
+        raise NotImplementedError("Not yet implemented")
+
     def load_pem_private_key(self, data, password):
         return self._load_key(
             self._lib.PEM_read_bio_PrivateKey,

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -221,6 +221,9 @@ class DummyX509Backend(object):
     def create_x509_crl(self, builder, private_key, algorithm):
         pass
 
+    def create_x509_revoked_certificate(self, builder):
+        pass
+
 
 class TestMultiBackend(object):
     def test_ciphers(self):
@@ -518,6 +521,7 @@ class TestMultiBackend(object):
         backend.create_x509_csr(object(), b"privatekey", hashes.SHA1())
         backend.create_x509_certificate(object(), b"privatekey", hashes.SHA1())
         backend.create_x509_crl(object(), b"privatekey", hashes.SHA1())
+        backend.create_x509_revoked_certificate(object())
 
         backend = MultiBackend([])
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
@@ -542,3 +546,5 @@ class TestMultiBackend(object):
             backend.create_x509_crl(
                 object(), b"privatekey", hashes.SHA1()
             )
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_X509):
+            backend.create_x509_revoked_certificate(object())

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -509,6 +509,12 @@ class TestOpenSSLSignX509CertificateRevocationList(object):
             backend.create_x509_crl(object(), private_key, hashes.SHA256())
 
 
+class TestOpenSSLCreateRevokedCertificate(object):
+    def test_not_yet_implemented(self):
+        with pytest.raises(NotImplementedError):
+            backend.create_x509_revoked_certificate(object())
+
+
 class TestOpenSSLSerializationWithOpenSSL(object):
     def test_pem_password_cb_buffer_too_small(self):
         ffi_cb, userdata = backend._pem_password_cb(b"aa")


### PR DESCRIPTION
refs #2533

This will be used in the upcoming `RevokedCertificateBuilder` PR.