### PR TITLE
Simplify and remove some 0.9.8 code from the EVP bindings

### DIFF
--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -154,7 +154,6 @@ int EVP_PKEY_verify(EVP_PKEY_CTX *, const unsigned char *, size_t,
                     const unsigned char *, size_t);
 int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *);
 int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *);
-int EVP_PKEY_id(const EVP_PKEY *);
 
 /* The following were macros in 0.9.8e. Once we drop support for RHEL/CentOS 5
    we should move these back to FUNCTIONS. */

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -110,6 +110,7 @@ int EVP_PKEY_cmp(const EVP_PKEY *, const EVP_PKEY *);
 
 EVP_PKEY *EVP_PKCS82PKEY(PKCS8_PRIV_KEY_INFO *);
 
+int EVP_PKEY_id(const EVP_PKEY *);
 int Cryptography_EVP_PKEY_id(const EVP_PKEY *);
 
 /* in 1.1.0 _create and _destroy were renamed to _new and _free. The following
@@ -204,15 +205,11 @@ int (*EVP_PKEY_assign_EC_KEY)(EVP_PKEY *, EC_KEY *) = NULL;
 EC_KEY *(*EVP_PKEY_get1_EC_KEY)(EVP_PKEY *) = NULL;
 int (*EVP_PKEY_set1_EC_KEY)(EVP_PKEY *, EC_KEY *) = NULL;
 #endif
-/* EVP_PKEY_id is not available on 0.9.8 so we'll define our own. This can
-   be removed when we remove 0.9.8 support. */
+
 int Cryptography_EVP_PKEY_id(const EVP_PKEY *key) {
-    #if OPENSSL_VERSION_NUMBER >= 0x10000000L
-        return EVP_PKEY_id(key);
-    #else
-        return key->type;
-    #endif
+    return EVP_PKEY_id(key);
 }
+
 EVP_MD_CTX *Cryptography_EVP_MD_CTX_new(void) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
     return EVP_MD_CTX_create();

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -485,7 +485,7 @@ class Backend(object):
         pointer.
         """
 
-        key_type = self._lib.Cryptography_EVP_PKEY_id(evp_pkey)
+        key_type = self._lib.EVP_PKEY_id(evp_pkey)
 
         if key_type == self._lib.EVP_PKEY_RSA:
             rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
@@ -512,7 +512,7 @@ class Backend(object):
         pointer.
         """
 
-        key_type = self._lib.Cryptography_EVP_PKEY_id(evp_pkey)
+        key_type = self._lib.EVP_PKEY_id(evp_pkey)
 
         if key_type == self._lib.EVP_PKEY_RSA:
             rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
@@ -1552,7 +1552,7 @@ class Backend(object):
         else:
             raise ValueError("Unsupported encryption type")
 
-        key_type = self._lib.Cryptography_EVP_PKEY_id(evp_pkey)
+        key_type = self._lib.EVP_PKEY_id(evp_pkey)
         if encoding is serialization.Encoding.PEM:
             if format is serialization.PrivateFormat.PKCS8:
                 write_bio = self._lib.PEM_write_bio_PKCS8PrivateKey
@@ -1641,9 +1641,7 @@ class Backend(object):
             key = evp_pkey
         elif format is serialization.PublicFormat.PKCS1:
             # Only RSA is supported here.
-            assert self._lib.Cryptography_EVP_PKEY_id(
-                evp_pkey
-            ) == self._lib.EVP_PKEY_RSA
+            assert self._lib.EVP_PKEY_id(evp_pkey) == self._lib.EVP_PKEY_RSA
             if encoding is serialization.Encoding.PEM:
                 write_bio = self._lib.PEM_write_bio_RSAPublicKey
             else:


### PR DESCRIPTION
The Cryptography_ symbol remains because pyOpenSSL uses. There's still other 0.9.8isms in this file.