### PR TITLE
Mark the minimum pytest version in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ else:
     setup_requirements.append("cffi>=1.4.1")
 
 test_requirements = [
-    "pytest",
+    "pytest>=2.9.0",
     "pretend",
     "iso8601",
     "pyasn1_modules",


### PR DESCRIPTION
Fixes #3034