### PR TITLE
some backends may error on non-block size aligned data in update

### DIFF
--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -107,8 +107,8 @@ class Fernet(object):
         decryptor = Cipher(
             algorithms.AES(self._encryption_key), modes.CBC(iv), self._backend
         ).decryptor()
-        plaintext_padded = decryptor.update(ciphertext)
         try:
+            plaintext_padded = decryptor.update(ciphertext)
             plaintext_padded += decryptor.finalize()
         except ValueError:
             raise InvalidToken


### PR DESCRIPTION
Some PKCS11 implementations require block size aligned data for the AES CBC mechanism (along with other block modes) in calls to update. This change allows the fernet tests to properly fail with InvalidToken when a ValueError is raised from update, not just finalize.