### PR TITLE
refactor travis custom openssl code to work with other versions

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -69,7 +69,7 @@ else
         OPENSSL_DIR="ossl-098l"
     fi
     # download, compile, and install if it's not already present via travis cache
-    if [ ! -z "$OPENSSL_DIR" ]; then
+    if [ -n "$OPENSSL_DIR" ]; then
         if [[ ! -f "$HOME/$OPENSSL_DIR/bin/openssl" ]]; then
             curl -O https://www.openssl.org/source/openssl-$OPENSSL_VERSION_NUMBER.tar.gz
             tar zxf openssl-$OPENSSL_VERSION_NUMBER.tar.gz

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -62,26 +62,22 @@ else
         pyenv global pypy-4.0.1
     fi
     if [[ "${OPENSSL}" == "0.9.8" ]]; then
-      # download, compile, and install if it's not already present via travis cache
-      # This is 0.9.8l rather than zh because we have some branches for handling
-      # < 0.9.8m that won't be exercised with a newer OpenSSL. (RHEL5 is 0.9.8e with
-      # patches, but while that's in jenkins we don't get coverage data from it)
-      if [[ ! -f "$HOME/ossl-098l/bin/openssl" ]]; then
-        curl -O https://www.openssl.org/source/openssl-0.9.8l.tar.gz
-        tar zxf openssl-0.9.8l.tar.gz
-        cd openssl-0.9.8l
-        echo "OPENSSL_0.9.8L_CUSTOM {
-            global:
-              *;
-        };" > openssl.ld
-        ./config no-asm no-ssl2 -Wl,--version-script=openssl.ld -Wl,-Bsymbolic-functions -fPIC shared --prefix=$HOME/ossl-098l
-        make depend
-        make install
-      fi
-      export PATH="$HOME/ossl-098l/bin:$PATH"
-      export CFLAGS="-I$HOME/ossl-098l/include"
-      export LDFLAGS="-L$HOME/ossl-098l/lib"
-      export LD_LIBRARY_PATH="$HOME/ossl-098l/lib"
+        # We use 0.9.8l rather than zh because we have some branches for handling
+        # < 0.9.8m that won't be exercised with a newer OpenSSL. (RHEL5 is 0.9.8e with
+        # patches, but while that's in jenkins we don't get coverage data from it).
+        OPENSSL_VERSION_NUMBER="0.9.8l"
+        OPENSSL_DIR="ossl-098l"
+    fi
+    # download, compile, and install if it's not already present via travis cache
+    if [ ! -z "$OPENSSL_DIR" ]; then
+        if [[ ! -f "$HOME/$OPENSSL_DIR/bin/openssl" ]]; then
+            curl -O https://www.openssl.org/source/openssl-$OPENSSL_VERSION_NUMBER.tar.gz
+            tar zxf openssl-$OPENSSL_VERSION_NUMBER.tar.gz
+            cd openssl-$OPENSSL_VERSION_NUMBER
+            ./config shared no-asm no-ssl2 -fPIC --prefix=$HOME/$OPENSSL_DIR
+            make depend
+            make install
+        fi
     fi
     pip install virtualenv
 fi

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -24,10 +24,14 @@ else
         eval "$(pyenv init -)"
     fi
     if [[ "${OPENSSL}" == "0.9.8" ]]; then
-      export PATH="$HOME/ossl-098l/bin:$PATH"
-      export CFLAGS="-I$HOME/ossl-098l/include"
-      export LDFLAGS="-L$HOME/ossl-098l/lib"
-      export LD_LIBRARY_PATH="$HOME/ossl-098l/lib"
+        OPENSSL_DIR="ossl-098l"
+    fi
+
+    if [ ! -z "$OPENSSL_DIR" ]; then
+        export PATH="$HOME/$OPENSSL_DIR/bin:$PATH"
+        export CFLAGS="-I$HOME/$OPENSSL_DIR/include"
+        # rpath on linux will cause it to use an absolute path so we don't need to do LD_LIBRARY_PATH
+        export LDFLAGS="-L$HOME/$OPENSSL_DIR/lib -Wl,-rpath=$HOME/$OPENSSL_DIR/lib"
     fi
 fi
 source ~/.venv/bin/activate

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -27,7 +27,7 @@ else
         OPENSSL_DIR="ossl-098l"
     fi
 
-    if [ ! -z "$OPENSSL_DIR" ]; then
+    if [ -n "$OPENSSL_DIR" ]; then
         export PATH="$HOME/$OPENSSL_DIR/bin:$PATH"
         export CFLAGS="-I$HOME/$OPENSSL_DIR/include"
         # rpath on linux will cause it to use an absolute path so we don't need to do LD_LIBRARY_PATH


### PR DESCRIPTION
extracted from #2625 so it can be reviewed separately.

The big change here is modifying the SHLIB versioning and using rpath. Ensuring that the SHLIB is not the same as the version installed by the operating system (which is 1.0.0 for versions 1.0.0, 1.0.1, and 1.0.2 of OpenSSL) allows the dynamic linker to easily distinguish between the two versions. rpath then allows us to embed information on where the library we want to load is located so we don't have to interpose via LD_LIBRARY_PATH.

I tried using rpath alone, but it appears that even with LDFLAGS and CFLAGS if the SHLIB version is the same as what's available in /lib/x86_64-linux-gnu then it links that instead of what's in our custom dir.