### PR TITLE
engine ECDH/ECDSA/STORE no longer exist in 1.1.0

### DIFF
--- a/src/_cffi_src/openssl/engine.py
+++ b/src/_cffi_src/openssl/engine.py
@@ -14,8 +14,6 @@ static const long Cryptography_HAS_ENGINE_CRYPTODEV;
 typedef ... ENGINE;
 typedef ... RSA_METHOD;
 typedef ... DSA_METHOD;
-typedef ... ECDH_METHOD;
-typedef ... ECDSA_METHOD;
 typedef ... DH_METHOD;
 typedef struct {
     void (*seed)(const void *, int);
@@ -25,7 +23,6 @@ typedef struct {
     int (*pseudorand)(unsigned char *, int);
     int (*status)();
 } RAND_METHOD;
-typedef ... STORE_METHOD;
 typedef int (*ENGINE_GEN_INT_FUNC_PTR)(ENGINE *);
 typedef ... *ENGINE_CTRL_FUNC_PTR;
 typedef ... *ENGINE_LOAD_KEY_PTR;
@@ -37,11 +34,8 @@ typedef ... UI_METHOD;
 static const unsigned int ENGINE_METHOD_RSA;
 static const unsigned int ENGINE_METHOD_DSA;
 static const unsigned int ENGINE_METHOD_RAND;
-static const unsigned int ENGINE_METHOD_ECDH;
-static const unsigned int ENGINE_METHOD_ECDSA;
 static const unsigned int ENGINE_METHOD_CIPHERS;
 static const unsigned int ENGINE_METHOD_DIGESTS;
-static const unsigned int ENGINE_METHOD_STORE;
 static const unsigned int ENGINE_METHOD_ALL;
 static const unsigned int ENGINE_METHOD_NONE;
 
@@ -58,22 +52,16 @@ int ENGINE_remove(ENGINE *);
 ENGINE *ENGINE_by_id(const char *);
 int ENGINE_init(ENGINE *);
 int ENGINE_finish(ENGINE *);
-void ENGINE_load_openssl(void);
-void ENGINE_load_dynamic(void);
 void ENGINE_load_builtin_engines(void);
 void ENGINE_cleanup(void);
 ENGINE *ENGINE_get_default_RSA(void);
 ENGINE *ENGINE_get_default_DSA(void);
-ENGINE *ENGINE_get_default_ECDH(void);
-ENGINE *ENGINE_get_default_ECDSA(void);
 ENGINE *ENGINE_get_default_DH(void);
 ENGINE *ENGINE_get_default_RAND(void);
 ENGINE *ENGINE_get_cipher_engine(int);
 ENGINE *ENGINE_get_digest_engine(int);
 int ENGINE_set_default_RSA(ENGINE *);
 int ENGINE_set_default_DSA(ENGINE *);
-int ENGINE_set_default_ECDH(ENGINE *);
-int ENGINE_set_default_ECDSA(ENGINE *);
 int ENGINE_set_default_DH(ENGINE *);
 int ENGINE_set_default_RAND(ENGINE *);
 int ENGINE_set_default_ciphers(ENGINE *);
@@ -88,21 +76,12 @@ void ENGINE_register_all_RSA(void);
 int ENGINE_register_DSA(ENGINE *);
 void ENGINE_unregister_DSA(ENGINE *);
 void ENGINE_register_all_DSA(void);
-int ENGINE_register_ECDH(ENGINE *);
-void ENGINE_unregister_ECDH(ENGINE *);
-void ENGINE_register_all_ECDH(void);
-int ENGINE_register_ECDSA(ENGINE *);
-void ENGINE_unregister_ECDSA(ENGINE *);
-void ENGINE_register_all_ECDSA(void);
 int ENGINE_register_DH(ENGINE *);
 void ENGINE_unregister_DH(ENGINE *);
 void ENGINE_register_all_DH(void);
 int ENGINE_register_RAND(ENGINE *);
 void ENGINE_unregister_RAND(ENGINE *);
 void ENGINE_register_all_RAND(void);
-int ENGINE_register_STORE(ENGINE *);
-void ENGINE_unregister_STORE(ENGINE *);
-void ENGINE_register_all_STORE(void);
 int ENGINE_register_ciphers(ENGINE *);
 void ENGINE_unregister_ciphers(ENGINE *);
 void ENGINE_register_all_ciphers(void);
@@ -123,11 +102,8 @@ int ENGINE_set_id(ENGINE *, const char *);
 int ENGINE_set_name(ENGINE *, const char *);
 int ENGINE_set_RSA(ENGINE *, const RSA_METHOD *);
 int ENGINE_set_DSA(ENGINE *, const DSA_METHOD *);
-int ENGINE_set_ECDH(ENGINE *, const ECDH_METHOD *);
-int ENGINE_set_ECDSA(ENGINE *, const ECDSA_METHOD *);
 int ENGINE_set_DH(ENGINE *, const DH_METHOD *);
 int ENGINE_set_RAND(ENGINE *, const RAND_METHOD *);
-int ENGINE_set_STORE(ENGINE *, const STORE_METHOD *);
 int ENGINE_set_destroy_function(ENGINE *, ENGINE_GEN_INT_FUNC_PTR);
 int ENGINE_set_init_function(ENGINE *, ENGINE_GEN_INT_FUNC_PTR);
 int ENGINE_set_finish_function(ENGINE *, ENGINE_GEN_INT_FUNC_PTR);
@@ -142,11 +118,8 @@ const char *ENGINE_get_id(const ENGINE *);
 const char *ENGINE_get_name(const ENGINE *);
 const RSA_METHOD *ENGINE_get_RSA(const ENGINE *);
 const DSA_METHOD *ENGINE_get_DSA(const ENGINE *);
-const ECDH_METHOD *ENGINE_get_ECDH(const ENGINE *);
-const ECDSA_METHOD *ENGINE_get_ECDSA(const ENGINE *);
 const DH_METHOD *ENGINE_get_DH(const ENGINE *);
 const RAND_METHOD *ENGINE_get_RAND(const ENGINE *);
-const STORE_METHOD *ENGINE_get_STORE(const ENGINE *);
 
 const EVP_CIPHER *ENGINE_get_cipher(ENGINE *, int);
 const EVP_MD *ENGINE_get_digest(ENGINE *, int);
@@ -158,6 +131,10 @@ void ENGINE_add_conf_module(void);
 """
 
 MACROS = """
+/* these became macros in 1.1.0 */
+void ENGINE_load_openssl(void);
+void ENGINE_load_dynamic(void);
+
 void ENGINE_load_cryptodev(void);
 """
 


### PR DESCRIPTION
And of course we were never using this ENGINE logic anyway.

Also, ENGINE_load_openssl and ENGINE_load_dynamic became macros.