### PR TITLE
Fixed #2836 -- error out on OpenSSL 0.9.8 by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Support for OpenSSL 0.9.8 has been removed. Users on older version of OpenSSL
+  will need to upgrade.
 
 1.3 - 2016-03-18
 ~~~~~~~~~~~~~~~~

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -46,7 +46,7 @@ Importing cryptography causes a ``RuntimeError`` about OpenSSL 0.9.8
 The OpenSSL project has dropped support for the 0.9.8 release series. Since it
 is no longer receiving security patches from upstream, ``cryptography`` is also
 dropping support for it. To fix this issue you should upgrade to a newer
-version of OpenSSL (1.0.1 or later), this may require you to upgrade to a newer
+version of OpenSSL (1.0.1 or later). This may require you to upgrade to a newer
 operating system.
 
 For the 1.4 release, you can set the ``CRYPTOGRAPHY_ALLOW_OPENSSL_098``

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -40,6 +40,19 @@ If you have no other libraries using OpenSSL in your process, or they do not
 appear to be at fault, it's possible that this is a bug in ``cryptography``.
 Please file an `issue`_ with instructions on how to reproduce it.
 
+Importing cryptography causes a ``RuntimeError`` about OpenSSL 0.9.8
+--------------------------------------------------------------------
+
+The OpenSSL project has dropped support for the 0.9.8 release series. Since it
+is no longer receiving security patches from upstream, ``cryptography`` is also
+dropping support for it. To fix this issue you should upgrade to a newer
+version of OpenSSL (1.0.1 or later), this may require you to upgrade to a newer
+operating system.
+
+For the 1.4 release, you can set the ``CRYPTOGRAPHY_ALLOW_OPENSSL_098``
+environment variable. Please note that this is *temporary* and will be removed
+in ``cryptography`` 1.5.
+
 .. _`NaCl`: https://nacl.cr.yp.to/
 .. _`PyNaCl`: https://pynacl.readthedocs.org
 .. _`WSGIApplicationGroup`: https://modwsgi.readthedocs.org/en/develop/configuration-directives/WSGIApplicationGroup.html

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,8 +39,8 @@ OpenSSL releases:
 
 .. warning::
     OpenSSL versions 0.9.8 and 1.0.0 are no longer supported by the OpenSSL
-    project. Support for OpenSSL 0.9.8 will be removed in the next
-    ``cryptography`` release.
+    project. Cryptography 1.4 has dropped support for OpenSSL 0.9.8, see the
+    :doc:`FAQ </faq>` for more details.
 
 On Windows
 ----------

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -227,8 +227,7 @@ def _verify_openssl_version(version):
                 utils.DeprecatedIn12
             )
         else:
-            # TODO: what exception type?
-            raise Exception(
+            raise RuntimeError(
                 "You are linking against OpenSSL 0.9.8, which is no longer "
                 "support by the OpenSSL project. You need to upgrade to a "
                 "newer version of OpenSSL."

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -10,7 +10,6 @@ import threading
 import types
 import warnings
 
-from cryptography import utils
 from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings._openssl import ffi, lib
 from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
@@ -224,7 +223,7 @@ def _verify_openssl_version(version):
                 "OpenSSL version 0.9.8 is no longer supported by the OpenSSL "
                 "project, please upgrade. The next version of cryptography "
                 "will completely remove support for it.",
-                utils.DeprecatedIn12
+                DeprecationWarning
             )
         else:
             raise RuntimeError(

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -178,7 +178,6 @@ class TestOpenSSL(object):
 
     def test_verify_openssl_version(self, monkeypatch):
         monkeypatch.delenv("CRYPTOGRAPHY_ALLOW_OPENSSL_098", raising=False)
-        # TODO: what exception type?
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             # OpenSSL 0.9.8zg
             _verify_openssl_version(0x9081DF)

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -8,7 +8,7 @@ import pytest
 
 from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings.openssl.binding import (
-    Binding, _OpenSSLErrorWithText, _openssl_assert
+    Binding, _OpenSSLErrorWithText, _openssl_assert, _verify_openssl_version
 )
 
 
@@ -175,3 +175,10 @@ class TestOpenSSL(object):
                 b'ex:data not multiple of block length'
             )
         )]
+
+    def test_verify_openssl_version(self, monkeypatch):
+        monkeypatch.delenv("CRYPTOGRAPHY_ALLOW_OPENSSL_098", raising=False)
+        # TODO: what exception type?
+        with pytest.raises(Exception):
+            # OpenSSL 0.9.8zg
+            _verify_openssl_version(0x9081DF)

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ deps =
     .[test]
     ./vectors
 passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH USERNAME
+setenv =
+    CRYPTOGRAPHY_ALLOW_OPENSSL_098=1
 commands =
     pip list
     python -c "from cryptography.hazmat.backends.openssl.backend import backend; print(backend.openssl_version_text())"


### PR DESCRIPTION
- [x] Get tests passing on Travis and Jenkins by setting `CRYPTOGRAPHY_ALLOW_OPENSSL_098`
- [x] Figure out which exception type to use for the "you are trying to use openssl 0.9.8" error
- [x] Figure out what to do in `installation.rst`
- [x] Do we document `CRYPTOGRAPHY_ALLOW_OPENSSL_098`?
- [x] Write tests for `_verify_openssl_version` so that we have full coverage