### PR TITLE
require mode nonce/iv/tag data to be bytes

### DIFF
--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -67,6 +67,9 @@ class CBC(object):
     name = "CBC"
 
     def __init__(self, initialization_vector):
+        if not isinstance(initialization_vector, bytes):
+            raise TypeError("initialization_vector must be bytes")
+
         self._initialization_vector = initialization_vector
 
     initialization_vector = utils.read_only_property("_initialization_vector")
@@ -87,6 +90,9 @@ class OFB(object):
     name = "OFB"
 
     def __init__(self, initialization_vector):
+        if not isinstance(initialization_vector, bytes):
+            raise TypeError("initialization_vector must be bytes")
+
         self._initialization_vector = initialization_vector
 
     initialization_vector = utils.read_only_property("_initialization_vector")
@@ -99,6 +105,9 @@ class CFB(object):
     name = "CFB"
 
     def __init__(self, initialization_vector):
+        if not isinstance(initialization_vector, bytes):
+            raise TypeError("initialization_vector must be bytes")
+
         self._initialization_vector = initialization_vector
 
     initialization_vector = utils.read_only_property("_initialization_vector")
@@ -111,6 +120,9 @@ class CFB8(object):
     name = "CFB8"
 
     def __init__(self, initialization_vector):
+        if not isinstance(initialization_vector, bytes):
+            raise TypeError("initialization_vector must be bytes")
+
         self._initialization_vector = initialization_vector
 
     initialization_vector = utils.read_only_property("_initialization_vector")
@@ -123,6 +135,9 @@ class CTR(object):
     name = "CTR"
 
     def __init__(self, nonce):
+        if not isinstance(nonce, bytes):
+            raise TypeError("nonce must be bytes")
+
         self._nonce = nonce
 
     nonce = utils.read_only_property("_nonce")
@@ -153,6 +168,12 @@ class GCM(object):
                 "Authentication tag must be {0} bytes or longer.".format(
                     min_tag_length)
             )
+
+        if not isinstance(initialization_vector, bytes):
+            raise TypeError("initialization_vector must be bytes")
+
+        if tag is not None and not isinstance(tag, bytes):
+            raise TypeError("tag must be bytes when provided")
 
         self._initialization_vector = initialization_vector
         self._tag = tag

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -173,7 +173,7 @@ class GCM(object):
             raise TypeError("initialization_vector must be bytes")
 
         if tag is not None and not isinstance(tag, bytes):
-            raise TypeError("tag must be bytes when provided")
+            raise TypeError("tag must be bytes or None")
 
         self._initialization_vector = initialization_vector
         self._tag = tag

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -177,3 +177,33 @@ class TestModeValidation(object):
                 modes.CTR(b"abc"),
                 backend,
             )
+
+
+class TestModesRequireBytes(object):
+    def test_cbc(self):
+        with pytest.raises(TypeError):
+            modes.CBC([1] * 16)
+
+    def test_cfb(self):
+        with pytest.raises(TypeError):
+            modes.CFB([1] * 16)
+
+    def test_cfb8(self):
+        with pytest.raises(TypeError):
+            modes.CFB8([1] * 16)
+
+    def test_ofb(self):
+        with pytest.raises(TypeError):
+            modes.OFB([1] * 16)
+
+    def test_ctr(self):
+        with pytest.raises(TypeError):
+            modes.CTR([1] * 16)
+
+    def test_gcm_iv(self):
+        with pytest.raises(TypeError):
+            modes.GCM([1] * 16)
+
+    def test_gcm_tag(self):
+        with pytest.raises(TypeError):
+            modes.GCM(b"\x00" * 16, [1] * 16)


### PR DESCRIPTION
partially resolves #2720 

Doing this for key material is trickier because projects like https://github.com/reaperhulk/cryptography-pkcs11 rely on being able to pass a key handle object there.