### PR TITLE
don't add the NXCOMPAT and DYNAMICBASE flags if the compiler isn't msvc

### DIFF
--- a/src/_cffi_src/build_constant_time.py
+++ b/src/_cffi_src/build_constant_time.py
@@ -5,9 +5,8 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import sys
 
-from _cffi_src.utils import build_ffi, extra_link_args
+from _cffi_src.utils import build_ffi, compiler_type, extra_link_args
 
 
 with open(os.path.join(
@@ -24,5 +23,5 @@ ffi = build_ffi(
     module_name="_constant_time",
     cdef_source=types,
     verify_source=functions,
-    extra_link_args=extra_link_args(sys.platform),
+    extra_link_args=extra_link_args(compiler_type()),
 )

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -7,7 +7,9 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
-from _cffi_src.utils import build_ffi_for_binding, extra_link_args
+from _cffi_src.utils import (
+    build_ffi_for_binding, compiler_type, extra_link_args
+)
 
 
 def _get_openssl_libraries(platform):
@@ -92,5 +94,5 @@ ffi = build_ffi_for_binding(
     pre_include=_OSX_PRE_INCLUDE,
     post_include=_OSX_POST_INCLUDE,
     libraries=_get_openssl_libraries(sys.platform),
-    extra_link_args=extra_link_args(sys.platform),
+    extra_link_args=extra_link_args(compiler_type()),
 )

--- a/src/_cffi_src/build_padding.py
+++ b/src/_cffi_src/build_padding.py
@@ -5,9 +5,8 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import sys
 
-from _cffi_src.utils import build_ffi, extra_link_args
+from _cffi_src.utils import build_ffi, compiler_type, extra_link_args
 
 
 with open(os.path.join(
@@ -24,5 +23,5 @@ ffi = build_ffi(
     module_name="_padding",
     cdef_source=types,
     verify_source=functions,
-    extra_link_args=extra_link_args(sys.platform),
+    extra_link_args=extra_link_args(compiler_type()),
 )


### PR DESCRIPTION
fixes #2339 

I'm not a fan of this distutils code, but evidently it's the best we can do. And it'd be nice to not break mingw users.