### PR TITLE
Update getting-started.rst to clarify OS X Homebrew pip install

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -1,6 +1,8 @@
 Getting started
 ===============
 
+Development dependencies
+------------------------
 Working on ``cryptography`` requires the installation of a small number of
 development dependencies in addition to the dependencies for
 :doc:`/installation`. These are listed in ``dev-requirements.txt`` and they can
@@ -13,25 +15,36 @@ dependencies, install ``cryptography`` in ``editable`` mode. For example:
     $ pip install --requirement dev-requirements.txt
     $ pip install --editable .
 
-On OS X:
-
-You must have installed `OpenSSL`_ via `Homebrew`_ or `MacPorts`_ and must set ``CFLAGS`` and ``LDFLAGS`` environment variables before installing the ``dev-requirements.txt`` otherwise pip will fail with include errors. For example with `Homebrew`_:
-
-.. code-block:: console
-
-    $ env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install --requirement ./dev-requirements.txt
-
-Alternatively for a static build you can specify ``CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1`` and ensure ``LDFLAGS`` points to the absolulte path for the `OpenSSL`_ libraries before calling pip.
-
-Generally:
-
 You will also need to install ``enchant`` using your system's package manager
 to check spelling in the documentation.
 
 You are now ready to run the tests and build the documentation.
 
+OpenSSL on OS X
+~~~~~~~~~~~~~~~
+
+You must have installed `OpenSSL`_ via `Homebrew`_ or `MacPorts`_ and must set
+``CFLAGS`` and ``LDFLAGS`` environment variables before installing the
+``dev-requirements.txt`` otherwise pip will fail with include errors.
+
+For example with `Homebrew`_:
+
+.. code-block:: console
+
+    $ env LDFLAGS="-L$(brew --prefix openssl)/lib" \
+        CFLAGS="-I$(brew --prefix openssl)/include" \
+        pip install --requirement ./dev-requirements.txt
+
+Alternatively for a static build you can specify
+``CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1`` and ensure ``LDFLAGS`` points to the
+absolute path for the `OpenSSL`_ libraries before calling pip.
+
+.. tip::
+    You will also need to set these values when `Building documentation`_.
+
+
 Running tests
-~~~~~~~~~~~~~
+-------------
 
 ``cryptography`` unit tests are found in the ``tests/`` directory and are
 designed to be run using `pytest`_. `pytest`_ will discover the tests
@@ -65,7 +78,7 @@ will see one or more ``InterpreterNotFound`` errors.
 
 
 Explicit backend selection
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 While testing you may want to run tests against a subset of the backends that
 cryptography supports. Explicit backend selection can be done via the
@@ -79,7 +92,7 @@ delimited list of backend names.
     $ py.test --backend=openssl,commoncrypto
 
 Building documentation
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 ``cryptography`` documentation is stored in the ``docs/`` directory. It is
 written in `reStructured Text`_ and rendered using `Sphinx`_.

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -15,11 +15,13 @@ dependencies, install ``cryptography`` in ``editable`` mode. For example:
 
 On OS X:
 
-If you have installed OpenSSL via Homebrew you may need to set ``CFLAGS`` and  ``LDFLAGS`` environment variables before installing the ``dev-requirements.txt`` otherwise pip may fail with include errors. For example:
+You must have installed OpenSSL via Homebrew or MacPorts and must set ``CFLAGS`` and ``LDFLAGS`` environment variables before installing the ``dev-requirements.txt`` otherwise pip may fail with include errors. For example with Homebrew:
 
 .. code-block:: console
 
     $ env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install --requirement ./dev-requirements.txt
+
+Alternatively for a static build you can specify ``CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1`` and ensure ``LDFLAGS`` points to the absolulte path for the OpenSSL libraries before calling pip.
 
 Generally:
 

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -13,6 +13,16 @@ dependencies, install ``cryptography`` in ``editable`` mode. For example:
     $ pip install --requirement dev-requirements.txt
     $ pip install --editable .
 
+On OS X:
+
+If you have installed OpenSSL via Homebrew you may need to set ``CFLAGS`` and  ``LDFLAGS`` environment variables before installing the ``dev-requirements.txt`` otherwise pip may fail with include errors. For example:
+
+.. code-block:: console
+
+    $ env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install --requirement ./dev-requirements.txt
+
+Generally:
+
 You will also need to install ``enchant`` using your system's package manager
 to check spelling in the documentation.
 


### PR DESCRIPTION
On OS X El Capitan following the current instructions fails with fatal error: 'openssl/opensslv.h' file not found on pip install -r dev-requirements.txt; this change adds to the instructions to clarify that CFLAGS and LDFLAGS may need to be set. I based this on the instructions in the Installation page.