### PR TITLE
CertificateBuilder accepts aware datetimes for not_valid_after and not_valid_before

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ Changelog
   methods to ECDSA keys.
 * Switched back to the older callback model on Python 3.5 in order to mitigate
   the locking callback problem with OpenSSL <1.1.0.
+* :class:`~cryptography.x509.CertificateBuilder` now also accepts aware
+  datetimes for 
+  :meth:`~cryptography.x509.CertificateBuilder.not_valid_before` and
+  :meth:`~cryptography.x509.CertificateBuilder.not_valid_after`
 
 
 1.4 - 2016-06-04
@@ -51,6 +55,8 @@ Changelog
 
 * Added two new OpenSSL functions to the bindings to support an upcoming
   ``pyOpenSSL`` release.
+* Support for OpenSSL 0.9.8 has been removed. Users on older version of OpenSSL
+  will need to upgrade.
 
 1.3.2 - 2016-05-04
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Changelog
 * Switched back to the older callback model on Python 3.5 in order to mitigate
   the locking callback problem with OpenSSL <1.1.0.
 * :class:`~cryptography.x509.CertificateBuilder` now also accepts aware
-  datetimes for 
+  ``datetime`` objects for
   :meth:`~cryptography.x509.CertificateBuilder.not_valid_before` and
   :meth:`~cryptography.x509.CertificateBuilder.not_valid_after`
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Changelog
   methods to ECDSA keys.
 * Switched back to the older callback model on Python 3.5 in order to mitigate
   the locking callback problem with OpenSSL <1.1.0.
-* :class:`~cryptography.x509.CertificateBuilder` now also accepts aware
+* :class:`~cryptography.x509.CertificateBuilder` now also accepts timezone aware
   ``datetime`` objects for
   :meth:`~cryptography.x509.CertificateBuilder.not_valid_before` and
   :meth:`~cryptography.x509.CertificateBuilder.not_valid_after`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,10 +20,10 @@ Changelog
   methods to ECDSA keys.
 * Switched back to the older callback model on Python 3.5 in order to mitigate
   the locking callback problem with OpenSSL <1.1.0.
-* :class:`~cryptography.x509.CertificateBuilder` now also accepts timezone
-  aware ``datetime`` objects for
-  :meth:`~cryptography.x509.CertificateBuilder.not_valid_before` and
-  :meth:`~cryptography.x509.CertificateBuilder.not_valid_after`
+* :class:`~cryptography.x509.CertificateBuilder`,
+  :class:`~cryptography.x509.CertificateRevocationListBuilder`, and
+  :class:`~cryptography.x509.RevokedCertificateBuilder` now accept timezone
+  aware ``datetime`` objects as method arguments
 
 
 1.4 - 2016-06-04

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,8 +20,8 @@ Changelog
   methods to ECDSA keys.
 * Switched back to the older callback model on Python 3.5 in order to mitigate
   the locking callback problem with OpenSSL <1.1.0.
-* :class:`~cryptography.x509.CertificateBuilder` now also accepts timezone aware
-  ``datetime`` objects for
+* :class:`~cryptography.x509.CertificateBuilder` now also accepts timezone
+  aware ``datetime`` objects for
   :meth:`~cryptography.x509.CertificateBuilder.not_valid_before` and
   :meth:`~cryptography.x509.CertificateBuilder.not_valid_after`
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,8 +55,6 @@ Changelog
 
 * Added two new OpenSSL functions to the bindings to support an upcoming
   ``pyOpenSSL`` release.
-* Support for OpenSSL 0.9.8 has been removed. Users on older version of OpenSSL
-  will need to upgrade.
 
 1.3.2 - 2016-05-04
 ~~~~~~~~~~~~~~~~~~

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 clint
 coverage
 invoke
-pytz
 requests
 tox
 twine

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 clint
 coverage
 invoke
+pytz
 requests
 tox
 twine

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ test_requirements = [
     "pretend",
     "iso8601",
     "pyasn1_modules",
+    "pytz",
 ]
 if sys.version_info[:2] > (2, 6):
     test_requirements.append("hypothesis>=1.11.4")

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -447,6 +447,10 @@ class CertificateBuilder(object):
             raise TypeError('Expecting datetime object.')
         if self._not_valid_before is not None:
             raise ValueError('The not valid before may only be set once.')
+        if time.tzinfo is not None:
+            offset = time.utcoffset()
+            offset = offset if offset else datetime.timedelta()
+            time = time.replace(tzinfo=None) - offset
         if time <= _UNIX_EPOCH:
             raise ValueError('The not valid before date must be after the unix'
                              ' epoch (1970 January 1).')
@@ -469,6 +473,10 @@ class CertificateBuilder(object):
             raise TypeError('Expecting datetime object.')
         if self._not_valid_after is not None:
             raise ValueError('The not valid after may only be set once.')
+        if time.tzinfo is not None:
+            offset = time.utcoffset()
+            offset = offset if offset else datetime.timedelta()
+            time = time.replace(tzinfo=None) - offset
         if time <= _UNIX_EPOCH:
             raise ValueError('The not valid after date must be after the unix'
                              ' epoch (1970 January 1).')

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -19,6 +19,20 @@ from cryptography.x509.name import Name
 _UNIX_EPOCH = datetime.datetime(1970, 1, 1)
 
 
+def _convert_to_naive_utc_time(time):
+    """Normalizes a datetime to a naive datetime in UTC.
+
+    time -- datetime to normalize. Assumed to be in UTC if not timezone
+            aware.
+    """
+    if time.tzinfo is not None:
+        offset = time.utcoffset()
+        offset = offset if offset else datetime.timedelta()
+        return time.replace(tzinfo=None) - offset
+    else:
+        return time
+
+
 class Version(Enum):
     v1 = 0
     v3 = 2
@@ -447,10 +461,7 @@ class CertificateBuilder(object):
             raise TypeError('Expecting datetime object.')
         if self._not_valid_before is not None:
             raise ValueError('The not valid before may only be set once.')
-        if time.tzinfo is not None:
-            offset = time.utcoffset()
-            offset = offset if offset else datetime.timedelta()
-            time = time.replace(tzinfo=None) - offset
+        time = _convert_to_naive_utc_time(time)
         if time <= _UNIX_EPOCH:
             raise ValueError('The not valid before date must be after the unix'
                              ' epoch (1970 January 1).')
@@ -473,10 +484,7 @@ class CertificateBuilder(object):
             raise TypeError('Expecting datetime object.')
         if self._not_valid_after is not None:
             raise ValueError('The not valid after may only be set once.')
-        if time.tzinfo is not None:
-            offset = time.utcoffset()
-            offset = offset if offset else datetime.timedelta()
-            time = time.replace(tzinfo=None) - offset
+        time = _convert_to_naive_utc_time(time)
         if time <= _UNIX_EPOCH:
             raise ValueError('The not valid after date must be after the unix'
                              ' epoch (1970 January 1).')
@@ -561,6 +569,7 @@ class CertificateRevocationListBuilder(object):
             raise TypeError('Expecting datetime object.')
         if self._last_update is not None:
             raise ValueError('Last update may only be set once.')
+        last_update = _convert_to_naive_utc_time(last_update)
         if last_update <= _UNIX_EPOCH:
             raise ValueError('The last update date must be after the unix'
                              ' epoch (1970 January 1).')
@@ -578,6 +587,7 @@ class CertificateRevocationListBuilder(object):
             raise TypeError('Expecting datetime object.')
         if self._next_update is not None:
             raise ValueError('Last update may only be set once.')
+        next_update = _convert_to_naive_utc_time(next_update)
         if next_update <= _UNIX_EPOCH:
             raise ValueError('The last update date must be after the unix'
                              ' epoch (1970 January 1).')
@@ -663,6 +673,7 @@ class RevokedCertificateBuilder(object):
             raise TypeError('Expecting datetime object.')
         if self._revocation_date is not None:
             raise ValueError('The revocation date may only be set once.')
+        time = _convert_to_naive_utc_time(time)
         if time <= _UNIX_EPOCH:
             raise ValueError('The revocation date must be after the unix'
                              ' epoch (1970 January 1).')

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -16,9 +16,9 @@ from pyasn1_modules import rfc2459
 
 import pytest
 
-import six
-
 import pytz
+
+import six
 
 from cryptography import utils, x509
 from cryptography.exceptions import UnsupportedAlgorithm

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -18,6 +18,8 @@ import pytest
 
 import six
 
+import pytz
+
 from cryptography import utils, x509
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends.interfaces import (
@@ -1745,6 +1747,14 @@ class TestCertificateBuilder(object):
         with pytest.raises(ValueError):
             builder.serial_number(20)
 
+    def test_aware_not_valid_after(self):
+        time = datetime.datetime(2012, 1, 16, 22, 43)
+        tz = pytz.timezone("US/Pacific")
+        time = tz.localize(time)
+        utc_time = datetime.datetime(2012, 1, 17, 6, 43)
+        cert_builder = x509.CertificateBuilder().not_valid_after(time)
+        assert cert_builder._not_valid_after == utc_time
+
     def test_invalid_not_valid_after(self):
         with pytest.raises(TypeError):
             x509.CertificateBuilder().not_valid_after(104204304504)
@@ -1766,6 +1776,14 @@ class TestCertificateBuilder(object):
             builder.not_valid_after(
                 datetime.datetime.now()
             )
+
+    def test_aware_not_valid_before(self):
+        time = datetime.datetime(2012, 1, 16, 22, 43)
+        tz = pytz.timezone("US/Pacific")
+        time = tz.localize(time)
+        utc_time = datetime.datetime(2012, 1, 17, 6, 43)
+        cert_builder = x509.CertificateBuilder().not_valid_before(time)
+        assert cert_builder._not_valid_before == utc_time
 
     def test_invalid_not_valid_before(self):
         with pytest.raises(TypeError):

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1747,13 +1747,29 @@ class TestCertificateBuilder(object):
         with pytest.raises(ValueError):
             builder.serial_number(20)
 
-    def test_aware_not_valid_after(self):
+    @pytest.mark.requires_backend_interface(interface=RSABackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
+    def test_aware_not_valid_after(self, backend):
         time = datetime.datetime(2012, 1, 16, 22, 43)
         tz = pytz.timezone("US/Pacific")
         time = tz.localize(time)
         utc_time = datetime.datetime(2012, 1, 17, 6, 43)
+        private_key = RSA_KEY_2048.private_key(backend)
         cert_builder = x509.CertificateBuilder().not_valid_after(time)
-        assert cert_builder._not_valid_after == utc_time
+        cert_builder = cert_builder.subject_name(
+            x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, u'US')])
+        ).issuer_name(
+            x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, u'US')])
+        ).serial_number(
+            1
+        ).public_key(
+            private_key.public_key()
+        ).not_valid_before(
+            utc_time - datetime.timedelta(days=365)
+        )
+
+        cert = cert_builder.sign(private_key, hashes.SHA256(), backend)
+        assert cert.not_valid_after == utc_time
 
     def test_invalid_not_valid_after(self):
         with pytest.raises(TypeError):
@@ -1777,13 +1793,29 @@ class TestCertificateBuilder(object):
                 datetime.datetime.now()
             )
 
-    def test_aware_not_valid_before(self):
+    @pytest.mark.requires_backend_interface(interface=RSABackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
+    def test_aware_not_valid_before(self, backend):
         time = datetime.datetime(2012, 1, 16, 22, 43)
         tz = pytz.timezone("US/Pacific")
         time = tz.localize(time)
         utc_time = datetime.datetime(2012, 1, 17, 6, 43)
+        private_key = RSA_KEY_2048.private_key(backend)
         cert_builder = x509.CertificateBuilder().not_valid_before(time)
-        assert cert_builder._not_valid_before == utc_time
+        cert_builder = cert_builder.subject_name(
+            x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, u'US')])
+        ).issuer_name(
+            x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, u'US')])
+        ).serial_number(
+            1
+        ).public_key(
+            private_key.public_key()
+        ).not_valid_after(
+            utc_time + datetime.timedelta(days=366)
+        )
+
+        cert = cert_builder.sign(private_key, hashes.SHA256(), backend)
+        assert cert.not_valid_before == utc_time
 
     def test_invalid_not_valid_before(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
These functions now accept aware datetimes and convert them to UTC

`pytz` has been added as a development dependency to test this behaviour, but is not required at runtime and the changes should work with any `tzinfo` objects.