### PR TITLE
support RSA key generation testing when key is not serializable

### DIFF
--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -60,6 +60,15 @@ class DummyHashAlgorithm(object):
     block_size = 64
 
 
+def _check_rsa_private_numbers_if_serializable(key):
+    if isinstance(key, rsa.RSAPrivateKeyWithSerialization):
+        _check_rsa_private_numbers(key.private_numbers())
+
+
+def test_check_rsa_private_numbers_if_serializable():
+    _check_rsa_private_numbers_if_serializable("notserializable")
+
+
 def _flatten_pkcs1_examples(vectors):
     flattened_vectors = []
     for vector in vectors:
@@ -123,7 +132,7 @@ class TestRSA(object):
         skey = rsa.generate_private_key(public_exponent, key_size, backend)
         assert skey.key_size == key_size
 
-        _check_rsa_private_numbers(skey.private_numbers())
+        _check_rsa_private_numbers_if_serializable(skey)
         pkey = skey.public_key()
         assert isinstance(pkey.public_numbers(), rsa.RSAPublicNumbers)
 


### PR DESCRIPTION
When generating keys they may not be serializable (e.g. keys generated by a PKCS11 module). Don't do these key checks if `private_numbers` isn't available.

There's a bit of indirection so we can keep 100% coverage since within the core cryptography project there are no backends that implement `RSAPrivateKey` without serialization.