### PR TITLE
ERR_load_RAND_strings changed function signature in 1.1.0

### DIFF
--- a/src/_cffi_src/openssl/rand.py
+++ b/src/_cffi_src/openssl/rand.py
@@ -13,7 +13,6 @@ static const long Cryptography_HAS_EGD;
 """
 
 FUNCTIONS = """
-void ERR_load_RAND_strings(void);
 void RAND_seed(const void *, int);
 void RAND_add(const void *, int, double);
 int RAND_status(void);
@@ -24,6 +23,12 @@ int RAND_bytes(unsigned char *, int);
 """
 
 MACROS = """
+/* ERR_LOAD_RAND_STRINGS started returning an int in 1.1.0. Unfortunately we
+   can't declare a conditional signature like that. Since it always returns
+   1 we'll just lie about the signature to preserve compatibility for
+   pyOpenSSL (which calls this in its rand.py as of mid-2016) */
+void ERR_load_RAND_strings(void);
+
 /* RAND_cleanup became a macro in 1.1.0 */
 void RAND_cleanup(void);
 

--- a/src/_cffi_src/openssl/rand.py
+++ b/src/_cffi_src/openssl/rand.py
@@ -23,7 +23,7 @@ int RAND_bytes(unsigned char *, int);
 """
 
 MACROS = """
-/* ERR_LOAD_RAND_STRINGS started returning an int in 1.1.0. Unfortunately we
+/* ERR_load_RAND_strings started returning an int in 1.1.0. Unfortunately we
    can't declare a conditional signature like that. Since it always returns
    1 we'll just lie about the signature to preserve compatibility for
    pyOpenSSL (which calls this in its rand.py as of mid-2016) */


### PR DESCRIPTION
This is a hack to avoid breaking pyOpenSSL. Better suggestions welcome.