### PR TITLE
Disable static callbacks on Python 3.5 (refs #2970)

### DIFF
--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import sys
+
 import cffi
 
 INCLUDES = """
@@ -44,7 +46,8 @@ CUSTOMIZATIONS = """
 static const long Cryptography_STATIC_CALLBACKS = 1;
 """
 
-if cffi.__version_info__ < (1, 4, 0):
+if cffi.__version_info__ < (1, 4, 0) or sys.version_info >= (3, 5):
     # backwards compatibility for old cffi version on PyPy
+    # and Python >=3.5 (https://github.com/pyca/cryptography/issues/2970)
     TYPES = "static const long Cryptography_STATIC_CALLBACKS;"
     CUSTOMIZATIONS = "static const long Cryptography_STATIC_CALLBACKS = 0;"


### PR DESCRIPTION
As suggested in https://github.com/pyca/cryptography/issues/2970#issuecomment-229367151, this PR disables static callbacks on Python 3.5+ to fix the `Cryptography_locking_cb()` errors.