### PR TITLE
sed the openssl makefile to change the shlib version

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -75,10 +75,11 @@ else
             tar zxf openssl-$OPENSSL_VERSION_NUMBER.tar.gz
             cd openssl-$OPENSSL_VERSION_NUMBER
             ./config shared no-asm no-ssl2 -fPIC --prefix="$HOME/$OPENSSL_DIR"
-            # modify the shlib version to a unique one to make sure it doesn't load the system one.
+            # modify the shlib version to a unique one to make sure the dynamic linker
+            # doesn't load the system one.
             sed -i "s/^SHLIB_MAJOR=.*/SHLIB_MAJOR=100/" Makefile
-            sed -i "s/^SHLIB_MINOR=.*/SHLIB_MINOR=0\.0/" Makefile
-            sed -i "s/^SHLIB_VERSION_NUMBER=.*/SHLIB_VERSION_NUMBER=100\.0\.0/" Makefile
+            sed -i "s/^SHLIB_MINOR=.*/SHLIB_MINOR=0.0/" Makefile
+            sed -i "s/^SHLIB_VERSION_NUMBER=.*/SHLIB_VERSION_NUMBER=100.0.0/" Makefile
             make depend
             make install
         fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -75,6 +75,10 @@ else
             tar zxf openssl-$OPENSSL_VERSION_NUMBER.tar.gz
             cd openssl-$OPENSSL_VERSION_NUMBER
             ./config shared no-asm no-ssl2 -fPIC --prefix="$HOME/$OPENSSL_DIR"
+            # modify the shlib version to a unique one to make sure it doesn't load the system one.
+            sed -i "s/^SHLIB_MAJOR=[0-9]/SHLIB_MAJOR=100/" Makefile
+            sed -i "s/^SHLIB_MINOR=[0-9].[0-9]/SHLIB_MINOR=0.0/" Makefile
+            sed -i "s/^SHLIB_VERSION_NUMBER=[0-9].[0-9].[0-9]/SHLIB_VERSION_NUMBER=100.0.0/" Makefile
             make depend
             make install
         fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -76,9 +76,9 @@ else
             cd openssl-$OPENSSL_VERSION_NUMBER
             ./config shared no-asm no-ssl2 -fPIC --prefix="$HOME/$OPENSSL_DIR"
             # modify the shlib version to a unique one to make sure it doesn't load the system one.
-            sed -i "s/^SHLIB_MAJOR=[0-9]/SHLIB_MAJOR=100/" Makefile
-            sed -i "s/^SHLIB_MINOR=[0-9].[0-9]/SHLIB_MINOR=0.0/" Makefile
-            sed -i "s/^SHLIB_VERSION_NUMBER=[0-9].[0-9].[0-9]/SHLIB_VERSION_NUMBER=100.0.0/" Makefile
+            sed -i "s/^SHLIB_MAJOR=.*/SHLIB_MAJOR=100/" Makefile
+            sed -i "s/^SHLIB_MINOR=.*/SHLIB_MINOR=0\.0/" Makefile
+            sed -i "s/^SHLIB_VERSION_NUMBER=.*/SHLIB_VERSION_NUMBER=100\.0\.0/" Makefile
             make depend
             make install
         fi


### PR DESCRIPTION
We do this to prevent a version collision between the custom one we're installing and whatever the system has. OpenSSL 1.0.0 through 1.0.2 all declare an SHLIB version of 1.0.0, so if Python has been linked against 1.0.1 and cryptography against 1.0.0, but then you try to load Python it will consider either 1.0.1 or 1.0.0 to satisfy the library version. This is, of course, nonsense since 1.0.1 has substantially more symbols than 1.0.0. The result is that if you do a LD_LIBRARY_PATH that points at the "real" 1.0.0 then Python will fail to load because there are missing symbols. We can avoid this entire nonsense by changing the major version. The dynamic linker will happily load both versions and nothing will kerplode.