### PR TITLE
some DSA backend changes to treat the struct as opaque

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/dsa.py
+++ b/src/cryptography/hazmat/backends/openssl/dsa.py
@@ -22,7 +22,13 @@ def _truncate_digest_for_dsa(dsa_cdata, digest, backend):
     truncation is not required in 0.9.8 because DSA is limited to SHA-1.
     """
 
-    order_bits = backend._lib.BN_num_bits(dsa_cdata.q)
+    q = backend._ffi.new("BIGNUM **")
+    backend._lib.DSA_get0_pqg(
+        dsa_cdata, backend._ffi.NULL, q, backend._ffi.NULL
+    )
+    backend.openssl_assert(q[0] != backend._ffi.NULL)
+
+    order_bits = backend._lib.BN_num_bits(q[0])
     return _truncate_digest(digest, order_bits)
 
 
@@ -88,6 +94,32 @@ class _DSASignatureContext(object):
         return self._backend._ffi.buffer(sig_buf)[:buflen[0]]
 
 
+def _dsa_num_bits(dsa_cdata, backend):
+    p = backend._ffi.new("BIGNUM **")
+    backend._lib.DSA_get0_pqg(
+        dsa_cdata, p, backend._ffi.NULL, backend._ffi.NULL
+    )
+    backend.openssl_assert(p[0] != backend._ffi.NULL)
+
+    return backend._lib.BN_num_bits(p[0])
+
+
+def _dsa_cdata_params_to_int(dsa_cdata, backend):
+    p = backend._ffi.new("BIGNUM **")
+    q = backend._ffi.new("BIGNUM **")
+    g = backend._ffi.new("BIGNUM **")
+    backend._lib.DSA_get0_pqg(dsa_cdata, p, q, g)
+    backend.openssl_assert(p[0] != backend._ffi.NULL)
+    backend.openssl_assert(q[0] != backend._ffi.NULL)
+    backend.openssl_assert(g[0] != backend._ffi.NULL)
+
+    return (
+        backend._bn_to_int(p[0]),
+        backend._bn_to_int(q[0]),
+        backend._bn_to_int(g[0])
+    )
+
+
 @utils.register_interface(dsa.DSAParametersWithNumbers)
 class _DSAParameters(object):
     def __init__(self, backend, dsa_cdata):
@@ -95,11 +127,8 @@ class _DSAParameters(object):
         self._dsa_cdata = dsa_cdata
 
     def parameter_numbers(self):
-        return dsa.DSAParameterNumbers(
-            p=self._backend._bn_to_int(self._dsa_cdata.p),
-            q=self._backend._bn_to_int(self._dsa_cdata.q),
-            g=self._backend._bn_to_int(self._dsa_cdata.g)
-        )
+        p, q, g = _dsa_cdata_params_to_int(self._dsa_cdata, self._backend)
+        return dsa.DSAParameterNumbers(p, q, g)
 
     def generate_private_key(self):
         return self._backend.generate_dsa_private_key(self)
@@ -111,7 +140,7 @@ class _DSAPrivateKey(object):
         self._backend = backend
         self._dsa_cdata = dsa_cdata
         self._evp_pkey = evp_pkey
-        self._key_size = self._backend._lib.BN_num_bits(self._dsa_cdata.p)
+        self._key_size = _dsa_num_bits(dsa_cdata, backend)
 
     key_size = utils.read_only_property("_key_size")
 
@@ -119,40 +148,45 @@ class _DSAPrivateKey(object):
         return _DSASignatureContext(self._backend, self, signature_algorithm)
 
     def private_numbers(self):
+        p, q, g = _dsa_cdata_params_to_int(self._dsa_cdata, self._backend)
+        pub_key = self._backend._ffi.new("BIGNUM **")
+        priv_key = self._backend._ffi.new("BIGNUM **")
+        self._backend._lib.DSA_get0_key(self._dsa_cdata, pub_key, priv_key)
+        self._backend.openssl_assert(pub_key[0] != self._backend._ffi.NULL)
+        self._backend.openssl_assert(priv_key[0] != self._backend._ffi.NULL)
         return dsa.DSAPrivateNumbers(
             public_numbers=dsa.DSAPublicNumbers(
-                parameter_numbers=dsa.DSAParameterNumbers(
-                    p=self._backend._bn_to_int(self._dsa_cdata.p),
-                    q=self._backend._bn_to_int(self._dsa_cdata.q),
-                    g=self._backend._bn_to_int(self._dsa_cdata.g)
-                ),
-                y=self._backend._bn_to_int(self._dsa_cdata.pub_key)
+                parameter_numbers=dsa.DSAParameterNumbers(p, q, g),
+                y=self._backend._bn_to_int(pub_key[0])
             ),
-            x=self._backend._bn_to_int(self._dsa_cdata.priv_key)
+            x=self._backend._bn_to_int(priv_key[0])
         )
 
     def public_key(self):
-        dsa_cdata = self._backend._lib.DSA_new()
+        dsa_cdata = self._backend._lib.DSAparams_dup(self._dsa_cdata)
         self._backend.openssl_assert(dsa_cdata != self._backend._ffi.NULL)
         dsa_cdata = self._backend._ffi.gc(
             dsa_cdata, self._backend._lib.DSA_free
         )
-        dsa_cdata.p = self._backend._lib.BN_dup(self._dsa_cdata.p)
-        dsa_cdata.q = self._backend._lib.BN_dup(self._dsa_cdata.q)
-        dsa_cdata.g = self._backend._lib.BN_dup(self._dsa_cdata.g)
-        dsa_cdata.pub_key = self._backend._lib.BN_dup(self._dsa_cdata.pub_key)
+        pub_key = self._backend._ffi.new("BIGNUM **")
+        self._backend._lib.DSA_get0_key(
+            self._dsa_cdata, pub_key, self._backend._ffi.NULL
+        )
+        self._backend.openssl_assert(pub_key[0] != self._backend._ffi.NULL)
+        pub_key_dup = self._backend._lib.BN_dup(pub_key[0])
+        res = self._backend._lib.DSA_set0_key(
+            dsa_cdata, pub_key_dup, self._backend._ffi.NULL
+        )
+        self._backend.openssl_assert(res == 1)
         evp_pkey = self._backend._dsa_cdata_to_evp_pkey(dsa_cdata)
         return _DSAPublicKey(self._backend, dsa_cdata, evp_pkey)
 
     def parameters(self):
-        dsa_cdata = self._backend._lib.DSA_new()
+        dsa_cdata = self._backend._lib.DSAparams_dup(self._dsa_cdata)
         self._backend.openssl_assert(dsa_cdata != self._backend._ffi.NULL)
         dsa_cdata = self._backend._ffi.gc(
             dsa_cdata, self._backend._lib.DSA_free
         )
-        dsa_cdata.p = self._backend._lib.BN_dup(self._dsa_cdata.p)
-        dsa_cdata.q = self._backend._lib.BN_dup(self._dsa_cdata.q)
-        dsa_cdata.g = self._backend._lib.BN_dup(self._dsa_cdata.g)
         return _DSAParameters(self._backend, dsa_cdata)
 
     def private_bytes(self, encoding, format, encryption_algorithm):
@@ -171,7 +205,7 @@ class _DSAPublicKey(object):
         self._backend = backend
         self._dsa_cdata = dsa_cdata
         self._evp_pkey = evp_pkey
-        self._key_size = self._backend._lib.BN_num_bits(self._dsa_cdata.p)
+        self._key_size = _dsa_num_bits(dsa_cdata, backend)
 
     key_size = utils.read_only_property("_key_size")
 
@@ -184,24 +218,22 @@ class _DSAPublicKey(object):
         )
 
     def public_numbers(self):
+        p, q, g = _dsa_cdata_params_to_int(self._dsa_cdata, self._backend)
+        pub_key = self._backend._ffi.new("BIGNUM **")
+        priv_key = self._backend._ffi.NULL
+        self._backend._lib.DSA_get0_key(self._dsa_cdata, pub_key, priv_key)
+        self._backend.openssl_assert(pub_key[0] != self._backend._ffi.NULL)
         return dsa.DSAPublicNumbers(
-            parameter_numbers=dsa.DSAParameterNumbers(
-                p=self._backend._bn_to_int(self._dsa_cdata.p),
-                q=self._backend._bn_to_int(self._dsa_cdata.q),
-                g=self._backend._bn_to_int(self._dsa_cdata.g)
-            ),
-            y=self._backend._bn_to_int(self._dsa_cdata.pub_key)
+            parameter_numbers=dsa.DSAParameterNumbers(p, q, g),
+            y=self._backend._bn_to_int(pub_key[0])
         )
 
     def parameters(self):
-        dsa_cdata = self._backend._lib.DSA_new()
+        dsa_cdata = self._backend._lib.DSAparams_dup(self._dsa_cdata)
         self._backend.openssl_assert(dsa_cdata != self._backend._ffi.NULL)
         dsa_cdata = self._backend._ffi.gc(
             dsa_cdata, self._backend._lib.DSA_free
         )
-        dsa_cdata.p = self._backend._lib.BN_dup(self._dsa_cdata.p)
-        dsa_cdata.q = self._backend._lib.BN_dup(self._dsa_cdata.q)
-        dsa_cdata.g = self._backend._lib.BN_dup(self._dsa_cdata.g)
         return _DSAParameters(self._backend, dsa_cdata)
 
     def public_bytes(self, encoding, format):


### PR DESCRIPTION
This is part of #2883 separated out to more easily isolate the problem with the CentOS 5 builder.