### PR TITLE
modify how revocation date is set on X509_REVOKED in the openssl backend

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1003,11 +1003,14 @@ class Backend(object):
             x509_revoked, serial_number
         )
         self.openssl_assert(res == 1)
-        res = self._lib.ASN1_TIME_set(
-            x509_revoked.revocationDate,
+        rev_date = self._lib.ASN1_TIME_set(
+            self._ffi.NULL,
             calendar.timegm(builder._revocation_date.timetuple())
         )
-        self.openssl_assert(res != self._ffi.NULL)
+        self.openssl_assert(rev_date != self._ffi.NULL)
+        rev_date = self._ffi.gc(rev_date, self._lib.ASN1_TIME_free)
+        res = self._lib.X509_REVOKED_set_revocationDate(x509_revoked, rev_date)
+        self.openssl_assert(res == 1)
         # add CRL entry extensions
         self._create_x509_extensions(
             extensions=builder._extensions,


### PR DESCRIPTION
In OpenSSL 1.1.0 there isn't a pre-existing ASN1_TIME object inside of an X509_REVOKED so we have ASN1_TIME_set make us a new one. In older OpenSSLs this is still safe because ASN1_TIME_set checks and frees any current value in the object.

For reference, X509_REVOKED_set_revocationDate from [0.9.8h](https://github.com/openssl/openssl/blob/2bf03f2389c44bdb40ca48fe6132343b8c71b64c/crypto/x509/x509cset.c#L136) and [1.0.2g](https://github.com/openssl/openssl/blob/902f3f50d051dfd6ebf009d352aaf581195caabf/crypto/x509/x509cset.c#L135)