### PR TITLE
add 5 accessor functions that exist in 1.1.0 to help opaque x509 structs

### DIFF
--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -396,8 +396,6 @@ void X509_REQ_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
     if (psig != NULL)
         *psig = req->signature;
     if (palg != NULL)
-        /* In 1.0.2 and below sig_alg is a pointer in the struct, so
-           we don't want to pass by reference. */
         *palg = req->sig_alg;
 }
 int i2d_re_X509_REQ_tbs(X509_REQ *req, unsigned char **pp)
@@ -414,12 +412,8 @@ void X509_CRL_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
                              X509_CRL *crl)
 {
     if (psig != NULL)
-        /* In 1.0.2 and below sigis a pointer in the struct, so
-           we don't want to pass by reference. */
         *psig = crl->signature;
     if (palg != NULL)
-        /* In 1.0.2 and below sig_alg is a pointer in the struct, so
-           we don't want to pass by reference. */
         *palg = crl->sig_alg;
 }
 ASN1_TIME *X509_REVOKED_get0_revocationDate(X509_REVOKED *x)
@@ -428,8 +422,6 @@ ASN1_TIME *X509_REVOKED_get0_revocationDate(X509_REVOKED *x)
 }
 ASN1_INTEGER *X509_REVOKED_get0_serialNumber(X509_REVOKED *x)
 {
-    /* In 1.0.2 and below serialNumber is a pointer in the struct, so
-       we don't want to pass by reference. */
     return x->serialNumber;
 }
 #endif

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -349,6 +349,15 @@ ASN1_OBJECT *sk_ASN1_OBJECT_value(Cryptography_STACK_OF_ASN1_OBJECT *, int);
 void sk_ASN1_OBJECT_free(Cryptography_STACK_OF_ASN1_OBJECT *);
 Cryptography_STACK_OF_ASN1_OBJECT *sk_ASN1_OBJECT_new_null(void);
 int sk_ASN1_OBJECT_push(Cryptography_STACK_OF_ASN1_OBJECT *, ASN1_OBJECT *);
+
+/* these functions were added in 1.1.0 */
+ASN1_INTEGER *X509_REVOKED_get0_serialNumber(X509_REVOKED *);
+ASN1_TIME *X509_REVOKED_get0_revocationDate(X509_REVOKED *);
+void X509_CRL_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
+                             X509_CRL *crl);
+int i2d_re_X509_REQ_tbs(X509_REQ *, unsigned char **);
+int i2d_re_X509_CRL_tbs(X509_CRL *, unsigned char **);
+void X509_REQ_get0_signature(ASN1_BIT_STRING **, X509_ALGOR **, X509_REQ *);
 """
 
 CUSTOMIZATIONS = """
@@ -377,4 +386,51 @@ X509_REVOKED *Cryptography_X509_REVOKED_dup(X509_REVOKED *rev) {
     return ASN1_item_dup(ASN1_ITEM_rptr(X509_REVOKED), rev);
 }
 
+/* Added in 1.1.0 but we need it in all versions now due to the great
+   opaquing. */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+/* from x509/x509_req.c */
+void X509_REQ_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
+                             X509_REQ *req)
+{
+    if (psig != NULL)
+        *psig = req->signature;
+    if (palg != NULL)
+        /* In 1.0.2 and below sig_alg is a pointer in the struct, so
+           we don't want to pass by reference. */
+        *palg = req->sig_alg;
+}
+int i2d_re_X509_REQ_tbs(X509_REQ *req, unsigned char **pp)
+{
+    req->req_info->enc.modified = 1;
+    return i2d_X509_REQ_INFO(req->req_info, pp);
+}
+int i2d_re_X509_CRL_tbs(X509_CRL *crl, unsigned char **pp) {
+    crl->crl->enc.modified = 1;
+    return i2d_X509_CRL_INFO(crl->crl, pp);
+}
+
+void X509_CRL_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
+                             X509_CRL *crl)
+{
+    if (psig != NULL)
+        /* In 1.0.2 and below sigis a pointer in the struct, so
+           we don't want to pass by reference. */
+        *psig = crl->signature;
+    if (palg != NULL)
+        /* In 1.0.2 and below sig_alg is a pointer in the struct, so
+           we don't want to pass by reference. */
+        *palg = crl->sig_alg;
+}
+ASN1_TIME *X509_REVOKED_get0_revocationDate(X509_REVOKED *x)
+{
+    return x->revocationDate;
+}
+ASN1_INTEGER *X509_REVOKED_get0_serialNumber(X509_REVOKED *x)
+{
+    /* In 1.0.2 and below serialNumber is a pointer in the struct, so
+       we don't want to pass by reference. */
+    return x->serialNumber;
+}
+#endif
 """


### PR DESCRIPTION
These functions, while added in 1.1.0, are *not* direct copies. This is because the opaque structs have changed (typically with regard to pointers vs direct struct reference. To review these functions you'll need to look at the struct definitions from OpenSSL <= 1.0.2.

This PR also makes use of the new bindings to more directly demonstrate that they work on < 1.1.0. Once this and #2802 merge then a followup PR could potentially be done to reduce some duplication.

The functions are: 
* X509_REVOKED_get0_serialNumber -- [X509_REVOKED definition](https://github.com/openssl/openssl/blob/902f3f50d051dfd6ebf009d352aaf581195caabf/crypto/x509/x509.h#L427)
* X509_REVOKED_get0_revocationDate -- same as above
* X509_CRL_get0_signature -- [X509_CRL definition](https://github.com/openssl/openssl/blob/902f3f50d051dfd6ebf009d352aaf581195caabf/crypto/x509/x509.h#L452)
* i2d_re_X509_CRL_tbs -- same as above
* i2d_re_X509_REQ_tbs -- [X509_REQ definition](https://github.com/openssl/openssl/blob/902f3f50d051dfd6ebf009d352aaf581195caabf/crypto/x509/x509.h#L235)
* X509_REQ_get0_signature -- same as above