### PR TITLE
move crypto_ex_data to macros, add i2d_re_X509_tbs & X509_get0_signature

### DIFF
--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -373,10 +373,11 @@ void X509_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
 /* from x509/x_x509.c */
 int i2d_re_X509_tbs(X509 *x, unsigned char **pp)
 {
-    /* In 1.0.1 and below cert_info is a pointer in the struct, so
-       we don't want to pass by reference. */
-    /* ideally we also call x->cert_info->enc.modified = 1 as 1.0.2+ does, but
-       older OpenSSLs don't have the enc ASN1_ENCODING on the struct */
+    /* in 1.0.2+ this function also sets x->cert_info->enc.modified = 1
+       but older OpenSSLs don't have the enc ASN1_ENCODING member in the
+       X509 struct.  Setting modified to 1 marks the encoding
+       (x->cert_info->enc.enc) as invalid, but since the entire struct isn't
+       present we don't care. */
     return i2d_X509_CINF(x->cert_info, pp);
 }
 #endif

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -369,7 +369,7 @@ void X509_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
 #endif
 /* Added in 1.0.2 but we need it in all versions now due to the great
    opaquing. */
-#if OPENSSL_VERSION_NUMBER < 0x1000200fL || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10002003L || defined(LIBRESSL_VERSION_NUMBER)
 /* from x509/x_x509.c */
 int i2d_re_X509_tbs(X509 *x, unsigned char **pp)
 {


### PR DESCRIPTION
And, of course, use them in the openssl bindings. These changes are a start towards opaquing all the X509 structs. The actual opaquing won't take place until the very end though to minimize pyOpenSSL breakage.

To ease review, here are the definitions for the added functions:

[X509_get0_signature](https://github.com/openssl/openssl/blob/902f3f50d051dfd6ebf009d352aaf581195caabf/crypto/asn1/x_x509.c#L217) (added in 1.0.2-beta1, which is 0x10002001L) 

[i2d_re_X509_tbs](https://github.com/openssl/openssl/blob/902f3f50d051dfd6ebf009d352aaf581195caabf/crypto/asn1/x_x509.c#L211) (not added until 1.0.2-beta3, which is 0x10002003L)