### PR TITLE
simplify extension creation by using X509V3_EXT_i2d

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -31,7 +31,8 @@ from cryptography.hazmat.backends.openssl.ec import (
 from cryptography.hazmat.backends.openssl.encode_asn1 import (
     _CRL_ENTRY_EXTENSION_ENCODE_HANDLERS,
     _CRL_EXTENSION_ENCODE_HANDLERS, _EXTENSION_ENCODE_HANDLERS,
-    _encode_asn1_int_gc, _encode_name_gc,
+    _encode_asn1_int_gc, _encode_asn1_str_gc, _encode_name_gc,
+    _txt2obj_gc,
 )
 from cryptography.hazmat.backends.openssl.hashes import _HashContext
 from cryptography.hazmat.backends.openssl.hmac import _HMACContext
@@ -978,10 +979,34 @@ class Backend(object):
             nid = self._lib.OBJ_txt2nid(
                 extension.oid.dotted_string.encode("ascii")
             )
+            backend.openssl_assert(nid != self._lib.NID_undef)
             x509_extension = self._lib.X509V3_EXT_i2d(
                 nid, 1 if extension.critical else 0, ext_struct
             )
+            if (
+                x509_extension == self._ffi.NULL and
+                extension.oid == x509.OID_CERTIFICATE_ISSUER
+            ):
+                # This path exists to support OpenSSL 0.9.8, which does
+                # not know how to encode a CERTIFICATE_ISSUER for CRLs. Once we
+                # drop 0.9.8 support we can remove this.
+                self._consume_errors()
+                pp = backend._ffi.new("unsigned char **")
+                r = self._lib.i2d_GENERAL_NAMES(ext_struct, pp)
+                backend.openssl_assert(r > 0)
+                pp = backend._ffi.gc(
+                    pp, lambda pointer: backend._lib.OPENSSL_free(pointer[0])
+                )
+                obj = _txt2obj_gc(self, extension.oid.dotted_string)
+                x509_extension = self._lib.X509_EXTENSION_create_by_OBJ(
+                    self._ffi.NULL,
+                    obj,
+                    1 if extension.critical else 0,
+                    _encode_asn1_str_gc(self, pp[0], r)
+                )
+
             self.openssl_assert(x509_extension != self._ffi.NULL)
+
             if gc:
                 x509_extension = self._ffi.gc(
                     x509_extension, self._lib.X509_EXTENSION_free

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -31,8 +31,7 @@ from cryptography.hazmat.backends.openssl.ec import (
 from cryptography.hazmat.backends.openssl.encode_asn1 import (
     _CRL_ENTRY_EXTENSION_ENCODE_HANDLERS,
     _CRL_EXTENSION_ENCODE_HANDLERS, _EXTENSION_ENCODE_HANDLERS,
-    _encode_asn1_int_gc, _encode_asn1_str_gc, _encode_name_gc,
-    _txt2obj_gc,
+    _encode_asn1_int_gc, _encode_name_gc,
 )
 from cryptography.hazmat.backends.openssl.hashes import _HashContext
 from cryptography.hazmat.backends.openssl.hmac import _HMACContext
@@ -975,13 +974,10 @@ class Backend(object):
                     'Extension not supported: {0}'.format(extension.oid)
                 )
 
-            pp, r = encode(self, extension.value)
-            obj = _txt2obj_gc(self, extension.oid.dotted_string)
-            x509_extension = self._lib.X509_EXTENSION_create_by_OBJ(
-                self._ffi.NULL,
-                obj,
-                1 if extension.critical else 0,
-                _encode_asn1_str_gc(self, pp[0], r)
+            ext_struct = encode(self, extension.value)
+            nid = self._lib.OBJ_txt2nid(extension.oid.dotted_string)
+            x509_extension = self._lib.X509V3_EXT_i2d(
+                nid, 1 if extension.critical else 0, ext_struct
             )
             self.openssl_assert(x509_extension != self._ffi.NULL)
             if gc:

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -975,7 +975,9 @@ class Backend(object):
                 )
 
             ext_struct = encode(self, extension.value)
-            nid = self._lib.OBJ_txt2nid(extension.oid.dotted_string)
+            nid = self._lib.OBJ_txt2nid(
+                extension.oid.dotted_string.encode("ascii")
+            )
             x509_extension = self._lib.X509V3_EXT_i2d(
                 nid, 1 if extension.critical else 0, ext_struct
             )

--- a/src/cryptography/hazmat/backends/openssl/encode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/encode_asn1.py
@@ -242,7 +242,7 @@ def _encode_ocsp_nocheck(backend, ext):
     The OCSP No Check extension is defined as a null ASN.1 value embedded in
     an ASN.1 string.
     """
-    return _encode_asn1_str_gc(backend, "\x05\x00", 2)
+    return _encode_asn1_str_gc(backend, b"\x05\x00", 2)
 
 
 def _encode_key_usage(backend, key_usage):

--- a/src/cryptography/hazmat/backends/openssl/encode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/encode_asn1.py
@@ -74,21 +74,8 @@ def _encode_asn1_str_gc(backend, data, length):
     return s
 
 
-def _encode_extension_to_der(backend, i2d_func, value):
-    pp = backend._ffi.new("unsigned char **")
-    r = i2d_func(value, pp)
-    backend.openssl_assert(r > 0)
-    pp = backend._ffi.gc(
-        pp, lambda pointer: backend._lib.OPENSSL_free(pointer[0])
-    )
-    return pp, r
-
-
 def _encode_inhibit_any_policy(backend, inhibit_any_policy):
-    asn1int = _encode_asn1_int_gc(backend, inhibit_any_policy.skip_certs)
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_ASN1_INTEGER, asn1int
-    )
+    return _encode_asn1_int_gc(backend, inhibit_any_policy.skip_certs)
 
 
 def _encode_name(backend, attributes):
@@ -137,10 +124,7 @@ def _encode_name_entry(backend, attribute):
 
 
 def _encode_crl_number(backend, crl_number):
-    asn1int = _encode_asn1_int_gc(backend, crl_number.crl_number)
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_ASN1_INTEGER, asn1int
-    )
+    return _encode_asn1_int_gc(backend, crl_number.crl_number)
 
 
 def _encode_crl_reason(backend, crl_reason):
@@ -152,9 +136,7 @@ def _encode_crl_reason(backend, crl_reason):
     )
     backend.openssl_assert(res == 1)
 
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_ASN1_ENUMERATED, asn1enum
-    )
+    return asn1enum
 
 
 def _encode_invalidity_date(backend, invalidity_date):
@@ -166,9 +148,7 @@ def _encode_invalidity_date(backend, invalidity_date):
     backend.openssl_assert(time != backend._ffi.NULL)
     time = backend._ffi.gc(time, backend._lib.ASN1_GENERALIZEDTIME_free)
 
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_ASN1_GENERALIZEDTIME, time
-    )
+    return time
 
 
 def _encode_certificate_policies(backend, certificate_policies):
@@ -218,9 +198,7 @@ def _encode_certificate_policies(backend, certificate_policies):
 
             pi.qualifiers = pqis
 
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_CERTIFICATEPOLICIES, cp
-    )
+    return cp
 
 
 def _encode_notice_reference(backend, notice):
@@ -261,10 +239,10 @@ def _txt2obj_gc(backend, name):
 
 def _encode_ocsp_nocheck(backend, ext):
     """
-    The OCSP No Check extension is defined as a null ASN.1 value. Rather than
-    calling OpenSSL we can return a Python bytestring value in a list.
+    The OCSP No Check extension is defined as a null ASN.1 value embedded in
+    an ASN.1 string.
     """
-    return [b"\x05\x00"], 2
+    return _encode_asn1_str_gc(backend, "\x05\x00", 2)
 
 
 def _encode_key_usage(backend, key_usage):
@@ -296,9 +274,7 @@ def _encode_key_usage(backend, key_usage):
         res = set_bit(ku, 8, 0)
         backend.openssl_assert(res == 1)
 
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_ASN1_BIT_STRING, ku
-    )
+    return ku
 
 
 def _encode_authority_key_identifier(backend, authority_keyid):
@@ -322,9 +298,7 @@ def _encode_authority_key_identifier(backend, authority_keyid):
             backend, authority_keyid.authority_cert_serial_number
         )
 
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_AUTHORITY_KEYID, akid
-    )
+    return akid
 
 
 def _encode_basic_constraints(backend, basic_constraints):
@@ -338,9 +312,7 @@ def _encode_basic_constraints(backend, basic_constraints):
             backend, basic_constraints.path_length
         )
 
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_BASIC_CONSTRAINTS, constraints
-    )
+    return constraints
 
 
 def _encode_authority_information_access(backend, authority_info_access):
@@ -360,9 +332,7 @@ def _encode_authority_information_access(backend, authority_info_access):
         res = backend._lib.sk_ACCESS_DESCRIPTION_push(aia, ad)
         backend.openssl_assert(res >= 1)
 
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_AUTHORITY_INFO_ACCESS, aia
-    )
+    return aia
 
 
 def _encode_general_names(backend, names):
@@ -381,16 +351,11 @@ def _encode_alt_name(backend, san):
     general_names = backend._ffi.gc(
         general_names, backend._lib.GENERAL_NAMES_free
     )
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_GENERAL_NAMES, general_names
-    )
+    return general_names
 
 
 def _encode_subject_key_identifier(backend, ski):
-    asn1_str = _encode_asn1_str_gc(backend, ski.digest, len(ski.digest))
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_ASN1_OCTET_STRING, asn1_str
-    )
+    return _encode_asn1_str_gc(backend, ski.digest, len(ski.digest))
 
 
 def _encode_general_name(backend, name):
@@ -488,10 +453,7 @@ def _encode_extended_key_usage(backend, extended_key_usage):
         res = backend._lib.sk_ASN1_OBJECT_push(eku, obj)
         backend.openssl_assert(res >= 1)
 
-    eku_ptr = backend._ffi.cast("EXTENDED_KEY_USAGE *", eku)
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_EXTENDED_KEY_USAGE, eku_ptr
-    )
+    return eku
 
 
 _CRLREASONFLAGS = {
@@ -545,14 +507,12 @@ def _encode_crl_distribution_points(backend, crl_distribution_points):
         res = backend._lib.sk_DIST_POINT_push(cdp, dp)
         backend.openssl_assert(res >= 1)
 
-    return _encode_extension_to_der(
-        backend, backend._lib.i2d_CRL_DIST_POINTS, cdp
-    )
+    return cdp
 
 
 def _encode_name_constraints(backend, name_constraints):
     nc = backend._lib.NAME_CONSTRAINTS_new()
-    assert nc != backend._ffi.NULL
+    backend.openssl_assert(nc != backend._ffi.NULL)
     nc = backend._ffi.gc(nc, backend._lib.NAME_CONSTRAINTS_free)
     permitted = _encode_general_subtree(
         backend, name_constraints.permitted_subtrees
@@ -563,9 +523,7 @@ def _encode_name_constraints(backend, name_constraints):
     )
     nc.excludedSubtrees = excluded
 
-    return _encode_extension_to_der(
-        backend, backend._lib.Cryptography_i2d_NAME_CONSTRAINTS, nc
-    )
+    return nc
 
 
 def _encode_general_subtree(backend, subtrees):


### PR DESCRIPTION
This was suggested by Stephen Henson in a conversation thread on openssl-dev when we asked about `i2d_NAME_CONSTRAINTS` a few months ago. Once this is done another PR to remove most of the `i2d_{EXTENSION_NAME}` macros can be put in.

Also this switch means we can support encoding of policy constraints in a future PR without binding any new symbols.