### PR TITLE
Formally deprecated support for OpenSSL 0.9.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Deprecated support for OpenSSL 0.9.8. Support will be removed in
+  ``cryptography`` 1.4.
+
 1.2.1 - 2016-01-08
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,8 +39,8 @@ OpenSSL releases:
 
 .. warning::
     OpenSSL versions 0.9.8 and 1.0.0 are no longer supported by the OpenSSL
-    project. A future version of cryptography will drop support for these
-    releases.
+    project. Support for OpenSSL 0.9.8 will be removed in the next
+    ``cryptography`` release.
 
 On Windows
 ----------

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -10,6 +10,7 @@ import threading
 import types
 import warnings
 
+from cryptography import utils
 from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings._openssl import ffi, lib
 from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
@@ -204,7 +205,14 @@ class Binding(object):
 # is per module so this approach will not work.
 Binding.init_static_locks()
 
-if Binding.lib.SSLeay() < 0x10001000:
+if Binding.lib.SSLeay() < 0x10000000:
+    warnings.warn(
+        "OpenSSL version 0.9.8 is no longer supported by the OpenSSL project, "
+        "please upgrade. The next version of cryptography will drop support "
+        "for it.",
+        utils.DeprecatedIn12
+    )
+elif Binding.lib.SSLeay() < 0x10001000:
     warnings.warn(
         "OpenSSL versions less than 1.0.1 are no longer supported by the "
         "OpenSSL project, please upgrade. A future version of cryptography "

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -15,7 +15,7 @@ import warnings
 # the functions deprecated in 1.0 are on an arbitrarily extended deprecation
 # cycle and should not be removed until we agree on when that cycle ends.
 DeprecatedIn10 = DeprecationWarning
-DeprecatedIn12 = PendingDeprecationWarning
+DeprecatedIn12 = DeprecationWarning
 
 
 def read_only_property(name):


### PR DESCRIPTION
As proposed on the mailing list: https://mail.python.org/pipermail/cryptography-dev/2016-January/000551.html