### PR TITLE
add a note on the install page about pip versioning on OS X

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -183,8 +183,13 @@ dependencies.
 Building cryptography on OS X
 -----------------------------
 
+.. note::
+
+    If installation gives a ``fatal error: 'openssl/aes.h' file not found``
+    see the :doc:`FAQ </faq>` for information about how to fix this issue.
+
 The wheel package on OS X is a statically linked build (as of 1.0.1) so for
-users with pip 1.5 or above you only need one step:
+users with pip 8 or above you only need one step:
 
 .. code-block:: console
 


### PR DESCRIPTION
and update the pip version needed to get wheels.


Turns out many questions keep appearing on Stack Overflow and people link to our install docs so we should cross link this FAQ issue to make it easier to figure out why users are seeing this install error.