### PR TITLE
Handle NumericString type in x509 name decoding (#2724)

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -707,13 +707,15 @@ def _asn1_string_to_ascii(backend, asn1_string):
 
 
 def _asn1_string_to_utf8(backend, asn1_string):
+    # ASN1_STRING_to_UTF8 does not support some kind of types.
+    # Handle them manually.
+    if asn1_string.type == 0x12:
+        # NumericString
+        return _asn1_string_to_bytes(backend, asn1_string).decode('utf8')
+
     buf = backend._ffi.new("unsigned char **")
     res = backend._lib.ASN1_STRING_to_UTF8(buf, asn1_string)
     if res == -1:
-        str_bytes = _asn1_string_to_bytes(backend, asn1_string)
-        if asn1_string.type == int('0x12', 16):
-            # NumericString
-            return str_bytes.decode('utf8')
         raise ValueError(
             "Unsupported ASN1 string type. Type: {0}".format(asn1_string.type)
         )

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -710,6 +710,10 @@ def _asn1_string_to_utf8(backend, asn1_string):
     buf = backend._ffi.new("unsigned char **")
     res = backend._lib.ASN1_STRING_to_UTF8(buf, asn1_string)
     if res == -1:
+        str_bytes = _asn1_string_to_bytes(backend, asn1_string)
+        if asn1_string.type == int('0x12', 16):
+            # NumericString
+            return str_bytes.decode('utf8')
         raise ValueError(
             "Unsupported ASN1 string type. Type: {0}".format(asn1_string.type)
         )

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -753,10 +753,11 @@ class TestGOSTCertificate(object):
             x509.load_der_x509_certificate,
             backend
         )
-        with pytest.raises(ValueError) as exc:
-            cert.subject
-
-        # We assert on the message in this case because if the certificate
-        # fails to load it will also raise a ValueError and this test could
-        # erroneously pass.
-        assert str(exc.value) == "Unsupported ASN1 string type. Type: 18"
+        oid = x509.ObjectIdentifier(u'1.2.643.3.131.1.1')
+        assert cert.subject.get_attributes_for_oid(oid) == [
+            x509.NameAttribute(oid, u'007710474375')
+        ]
+        oid = x509.ObjectIdentifier(u'1.2.643.100.1')
+        assert cert.subject.get_attributes_for_oid(oid) == [
+            x509.NameAttribute(oid, u'1047702026701')
+        ]


### PR DESCRIPTION
`ASN1_STRING_to_UTF8()` returns -1, but we could get raw data with `ASN1_STRING_data()`
and process it according to `ASN1_STRING_type()`.