### PR TITLE
deprecationwarning for OpenSSL < 1.0.1 as upstream has dropped support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Changelog
   * :class:`~cryptography.x509.CertificateIssuer`
   * :class:`~cryptography.x509.CRLReason`
   * :class:`~cryptography.x509.InvalidityDate`
+* Deprecated support for OpenSSL 0.9.8 and 1.0.0. At this time there is no time
+  table for actually dropping support, however we strongly encourage all users
+  to upgrade, as those versions no longer receives support from the OpenSSL
+  project.
 * The :class:`~cryptography.x509.Certificate` class now has
   :attr:`~cryptography.x509.Certificate.signature` and
   :attr:`~cryptography.x509.Certificate.tbs_certificate_bytes` attributes.

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -8,6 +8,7 @@ import collections
 import os
 import threading
 import types
+import warnings
 
 from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings._openssl import ffi, lib
@@ -180,3 +181,11 @@ class Binding(object):
 # condition registering the OpenSSL locks. On Python 3.4+ the import lock
 # is per module so this approach will not work.
 Binding.init_static_locks()
+
+if Binding.lib.SSLeay() < 0x10001000:
+    warnings.warn(
+        "OpenSSL versions less than 1.0.1 are no longer supported by the "
+        "OpenSSL project, please upgrade. A future version of cryptography "
+        "will drop support for these versions.",
+        DeprecationWarning
+    )


### PR DESCRIPTION
fixes #2510 