### PR TITLE
complete deprecation of CRLExtensionOID in favor of CRLEntryExtensionOID

### DIFF
--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -15,7 +15,6 @@ import warnings
 # the functions deprecated in 1.0 are on an arbitrarily extended deprecation
 # cycle and should not be removed until we agree on when that cycle ends.
 DeprecatedIn10 = DeprecationWarning
-DeprecatedIn12 = DeprecationWarning
 
 
 def read_only_property(name):

--- a/src/cryptography/x509/__init__.py
+++ b/src/cryptography/x509/__init__.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from cryptography import utils
 from cryptography.x509.base import (
     Certificate, CertificateBuilder, CertificateRevocationList,
     CertificateRevocationListBuilder,
@@ -37,13 +36,6 @@ from cryptography.x509.oid import (
     ObjectIdentifier, SignatureAlgorithmOID, _SIG_OIDS_TO_HASH
 )
 
-
-CRLExtensionOID = utils.deprecated(
-    CRLEntryExtensionOID,
-    __name__,
-    "CRLExtensionOID has been renamed to CRLEntryExtensionOID",
-    utils.DeprecatedIn12
-)
 
 OID_AUTHORITY_INFORMATION_ACCESS = ExtensionOID.AUTHORITY_INFORMATION_ACCESS
 OID_AUTHORITY_KEY_IDENTIFIER = ExtensionOID.AUTHORITY_KEY_IDENTIFIER
@@ -174,7 +166,6 @@ __all__ = [
     "OID_CA_ISSUERS",
     "OID_OCSP",
     "_GENERAL_NAMES",
-    "CRLExtensionOID",
     "CertificateIssuer",
     "CRLReason",
     "InvalidityDate",

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -94,14 +94,6 @@ class CRLEntryExtensionOID(object):
     INVALIDITY_DATE = ObjectIdentifier("2.5.29.24")
 
 
-CRLExtensionOID = utils.deprecated(
-    CRLEntryExtensionOID,
-    __name__,
-    "CRLExtensionOID has been renamed to CRLEntryExtensionOID",
-    utils.DeprecatedIn12
-)
-
-
 class NameOID(object):
     COMMON_NAME = ObjectIdentifier("2.5.4.3")
     COUNTRY_NAME = ObjectIdentifier("2.5.4.6")


### PR DESCRIPTION
Deprecated in 1.2, removed in 1.4 per policy. Fixes #2842 