### PR TITLE
WIP: Add a recipe for generating secrets

### DIFF
--- a/src/cryptography/gibberish.py
+++ b/src/cryptography/gibberish.py
@@ -1,0 +1,61 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import base64
+import json
+import os
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+
+def _encode_key_material(data):
+    return base64.b64encode(data).rstrip(b"=")
+
+
+def _decode_key_material(data):
+    # Restore our padding
+    data += (b"=" * (len(data) % 4))
+    return base64.urlsafe_b64decode(data)
+
+
+class Gibberish(object):
+
+    _algorithm = hashes.SHA512()
+
+    def __init__(self, key, backend=None):
+        if backend is None:
+            backend = default_backend()
+
+        data = json.loads(_decode_key_material(key).decode("ascii"))
+
+        self._backend = backend
+        self._salt = _decode_key_material(data["salt"].encode("ascii"))
+        self._secret = _decode_key_material(data["secret"].encode("ascii"))
+
+    @classmethod
+    def generate_key(cls):
+        data = {
+            "salt": _encode_key_material(os.urandom(16)).decode("ascii"),
+            "secret": _encode_key_material(os.urandom(16)).decode("ascii"),
+        }
+        data = json.dumps(data, sort_keys=True, separators=(",", ":"))
+        return _encode_key_material(data.encode("ascii"))
+
+    def derive_secret(self, name, length=None):
+        if length is None:
+            length = 255 * (self._algorithm.digest_size // 8)
+
+        hkdf = HKDF(
+            backend=self._backend,
+            algorithm=self._algorithm,
+            length=length,
+            salt=self._salt,
+            info=name,
+        )
+
+        return hkdf.derive(self._secret)


### PR DESCRIPTION
I don't know if this is something we want to do, but I thought it might be generally useful. It's not uncommon for applications to want to generate a number of secrets based off of a single master secret and currently if they want to do that, they're stuck using hazmat instead of a nice, clean, recipe.

So this implements that with an API like:

``` python
from cryptography.gibberish import Gibberish

key = Gibberish.generate_key()
secret_generator = Gibberish(key)

encryption_secret = secret_generator.derive_secret(b"encryption", length=16)
signing_secret = secret_generator.derive_secret(b"signing", length=16)
session_secret = secret_generator.derive_secret(b"sessions", length=24)
some_really_long_secret = secret_generator.derive_secret("really long")
```

A few decisions made here:
- It uses HKDF with SHA512 to enable a maximum secret length of 2040.
- The "Key" is urlsafe base64 encoded data, which is a chunk of JSON, which contains two values, which are regular base64 encoded data representing the secret and the salt. The `Gibberish.generate_key()`  method generates fully random values for both salt and secret.
- It defaults to the maximum length secret.

Some open questions:
- Is this sort of recipe something that we event want here?
- Do we want to use SHA256 instead?
- Is using JSON and double base64 really a reasonable way of handling this?
- Is 16 bytes a good length for the salt? The HKDF documentation recommends matching the digest size,  which if we use SHA512 would then mean a 64 byte salt.
- Is 16 bytes a good length for the secret? The HKDF documentation doesn't give any input here.
- Would we rather want it to just take separate parameters for secret key and salt, allowing people to put something like a user entered "password" in for the secret key?
- What should we name this, `Gibberish` is a terrible name, I just couldn't think of anything better.
