### PR TITLE
Fixed openssl binding if no-cmac

### DIFF
--- a/src/_cffi_src/openssl/cmac.py
+++ b/src/_cffi_src/openssl/cmac.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 INCLUDES = """
-#if CRYPTOGRAPHY_OPENSSL_101_OR_GREATER
+#if !defined(OPENSSL_NO_CMAC) && CRYPTOGRAPHY_OPENSSL_101_OR_GREATER
 #include <openssl/cmac.h>
 #endif
 """
@@ -28,7 +28,7 @@ void CMAC_CTX_free(CMAC_CTX *);
 """
 
 CUSTOMIZATIONS = """
-#if CRYPTOGRAPHY_OPENSSL_101_OR_GREATER
+#if !defined(OPENSSL_NO_CMAC) && CRYPTOGRAPHY_OPENSSL_101_OR_GREATER
 static const long Cryptography_HAS_CMAC = 1;
 #else
 static const long Cryptography_HAS_CMAC = 0;


### PR DESCRIPTION
For instance, LEDE recently [removed CMAC](https://git.lede-project.org/?p=source.git;a=commit;h=41da31ac2ca2306e9cff070f650f6012af753517) from its OpenSSL package.