### PR TITLE
move more functions out of the openssl backend class

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import calendar
 import collections
-import datetime
 import itertools
 from contextlib import contextmanager
 
@@ -1657,55 +1656,6 @@ class Backend(object):
         res = write_bio(bio, key)
         self.openssl_assert(res == 1)
         return self._read_mem_bio(bio)
-
-    def _asn1_integer_to_int(self, asn1_int):
-        bn = self._lib.ASN1_INTEGER_to_BN(asn1_int, self._ffi.NULL)
-        self.openssl_assert(bn != self._ffi.NULL)
-        bn = self._ffi.gc(bn, self._lib.BN_free)
-        return self._bn_to_int(bn)
-
-    def _asn1_string_to_bytes(self, asn1_string):
-        return self._ffi.buffer(asn1_string.data, asn1_string.length)[:]
-
-    def _asn1_string_to_ascii(self, asn1_string):
-        return self._asn1_string_to_bytes(asn1_string).decode("ascii")
-
-    def _asn1_string_to_utf8(self, asn1_string):
-        buf = self._ffi.new("unsigned char **")
-        res = self._lib.ASN1_STRING_to_UTF8(buf, asn1_string)
-        self.openssl_assert(res >= 0)
-        self.openssl_assert(buf[0] != self._ffi.NULL)
-        buf = self._ffi.gc(
-            buf, lambda buffer: self._lib.OPENSSL_free(buffer[0])
-        )
-        return self._ffi.buffer(buf[0], res)[:].decode('utf8')
-
-    def _asn1_to_der(self, asn1_type):
-        buf = self._ffi.new("unsigned char **")
-        res = self._lib.i2d_ASN1_TYPE(asn1_type, buf)
-        self.openssl_assert(res >= 0)
-        self.openssl_assert(buf[0] != self._ffi.NULL)
-        buf = self._ffi.gc(
-            buf, lambda buffer: self._lib.OPENSSL_free(buffer[0])
-        )
-        return self._ffi.buffer(buf[0], res)[:]
-
-    def _parse_asn1_time(self, asn1_time):
-        self.openssl_assert(asn1_time != self._ffi.NULL)
-        generalized_time = self._lib.ASN1_TIME_to_generalizedtime(
-            asn1_time, self._ffi.NULL
-        )
-        self.openssl_assert(generalized_time != self._ffi.NULL)
-        generalized_time = self._ffi.gc(
-            generalized_time, self._lib.ASN1_GENERALIZEDTIME_free
-        )
-        return self._parse_asn1_generalized_time(generalized_time)
-
-    def _parse_asn1_generalized_time(self, generalized_time):
-        time = self._asn1_string_to_ascii(
-            self._ffi.cast("ASN1_STRING *", generalized_time)
-        )
-        return datetime.datetime.strptime(time, "%Y%m%d%H%M%SZ")
 
 
 class GetCipherByName(object):


### PR DESCRIPTION
Move some decoding functions out of the backend class and update the call sites. We're down to a mere ~1600 lines in `backend.py` now.