### PR TITLE
BIO_ptr_ctrl's ret type changed from char to void...but we don't use it

### DIFF
--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -113,7 +113,6 @@ long BIO_callback_ctrl(
     int,
     void (*)(struct bio_st *, int, const char *, int, long, long)
 );
-char *BIO_ptr_ctrl(BIO *, int, long);
 long BIO_int_ctrl(BIO *, int, long, int);
 size_t BIO_ctrl_pending(BIO *);
 size_t BIO_ctrl_wpending(BIO *);


### PR DESCRIPTION
So let's reduce our exposure to this sort of thing and remove it.

pyOpenSSL doesn't use this either.