### PR TITLE
fernet fix: ignore the timestamp entirely when no ttl is set

### DIFF
--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -91,8 +91,10 @@ class Fernet(object):
         if ttl is not None:
             if timestamp + ttl < current_time:
                 raise InvalidToken
-        if current_time + _MAX_CLOCK_SKEW < timestamp:
-            raise InvalidToken
+
+            if current_time + _MAX_CLOCK_SKEW < timestamp:
+                raise InvalidToken
+
         h = HMAC(self._signing_key, hashes.SHA256(), backend=self._backend)
         h.update(data[:-32])
         try:

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -103,6 +103,15 @@ class TestFernet(object):
         with pytest.raises(TypeError):
             f.decrypt(u"")
 
+    def test_timestamp_ignored_no_ttl(self, monkeypatch, backend):
+        f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
+        pt = b"encrypt me"
+        token = f.encrypt(pt)
+        ts = "1985-10-26T01:20:01-07:00"
+        current_time = calendar.timegm(iso8601.parse_date(ts).utctimetuple())
+        monkeypatch.setattr(time, "time", lambda: current_time)
+        assert f.decrypt(token, ttl=None) == pt
+
     @pytest.mark.parametrize("message", [b"", b"Abc!", b"\x00\xFF\x00\x80"])
     def test_roundtrips(self, message, backend):
         f = Fernet(Fernet.generate_key(), backend=backend)


### PR DESCRIPTION
Previously if the token claimed to have been generated more than 60 seconds in the future we would raise InvalidToken even if ttl was set to None.

fixes #2680 