### PR TITLE
Replacing test_osrandom_engine_is_default.

### DIFF
--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -6,9 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 import os
-import subprocess
-import sys
-import textwrap
 
 import pytest
 
@@ -208,7 +205,6 @@ class TestOpenSSL(object):
 
 
 
-
 class TestOpenSSLRandomEngine(object):
 
     def setup(self):
@@ -224,12 +220,13 @@ class TestOpenSSLRandomEngine(object):
         # for all these tests.
 
         # First check that osrandom was actually the default before the test.
-        assert self.default_engine_name == backend._binding._osrandom_engine_name
+        osrandom_engine_name = backend._binding._osrandom_engine_name
+        assert self.default_engine_name == osrandom_engine_name
 
         backend.activate_osrandom_engine()
         current_default = backend._lib.ENGINE_get_default_RAND()
         name = backend._lib.ENGINE_get_name(current_default)
-        assert name == backend._binding._osrandom_engine_name
+        assert name == osrandom_engine_name
 
     def test_osrandom_sanity_check(self):
         # This test serves as a check against catastrophic failure.

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -204,7 +204,6 @@ class TestOpenSSL(object):
         assert backend._ffi.buffer(buf)[0:length] == sample_data
 
 
-
 class TestOpenSSLRandomEngine(object):
 
     def setup(self):

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -211,24 +211,20 @@ class TestOpenSSLRandomEngine(object):
 
     def setup(self):
         # The default RAND engine is global and shared between
-        # tests. We store the current default in setup, and restore it
-        # in teardown. This also implicitly tests that the default
-        # engine is osrandom.
-        e = backend._lib.ENGINE_get_default_RAND()
-        self.default_engine_name = backend._lib.ENGINE_get_name(e)
+        # tests. We make sure that the default engine is osrandom
+        # before we start each test and restore the global state to
+        # that engine in teardown.
+        current_default = backend._lib.ENGINE_get_default_RAND()
+        name = backend._lib.ENGINE_get_name(current_default)
+        assert name == backend._binding._osrandom_engine_name
 
     def teardown_method(self, method):
         # we need to reset state to being default. backend is a shared global
         # for all these tests.
-
-        # First check that osrandom was actually the default before the test.
-        osrandom_engine_name = backend._binding._osrandom_engine_name
-        assert self.default_engine_name == osrandom_engine_name
-
         backend.activate_osrandom_engine()
         current_default = backend._lib.ENGINE_get_default_RAND()
         name = backend._lib.ENGINE_get_name(current_default)
-        assert name == osrandom_engine_name
+        assert name == backend._binding._osrandom_engine_name
 
     @pytest.mark.skipif(sys.executable is None,
                         reason="No Python interpreter available.")


### PR DESCRIPTION
test_osrandom_engine_is_default depends on having a valid
sys.executable. This attribute is not always set (see
https://docs.python.org/2/library/sys.html#sys.executable ) so, in some
environments, this test fails. I moved the functionality of the test
into the setup and teardown methods so the correct behavior is still
tested.