### PR TITLE
bump version and changelog for the twelfth release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,8 @@
 Changelog
 =========
 
-1.2 - `master`_
-~~~~~~~~~~~~~~~
-
-.. note:: This version is not yet released and is under active development.
+1.2 - 2016-01-08
+~~~~~~~~~~~~~~~~
 
 * **BACKWARDS INCOMPATIBLE:**
   :class:`~cryptography.x509.RevokedCertificate`

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -14,7 +14,7 @@ __summary__ = ("cryptography is a package which provides cryptographic recipes"
                " and primitives to Python developers.")
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "1.2.dev1"
+__version__ = "1.2"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -14,7 +14,7 @@ __summary__ = "Test vectors for the cryptography package."
 
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "1.2.dev1"
+__version__ = "1.2"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"


### PR DESCRIPTION
Don't merge until #2649, #2647 and #2646 have merged.

Happy 2nd anniversary pyca/cryptography :birthday: 