### PR TITLE
improve the messages from openssl InternalError

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -17,8 +17,8 @@ from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
 
 _OpenSSLError = collections.namedtuple("_OpenSSLError",
                                        ["code", "lib", "func", "reason"])
-_OpenSSLErrorText = collections.namedtuple(
-    "_OpenSSLErrorText", ["code", "lib", "func", "reason", "reason_text"]
+_OpenSSLErrorWithText = collections.namedtuple(
+    "_OpenSSLErrorWithText", ["code", "lib", "func", "reason", "reason_text"]
 )
 
 
@@ -47,7 +47,7 @@ def _openssl_assert(lib, ok):
                 lib.ERR_error_string(err.code, ffi.NULL)
             )
             errors_with_text.append(
-                _OpenSSLErrorText(
+                _OpenSSLErrorWithText(
                     err.code, err.lib, err.func, err.reason, err_text_reason
                 )
             )

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -15,8 +15,10 @@ from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings._openssl import ffi, lib
 from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
 
-_OpenSSLError = collections.namedtuple(
-    "_OpenSSLError", ["code", "lib", "func", "reason", "reason_text"]
+_OpenSSLError = collections.namedtuple("_OpenSSLError",
+                                       ["code", "lib", "func", "reason"])
+_OpenSSLErrorText = collections.namedtuple(
+    "_OpenSSLErrorText", ["code", "lib", "func", "reason", "reason_text"]
 )
 
 
@@ -30,11 +32,8 @@ def _consume_errors(lib):
         err_lib = lib.ERR_GET_LIB(code)
         err_func = lib.ERR_GET_FUNC(code)
         err_reason = lib.ERR_GET_REASON(code)
-        err_text_reason = ffi.string(lib.ERR_error_string(code, ffi.NULL))
 
-        errors.append(
-            _OpenSSLError(code, err_lib, err_func, err_reason, err_text_reason)
-        )
+        errors.append(_OpenSSLError(code, err_lib, err_func, err_reason))
 
     return errors
 
@@ -42,15 +41,26 @@ def _consume_errors(lib):
 def _openssl_assert(lib, ok):
     if not ok:
         errors = _consume_errors(lib)
+        errors_with_text = []
+        for err in errors:
+            err_text_reason = ffi.string(
+                lib.ERR_error_string(err.code, ffi.NULL)
+            )
+            errors_with_text.append(
+                _OpenSSLErrorText(
+                    err.code, err.lib, err.func, err.reason, err_text_reason
+                )
+            )
+
         raise InternalError(
             "Unknown OpenSSL error. This error is commonly encountered when "
             "another library is not cleaning up the OpenSSL error stack. If "
-            "you are using cryptography with another Python library that "
-            "uses OpenSSL try disabling it before reporting a bug. Otherwise "
-            "iplease file an issue at https://github.com/pyca/cryptography/"
+            "you are using cryptography with another library that uses "
+            "OpenSSL try disabling it before reporting a bug. Otherwise "
+            "please file an issue at https://github.com/pyca/cryptography/"
             "issues with information on how to reproduce "
-            "this. ({0!r})".format(errors),
-            errors
+            "this. ({0!r})".format(errors_with_text),
+            errors_with_text
         )
 
 

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -15,8 +15,9 @@ from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings._openssl import ffi, lib
 from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
 
-_OpenSSLError = collections.namedtuple("_OpenSSLError",
-                                       ["code", "lib", "func", "reason"])
+_OpenSSLError = collections.namedtuple(
+    "_OpenSSLError", ["code", "lib", "func", "reason", "reason_text"]
+)
 
 
 def _consume_errors(lib):
@@ -29,8 +30,12 @@ def _consume_errors(lib):
         err_lib = lib.ERR_GET_LIB(code)
         err_func = lib.ERR_GET_FUNC(code)
         err_reason = lib.ERR_GET_REASON(code)
+        err_text_reason = ffi.string(lib.ERR_error_string(code, ffi.NULL))
 
-        errors.append(_OpenSSLError(code, err_lib, err_func, err_reason))
+        errors.append(
+            _OpenSSLError(code, err_lib, err_func, err_reason, err_text_reason)
+        )
+
     return errors
 
 
@@ -38,8 +43,12 @@ def _openssl_assert(lib, ok):
     if not ok:
         errors = _consume_errors(lib)
         raise InternalError(
-            "Unknown OpenSSL error. Please file an issue at https://github.com"
-            "/pyca/cryptography/issues with information on how to reproduce "
+            "Unknown OpenSSL error. This error is commonly encountered when "
+            "another library is not cleaning up the OpenSSL error stack. If "
+            "you are using cryptography with another Python library that "
+            "uses OpenSSL try disabling it before reporting a bug. Otherwise "
+            "iplease file an issue at https://github.com/pyca/cryptography/"
+            "issues with information on how to reproduce "
             "this. ({0!r})".format(errors),
             errors
         )

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -156,12 +156,9 @@ class TestOpenSSL(object):
     def test_openssl_assert_error_on_stack(self):
         b = Binding()
         b.lib.ERR_put_error(
-            b.lib.ERR_LIB_RSA,
-            # the following value corresponds to
-            # RSA_F_RSA_PADDING_ADD_PKCS1_OAEP_MGF1 but we don't really bind
-            # func codes in our bindings.
-            160,
-            b.lib.RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE,
+            b.lib.ERR_LIB_EVP,
+            b.lib.EVP_F_EVP_ENCRYPTFINAL_EX,
+            b.lib.EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH,
             b"",
             -1
         )
@@ -169,12 +166,12 @@ class TestOpenSSL(object):
             _openssl_assert(b.lib, False)
 
         assert exc_info.value.err_code == [_OpenSSLErrorWithText(
-            code=67764334,
-            lib=b.lib.ERR_LIB_RSA,
-            func=160,
-            reason=b.lib.RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE,
+            code=101183626,
+            lib=b.lib.ERR_LIB_EVP,
+            func=b.lib.EVP_F_EVP_ENCRYPTFINAL_EX,
+            reason=b.lib.EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH,
             reason_text=(
-                b'error:040A006E:rsa routines:RSA_padding_add_PKCS1_OAEP_mgf1'
-                b':data too large for key size'
+                b'error:0607F08A:digital envelope routines:EVP_EncryptFinal_'
+                b'ex:data not multiple of block length'
             )
         )]


### PR DESCRIPTION
Improve the error msgs when an InternalError happens. We should have a followup PR to add some language about mod_wsgi failures that links to a FAQ entry describing `%{GLOBAL}` as a workaround. (Or maybe we catch failures during engine initialization and raise a different error)

Refs #2471 