### PR TITLE
Don't make this struct opaque

### DIFF
--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -12,7 +12,7 @@ TYPES = """
 typedef ... EVP_CIPHER;
 typedef ... EVP_CIPHER_CTX;
 typedef ... EVP_MD;
-typedef { ...; } EVP_MD_CTX;
+typedef struct { ...; } EVP_MD_CTX;
 
 typedef ... EVP_PKEY;
 typedef ... EVP_PKEY_CTX;

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -12,7 +12,7 @@ TYPES = """
 typedef ... EVP_CIPHER;
 typedef ... EVP_CIPHER_CTX;
 typedef ... EVP_MD;
-typedef ... EVP_MD_CTX;
+typedef { ...; } EVP_MD_CTX;
 
 typedef ... EVP_PKEY;
 typedef ... EVP_PKEY_CTX;


### PR DESCRIPTION
it breaks pyopenssl: https://jenkins.cryptography.io/job/pyopenssl-smoke/label=debian7,version=master/80/console