### PR TITLE
remove RAND_pseudo_bytes + make EGD conditional for 1.1.0

### DIFF
--- a/src/_cffi_src/openssl/rand.py
+++ b/src/_cffi_src/openssl/rand.py
@@ -22,7 +22,6 @@ int RAND_load_file(const char *, long);
 int RAND_write_file(const char *);
 void RAND_cleanup(void);
 int RAND_bytes(unsigned char *, int);
-int RAND_pseudo_bytes(unsigned char *, int);
 """
 
 MACROS = """
@@ -32,7 +31,7 @@ int RAND_query_egd_bytes(const char *, unsigned char *, int);
 """
 
 CUSTOMIZATIONS = """
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER >= 0x10100000L
 static const long Cryptography_HAS_EGD = 0;
 int (*RAND_egd)(const char *) = NULL;
 int (*RAND_egd_bytes)(const char *, int) = NULL;


### PR DESCRIPTION
1.1.0 doesn't have a pseudo_bytes (and we don't use it from the bindings, nor does pyopenssl)