### PR TITLE
bind SSL_CTX_get_ssl_method

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -374,8 +374,6 @@ void (*SSL_CTX_get_info_callback(SSL_CTX *))(const SSL *, int, int);
    RHEL/CentOS 5 this can be moved back to FUNCTIONS. */
 SSL_CTX *SSL_set_SSL_CTX(SSL *, SSL_CTX *);
 
-const SSL_METHOD *Cryptography_SSL_CTX_get_method(const SSL_CTX *);
-
 /* NPN APIs were introduced in OpenSSL 1.0.1.  To continue to support earlier
  * versions some special handling of these is necessary.
  */
@@ -424,9 +422,21 @@ long SSL_get_server_tmp_key(SSL *, EVP_PKEY **);
  */
 void SSL_CTX_set_cert_cb(SSL_CTX *, int (*)(SSL *, void *), void *);
 void SSL_set_cert_cb(SSL *, int (*)(SSL *, void *), void *);
+
+/* Added in 1.0.2 */
+const SSL_METHOD *SSL_CTX_get_ssl_method(SSL_CTX *);
 """
 
 CUSTOMIZATIONS = """
+/* Added in 1.0.2 but we need it in all versions now due to the great
+   opaquing. */
+#if OPENSSL_VERSION_NUMBER < 0x10002001L || defined(LIBRESSL_VERSION_NUMBER)
+/* from ssl/ssl_lib.c */
+const SSL_METHOD *SSL_CTX_get_ssl_method(SSL_CTX *ctx) {
+    return ctx->method;
+}
+#endif
+
 /** Secure renegotiation is supported in OpenSSL >= 0.9.8m
  *  But some Linux distributions have back ported some features.
  */
@@ -566,11 +576,6 @@ static const long Cryptography_HAS_NETBSD_D1_METH = 1;
 #else
 static const long Cryptography_HAS_NETBSD_D1_METH = 1;
 #endif
-
-/* Workaround for #794 caused by cffi const** bug. */
-const SSL_METHOD *Cryptography_SSL_CTX_get_method(const SSL_CTX *ctx) {
-    return ctx->method;
-}
 
 /* Because OPENSSL defines macros that claim lack of support for things, rather
  * than macros that claim support for things, we need to do a version check in


### PR DESCRIPTION
When we opaque the SSL struct this will be how you have to access the various struct members.

Links to definitions in OpenSSL:

[SSL_CTX_get_ssl_method](https://github.com/openssl/openssl/blob/902f3f50d051dfd6ebf009d352aaf581195caabf/ssl/ssl_lib.c#L2648) (added 1.0.2)
[SSL_SESSION_set1_id_context](https://github.com/openssl/openssl/blob/57ac73fb5d0a878f282cbcd9e7951c77fdc59e3c/ssl/ssl_sess.c#L1016)(added 1.0.1)
[SSL_SESSION_get_master_key](https://github.com/openssl/openssl/blob/0d4d5ab81980888e06b457fb00a1b224e921976f/ssl/ssl_lib.c#L3505) (added 1.1.0)
[SSL_get_client_random](https://github.com/openssl/openssl/blob/0d4d5ab81980888e06b457fb00a1b224e921976f/ssl/ssl_lib.c#L3485) (added 1.1.0)
[SSL_get_server_random](https://github.com/openssl/openssl/blob/0d4d5ab81980888e06b457fb00a1b224e921976f/ssl/ssl_lib.c#L3495) (added 1.1.0)