### PR TITLE
Added support for padding ANSI X.923

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Added support for padding ANSI X.923 with
+  :class:`~cryptography.hazmat.primitives.padding.ANSIX923`.
 * Deprecated support for OpenSSL 0.9.8. Support will be removed in
   ``cryptography`` 1.4.
 

--- a/docs/hazmat/primitives/padding.rst
+++ b/docs/hazmat/primitives/padding.rst
@@ -54,6 +54,47 @@ multiple of the block size.
             provider.
 
 
+.. class:: ANSIX923(block_size)
+
+    ANSI X.923 padding works by appending ``N-1`` bytes with the value of ``0``
+    and a last byte with the value of ``chr(N)``, where ``N`` is the number of
+    bytes required to make the final block of data the same size as the block
+    size. A simple example of padding is:
+
+    .. doctest::
+
+        >>> padder = padding.ANSIX923(128).padder()
+        >>> padded_data = padder.update(b"11111111111111112222222222")
+        >>> padded_data
+        '1111111111111111'
+        >>> padded_data += padder.finalize()
+        >>> padded_data
+        '11111111111111112222222222\x00\x00\x00\x00\x00\x06'
+        >>> unpadder = padding.ANSIX923(128).unpadder()
+        >>> data = unpadder.update(padded_data)
+        >>> data
+        '1111111111111111'
+        >>> data + unpadder.finalize()
+        '11111111111111112222222222'
+
+    :param block_size: The size of the block in bits that the data is being
+        padded to.
+    :raises ValueError: Raised if block size is not a multiple of 8 or is not
+        between 0 and 256.
+
+    .. method:: padder()
+
+        :returns: A padding
+            :class:`~cryptography.hazmat.primitives.padding.PaddingContext`
+            provider
+
+    .. method:: unpadder()
+
+        :returns: An unpadding
+            :class:`~cryptography.hazmat.primitives.padding.PaddingContext`
+            provider.
+
+
 .. class:: PaddingContext
 
     When calling ``padder()`` or ``unpadder()`` the result will conform to the

--- a/docs/hazmat/primitives/padding.rst
+++ b/docs/hazmat/primitives/padding.rst
@@ -56,10 +56,10 @@ multiple of the block size.
 
 .. class:: ANSIX923(block_size)
 
-    ANSI X.923 padding works by appending ``N-1`` bytes with the value of ``0``
-    and a last byte with the value of ``chr(N)``, where ``N`` is the number of
-    bytes required to make the final block of data the same size as the block
-    size. A simple example of padding is:
+    `ANSI X.923`_ padding works by appending ``N-1`` bytes with the value of
+    ``0`` and a last byte with the value of ``chr(N)``, where ``N`` is the
+    number of bytes required to make the final block of data the same size as
+    the block size. A simple example of padding is:
 
     .. doctest::
 
@@ -123,3 +123,5 @@ multiple of the block size.
         :raises TypeError: Raised if data is not bytes.
         :raises ValueError: When trying to remove padding from incorrectly
                             padded data.
+
+.. _`ANSI X.923`: https://en.wikipedia.org/wiki/Padding_%28cryptography%29#ANSI_X.923

--- a/docs/hazmat/primitives/padding.rst
+++ b/docs/hazmat/primitives/padding.rst
@@ -56,6 +56,8 @@ multiple of the block size.
 
 .. class:: ANSIX923(block_size)
 
+    .. versionadded:: 1.3
+
     `ANSI X.923`_ padding works by appending ``N-1`` bytes with the value of
     ``0`` and a last byte with the value of ``chr(N)``, where ``N`` is the
     number of bytes required to make the final block of data the same size as

--- a/src/_cffi_src/hazmat_src/padding.h
+++ b/src/_cffi_src/hazmat_src/padding.h
@@ -3,3 +3,4 @@
 // repository for complete details.
 
 uint8_t Cryptography_check_pkcs7_padding(const uint8_t *, uint8_t);
+uint8_t Cryptography_check_ansix923_padding(const uint8_t *, uint8_t);

--- a/src/cryptography/hazmat/primitives/padding.py
+++ b/src/cryptography/hazmat/primitives/padding.py
@@ -39,6 +39,7 @@ class _BytePadding(object):
         self.block_size = block_size
 
 
+@six.add_metaclass(abc.ABCMeta)
 class _BytePaddingContext(object):
     def __init__(self, block_size):
         self.block_size = block_size
@@ -61,8 +62,11 @@ class _BytePaddingContext(object):
 
         return result
 
+    @abc.abstractmethod
     def _padding(self, size):
-        return NotImplemented
+        """
+        Returns the padding for the size.
+        """
 
     def finalize(self):
         if self._buffer is None:
@@ -74,6 +78,7 @@ class _BytePaddingContext(object):
         return result
 
 
+@six.add_metaclass(abc.ABCMeta)
 class _ByteUnpaddingContext(object):
     def __init__(self, block_size):
         self.block_size = block_size
@@ -99,8 +104,11 @@ class _ByteUnpaddingContext(object):
 
         return result
 
+    @abc.abstractmethod
     def _check_padding(self):
-        return NotImplemented
+        """
+        Returns if the padding is valid.
+        """
 
     def finalize(self):
         if self._buffer is None:

--- a/src/cryptography/hazmat/primitives/padding.py
+++ b/src/cryptography/hazmat/primitives/padding.py
@@ -165,4 +165,6 @@ class _ANSIX923PaddingContext(_BytePaddingContext):
 class _ANSIX923UnpaddingContext(_ByteUnpaddingContext):
 
     def _check_padding(self):
-        return True
+        return lib.Cryptography_check_ansix923_padding(
+            self._buffer, self.block_size // 8
+        )

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -102,6 +102,21 @@ class TestPKCS7(object):
 
 
 class TestANSIX923(object):
+    @pytest.mark.parametrize(("size", "padded"), [
+        (128, b"1111"),
+        (128, b"1111111111111111"),
+        (128, b"111111111111111\x06"),
+        (128, b"1111111111\x06\x06\x06\x06\x06\x06"),
+        (128, b""),
+        (128, b"\x06" * 6),
+        (128, b"\x00" * 16),
+    ])
+    def test_invalid_padding(self, size, padded):
+        unpadder = padding.ANSIX923(size).unpadder()
+        with pytest.raises(ValueError):
+            unpadder.update(padded)
+            unpadder.finalize()
+
     @pytest.mark.parametrize(("size", "unpadded", "padded"), [
         (
             128,

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -99,3 +99,51 @@ class TestPKCS7(object):
             unpadder.update(b"")
         with pytest.raises(AlreadyFinalized):
             unpadder.finalize()
+
+
+class TestANSIX923(object):
+    @pytest.mark.parametrize(("size", "unpadded", "padded"), [
+        (
+            128,
+            b"1111111111",
+            b"1111111111\x00\x00\x00\x00\x00\x06",
+        ),
+        (
+            128,
+            b"111111111111111122222222222222",
+            b"111111111111111122222222222222\x00\x02",
+        ),
+        (
+            128,
+            b"1" * 16,
+            b"1" * 16 + b"\x00" * 15 + b"\x10",
+        ),
+        (
+            128,
+            b"1" * 17,
+            b"1" * 17 + b"\x00" * 14 + b"\x0F",
+        )
+    ])
+    def test_pad(self, size, unpadded, padded):
+        padder = padding.ANSIX923(size).padder()
+        result = padder.update(unpadded)
+        result += padder.finalize()
+        assert result == padded
+
+    @pytest.mark.parametrize(("size", "unpadded", "padded"), [
+        (
+            128,
+            b"1111111111",
+            b"1111111111\x00\x00\x00\x00\x00\x06",
+        ),
+        (
+            128,
+            b"111111111111111122222222222222",
+            b"111111111111111122222222222222\x00\x02",
+        ),
+    ])
+    def test_unpad(self, size, unpadded, padded):
+        unpadder = padding.ANSIX923(size).unpadder()
+        result = unpadder.update(padded)
+        result += unpadder.finalize()
+        assert result == unpadded

--- a/tests/hypothesis/test_padding.py
+++ b/tests/hypothesis/test_padding.py
@@ -5,7 +5,7 @@
 from hypothesis import given
 from hypothesis.strategies import binary, integers
 
-from cryptography.hazmat.primitives.padding import PKCS7
+from cryptography.hazmat.primitives.padding import ANSIX923, PKCS7
 
 
 @given(integers(min_value=1, max_value=31), binary())
@@ -15,6 +15,17 @@ def test_pkcs7(block_size, data):
     p = PKCS7(block_size=block_size * 8)
     padder = p.padder()
     unpadder = p.unpadder()
+
+    padded = padder.update(data) + padder.finalize()
+
+    assert unpadder.update(padded) + unpadder.finalize() == data
+
+
+@given(integers(min_value=1, max_value=31), binary())
+def test_ansix923(block_size, data):
+    a = ANSIX923(block_size=block_size * 8)
+    padder = a.padder()
+    unpadder = a.unpadder()
 
     padded = padder.update(data) + padder.finalize()
 


### PR DESCRIPTION
I'm implementing an EBICS library and this protocol requires to pad using ANSI X.923.
So I think it will be good to have it in cryptography library.