### PR TITLE
ECDSA_SIG can be opaque too

### DIFF
--- a/src/_cffi_src/openssl/ecdsa.py
+++ b/src/_cffi_src/openssl/ecdsa.py
@@ -13,10 +13,7 @@ INCLUDES = """
 TYPES = """
 static const int Cryptography_HAS_ECDSA;
 
-typedef struct {
-    BIGNUM *r;
-    BIGNUM *s;
-} ECDSA_SIG;
+typedef ... ECDSA_SIG;
 
 typedef ... CRYPTO_EX_new;
 typedef ... CRYPTO_EX_dup;


### PR DESCRIPTION
If we need to reach into it in the future we can use `ECDSA_SIG_get0` (and backport that function for older OpenSSLs). It's easy to do, but no reason for it since we treat this as opaque already.