### PR TITLE
Fixed #2605 -- require setuptools 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = [
     "idna>=2.0",
     "pyasn1>=0.1.8",
     "six>=1.4.1",
-    "setuptools",
+    "setuptools>=1.0",
 ]
 setup_requirements = []
 


### PR DESCRIPTION
Per @dstufft:

- 0.6.28 or something around there that supports wheels
- 0.7 is the version that introduced marker support in setuptools
- 1.0 is the version where setuptools started using and verifying tls