### PR TITLE
Remove Python 2.6 on OS X from the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,6 @@ matrix:
           # 7.1 is OS X 10.10.x
           # see: https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
           osx_image: xcode7.1
-          env: TOXENV=py26 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
-        - language: generic
-          os: osx
-          osx_image: xcode7.1
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx
@@ -81,10 +77,6 @@ matrix:
         - language: generic
           os: osx
           # 7.2 is OS X 10.11.x
-          osx_image: xcode7.2
-          env: TOXENV=py26 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
-        - language: generic
-          os: osx
           osx_image: xcode7.2
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic


### PR DESCRIPTION
Build times on these jobs have somehow crept up to nearly (and occasionally surpassing) the Travis timeout (50 minutes). Additionally, a look at the PyPI bigquery data indicates that 2.6 represents approximately 0.4% of OS X downloads. Since this CI overhead is causing the project significant pain for almost no gain, it's time to eliminate it.

If anyone has suggestions on how to add language to `installation.rst` that states that we no longer do CI for 2.6 on OS X I'm happy to add it.