### PR TITLE
AES_ctr128_encrypt needs to be in macros as it's a conditional binding

### DIFF
--- a/src/_cffi_src/openssl/aes.py
+++ b/src/_cffi_src/openssl/aes.py
@@ -26,6 +26,9 @@ int AES_wrap_key(AES_KEY *, const unsigned char *, unsigned char *,
                  const unsigned char *, unsigned int);
 int AES_unwrap_key(AES_KEY *, const unsigned char *, unsigned char *,
                    const unsigned char *, unsigned int);
+"""
+
+MACROS = """
 /* The ctr128_encrypt function is only useful in 1.0.0. We can use EVP for
    this in 1.0.1+. */
 void AES_ctr128_encrypt(const unsigned char *, unsigned char *,
@@ -33,15 +36,12 @@ void AES_ctr128_encrypt(const unsigned char *, unsigned char *,
                         unsigned char[], unsigned int *);
 """
 
-MACROS = """
-"""
-
 CUSTOMIZATIONS = """
 static const long Cryptography_HAS_AES_WRAP = 1;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 static const int Cryptography_HAS_AES_CTR128_ENCRYPT = 0;
 void (*AES_ctr128_encrypt)(const unsigned char *, unsigned char *,
-                           const size_t, const AES_KEY *,
+                           size_t, const AES_KEY *,
                            unsigned char[], unsigned char[],
                            unsigned int *) = NULL;
 #else


### PR DESCRIPTION
Once 1.0.0 is dead we'll be able to just entirely remove this but for now it needs to be in macros.