### PR TITLE
these bio types no longer exist in 1.1.0

### DIFF
--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -68,8 +68,6 @@ static const int BIO_CTRL_WPENDING;
 static const int BIO_C_FILE_SEEK;
 static const int BIO_C_FILE_TELL;
 static const int BIO_TYPE_NONE;
-static const int BIO_TYPE_PROXY_CLIENT;
-static const int BIO_TYPE_PROXY_SERVER;
 static const int BIO_TYPE_NBIO_TEST;
 static const int BIO_TYPE_BER;
 static const int BIO_TYPE_BIO;


### PR DESCRIPTION
and...you guessed it, we don't use them and neither does pyOpenSSL