### PR TITLE
In OpenSSL 1.1.0 AES_ctr128_encrypt no longer exists

### DIFF
--- a/src/_cffi_src/openssl/aes.py
+++ b/src/_cffi_src/openssl/aes.py
@@ -10,6 +10,7 @@ INCLUDES = """
 
 TYPES = """
 static const int Cryptography_HAS_AES_WRAP;
+static const int Cryptography_HAS_AES_CTR128_ENCRYPT;
 
 struct aes_key_st {
     ...;
@@ -50,5 +51,13 @@ int (*AES_wrap_key)(AES_KEY *, const unsigned char *, unsigned char *,
 int (*AES_unwrap_key)(AES_KEY *, const unsigned char *, unsigned char *,
                       const unsigned char *, unsigned int) = NULL;
 #endif
-
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+static const int Cryptography_HAS_AES_CTR128_ENCRYPT = 0;
+void (*AES_ctr128_encrypt)(const unsigned char *, unsigned char *,
+                           const size_t, const AES_KEY *,
+                           unsigned char[], unsigned char[],
+                           unsigned int *) = NULL;
+#else
+static const int Cryptography_HAS_AES_CTR128_ENCRYPT = 1;
+#endif
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -411,4 +411,7 @@ CONDITIONAL_NAMES = {
         "SSL_CTX_set_cert_cb",
         "SSL_set_cert_cb",
     ],
+    "Cryptography_HAS_AES_CTR128_ENCRYPT": [
+        "AES_ctr128_encrypt",
+    ],
 }


### PR DESCRIPTION
This is OpenSSL 1.1.0 compatibility patch 1 of n

I have no idea how many of these PRs will eventually be submitted, but the goal here is that every PR should work on our current CI. As we get further along I'll turn on a separate (and obviously non-gating) 1.1.0 job so we can see how close we're getting. Right now there are too many errors for it to be particularly useful.

OpenSSL 1.1.0 beta 1 should be released March 10 (with final on April 28, 2016) and most (all?) of the opaquing is done so it's time to get moving.