### PR TITLE
error loading strings that no longer exist and are unused

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -236,8 +236,6 @@ static const int RSA_F_RSA_SIGN;
 """
 
 FUNCTIONS = """
-void ERR_load_crypto_strings(void);
-void ERR_load_SSL_strings(void);
 void ERR_free_strings(void);
 char *ERR_error_string(unsigned long, char *);
 void ERR_error_string_n(unsigned long, char *, size_t);


### PR DESCRIPTION
pyopenssl does not use this either (and indeed no one should since `SSL_load_error_strings` does this for you)