### PR TITLE
rename _create_mem_bio to _create_mem_bio_gc for consistency

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1045,7 +1045,7 @@ class Backend(object):
 
         return _MemoryBIO(self._ffi.gc(bio, self._lib.BIO_free), data_char_p)
 
-    def _create_mem_bio(self):
+    def _create_mem_bio_gc(self):
         """
         Creates an empty memory BIO.
         """
@@ -2168,7 +2168,7 @@ class Backend(object):
         else:
             raise TypeError("encoding must be an item from the Encoding enum")
 
-        bio = self._create_mem_bio()
+        bio = self._create_mem_bio_gc()
         res = write_bio(
             bio,
             key,
@@ -2191,7 +2191,7 @@ class Backend(object):
             self.openssl_assert(key_type == self._lib.EVP_PKEY_DSA)
             write_bio = self._lib.i2d_DSAPrivateKey_bio
 
-        bio = self._create_mem_bio()
+        bio = self._create_mem_bio_gc()
         res = write_bio(bio, cdata)
         self.openssl_assert(res == 1)
         return self._read_mem_bio(bio)
@@ -2223,7 +2223,7 @@ class Backend(object):
                 "format must be an item from the PublicFormat enum"
             )
 
-        bio = self._create_mem_bio()
+        bio = self._create_mem_bio_gc()
         res = write_bio(bio, key)
         self.openssl_assert(res == 1)
         return self._read_mem_bio(bio)

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -353,7 +353,7 @@ class _Certificate(object):
         return self._backend._ffi.buffer(pp[0], res)[:]
 
     def public_bytes(self, encoding):
-        bio = self._backend._create_mem_bio()
+        bio = self._backend._create_mem_bio_gc()
         if encoding is serialization.Encoding.PEM:
             res = self._backend._lib.PEM_write_bio_X509(bio, self._x509)
         elif encoding is serialization.Encoding.DER:
@@ -827,7 +827,7 @@ class _CertificateRevocationList(object):
 
     def fingerprint(self, algorithm):
         h = hashes.Hash(algorithm, self._backend)
-        bio = self._backend._create_mem_bio()
+        bio = self._backend._create_mem_bio_gc()
         res = self._backend._lib.i2d_X509_CRL_bio(
             bio, self._x509_crl
         )
@@ -880,7 +880,7 @@ class _CertificateRevocationList(object):
         return self._backend._ffi.buffer(pp[0], res)[:]
 
     def public_bytes(self, encoding):
-        bio = self._backend._create_mem_bio()
+        bio = self._backend._create_mem_bio_gc()
         if encoding is serialization.Encoding.PEM:
             res = self._backend._lib.PEM_write_bio_X509_CRL(
                 bio, self._x509_crl
@@ -975,7 +975,7 @@ class _CertificateSigningRequest(object):
         return _CSR_EXTENSION_PARSER.parse(self._backend, x509_exts)
 
     def public_bytes(self, encoding):
-        bio = self._backend._create_mem_bio()
+        bio = self._backend._create_mem_bio_gc()
         if encoding is serialization.Encoding.PEM:
             res = self._backend._lib.PEM_write_bio_X509_REQ(
                 bio, self._x509_req


### PR DESCRIPTION
For functions where we return a cdata object that is already registered for garbage collection we are (mostly) consistent with calling that `*_gc`. This makes us a bit more consistent.