### PR TITLE
Use `d` instead of `private_exponent` for consistency

### DIFF
--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -476,15 +476,15 @@ this without having to do the math themselves.
 
     .. versionadded:: 0.4
 
-    Computes the ``dmp1`` parameter from the RSA private exponent and prime
-    ``p``.
+    Computes the ``dmp1`` parameter from the RSA private exponent (``d``) and
+    prime ``p``.
 
 .. function:: rsa_crt_dmq1(private_exponent, q)
 
     .. versionadded:: 0.4
 
-    Computes the ``dmq1`` parameter from the RSA private exponent and prime
-    ``q``.
+    Computes the ``dmq1`` parameter from the RSA private exponent (``d``) and
+    prime ``q``.
 
 .. function:: rsa_recover_prime_factors(n, e, d)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -199,7 +199,7 @@ def rsa_crt_iqmp(p, q):
 def rsa_crt_dmp1(private_exponent, p):
     """
     Compute the CRT private_exponent % (p - 1) value from the RSA
-    private_exponent and p.
+    private_exponent (d) and p.
     """
     return private_exponent % (p - 1)
 
@@ -207,7 +207,7 @@ def rsa_crt_dmp1(private_exponent, p):
 def rsa_crt_dmq1(private_exponent, q):
     """
     Compute the CRT private_exponent % (q - 1) value from the RSA
-    private_exponent and q.
+    private_exponent (d) and q.
     """
     return private_exponent % (q - 1)
 


### PR DESCRIPTION
True story: I used `e` instead of `d` because it seemed more closely related
to `private_exponent`. Should have looked it up, of course... but the docs could be better.