### PR TITLE
partially opaque RAND_METHOD

### DIFF
--- a/src/_cffi_src/openssl/engine.py
+++ b/src/_cffi_src/openssl/engine.py
@@ -16,12 +16,10 @@ typedef ... RSA_METHOD;
 typedef ... DSA_METHOD;
 typedef ... DH_METHOD;
 typedef struct {
-    void (*seed)(const void *, int);
     int (*bytes)(unsigned char *, int);
-    void (*cleanup)();
-    void (*add)(const void *, int, double);
     int (*pseudorand)(unsigned char *, int);
     int (*status)();
+    ...;
 } RAND_METHOD;
 typedef int (*ENGINE_GEN_INT_FUNC_PTR)(ENGINE *);
 typedef ... *ENGINE_CTRL_FUNC_PTR;


### PR DESCRIPTION
We only populate bytes, pseudobytes, and status and in OpenSSL 1.1.0 `seed` and `add` changed signature (from void return to int). So let's just not bind these.