### PR TITLE
Add docstring to cryptography.hazmat

### DIFF
--- a/src/cryptography/hazmat/__init__.py
+++ b/src/cryptography/hazmat/__init__.py
@@ -1,5 +1,11 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+"""
+Hazardous Materials
 
+This is a "Hazardous Materials" module. You should ONLY use it if you're
+100% absolutely sure that you know what you're doing because this module
+is full of land mines, dragons, and dinosaurs with laser guns.
+"""
 from __future__ import absolute_import, division, print_function


### PR DESCRIPTION
This shows the warning which is in the docs if someone does this:
```
>>>> import cryptography.hazmat
>>>> help(cryptography.hazmat)
```