### PR TITLE
consolidate the windows specific header trickery we need to do

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -37,7 +37,11 @@ def _osx_libraries(build_static):
         return ["ssl", "crypto"]
 
 
-_OSX_PRE_INCLUDE = """
+_PRE_INCLUDE = """
+#include <openssl/e_os2.h>
+#if defined(OPENSSL_SYS_WINDOWS)
+#include <windows.h>
+#endif
 #ifdef __APPLE__
 #include <AvailabilityMacros.h>
 #define __ORIG_DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER \
@@ -47,7 +51,7 @@ _OSX_PRE_INCLUDE = """
 #endif
 """
 
-_OSX_POST_INCLUDE = """
+_POST_INCLUDE = """
 #ifdef __APPLE__
 #undef DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
 #define DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER \
@@ -92,8 +96,8 @@ ffi = build_ffi_for_binding(
         "pkcs7",
         "callbacks",
     ],
-    pre_include=_OSX_PRE_INCLUDE,
-    post_include=_OSX_POST_INCLUDE,
+    pre_include=_PRE_INCLUDE,
+    post_include=_POST_INCLUDE,
     libraries=_get_openssl_libraries(sys.platform),
     extra_link_args=extra_link_args(compiler_type()),
 )

--- a/src/_cffi_src/openssl/cms.py
+++ b/src/_cffi_src/openssl/cms.py
@@ -6,11 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 INCLUDES = """
 #if !defined(OPENSSL_NO_CMS) && OPENSSL_VERSION_NUMBER >= 0x0090808fL
-/* The next define should really be in the OpenSSL header, but it is missing.
-   Failing to include this on Windows causes compilation failures. */
-#if defined(OPENSSL_SYS_WINDOWS)
-#include <windows.h>
-#endif
 #include <openssl/cms.h>
 #endif
 """


### PR DESCRIPTION
Import `e_os2.h` to get the proper Windows defines, then import `windows.h`. Hoist all of this up so it happens before anything else gets included so subsequent includes of things like cms, ssl, and ocsp will include without redefinition errors.