### PR TITLE
Error on unusual encodings

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -710,7 +710,7 @@ def _asn1_string_to_utf8(backend, asn1_string):
     buf = backend._ffi.new("unsigned char **")
     res = backend._lib.ASN1_STRING_to_UTF8(buf, asn1_string)
     if res == -1:
-        raise TypeError(
+        raise ValueError(
             "Unsupported ASN1 string type. Type: {0}".format(asn1_string.type)
         )
 

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -709,7 +709,11 @@ def _asn1_string_to_ascii(backend, asn1_string):
 def _asn1_string_to_utf8(backend, asn1_string):
     buf = backend._ffi.new("unsigned char **")
     res = backend._lib.ASN1_STRING_to_UTF8(buf, asn1_string)
-    backend.openssl_assert(res >= 0)
+    if res == -1:
+        raise TypeError(
+            "Unsupported ASN1 string type. Type: {0}".format(asn1_string.type)
+        )
+
     backend.openssl_assert(buf[0] != backend._ffi.NULL)
     buf = backend._ffi.gc(
         buf, lambda buffer: backend._lib.OPENSSL_free(buffer[0])

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -676,4 +676,4 @@ class TestGOSTCertificate(object):
         # We assert on the message in this case because if the certificate
         # fails to load it will also raise a ValueError and this test could
         # erroneously pass.
-        assert exc.value.message == "Unsupported ASN1 string type. Type: 18"
+        assert str(exc.value) == "Unsupported ASN1 string type. Type: 18"

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -31,6 +31,7 @@ from ..primitives.test_ec import _skip_curve_unsupported
 from ...doubles import (
     DummyAsymmetricPadding, DummyCipherAlgorithm, DummyHashAlgorithm, DummyMode
 )
+from ...test_x509 import _load_cert
 from ...utils import load_vectors_from_file, raises_unsupported_algorithm
 
 
@@ -656,3 +657,23 @@ class TestRSAPEMSerialization(object):
                 serialization.PrivateFormat.PKCS8,
                 serialization.BestAvailableEncryption(password)
             )
+
+
+class TestGOSTCertificate(object):
+    @pytest.mark.skipif(
+        backend._lib.OPENSSL_VERSION_NUMBER < 0x1000000f,
+        reason="Requires a newer OpenSSL. Must be >= 1.0.0"
+    )
+    def test_numeric_string_x509_name_entry(self):
+        cert = _load_cert(
+            os.path.join("x509", "e-trust.ru.der"),
+            x509.load_der_x509_certificate,
+            backend
+        )
+        with pytest.raises(ValueError) as exc:
+            cert.subject
+
+        # We assert on the message in this case because if the certificate
+        # fails to load it will also raise a ValueError and this test could
+        # erroneously pass.
+        assert exc.value.message == "Unsupported ASN1 string type. Type: 18"

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -3157,6 +3157,18 @@ class TestDSACertificateRequest(object):
         verifier.verify()
 
 
+@pytest.mark.requires_backend_interface(interface=X509Backend)
+class TestGOSTCertificate(object):
+    def test_numeric_string_x509_name_entry(self, backend):
+        cert = _load_cert(
+            os.path.join("x509", "e-trust.ru.der"),
+            x509.load_der_x509_certificate,
+            backend
+        )
+        with pytest.raises(TypeError):
+            cert.subject
+
+
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
 class TestECDSACertificate(object):

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -3157,18 +3157,6 @@ class TestDSACertificateRequest(object):
         verifier.verify()
 
 
-@pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestGOSTCertificate(object):
-    def test_numeric_string_x509_name_entry(self, backend):
-        cert = _load_cert(
-            os.path.join("x509", "e-trust.ru.der"),
-            x509.load_der_x509_certificate,
-            backend
-        )
-        with pytest.raises(TypeError):
-            cert.subject
-
-
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
 class TestECDSACertificate(object):


### PR DESCRIPTION
When encountering asn1 string types that can't be parsed via `ASN1_STRING_to_UTF8` let's error out with a TypeError for now.

Depends on #2814, refs #2724 