### PR TITLE
Additional exclusion to keywords_with_side_effects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ def keywords_with_side_effects(argv):
         '-q', '--quiet',
         '-v', '--verbose',
         '-V', '--version',
+        '-k', '--keep-temp',
         '--author',
         '--author-email',
         '--classifiers',


### PR DESCRIPTION
At some point during build I do something like `python setup.py -k sdist` - but in my build cleanroom this is happening when mixing the source dist with the debian bits before cffi and stuff is installed, so it blows up.  It _seems_ like this code is trying to prevent exactly that and just missed an option, or maybe it's just supposed to work as soon as it sees `sdist`?  `sdist -k` or `-k sdist` didn't _seem_ to make any difference?  If this is the right way to go, I actually think `sdist` has a few other flags that should be added to this list...
