### PR TITLE
opaque X509_EXTENSION

### DIFF
--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -36,7 +36,13 @@ typedef struct {
     ...;
 } X509_CINF;
 
-typedef ... X509_EXTENSION;
+/* TODO: opaque X509_EXTENSION. Cryptography no longer depends on it being
+   non-opaque but pyOpenSSL needs a release where it doesn't depend on this */
+typedef struct {
+    ASN1_OBJECT *object;
+    ASN1_BOOLEAN critical;
+    ASN1_OCTET_STRING *value;
+} X509_EXTENSION;
 
 typedef ... X509_EXTENSIONS;
 typedef ... X509_REQ_INFO;

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -36,11 +36,7 @@ typedef struct {
     ...;
 } X509_CINF;
 
-typedef struct {
-    ASN1_OBJECT *object;
-    ASN1_BOOLEAN critical;
-    ASN1_OCTET_STRING *value;
-} X509_EXTENSION;
+typedef ... X509_EXTENSION;
 
 typedef ... X509_EXTENSIONS;
 typedef ... X509_REQ_INFO;

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -198,7 +198,9 @@ class _X509ExtensionParser(object):
             backend.openssl_assert(ext != backend._ffi.NULL)
             crit = backend._lib.X509_EXTENSION_get_critical(ext)
             critical = crit == 1
-            oid = x509.ObjectIdentifier(_obj2txt(backend, ext.object))
+            oid = x509.ObjectIdentifier(
+                _obj2txt(backend, backend._lib.X509_EXTENSION_get_object(ext))
+            )
             if oid in seen_oids:
                 raise x509.DuplicateExtension(
                     "Duplicate {0} extension found".format(oid), oid
@@ -652,9 +654,10 @@ def _decode_cert_issuer(backend, ext):
     """
 
     data_ptr_ptr = backend._ffi.new("const unsigned char **")
-    data_ptr_ptr[0] = ext.value.data
+    value = backend._lib.X509_EXTENSION_get_data(ext)
+    data_ptr_ptr[0] = value.data
     gns = backend._lib.d2i_GENERAL_NAMES(
-        backend._ffi.NULL, data_ptr_ptr, ext.value.length
+        backend._ffi.NULL, data_ptr_ptr, value.length
     )
 
     # Check the result of d2i_GENERAL_NAMES() is valid. Usually this is covered


### PR DESCRIPTION
`X509_EXTENSION_get_object` and `X509_EXTENSION_get_data` in this PR *do not* increment refcount. The memory they return is tied to the lifetime of the parent object (which should already be registered for gc).