### PR TITLE
some ECDH functions we don't use that are no longer present in 1.1.0

### DIFF
--- a/src/_cffi_src/openssl/ecdh.py
+++ b/src/_cffi_src/openssl/ecdh.py
@@ -20,13 +20,6 @@ FUNCTIONS = """
 MACROS = """
 int ECDH_compute_key(void *, size_t, const EC_POINT *, EC_KEY *,
                      void *(*)(const void *, size_t, void *, size_t *));
-
-int ECDH_get_ex_new_index(long, void *, CRYPTO_EX_new *, CRYPTO_EX_dup *,
-                          CRYPTO_EX_free *);
-
-int ECDH_set_ex_data(EC_KEY *, int, void *);
-
-void *ECDH_get_ex_data(EC_KEY *, int);
 """
 
 CUSTOMIZATIONS = """
@@ -36,13 +29,6 @@ static const long Cryptography_HAS_ECDH = 0;
 int (*ECDH_compute_key)(void *, size_t, const EC_POINT *, EC_KEY *,
                         void *(*)(const void *, size_t, void *,
                         size_t *)) = NULL;
-
-int (*ECDH_get_ex_new_index)(long, void *, CRYPTO_EX_new *, CRYPTO_EX_dup *,
-                             CRYPTO_EX_free *) = NULL;
-
-int (*ECDH_set_ex_data)(EC_KEY *, int, void *) = NULL;
-
-void *(*ECDH_get_ex_data)(EC_KEY *, int) = NULL;
 
 #else
 static const long Cryptography_HAS_ECDH = 1;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -168,9 +168,6 @@ CONDITIONAL_NAMES = {
     ],
     "Cryptography_HAS_ECDH": [
         "ECDH_compute_key",
-        "ECDH_get_ex_new_index",
-        "ECDH_set_ex_data",
-        "ECDH_get_ex_data",
     ],
     "Cryptography_HAS_ECDSA": [
         "ECDSA_SIG_new",


### PR DESCRIPTION
pyOpenSSL does not use these.