### PR TITLE
Make the linkcheck builder more resillient against transient network …

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,3 +273,7 @@ texinfo_documents = [
 intersphinx_mapping = {'https://docs.python.org/3': None}
 
 epub_theme = 'epub'
+
+# Retry requests in the linkcheck builder so that we're resillient against
+# transient network errors.
+linkcheck_retries = 2


### PR DESCRIPTION
…errors.

Not in a release yet, but landed on master: https://github.com/sphinx-doc/sphinx/pull/2312

We'll start at 2 retries and increase if it turns out to be insufficient to handle real world transient errors.