### PR TITLE
Add bindings for cert validation on Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,10 @@ def cc_is_available():
         int, platform.mac_ver()[0].split("."))) >= [10, 8, 0]
 
 
+def crypt32_is_available():
+    return sys.platform == "win32"
+
+
 backends = [
     "openssl = cryptography.hazmat.backends.openssl:backend"
 ]
@@ -214,6 +218,8 @@ def keywords_with_side_effects(argv):
         ]
         if cc_is_available():
             cffi_modules.append("src/_cffi_src/build_commoncrypto.py:ffi")
+        if crypt32_is_available():
+            cffi_modules.append("src/_cffi_src/build_crypt32.py:ffi")
 
         return {
             "setup_requires": setup_requirements,

--- a/src/_cffi_src/build_crypt32.py
+++ b/src/_cffi_src/build_crypt32.py
@@ -1,0 +1,19 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+from _cffi_src.utils import build_ffi_for_binding
+
+
+ffi = build_ffi_for_binding(
+    module_name="_crypt32",
+    module_prefix="_cffi_src.crypt32.",
+    modules=[
+        "crypt32",
+    ],
+    libraries=[
+        "crypt32",
+    ],
+)

--- a/src/_cffi_src/crypt32/__init__.py
+++ b/src/_cffi_src/crypt32/__init__.py
@@ -1,0 +1,5 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function

--- a/src/_cffi_src/crypt32/crypt32.py
+++ b/src/_cffi_src/crypt32/crypt32.py
@@ -74,7 +74,7 @@ typedef struct _CERT_TRUST_STATUS {
     DWORD dwInfoStatus;
 } CERT_TRUST_STATUS, *PCERT_TRUST_STATUS;
 
-typedef const struct _CERT_CHAIN_CONTEXT* PCCERT_CHAIN_CONTEXT;
+typedef const struct _CERT_CHAIN_CONTEXT *PCCERT_CHAIN_CONTEXT;
 typedef struct _CERT_CHAIN_CONTEXT {
     DWORD cbSize;
     CERT_TRUST_STATUS TrustStatus;

--- a/src/_cffi_src/crypt32/crypt32.py
+++ b/src/_cffi_src/crypt32/crypt32.py
@@ -42,13 +42,7 @@ typedef struct _CERT_USAGE_MATCH {
 typedef struct _CERT_CHAIN_PARA {
   DWORD                   cbSize;
   CERT_USAGE_MATCH        RequestedUsage;
-  CERT_USAGE_MATCH        RequestedIssuancePolicy;
-  DWORD                   dwUrlRetrievalTimeout;
-  BOOL                    fCheckRevocationFreshnessTime;
-  DWORD                   dwRevocationFreshnessTime;
-  LPFILETIME              pftCacheResync;
-  PCCERT_STRONG_SIGN_PARA pStrongSignPara;
-  DWORD                   dwStrongSignFlags;
+  ...;
 } CERT_CHAIN_PARA, *PCERT_CHAIN_PARA;
 
 typedef struct _HTTPSPolicyCallbackData {

--- a/src/_cffi_src/crypt32/crypt32.py
+++ b/src/_cffi_src/crypt32/crypt32.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function
 
 INCLUDES = """
-#define CERT_CHAIN_PARA_HAS_EXTRA_FIELDS
 #include <windows.h>
 #include <Wincrypt.h>
 #include <schannel.h>

--- a/src/_cffi_src/crypt32/crypt32.py
+++ b/src/_cffi_src/crypt32/crypt32.py
@@ -1,0 +1,177 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+INCLUDES = """
+#define CERT_CHAIN_PARA_HAS_EXTRA_FIELDS
+#include <windows.h>
+#include <Wincrypt.h>
+#include <schannel.h>
+"""
+
+TYPES = """
+typedef int BOOL;
+typedef unsigned long DWORD;
+typedef wchar_t WCHAR;
+typedef long LONG;
+typedef void *LPVOID;
+typedef const char *LPCSTR;
+typedef char *LPSTR;
+
+typedef ... *LPFILETIME;
+
+typedef ... *HCERTCHAINENGINE;
+typedef ... *HCERTSTORE;
+typedef ... *PCERT_INFO;
+typedef ... *HCRYPTPROV_LEGACY;
+typedef ... *PCCERT_STRONG_SIGN_PARA;
+typedef ... *PCERT_SIMPLE_CHAIN;
+
+typedef struct _CTL_USAGE {
+  DWORD cUsageIdentifier;
+  LPSTR *rgpszUsageIdentifier;
+} CTL_USAGE, *PCTL_USAGE, CERT_ENHKEY_USAGE, *PCERT_ENHKEY_USAGE;
+
+typedef struct _CERT_USAGE_MATCH {
+  DWORD             dwType;
+  CERT_ENHKEY_USAGE Usage;
+} CERT_USAGE_MATCH, *PCERT_USAGE_MATCH;
+
+typedef struct _CERT_CHAIN_PARA {
+  DWORD                   cbSize;
+  CERT_USAGE_MATCH        RequestedUsage;
+  CERT_USAGE_MATCH        RequestedIssuancePolicy;
+  DWORD                   dwUrlRetrievalTimeout;
+  BOOL                    fCheckRevocationFreshnessTime;
+  DWORD                   dwRevocationFreshnessTime;
+  LPFILETIME              pftCacheResync;
+  PCCERT_STRONG_SIGN_PARA pStrongSignPara;
+  DWORD                   dwStrongSignFlags;
+} CERT_CHAIN_PARA, *PCERT_CHAIN_PARA;
+
+typedef struct _HTTPSPolicyCallbackData {
+  union {
+    DWORD cbStruct;
+    DWORD cbSize;
+  };
+  DWORD dwAuthType;
+  DWORD fdwChecks;
+  WCHAR *pwszServerName;
+} HTTPSPolicyCallbackData, *PHTTPSPolicyCallbackData, SSL_EXTRA_CERT_CHAIN_POLICY_PARA, *PSSL_EXTRA_CERT_CHAIN_POLICY_PARA;
+
+typedef struct _CERT_CHAIN_POLICY_PARA {
+  DWORD cbSize;
+  DWORD dwFlags;
+  void  *pvExtraPolicyPara;
+} CERT_CHAIN_POLICY_PARA, *PCERT_CHAIN_POLICY_PARA;
+
+typedef struct _CERT_CHAIN_POLICY_STATUS {
+  DWORD cbSize;
+  DWORD dwError;
+  LONG  lChainIndex;
+  LONG  lElementIndex;
+  void  *pvExtraPolicyStatus;
+} CERT_CHAIN_POLICY_STATUS, *PCERT_CHAIN_POLICY_STATUS;
+
+typedef struct _CERT_TRUST_STATUS {
+  DWORD dwErrorStatus;
+  DWORD dwInfoStatus;
+} CERT_TRUST_STATUS, *PCERT_TRUST_STATUS;
+
+typedef const struct _CERT_CHAIN_CONTEXT* PCCERT_CHAIN_CONTEXT;
+typedef struct _CERT_CHAIN_CONTEXT {
+  DWORD cbSize;
+  CERT_TRUST_STATUS TrustStatus;
+  DWORD  cChain;
+  PCERT_SIMPLE_CHAIN *rgpChain;
+  DWORD cLowerQualityChainContext;
+  PCCERT_CHAIN_CONTEXT *rgpLowerQualityChainContext;
+  BOOL fHasRevocationFreshnessTime;
+  DWORD dwRevocationFreshnessTime;
+} CERT_CHAIN_CONTEXT, *PCERT_CHAIN_CONTEXT;
+
+typedef struct _CERT_CONTEXT {
+  DWORD dwCertEncodingType;
+  BYTE *pbCertEncoded;
+  DWORD cbCertEncoded;
+  PCERT_INFO pCertInfo;
+  HCERTSTORE hCertStore;
+} CERT_CONTEXT, *PCERT_CONTEXT;
+typedef const CERT_CONTEXT *PCCERT_CONTEXT;
+"""
+
+FUNCTIONS = """
+HCERTSTORE CertOpenStore(
+  LPCSTR,
+  DWORD,
+  HCRYPTPROV_LEGACY,
+  DWORD,
+  const void*
+);
+
+BOOL CertCloseStore(
+  HCERTSTORE,
+  DWORD
+);
+
+BOOL CertAddEncodedCertificateToStore(
+  HCERTSTORE,
+  DWORD,
+  const BYTE *,
+  DWORD,
+  DWORD,
+  PCCERT_CONTEXT *
+);
+
+BOOL CertFreeCertificateContext(
+  PCCERT_CONTEXT
+);
+
+BOOL CertGetCertificateChain(
+  HCERTCHAINENGINE,
+  PCCERT_CONTEXT,
+  LPFILETIME,
+  HCERTSTORE,
+  PCERT_CHAIN_PARA,
+  DWORD,
+  LPVOID,
+  PCCERT_CHAIN_CONTEXT *
+);
+
+VOID CertFreeCertificateChain(
+  PCCERT_CHAIN_CONTEXT
+);
+
+BOOL CertVerifyCertificateChainPolicy(
+  LPCSTR,
+  PCCERT_CHAIN_CONTEXT,
+  PCERT_CHAIN_POLICY_PARA,
+  PCERT_CHAIN_POLICY_STATUS
+);
+"""
+
+MACROS = """
+static const LPCSTR szOID_PKIX_KP_SERVER_AUTH;
+static const LPCSTR szOID_SERVER_GATED_CRYPTO;
+static const LPCSTR szOID_SGC_NETSCAPE;
+static const LPCSTR szOID_PKIX_KP_CLIENT_AUTH;
+
+static const DWORD USAGE_MATCH_TYPE_AND;
+static const DWORD USAGE_MATCH_TYPE_OR;
+
+static const DWORD AUTHTYPE_CLIENT;
+static const DWORD AUTHTYPE_SERVER;
+
+static const LPCSTR CERT_CHAIN_POLICY_SSL = ((LPCSTR)4);
+
+static const LPCSTR CERT_STORE_PROV_MEMORY = ((LPCSTR)2);
+static const DWORD CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG;
+
+static const DWORD CERT_STORE_ADD_ALWAYS;
+static const DWORD X509_ASN_ENCODING;
+"""
+
+CUSTOMIZATIONS = """
+"""

--- a/src/_cffi_src/crypt32/crypt32.py
+++ b/src/_cffi_src/crypt32/crypt32.py
@@ -59,7 +59,8 @@ typedef struct _HTTPSPolicyCallbackData {
   DWORD dwAuthType;
   DWORD fdwChecks;
   WCHAR *pwszServerName;
-} HTTPSPolicyCallbackData, *PHTTPSPolicyCallbackData, SSL_EXTRA_CERT_CHAIN_POLICY_PARA, *PSSL_EXTRA_CERT_CHAIN_POLICY_PARA;
+} HTTPSPolicyCallbackData, *PHTTPSPolicyCallbackData,
+SSL_EXTRA_CERT_CHAIN_POLICY_PARA, *PSSL_EXTRA_CERT_CHAIN_POLICY_PARA;
 
 typedef struct _CERT_CHAIN_POLICY_PARA {
   DWORD cbSize;

--- a/src/_cffi_src/crypt32/crypt32.py
+++ b/src/_cffi_src/crypt32/crypt32.py
@@ -30,121 +30,93 @@ typedef ... *PCCERT_STRONG_SIGN_PARA;
 typedef ... *PCERT_SIMPLE_CHAIN;
 
 typedef struct _CTL_USAGE {
-  DWORD cUsageIdentifier;
-  LPSTR *rgpszUsageIdentifier;
+    DWORD cUsageIdentifier;
+    LPSTR *rgpszUsageIdentifier;
 } CTL_USAGE, *PCTL_USAGE, CERT_ENHKEY_USAGE, *PCERT_ENHKEY_USAGE;
 
 typedef struct _CERT_USAGE_MATCH {
-  DWORD             dwType;
-  CERT_ENHKEY_USAGE Usage;
+    DWORD dwType;
+    CERT_ENHKEY_USAGE Usage;
 } CERT_USAGE_MATCH, *PCERT_USAGE_MATCH;
 
 typedef struct _CERT_CHAIN_PARA {
-  DWORD                   cbSize;
-  CERT_USAGE_MATCH        RequestedUsage;
-  ...;
+    DWORD cbSize;
+    CERT_USAGE_MATCH RequestedUsage;
+    ...;
 } CERT_CHAIN_PARA, *PCERT_CHAIN_PARA;
 
 typedef struct _HTTPSPolicyCallbackData {
-  union {
-    DWORD cbStruct;
-    DWORD cbSize;
-  };
-  DWORD dwAuthType;
-  DWORD fdwChecks;
-  WCHAR *pwszServerName;
+    union {
+        DWORD cbStruct;
+        DWORD cbSize;
+    };
+    DWORD dwAuthType;
+    DWORD fdwChecks;
+    WCHAR *pwszServerName;
 } HTTPSPolicyCallbackData, *PHTTPSPolicyCallbackData,
 SSL_EXTRA_CERT_CHAIN_POLICY_PARA, *PSSL_EXTRA_CERT_CHAIN_POLICY_PARA;
 
 typedef struct _CERT_CHAIN_POLICY_PARA {
-  DWORD cbSize;
-  DWORD dwFlags;
-  void  *pvExtraPolicyPara;
+    DWORD cbSize;
+    DWORD dwFlags;
+    void *pvExtraPolicyPara;
 } CERT_CHAIN_POLICY_PARA, *PCERT_CHAIN_POLICY_PARA;
 
 typedef struct _CERT_CHAIN_POLICY_STATUS {
-  DWORD cbSize;
-  DWORD dwError;
-  LONG  lChainIndex;
-  LONG  lElementIndex;
-  void  *pvExtraPolicyStatus;
+    DWORD cbSize;
+    DWORD dwError;
+    LONG lChainIndex;
+    LONG lElementIndex;
+    void *pvExtraPolicyStatus;
 } CERT_CHAIN_POLICY_STATUS, *PCERT_CHAIN_POLICY_STATUS;
 
 typedef struct _CERT_TRUST_STATUS {
-  DWORD dwErrorStatus;
-  DWORD dwInfoStatus;
+    DWORD dwErrorStatus;
+    DWORD dwInfoStatus;
 } CERT_TRUST_STATUS, *PCERT_TRUST_STATUS;
 
 typedef const struct _CERT_CHAIN_CONTEXT* PCCERT_CHAIN_CONTEXT;
 typedef struct _CERT_CHAIN_CONTEXT {
-  DWORD cbSize;
-  CERT_TRUST_STATUS TrustStatus;
-  DWORD  cChain;
-  PCERT_SIMPLE_CHAIN *rgpChain;
-  DWORD cLowerQualityChainContext;
-  PCCERT_CHAIN_CONTEXT *rgpLowerQualityChainContext;
-  BOOL fHasRevocationFreshnessTime;
-  DWORD dwRevocationFreshnessTime;
+    DWORD cbSize;
+    CERT_TRUST_STATUS TrustStatus;
+    DWORD cChain;
+    PCERT_SIMPLE_CHAIN *rgpChain;
+    DWORD cLowerQualityChainContext;
+    PCCERT_CHAIN_CONTEXT *rgpLowerQualityChainContext;
+    BOOL fHasRevocationFreshnessTime;
+    DWORD dwRevocationFreshnessTime;
 } CERT_CHAIN_CONTEXT, *PCERT_CHAIN_CONTEXT;
 
 typedef struct _CERT_CONTEXT {
-  DWORD dwCertEncodingType;
-  BYTE *pbCertEncoded;
-  DWORD cbCertEncoded;
-  PCERT_INFO pCertInfo;
-  HCERTSTORE hCertStore;
+    DWORD dwCertEncodingType;
+    BYTE *pbCertEncoded;
+    DWORD cbCertEncoded;
+    PCERT_INFO pCertInfo;
+    HCERTSTORE hCertStore;
 } CERT_CONTEXT, *PCERT_CONTEXT;
 typedef const CERT_CONTEXT *PCCERT_CONTEXT;
 """
 
 FUNCTIONS = """
-HCERTSTORE WINAPI CertOpenStore(
-  LPCSTR,
-  DWORD,
-  HCRYPTPROV_LEGACY,
-  DWORD,
-  const void*
-);
+HCERTSTORE WINAPI CertOpenStore(LPCSTR, DWORD, HCRYPTPROV_LEGACY, DWORD,
+                                const void*);
 
-BOOL WINAPI CertCloseStore(
-  HCERTSTORE,
-  DWORD
-);
+BOOL WINAPI CertCloseStore(HCERTSTORE, DWORD);
 
-BOOL WINAPI CertAddEncodedCertificateToStore(
-  HCERTSTORE,
-  DWORD,
-  const BYTE *,
-  DWORD,
-  DWORD,
-  PCCERT_CONTEXT *
-);
+BOOL WINAPI CertAddEncodedCertificateToStore(HCERTSTORE, DWORD, const BYTE *,
+                                             DWORD, DWORD, PCCERT_CONTEXT *);
 
-BOOL WINAPI CertFreeCertificateContext(
-  PCCERT_CONTEXT
-);
+BOOL WINAPI CertFreeCertificateContext(PCCERT_CONTEXT);
 
-BOOL WINAPI CertGetCertificateChain(
-  HCERTCHAINENGINE,
-  PCCERT_CONTEXT,
-  LPFILETIME,
-  HCERTSTORE,
-  PCERT_CHAIN_PARA,
-  DWORD,
-  LPVOID,
-  PCCERT_CHAIN_CONTEXT *
-);
+BOOL WINAPI CertGetCertificateChain(HCERTCHAINENGINE, PCCERT_CONTEXT,
+                                    LPFILETIME, HCERTSTORE, PCERT_CHAIN_PARA,
+                                    DWORD, LPVOID, PCCERT_CHAIN_CONTEXT *);
 
-VOID WINAPI CertFreeCertificateChain(
-  PCCERT_CHAIN_CONTEXT
-);
+VOID WINAPI CertFreeCertificateChain(PCCERT_CHAIN_CONTEXT);
 
-BOOL WINAPI CertVerifyCertificateChainPolicy(
-  LPCSTR,
-  PCCERT_CHAIN_CONTEXT,
-  PCERT_CHAIN_POLICY_PARA,
-  PCERT_CHAIN_POLICY_STATUS
-);
+BOOL WINAPI CertVerifyCertificateChainPolicy(LPCSTR, PCCERT_CHAIN_CONTEXT,
+                                             PCERT_CHAIN_POLICY_PARA,
+                                             PCERT_CHAIN_POLICY_STATUS);
 """
 
 MACROS = """

--- a/src/_cffi_src/crypt32/crypt32.py
+++ b/src/_cffi_src/crypt32/crypt32.py
@@ -98,7 +98,7 @@ typedef const CERT_CONTEXT *PCCERT_CONTEXT;
 """
 
 FUNCTIONS = """
-HCERTSTORE CertOpenStore(
+HCERTSTORE WINAPI CertOpenStore(
   LPCSTR,
   DWORD,
   HCRYPTPROV_LEGACY,
@@ -106,12 +106,12 @@ HCERTSTORE CertOpenStore(
   const void*
 );
 
-BOOL CertCloseStore(
+BOOL WINAPI CertCloseStore(
   HCERTSTORE,
   DWORD
 );
 
-BOOL CertAddEncodedCertificateToStore(
+BOOL WINAPI CertAddEncodedCertificateToStore(
   HCERTSTORE,
   DWORD,
   const BYTE *,
@@ -120,11 +120,11 @@ BOOL CertAddEncodedCertificateToStore(
   PCCERT_CONTEXT *
 );
 
-BOOL CertFreeCertificateContext(
+BOOL WINAPI CertFreeCertificateContext(
   PCCERT_CONTEXT
 );
 
-BOOL CertGetCertificateChain(
+BOOL WINAPI CertGetCertificateChain(
   HCERTCHAINENGINE,
   PCCERT_CONTEXT,
   LPFILETIME,
@@ -135,11 +135,11 @@ BOOL CertGetCertificateChain(
   PCCERT_CHAIN_CONTEXT *
 );
 
-VOID CertFreeCertificateChain(
+VOID WINAPI CertFreeCertificateChain(
   PCCERT_CHAIN_CONTEXT
 );
 
-BOOL CertVerifyCertificateChainPolicy(
+BOOL WINAPI CertVerifyCertificateChainPolicy(
   LPCSTR,
   PCCERT_CHAIN_CONTEXT,
   PCERT_CHAIN_POLICY_PARA,

--- a/src/cryptography/hazmat/bindings/crypt32/__init__.py
+++ b/src/cryptography/hazmat/bindings/crypt32/__init__.py
@@ -1,0 +1,5 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function

--- a/src/cryptography/hazmat/bindings/crypt32/binding.py
+++ b/src/cryptography/hazmat/bindings/crypt32/binding.py
@@ -1,0 +1,15 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+from cryptography.hazmat.bindings._crypt32 import ffi, lib
+
+
+class Binding(object):
+    """
+    Crypt32 API wrapper.
+    """
+    lib = lib
+    ffi = ffi


### PR DESCRIPTION
As part of the work I'm doing on certitude, I wanted to be able to use the Windows native crypto APIs to validate certificate chains. This diff exposes bindings used for doing just that.

This is obviously a bit tricky because it introduces a new bindings source, so I suspect I haven't done everything you need me to do on that front: please let me know what you need and I'll make the appropriate changes.

In the event that you want to test that everything works fine, you can use the test file available [here](https://gist.github.com/Lukasa/dc754d2193c53fdecde2).