### PR TITLE
opaque EVP_PKEY since EVP_PKEY_id exists

### DIFF
--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -229,8 +229,13 @@ int (*EVP_PKEY_assign_EC_KEY)(EVP_PKEY *, EC_KEY *) = NULL;
 EC_KEY *(*EVP_PKEY_get1_EC_KEY)(EVP_PKEY *) = NULL;
 int (*EVP_PKEY_set1_EC_KEY)(EVP_PKEY *, EC_KEY *) = NULL;
 #endif
-/* EVP_PKEY_id is not available on RHEL5 0.9.8e so we'll define our own */
+/* EVP_PKEY_id is not available on 0.9.8 so we'll define our own. This can
+   be removed when we remove 0.9.8 support. */
 int Cryptography_EVP_PKEY_id(const EVP_PKEY *key) {
-    return key->type;
+    #if OPENSSL_VERSION_NUMBER >= 0x10000000L
+        return EVP_PKEY_id(key);
+    #else
+        return key->type;
+    #endif
 }
 """

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -119,6 +119,8 @@ int EVP_PKEY_add1_attr_by_txt(EVP_PKEY *, const char *, int,
 int EVP_PKEY_cmp(const EVP_PKEY *, const EVP_PKEY *);
 
 EVP_PKEY *EVP_PKCS82PKEY(PKCS8_PRIV_KEY_INFO *);
+
+int Cryptography_EVP_PKEY_id(const EVP_PKEY *);
 """
 
 MACROS = """
@@ -227,4 +229,8 @@ int (*EVP_PKEY_assign_EC_KEY)(EVP_PKEY *, EC_KEY *) = NULL;
 EC_KEY *(*EVP_PKEY_get1_EC_KEY)(EVP_PKEY *) = NULL;
 int (*EVP_PKEY_set1_EC_KEY)(EVP_PKEY *, EC_KEY *) = NULL;
 #endif
+/* EVP_PKEY_id is not available on RHEL5 0.9.8e so we'll define our own */
+int Cryptography_EVP_PKEY_id(const EVP_PKEY *key) {
+    return key->type;
+}
 """

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -21,10 +21,7 @@ typedef struct env_md_ctx_st {
     ...;
 } EVP_MD_CTX;
 
-typedef struct evp_pkey_st {
-    int type;
-    ...;
-} EVP_PKEY;
+typedef ... EVP_PKEY;
 typedef ... EVP_PKEY_CTX;
 static const int EVP_PKEY_RSA;
 static const int EVP_PKEY_DSA;

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1077,7 +1077,7 @@ class Backend(object):
         pointer.
         """
 
-        key_type = self._lib.EVP_PKEY_id(evp_pkey)
+        key_type = self._lib.Cryptography_EVP_PKEY_id(evp_pkey)
 
         if key_type == self._lib.EVP_PKEY_RSA:
             rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
@@ -1104,7 +1104,7 @@ class Backend(object):
         pointer.
         """
 
-        key_type = self._lib.EVP_PKEY_id(evp_pkey)
+        key_type = self._lib.Cryptography_EVP_PKEY_id(evp_pkey)
 
         if key_type == self._lib.EVP_PKEY_RSA:
             rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
@@ -2132,7 +2132,7 @@ class Backend(object):
         else:
             raise ValueError("Unsupported encryption type")
 
-        key_type = self._lib.EVP_PKEY_id(evp_pkey)
+        key_type = self._lib.Cryptography_EVP_PKEY_id(evp_pkey)
         if encoding is serialization.Encoding.PEM:
             if format is serialization.PrivateFormat.PKCS8:
                 write_bio = self._lib.PEM_write_bio_PKCS8PrivateKey
@@ -2209,7 +2209,9 @@ class Backend(object):
             key = evp_pkey
         elif format is serialization.PublicFormat.PKCS1:
             # Only RSA is supported here.
-            assert self._lib.EVP_PKEY_id(evp_pkey) == self._lib.EVP_PKEY_RSA
+            assert self._lib.Cryptography_EVP_PKEY_id(
+                evp_pkey
+            ) == self._lib.EVP_PKEY_RSA
             if encoding is serialization.Encoding.PEM:
                 write_bio = self._lib.PEM_write_bio_RSAPublicKey
             else:

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -621,7 +621,7 @@ class TestOpenSSLSerializationWithOpenSSL(object):
         assert backend._ffi.string(buf, len(password)) == password
 
     def test_unsupported_evp_pkey_type(self):
-        key = pretend.stub(type="unsupported")
+        key = backend._create_evp_pkey_gc()
         with raises_unsupported_algorithm(None):
             backend._evp_pkey_to_private_key(key)
         with raises_unsupported_algorithm(None):

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -10,8 +10,6 @@ import subprocess
 import sys
 import textwrap
 
-import pretend
-
 import pytest
 
 from cryptography import utils, x509


### PR DESCRIPTION
We should treat `EVP_PKEY` as fully opaque since we can get the type with `EVP_PKEY_id` anyway.