### PR TITLE
disable blowfish in commoncrypto backend for key lengths under 64-bit

### DIFF
--- a/src/cryptography/hazmat/backends/commoncrypto/backend.py
+++ b/src/cryptography/hazmat/backends/commoncrypto/backend.py
@@ -104,7 +104,12 @@ class Backend(object):
         return _HMACContext(self, key, algorithm)
 
     def cipher_supported(self, cipher, mode):
-        return (type(cipher), type(mode)) in self._cipher_registry
+        # In OS X 10.11.2-5 (as of this writing) CommonCrypto has a bug with
+        # Blowfish key lengths less than 64-bit. Filed as radar://26636600
+        if isinstance(cipher, Blowfish) and len(cipher.key) < 8:
+            return False
+        else:
+            return (type(cipher), type(mode)) in self._cipher_registry
 
     def create_symmetric_encryption_ctx(self, cipher, mode):
         if isinstance(mode, GCM):

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -47,6 +47,11 @@ def generate_encrypt_test(param_loader, path, file_names, cipher_factory,
 
 
 def encrypt_test(backend, cipher_factory, mode_factory, params):
+    if not backend.cipher_supported(
+        cipher_factory(**params), mode_factory(**params)
+    ):
+        pytest.skip("cipher/mode combo is unsupported by this backend")
+
     plaintext = params["plaintext"]
     ciphertext = params["ciphertext"]
     cipher = Cipher(


### PR DESCRIPTION
This is due to a bug in CommonCrypto present in 10.11.x. Filed as radar://26636600