### PR TITLE
SSLeay begone

### DIFF
--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -16,6 +16,11 @@ static const int SSLEAY_CFLAGS;
 static const int SSLEAY_PLATFORM;
 static const int SSLEAY_DIR;
 static const int SSLEAY_BUILT_ON;
+static const int OPENSSL_VERSION;
+static const int OPENSSL_CFLAGS;
+static const int OPENSSL_BUILT_ON;
+static const int OPENSSL_PLATFORM;
+static const int OPENSSL_DIR;
 static const int CRYPTO_MEM_CHECK_ON;
 static const int CRYPTO_MEM_CHECK_OFF;
 static const int CRYPTO_MEM_CHECK_ENABLE;
@@ -28,9 +33,6 @@ static const int CRYPTO_LOCK_SSL;
 """
 
 FUNCTIONS = """
-unsigned long SSLeay(void);
-const char *SSLeay_version(int);
-
 void CRYPTO_free(void *);
 int CRYPTO_mem_ctrl(int);
 int CRYPTO_is_mem_check_on(void);
@@ -47,9 +49,39 @@ void OPENSSL_free(void *);
 """
 
 MACROS = """
+/* SSLeay was removed in 1.1.0 */
+unsigned long SSLeay(void);
+const char *SSLeay_version(int);
+/* these functions were added to replace the SSLeay functions in 1.1.0 */
+unsigned long OpenSSL_version_num(void);
+const char *OpenSSL_version(int);
+
 void CRYPTO_add(int *, int, int);
 void CRYPTO_malloc_init(void);
 """
 
 CUSTOMIZATIONS = """
+/* In 1.1.0 SSLeay has finally been retired. We bidirectionally define the
+   values so you can use either one. This is so we can use the new function
+   names no matter what OpenSSL we're running on, but users on older pyOpenSSL
+   releases won't see issues if they're running OpenSSL 1.1.0 */
+#if !defined(SSLEAY_VERSION)
+# define SSLeay                  OpenSSL_version_num
+# define SSLeay_version          OpenSSL_version
+# define SSLEAY_VERSION_NUMBER   OPENSSL_VERSION_NUMBER
+# define SSLEAY_VERSION          OPENSSL_VERSION
+# define SSLEAY_CFLAGS           OPENSSL_CFLAGS
+# define SSLEAY_BUILT_ON         OPENSSL_BUILT_ON
+# define SSLEAY_PLATFORM         OPENSSL_PLATFORM
+# define SSLEAY_DIR              OPENSSL_DIR
+#endif
+#if !defined(OPENSSL_VERSION)
+# define OpenSSL_version_num     SSLeay
+# define OpenSSL_version         SSLeay_version
+# define OPENSSL_VERSION         SSLEAY_VERSION
+# define OPENSSL_CFLAGS          SSLEAY_CFLAGS
+# define OPENSSL_BUILT_ON        SSLEAY_BUILT_ON
+# define OPENSSL_PLATFORM        SSLEAY_PLATFORM
+# define OPENSSL_DIR             SSLEAY_DIR
+#endif
 """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -179,7 +179,7 @@ class Backend(object):
         Example: OpenSSL 1.0.1e 11 Feb 2013
         """
         return self._ffi.string(
-            self._lib.SSLeay_version(self._lib.SSLEAY_VERSION)
+            self._lib.OpenSSL_version(self._lib.OPENSSL_VERSION)
         ).decode("ascii")
 
     def create_hmac_ctx(self, key, algorithm):


### PR DESCRIPTION
In OpenSSL 1.1.0 SSLeay is no longer a thing. Farewell.

The approach here will break pyOpenSSL, which assumes SSLeay is a thing. We probably need to reimplement the old functions using the new functions to prevent breakage. Opinions?