### PR TITLE
fix libressl breakage reported in #2858

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -46,7 +46,7 @@ _PRE_INCLUDE = """
 #if !defined(LIBRESSL_VERSION_NUMBER)
 #include <openssl/e_os2.h>
 #endif
-#if defined(OPENSSL_SYS_WINDOWS) || defined(_WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 """

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -38,8 +38,15 @@ def _osx_libraries(build_static):
 
 
 _PRE_INCLUDE = """
+#include <openssl/opensslv.h>
+/*
+    LibreSSL removed e_os2.h from the public headers so we'll only include it
+    if we're using vanilla OpenSSL.
+*/
+#if !defined(LIBRESSL_VERSION_NUMBER)
 #include <openssl/e_os2.h>
-#if defined(OPENSSL_SYS_WINDOWS)
+#endif
+#if defined(OPENSSL_SYS_WINDOWS) || defined(_WIN32)
 #include <windows.h>
 #endif
 """


### PR DESCRIPTION
As part of this the libressl builder has been upgraded to 2.3.3 (the latest libre).