### PR TITLE
ASN1_TIME is actually an ASN1_STRING so typedef it

### DIFF
--- a/src/_cffi_src/openssl/asn1.py
+++ b/src/_cffi_src/openssl/asn1.py
@@ -24,6 +24,7 @@ struct asn1_string_st {
 typedef struct asn1_string_st ASN1_OCTET_STRING;
 typedef struct asn1_string_st ASN1_IA5STRING;
 typedef struct asn1_string_st ASN1_BIT_STRING;
+typedef struct asn1_string_st ASN1_TIME;
 typedef ... ASN1_OBJECT;
 typedef struct asn1_string_st ASN1_STRING;
 typedef struct asn1_string_st ASN1_UTF8STRING;
@@ -33,9 +34,6 @@ typedef ... ASN1_ENUMERATED;
 typedef ... ASN1_ITEM;
 typedef ... ASN1_VALUE;
 
-typedef struct {
-    ...;
-} ASN1_TIME;
 typedef ... ASN1_ITEM_EXP;
 
 typedef ... ASN1_UTCTIME;


### PR DESCRIPTION
This will be useful in OpenSSL 1.1.0 since you sometimes need to duplicate a time.