### PR TITLE
remove long deprecated locking callback and CRYPTO_malloc_init

### DIFF
--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -40,8 +40,6 @@ void CRYPTO_mem_leaks(struct bio_st *);
 void CRYPTO_cleanup_all_ex_data(void);
 int CRYPTO_num_locks(void);
 void CRYPTO_set_locking_callback(void(*)(int, int, const char *, int));
-void CRYPTO_set_id_callback(unsigned long (*)(void));
-unsigned long (*CRYPTO_get_id_callback(void))(void);
 void (*CRYPTO_get_locking_callback(void))(int, int, const char *, int);
 void CRYPTO_lock(int, int, const char *, int);
 
@@ -57,7 +55,6 @@ unsigned long OpenSSL_version_num(void);
 const char *OpenSSL_version(int);
 
 void CRYPTO_add(int *, int, int);
-void CRYPTO_malloc_init(void);
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
The standard refrain: we don't use them and neither does pyOpenSSL