### PR TITLE
Clarify what to pass to the sign-function

### DIFF
--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -415,7 +415,7 @@ Key Interfaces
         :param bytes data: The message string to sign.
 
         :param signature_algorithm: An instance of
-            :class:`EllipticCurveSignatureAlgorithm`.
+            :class:`EllipticCurveSignatureAlgorithm`, such as :class:`ECDSA`.
 
         :return bytes: Signature.
 


### PR DESCRIPTION
Sign needs an ECDSA instance and from following the link to EllipticCurveSignatureAlgorithm, that wasn't clear directly.