### PR TITLE
Add convenience methods to sign and verify w/ RSA

### DIFF
--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -153,6 +153,20 @@ secure hash function and padding:
     >>> signer.update(message)
     >>> signature = signer.finalize()
 
+There is a shortcut to sign sufficiently short messages directly:
+
+.. doctest::
+
+    >>> message = b"A message I want to sign"
+    >>> signature = private_key.sign(
+    ...     message,
+    ...     padding.PSS(
+    ...         mgf=padding.MGF1(hashes.SHA256()),
+    ...         salt_length=padding.PSS.MAX_LENGTH
+    ...     ),
+    ...     hashes.SHA256()
+    ... )
+
 Valid paddings for signatures are
 :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` and
 :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`. ``PSS``
@@ -189,6 +203,20 @@ a public key to use in verification using
 
 If the signature does not match, ``verify()`` will raise an
 :class:`~cryptography.exceptions.InvalidSignature` exception.
+
+There is a shortcut to verify sufficiently short messages directly:
+
+.. doctest::
+
+    >>> public_key.verify(
+    ...     signature,
+    ...     message,
+    ...     padding.PSS(
+    ...         mgf=padding.MGF1(hashes.SHA256()),
+    ...         salt_length=padding.PSS.MAX_LENGTH
+    ...     ),
+    ...     hashes.SHA256()
+    ... )
 
 Encryption
 ~~~~~~~~~~
@@ -486,7 +514,8 @@ Key interfaces
 
         .. versionadded:: 0.3
 
-        Sign data which can be verified later by others using the public key.
+        Get signer to sign data which can be verified later by others using
+        the public key.
 
         :param padding: An instance of a
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
@@ -524,6 +553,25 @@ Key interfaces
         :type: int
 
         The bit length of the modulus.
+
+    .. method:: sign(data, padding, algorithm)
+
+        .. versionadded:: 1.4
+
+        Sign one block of data which can be verified later by others using the
+        public key.
+
+        :param bytes data: The message string to sign.
+
+        :param padding: An instance of an
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+            provider.
+
+        :param algorithm: An instance of a
+            :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+            provider.
+
+        :return: bytes: Signature.
 
 
 .. class:: RSAPrivateKeyWithSerialization
@@ -580,8 +628,8 @@ Key interfaces
 
         .. versionadded:: 0.3
 
-        Verify data was signed by the private key associated with this public
-        key.
+        Get verifier to verify data was signed by the private key associated
+        with this public key.
 
         :param bytes signature: The signature to verify.
 
@@ -644,6 +692,28 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.serialization.PublicFormat` enum.
 
         :return bytes: Serialized key.
+
+    .. method:: verify(signature, data, padding, algorithm)
+
+        .. versionadded:: 1.4
+
+        Verify one block of data which can be verified later by others using the
+        public key.
+
+        :param bytes signature: The signature to verify.
+
+        :param bytes data: The message string that was signed.
+
+        :param padding: An instance of an
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+            provider.
+
+        :param algorithm: An instance of a
+            :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+            provider.
+
+        :raises cryptography.exceptions.InvalidSignature: If the signature does
+            not validate.
 
 
 .. class:: RSAPublicKeyWithSerialization

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -596,6 +596,12 @@ class _RSAPrivateKey(object):
             self._rsa_cdata
         )
 
+    def sign(self, data, padding, algorithm):
+        signer = self.signer(padding, algorithm)
+        signer.update(data)
+        signature = signer.finalize()
+        return signature
+
 
 @utils.register_interface(RSAPublicKeyWithSerialization)
 class _RSAPublicKey(object):
@@ -645,3 +651,8 @@ class _RSAPublicKey(object):
             self._evp_pkey,
             self._rsa_cdata
         )
+
+    def verify(self, signature, data, padding, algorithm):
+        verifier = self.verifier(signature, padding, algorithm)
+        verifier.update(data)
+        verifier.verify()

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -40,6 +40,12 @@ class RSAPrivateKey(object):
         The RSAPublicKey associated with this private key.
         """
 
+    @abc.abstractmethod
+    def sign(self, data, padding, algorithm):
+        """
+        Signs the data.
+        """
+
 
 @six.add_metaclass(abc.ABCMeta)
 class RSAPrivateKeyWithSerialization(RSAPrivateKey):
@@ -86,6 +92,12 @@ class RSAPublicKey(object):
     def public_bytes(self, encoding, format):
         """
         Returns the key serialized as bytes.
+        """
+
+    @abc.abstractmethod
+    def verify(self, signature, data, padding, algorithm):
+        """
+        Verifies the signature of the data.
         """
 
 

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -445,6 +445,17 @@ class TestRSASignature(object):
         signer.update(b"no failure")
         signer.finalize()
 
+    def test_sign(self, backend):
+        private_key = RSA_KEY_512.private_key(backend)
+        message = b"one little message"
+        pkcs = padding.PKCS1v15()
+        algorithm = hashes.SHA1()
+        signature = private_key.sign(message, pkcs, algorithm)
+        public_key = private_key.public_key()
+        verifier = public_key.verifier(signature, pkcs, algorithm)
+        verifier.update(message)
+        verifier.verify()
+
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 class TestRSAVerification(object):
@@ -799,6 +810,17 @@ class TestRSAVerification(object):
         verifier.update(b"sign me")
         with pytest.raises(InvalidSignature):
             verifier.verify()
+
+    def test_verify(self, backend):
+        private_key = RSA_KEY_512.private_key(backend)
+        message = b"one little message"
+        pkcs = padding.PKCS1v15()
+        algorithm = hashes.SHA1()
+        signer = private_key.signer(pkcs, algorithm)
+        signer.update(message)
+        signature = signer.finalize()
+        public_key = private_key.public_key()
+        public_key.verify(signature, message, pkcs, algorithm)
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)


### PR DESCRIPTION
This patch adds wrapper methods to allow the user to sign and verify a
single message block without having to go through the multi-step
process of creating a signer or verifier, updating it with the one
message, and finalizing the result. This will make signing and
verifying data more user-friendly when only using small messages.

Partial bug #1529