### PR TITLE
Backticks are apparently legacy.

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -41,5 +41,5 @@ source ~/.venv/bin/activate
 tox -- $TOX_FLAGS
 # Output information about linking of the OpenSSL library on OS X
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    otool -L `find .tox -name "_openssl*.so"`
+    otool -L $(find .tox -name "_openssl*.so")
 fi


### PR DESCRIPTION
I just do what shellcheck tells me