### PR TITLE
Removed kSecTrustResultConfirm, which breaks the build on 10.10 since…

### DIFF
--- a/src/_cffi_src/commoncrypto/sectrust.py
+++ b/src/_cffi_src/commoncrypto/sectrust.py
@@ -15,7 +15,6 @@ typedef uint32_t SecTrustResultType;
 enum {
     kSecTrustResultInvalid,
     kSecTrustResultProceed,
-    kSecTrustResultConfirm,
     kSecTrustResultDeny,
     kSecTrustResultUnspecified,
     kSecTrustResultRecoverableTrustFailure,


### PR DESCRIPTION
… it's deprecated

See: https://jenkins.cryptography.io/job/cryptography-master/TOXENV=py27,label=10.10/1518/console