### PR TITLE
add the scripts we use to build the wheels in jenkins to version control

### DIFF
--- a/.jenkins/mac-wheel.bat
+++ b/.jenkins/mac-wheel.bat
@@ -1,0 +1,62 @@
+#!/bin/bash -xe
+# output the list of things we've installed as a point in time check of how up to date the builder is
+/usr/sbin/system_profiler SPInstallHistoryDataType
+# Jenkins logs in as a non-interactive shell, so we don't even have /usr/local/bin in PATH
+export PATH=/usr/local/bin:$PATH
+# pyenv is nothing but trouble with non-interactive shells so we can't eval "$(pyenv init -)"
+export PATH="/Users/jenkins/.pyenv/shims:${PATH}"
+export PYENV_SHELL=bash
+
+# TODO: upgrade wheel builder VM and run it on El Cap with python.org Pythons.
+if [[ "${label}" == "10.10" ]]; then
+    case "${TOXENV}" in
+        py26)
+            PYTHON=/usr/bin/python2.6
+            ;;
+        py27)
+            PYTHON=/usr/bin/python2.7
+            ;;
+        py33)
+            PYTHON=python3.3
+            ;;
+        py34)
+            PYTHON=python3.4
+            ;;
+        py35)
+            PYTHON=python3.5
+            ;;
+        pypy)
+            PYTHON=pypy
+            ;;
+    esac
+else
+    case "${TOXENV}" in
+        py27)
+            PYTHON=/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7
+            ;;
+        py33)
+            PYTHON=/Library/Frameworks/Python.framework/Versions/3.3/bin/python3.3
+            ;;
+        py34)
+            PYTHON=/Library/Frameworks/Python.framework/Versions/3.4/bin/python3.4
+            ;;
+        py35)
+            PYTHON=/Library/Frameworks/Python.framework/Versions/3.5/bin/python3.5
+            ;;
+    esac
+fi
+printenv
+
+virtualenv .venv -p $PYTHON
+source .venv/bin/activate
+if [[ "${TOXENV}" == "pypy" ]]; then
+    pip install -U wheel # upgrade wheel to latest before we use it to build the wheel
+else
+    pip install -U wheel==0.26.0 # handles 2.7 SOABI issue for users on pip < 8.1
+fi
+CRYPTOGRAPHY_OSX_NO_LINK_FLAGS="1" LDFLAGS="/usr/local/opt/openssl/lib/libcrypto.a /usr/local/opt/openssl/lib/libssl.a" CFLAGS="-I/usr/local/opt/openssl/include" pip wheel cryptography --wheel-dir=wheelhouse --no-use-wheel
+pip install -f wheelhouse cryptography --no-index
+python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"
+otool -L `find .venv -name '_openssl*.so'`
+lipo -info `find .venv -name '*.so'`
+otool -L `find .venv -name '_openssl*.so'` | grep -vG "libcrypto\|libssl"

--- a/.jenkins/mac-wheel.sh
+++ b/.jenkins/mac-wheel.sh
@@ -16,6 +16,9 @@ if [[ "${label}" == "10.10" ]]; then
         py27)
             PYTHON=/usr/bin/python2.7
             ;;
+        py27u)
+            PYTHON=python2.7
+            ;;
         py33)
             PYTHON=python3.3
             ;;
@@ -49,11 +52,7 @@ printenv
 
 virtualenv .venv -p $PYTHON
 source .venv/bin/activate
-if [[ "${TOXENV}" == "pypy" ]]; then
-    pip install -U wheel # upgrade wheel to latest before we use it to build the wheel
-else
-    pip install -U wheel==0.26.0 # handles 2.7 SOABI issue for users on pip < 8.1
-fi
+pip install -U wheel # upgrade wheel to latest before we use it to build the wheel
 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS="1" LDFLAGS="/usr/local/opt/openssl/lib/libcrypto.a /usr/local/opt/openssl/lib/libssl.a" CFLAGS="-I/usr/local/opt/openssl/include" pip wheel cryptography --wheel-dir=wheelhouse --no-use-wheel
 pip install -f wheelhouse cryptography --no-index
 python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"

--- a/.jenkins/windows-wheel.bat
+++ b/.jenkins/windows-wheel.bat
@@ -1,0 +1,42 @@
+wmic qfe
+@set PATH="C:\Python27";"C:\Python27\Scripts";%PATH%
+SET
+if "%TOXENV%" == "py26" (
+    @set PYTHON="C:\Python26\python.exe"
+)
+if "%TOXENV%" == "py27" (
+    @set PYTHON="C:\Python27\python.exe"
+)
+if "%TOXENV%" == "py33" (
+    @set PYTHON="C:\Python33\python.exe"
+)
+if "%TOXENV%" == "py34" (
+    @set PYTHON="C:\Python34\python.exe"
+)
+if "%TOXENV%" == "py35" (
+    @set PYTHON="C:\Python35\python.exe"
+    if %label% == windows (
+        @set INCLUDE="C:\OpenSSL-Win32-2015\include";%INCLUDE%
+        @set LIB="C:\OpenSSL-Win32-2015\lib";%LIB%
+    ) else (
+        @set INCLUDE="C:\OpenSSL-Win64-2015\include";%INCLUDE%
+        @set LIB="C:\OpenSSL-Win64-2015\lib";%LIB%
+    )
+) else (
+    if %label% == windows (
+        @set INCLUDE="C:\OpenSSL-Win32-2010\include";%INCLUDE%
+        @set LIB="C:\OpenSSL-Win32-2010\lib";%LIB%
+    ) else (
+        @set INCLUDE="C:\OpenSSL-Win64-2010\include";%INCLUDE%
+        @set LIB="C:\OpenSSL-Win64-2010\lib";%LIB%
+    )
+)
+
+virtualenv -p %PYTHON% .release
+call .release\Scripts\activate
+pip install wheel virtualenv
+pip wheel cryptography --wheel-dir=wheelhouse --no-use-wheel
+for %%x in (wheelhouse\*.whl) do (
+   pip install %%x
+)
+python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"


### PR DESCRIPTION
This is a copy of exactly what the cryptography-wheel-builder job currently does. Once this is merged we can switch the job to just invoke these scripts.