### PR TITLE
in 1.1.0 OpenSSL does its own locking now! locking funcs are now macros

### DIFF
--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -25,11 +25,6 @@ static const int CRYPTO_MEM_CHECK_ON;
 static const int CRYPTO_MEM_CHECK_OFF;
 static const int CRYPTO_MEM_CHECK_ENABLE;
 static const int CRYPTO_MEM_CHECK_DISABLE;
-static const int CRYPTO_LOCK;
-static const int CRYPTO_UNLOCK;
-static const int CRYPTO_READ;
-static const int CRYPTO_WRITE;
-static const int CRYPTO_LOCK_SSL;
 """
 
 FUNCTIONS = """
@@ -38,14 +33,16 @@ int CRYPTO_mem_ctrl(int);
 int CRYPTO_is_mem_check_on(void);
 void CRYPTO_mem_leaks(struct bio_st *);
 void CRYPTO_cleanup_all_ex_data(void);
-int CRYPTO_num_locks(void);
-void CRYPTO_set_locking_callback(void(*)(int, int, const char *, int));
-void (*CRYPTO_get_locking_callback(void))(int, int, const char *, int);
-void CRYPTO_lock(int, int, const char *, int);
 
 """
 
 MACROS = """
+/* as of 1.1.0 OpenSSL does its own locking *angelic chorus*. These functions
+   have become macros that are no ops */
+int CRYPTO_num_locks(void);
+void CRYPTO_set_locking_callback(void(*)(int, int, const char *, int));
+void (*CRYPTO_get_locking_callback(void))(int, int, const char *, int);
+
 /* SSLeay was removed in 1.1.0 */
 unsigned long SSLeay(void);
 const char *SSLeay_version(int);

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -60,6 +60,9 @@ void CRYPTO_add(int *, int, int);
 
 /* this is a macro in 1.1.0 */
 void OPENSSL_free(void *);
+
+/* This was removed in 1.1.0 */
+void CRYPTO_lock(int, int, const char *, int);
 """
 
 CUSTOMIZATIONS = """
@@ -92,6 +95,7 @@ static const long CRYPTO_LOCK = 0;
 static const long CRYPTO_UNLOCK = 0;
 static const long CRYPTO_READ = 0;
 static const long CRYPTO_LOCK_SSL = 0;
+void (*CRYPTO_lock)(int, int, const char *, int) = NULL;
 #else
 static const long Cryptography_HAS_LOCKING_CALLBACKS = 1;
 #endif

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -9,6 +9,8 @@ INCLUDES = """
 """
 
 TYPES = """
+static const long Cryptography_HAS_LOCKING_CALLBACKS;
+
 typedef ... CRYPTO_THREADID;
 
 static const int SSLEAY_VERSION;
@@ -25,6 +27,8 @@ static const int CRYPTO_MEM_CHECK_ON;
 static const int CRYPTO_MEM_CHECK_OFF;
 static const int CRYPTO_MEM_CHECK_ENABLE;
 static const int CRYPTO_MEM_CHECK_DISABLE;
+static const int CRYPTO_LOCK;
+static const int CRYPTO_UNLOCK;
 """
 
 FUNCTIONS = """
@@ -79,5 +83,12 @@ CUSTOMIZATIONS = """
 # define OPENSSL_BUILT_ON        SSLEAY_BUILT_ON
 # define OPENSSL_PLATFORM        SSLEAY_PLATFORM
 # define OPENSSL_DIR             SSLEAY_DIR
+#endif
+#if !defined(CRYPTO_LOCK)
+static const long Cryptography_HAS_LOCKING_CALLBACKS = 0;
+static const long CRYPTO_LOCK = 0;
+static const long CRYPTO_UNLOCK = 0;
+#else
+static const long Cryptography_HAS_LOCKING_CALLBACKS = 1;
 #endif
 """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -29,6 +29,7 @@ static const int CRYPTO_MEM_CHECK_ENABLE;
 static const int CRYPTO_MEM_CHECK_DISABLE;
 static const int CRYPTO_LOCK;
 static const int CRYPTO_UNLOCK;
+static const int CRYPTO_READ;
 static const int CRYPTO_LOCK_SSL;
 """
 
@@ -89,6 +90,7 @@ CUSTOMIZATIONS = """
 static const long Cryptography_HAS_LOCKING_CALLBACKS = 0;
 static const long CRYPTO_LOCK = 0;
 static const long CRYPTO_UNLOCK = 0;
+static const long CRYPTO_READ = 0;
 static const long CRYPTO_LOCK_SSL = 0;
 #else
 static const long Cryptography_HAS_LOCKING_CALLBACKS = 1;

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -29,6 +29,7 @@ static const int CRYPTO_MEM_CHECK_ENABLE;
 static const int CRYPTO_MEM_CHECK_DISABLE;
 static const int CRYPTO_LOCK;
 static const int CRYPTO_UNLOCK;
+static const int CRYPTO_LOCK_SSL;
 """
 
 FUNCTIONS = """
@@ -88,6 +89,7 @@ CUSTOMIZATIONS = """
 static const long Cryptography_HAS_LOCKING_CALLBACKS = 0;
 static const long CRYPTO_LOCK = 0;
 static const long CRYPTO_UNLOCK = 0;
+static const long CRYPTO_LOCK_SSL = 0;
 #else
 static const long Cryptography_HAS_LOCKING_CALLBACKS = 1;
 #endif

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -412,4 +412,8 @@ CONDITIONAL_NAMES = {
         "TLS_ST_BEFORE",
         "TLS_ST_OK",
     ],
+    "Cryptography_HAS_LOCKING_CALLBACKS": [
+        "CRYPTO_LOCK",
+        "CRYPTO_UNLOCK",
+    ]
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -415,5 +415,6 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_LOCKING_CALLBACKS": [
         "CRYPTO_LOCK",
         "CRYPTO_UNLOCK",
+        "CRYPTO_LOCK_SSL",
     ]
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -417,5 +417,6 @@ CONDITIONAL_NAMES = {
         "CRYPTO_UNLOCK",
         "CRYPTO_READ",
         "CRYPTO_LOCK_SSL",
+        "CRYPTO_lock",
     ]
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -415,6 +415,7 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_LOCKING_CALLBACKS": [
         "CRYPTO_LOCK",
         "CRYPTO_UNLOCK",
+        "CRYPTO_READ",
         "CRYPTO_LOCK_SSL",
     ]
 }


### PR DESCRIPTION
the macros are no ops. Also remove some constants that we never used and were related to locking.

Also, `CRYPTO_lock`, which was super deprecated and we didn't use, is gone entirely.