### PR TITLE
opaque x509 store context

### DIFF
--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -27,21 +27,7 @@ typedef ... Cryptography_STACK_OF_ASN1_OBJECT;
 
 typedef ... X509_STORE;
 typedef ... X509_VERIFY_PARAM;
-
-typedef struct x509_store_ctx_st X509_STORE_CTX;
-struct x509_store_ctx_st {
-    X509_STORE *ctx;
-    int current_method;
-    X509 *cert;
-    Cryptography_STACK_OF_X509 *untrusted;
-    Cryptography_STACK_OF_X509_CRL *crls;
-    X509_VERIFY_PARAM *param;
-    void *other_ctx;
-    int (*verify)(X509_STORE_CTX *);
-    int (*verify_cb)(int, X509_STORE_CTX *);
-    int (*get_issuer)(X509 **, X509_STORE_CTX *, X509 *);
-    ...;
-};
+typedef ... X509_STORE_CTX;
 
 /* While these are defined in the source as ints, they're tagged here
    as longs, just in case they ever grow to large, such as what we saw


### PR DESCRIPTION
pyOpenSSL 16.0.0 does not require this.