### PR TITLE
remove deprecated methods

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/utils.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/utils.py
@@ -4,15 +4,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-import warnings
-
 from pyasn1.codec.der import decoder, encoder
 from pyasn1.error import PyAsn1Error
 from pyasn1.type import namedtype, univ
 
 import six
-
-from cryptography import utils
 
 
 class _DSSSigValue(univ.Sequence):
@@ -20,17 +16,6 @@ class _DSSSigValue(univ.Sequence):
         namedtype.NamedType('r', univ.Integer()),
         namedtype.NamedType('s', univ.Integer())
     )
-
-
-def decode_rfc6979_signature(signature):
-    warnings.warn(
-        "decode_rfc6979_signature is deprecated and will "
-        "be removed in a future version, use decode_dss_signature instead "
-        "instead.",
-        utils.DeprecatedIn10,
-        stacklevel=2
-    )
-    return decode_dss_signature(signature)
 
 
 def decode_dss_signature(signature):
@@ -47,17 +32,6 @@ def decode_dss_signature(signature):
     r = int(data.getComponentByName('r'))
     s = int(data.getComponentByName('s'))
     return (r, s)
-
-
-def encode_rfc6979_signature(r, s):
-    warnings.warn(
-        "encode_rfc6979_signature is deprecated and will "
-        "be removed in a future version, use encode_dss_signature instead "
-        "instead.",
-        utils.DeprecatedIn10,
-        stacklevel=2
-    )
-    return encode_dss_signature(r, s)
 
 
 def encode_dss_signature(r, s):

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -12,9 +12,6 @@ import sys
 import warnings
 
 
-DeprecatedIn10 = DeprecationWarning
-
-
 def read_only_property(name):
     return property(lambda self: getattr(self, name))
 

--- a/tests/hazmat/primitives/test_asym_utils.py
+++ b/tests/hazmat/primitives/test_asym_utils.py
@@ -7,16 +7,8 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 from cryptography.hazmat.primitives.asymmetric.utils import (
-    decode_dss_signature, decode_rfc6979_signature,
-    encode_dss_signature, encode_rfc6979_signature
+    decode_dss_signature, encode_dss_signature
 )
-
-
-def test_deprecated_rfc6979_signature():
-    sig = pytest.deprecated_call(encode_rfc6979_signature, 1, 1)
-    assert sig == b"0\x06\x02\x01\x01\x02\x01\x01"
-    decoded = pytest.deprecated_call(decode_rfc6979_signature, sig)
-    assert decoded == (1, 1)
 
 
 def test_dss_signature():


### PR DESCRIPTION
We forgot to do this when we started the twelfth release.