### PR TITLE
opaque HMAC_CTX, which requires some helper functions

### DIFF
--- a/src/_cffi_src/openssl/hmac.py
+++ b/src/_cffi_src/openssl/hmac.py
@@ -87,11 +87,6 @@ HMAC_CTX *Cryptography_HMAC_CTX_new(void) {
     /* This uses OPENSSL_zalloc in 1.1.0, which is malloc + memset */
     HMAC_CTX *ctx = (HMAC_CTX *)OPENSSL_malloc(sizeof(HMAC_CTX));
     memset(ctx, 0, sizeof(HMAC_CTX));
-    /*if (ctx)
-        if (!HMAC_CTX_reset(ctx)) {
-            HMAC_CTX_free(ctx);
-            ctx = NULL;
-        }*/
     return ctx;
 #endif
 }

--- a/src/_cffi_src/openssl/hmac.py
+++ b/src/_cffi_src/openssl/hmac.py
@@ -103,10 +103,6 @@ void Cryptography_HMAC_CTX_free(HMAC_CTX *ctx) {
     return HMAC_CTX_free(ctx);
 #else
     if (ctx != NULL) {
-        ctx->md = NULL;
-        ctx->key_length = 0;
-        memset(ctx->key, 0, sizeof(HMAC_MAX_MD_CBLOCK));
-
         HMAC_CTX_cleanup(ctx);
         OPENSSL_free(ctx);
     }

--- a/src/cryptography/hazmat/backends/openssl/hmac.py
+++ b/src/cryptography/hazmat/backends/openssl/hmac.py
@@ -20,10 +20,10 @@ class _HMACContext(object):
         self._backend = backend
 
         if ctx is None:
-            ctx = self._backend._ffi.new("HMAC_CTX *")
-            self._backend._lib.HMAC_CTX_init(ctx)
+            ctx = self._backend._lib.Cryptography_HMAC_CTX_new()
+            self._backend.openssl_assert(ctx != self._backend._ffi.NULL)
             ctx = self._backend._ffi.gc(
-                ctx, self._backend._lib.HMAC_CTX_cleanup
+                ctx, self._backend._lib.Cryptography_HMAC_CTX_free
             )
             evp_md = self._backend._lib.EVP_get_digestbyname(
                 algorithm.name.encode('ascii'))
@@ -44,10 +44,10 @@ class _HMACContext(object):
     algorithm = utils.read_only_property("_algorithm")
 
     def copy(self):
-        copied_ctx = self._backend._ffi.new("HMAC_CTX *")
-        self._backend._lib.HMAC_CTX_init(copied_ctx)
+        copied_ctx = self._backend._lib.Cryptography_HMAC_CTX_new()
+        self._backend.openssl_assert(copied_ctx != self._backend._ffi.NULL)
         copied_ctx = self._backend._ffi.gc(
-            copied_ctx, self._backend._lib.HMAC_CTX_cleanup
+            copied_ctx, self._backend._lib.Cryptography_HMAC_CTX_free
         )
         res = self._backend._lib.Cryptography_HMAC_CTX_copy(
             copied_ctx, self._ctx
@@ -72,7 +72,6 @@ class _HMACContext(object):
         )
         self._backend.openssl_assert(res != 0)
         self._backend.openssl_assert(outlen[0] == self.algorithm.digest_size)
-        self._backend._lib.HMAC_CTX_cleanup(self._ctx)
         return self._backend._ffi.buffer(buf)[:outlen[0]]
 
     def verify(self, signature):


### PR DESCRIPTION
The first somewhat complex 1.1.0 compatibility PR. In 1.1.0 `HMAC_CTX` is opaque. We don't reach inside it, but it now means we need allocate/free functions since we don't know its size any more. We add two functions that wrap the new ones on 1.1.0 and emulate them on 1.0.2 and lower. HMAC_CTX_new is reasonably straightforward, but free is a bit confusing. Free calls these functions in 1.1.0:

```c
static void hmac_ctx_cleanup(HMAC_CTX *ctx)
{
    EVP_MD_CTX_reset(ctx->i_ctx);
    EVP_MD_CTX_reset(ctx->o_ctx);
    EVP_MD_CTX_reset(ctx->md_ctx);
    ctx->md = NULL;
    ctx->key_length = 0;
    memset(ctx->key, 0, sizeof(HMAC_MAX_MD_CBLOCK));
}

void HMAC_CTX_free(HMAC_CTX *ctx)
{
    if (ctx != NULL) {
        hmac_ctx_cleanup(ctx);
        EVP_MD_CTX_free(ctx->i_ctx);
        EVP_MD_CTX_free(ctx->o_ctx);
        EVP_MD_CTX_free(ctx->md_ctx);
        OPENSSL_free(ctx);
    }
}



void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
{
    EVP_MD_CTX_reset(ctx);
    OPENSSL_free(ctx);
}


int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
{
    if (ctx == NULL)
        return 1;

    /*
     * Don't assume ctx->md_data was cleaned in EVP_Digest_Final, because
     * sometimes only copies of the context are ever finalised.
     */
    if (ctx->digest && ctx->digest->cleanup
        && !EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_CLEANED))
        ctx->digest->cleanup(ctx);
    if (ctx->digest && ctx->digest->ctx_size && ctx->md_data
        && !EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_REUSE)) {
        OPENSSL_clear_free(ctx->md_data, ctx->digest->ctx_size);
    }
    EVP_PKEY_CTX_free(ctx->pctx);
#ifndef OPENSSL_NO_ENGINE
    ENGINE_finish(ctx->engine);
#endif
    memset(ctx, 0, sizeof(*ctx));

    return 1;
}
```

In 1.0.2 some of these functions do exist, they just have different names. For example, most of `EVP_MD_CTX_free` is inside `EVP_MD_CTX_cleanup` and and `HMAC_CTX_cleanup` is similar. So the code in this PR merges what it can together to emulate the behavior of 1.1.0 

For reference here are `EVP_MD_CTX_cleanup` and `HMAC_CTX_cleanup`:

```c
void HMAC_CTX_cleanup(HMAC_CTX *ctx)
    {
#ifdef OPENSSL_FIPS
    if (FIPS_mode() && !ctx->i_ctx.engine)
        {
        FIPS_hmac_ctx_cleanup(ctx);
        return;
        }
#endif
    EVP_MD_CTX_cleanup(&ctx->i_ctx);
    EVP_MD_CTX_cleanup(&ctx->o_ctx);
    EVP_MD_CTX_cleanup(&ctx->md_ctx);
    memset(ctx,0,sizeof *ctx);
    }

/* This call frees resources associated with the context */
int EVP_MD_CTX_cleanup(EVP_MD_CTX *ctx)
    {
#ifndef OPENSSL_FIPS
    /* Don't assume ctx->md_data was cleaned in EVP_Digest_Final,
     * because sometimes only copies of the context are ever finalised.
     */
    if (ctx->digest && ctx->digest->cleanup
        && !EVP_MD_CTX_test_flags(ctx,EVP_MD_CTX_FLAG_CLEANED))
        ctx->digest->cleanup(ctx);
    if (ctx->digest && ctx->digest->ctx_size && ctx->md_data
        && !EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_REUSE))
        {
        OPENSSL_cleanse(ctx->md_data,ctx->digest->ctx_size);
        OPENSSL_free(ctx->md_data);
        }
#endif
    if (ctx->pctx)
        EVP_PKEY_CTX_free(ctx->pctx);
#ifndef OPENSSL_NO_ENGINE
    if(ctx->engine)
        /* The EVP_MD we used belongs to an ENGINE, release the
         * functional reference we held for this reason. */
        ENGINE_finish(ctx->engine);
#endif
#ifdef OPENSSL_FIPS
    FIPS_md_ctx_cleanup(ctx);
#endif
    memset(ctx,'\0',sizeof *ctx);

    return 1;
    }
```