### PR TITLE
blake2b/blake2s support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Added support for :class:`~cryptography.hazmat.primitives.hashes.BLAKE2b` and
+  :class:`~cryptography.hazmat.primitives.hashes.BLAKE2s` when using OpenSSL
+  1.1.0.
+
 1.5 - 2016-08-26
 ~~~~~~~~~~~~~~~~
 

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -117,6 +117,35 @@ SHA-2 family
     SHA-512 is a cryptographic hash function from the SHA-2 family and is
     standardized by NIST. It produces a 512-bit message digest.
 
+BLAKE2
+~~~~~~
+
+`BLAKE2`_ is a cryptographic hash function specified in :rfc:`7693`. It supports
+keying, personalization, and salting.
+
+.. note::
+
+    As of OpenSSL 1.1.0 BLAKE2 is only supported as an unkeyed hash with no
+    personalization or salting features.
+
+.. class:: BLAKE2b(digest_size)
+
+    BLAKE2b is optimized for 64-bit platforms and produces an 1 to 64-byte
+    message digest.
+
+    :param int digest_size: The desired size of the hash output in bytes.
+
+    :raises ValueError: If the digest_size is invalid.
+
+.. class:: BLAKE2s(digest_size)
+
+    BLAKE2s is optimized for 8 to 32-bit platforms and produces a
+    1 to 32-byte message digest.
+
+    :param int digest_size: The desired size of the hash output in bytes.
+
+    :raises ValueError: If the digest_size is invalid.
+
 RIPEMD160
 ~~~~~~~~~
 
@@ -193,3 +222,4 @@ Interfaces
 
 
 .. _`Lifetimes of cryptographic hash functions`: http://valerieaurora.org/hash.html
+.. _`BLAKE2`: https://blake2.net

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -120,13 +120,12 @@ SHA-2 family
 BLAKE2
 ~~~~~~
 
-`BLAKE2`_ is a cryptographic hash function specified in :rfc:`7693`. It
-supports keying, personalization, and salting.
+`BLAKE2`_ is a cryptographic hash function specified in :rfc:`7693`.
 
 .. note::
 
-    As of OpenSSL 1.1.0 BLAKE2 is only supported as an unkeyed hash with no
-    personalization or salting features.
+    While the RFC specifies keying, personalization, and salting features,
+    these are not supported at this time due to limitations in OpenSSL 1.1.0.
 
 .. class:: BLAKE2b(digest_size)
 

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -125,7 +125,7 @@ keying, personalization, and salting.
 
 .. note::
 
-    As of OpenSSL 1.1.0 BLAKE2 is only supported as an unkeyed hash with no
+    As of OpenSSL 1.1.0 BLAKE2 is only supported as an un-keyed hash with no
     personalization or salting features.
 
 .. class:: BLAKE2b(digest_size)
@@ -135,7 +135,7 @@ keying, personalization, and salting.
 
     :param int digest_size: The desired size of the hash output in bytes.
 
-    :raises ValueError: If the digest_size is invalid.
+    :raises ValueError: If the ``digest_size`` is invalid.
 
 .. class:: BLAKE2s(digest_size)
 
@@ -144,7 +144,7 @@ keying, personalization, and salting.
 
     :param int digest_size: The desired size of the hash output in bytes.
 
-    :raises ValueError: If the digest_size is invalid.
+    :raises ValueError: If the ``digest_size`` is invalid.
 
 RIPEMD160
 ~~~~~~~~~

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -125,7 +125,7 @@ keying, personalization, and salting.
 
 .. note::
 
-    As of OpenSSL 1.1.0 BLAKE2 is only supported as an un-keyed hash with no
+    As of OpenSSL 1.1.0 BLAKE2 is only supported as an unkeyed hash with no
     personalization or salting features.
 
 .. class:: BLAKE2b(digest_size)

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -132,7 +132,8 @@ BLAKE2
     BLAKE2b is optimized for 64-bit platforms and produces an 1 to 64-byte
     message digest.
 
-    :param int digest_size: The desired size of the hash output in bytes.
+    :param int digest_size: The desired size of the hash output in bytes. Only
+        ``64`` is supported at this time.
 
     :raises ValueError: If the ``digest_size`` is invalid.
 
@@ -141,7 +142,8 @@ BLAKE2
     BLAKE2s is optimized for 8 to 32-bit platforms and produces a
     1 to 32-byte message digest.
 
-    :param int digest_size: The desired size of the hash output in bytes.
+    :param int digest_size: The desired size of the hash output in bytes. Only
+        ``32`` is supported at this time.
 
     :raises ValueError: If the ``digest_size`` is invalid.
 

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -120,8 +120,8 @@ SHA-2 family
 BLAKE2
 ~~~~~~
 
-`BLAKE2`_ is a cryptographic hash function specified in :rfc:`7693`. It supports
-keying, personalization, and salting.
+`BLAKE2`_ is a cryptographic hash function specified in :rfc:`7693`. It
+supports keying, personalization, and salting.
 
 .. note::
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -74,6 +74,7 @@ Tanja
 testability
 Ubuntu
 unencrypted
+unkeyed
 unpadded
 unpadding
 verifier

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -74,7 +74,6 @@ Tanja
 testability
 Ubuntu
 unencrypted
-unkeyed
 unpadded
 unpadding
 verifier

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -185,8 +185,19 @@ class Backend(object):
     def create_hmac_ctx(self, key, algorithm):
         return _HMACContext(self, key, algorithm)
 
+    def _build_openssl_digest_name(self, algorithm):
+        if algorithm.name == "blake2b" or algorithm.name == "blake2s":
+            alg = "{0}{1}".format(
+                algorithm.name, algorithm.digest_size * 8
+            ).encode("ascii")
+        else:
+            alg = algorithm.name.encode("ascii")
+
+        return alg
+
     def hash_supported(self, algorithm):
-        digest = self._lib.EVP_get_digestbyname(algorithm.name.encode("ascii"))
+        name = self._build_openssl_digest_name(algorithm)
+        digest = self._lib.EVP_get_digestbyname(name)
         return digest != self._ffi.NULL
 
     def hmac_supported(self, algorithm):

--- a/src/cryptography/hazmat/backends/openssl/hashes.py
+++ b/src/cryptography/hazmat/backends/openssl/hashes.py
@@ -22,8 +22,8 @@ class _HashContext(object):
             ctx = self._backend._ffi.gc(
                 ctx, self._backend._lib.Cryptography_EVP_MD_CTX_free
             )
-            evp_md = self._backend._lib.EVP_get_digestbyname(
-                algorithm.name.encode("ascii"))
+            name = self._backend._build_openssl_digest_name(algorithm)
+            evp_md = self._backend._lib.EVP_get_digestbyname(name)
             if evp_md == self._backend._ffi.NULL:
                 raise UnsupportedAlgorithm(
                     "{0} is not a supported hash on this backend.".format(

--- a/src/cryptography/hazmat/backends/openssl/hashes.py
+++ b/src/cryptography/hazmat/backends/openssl/hashes.py
@@ -27,7 +27,7 @@ class _HashContext(object):
             if evp_md == self._backend._ffi.NULL:
                 raise UnsupportedAlgorithm(
                     "{0} is not a supported hash on this backend.".format(
-                        algorithm.name),
+                        name),
                     _Reasons.UNSUPPORTED_HASH
                 )
             res = self._backend._lib.EVP_DigestInit_ex(ctx, evp_md,

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -166,7 +166,6 @@ class MD5(object):
 @utils.register_interface(HashAlgorithm)
 class BLAKE2b(object):
     name = "blake2b"
-    digest_size = None
     _max_digest_size = 64
     _min_digest_size = 1
     block_size = 128
@@ -180,14 +179,15 @@ class BLAKE2b(object):
                 self._min_digest_size, self._max_digest_size)
             )
 
-        self.digest_size = digest_size
+        self._digest_size = digest_size
+
+    digest_size = utils.read_only_property("_digest_size")
 
 
 @utils.register_interface(HashAlgorithm)
 class BLAKE2s(object):
     name = "blake2s"
     block_size = 64
-    digest_size = None
     _max_digest_size = 32
     _min_digest_size = 1
 
@@ -200,4 +200,6 @@ class BLAKE2s(object):
                 self._min_digest_size, self._max_digest_size)
             )
 
-        self.digest_size = digest_size
+        self._digest_size = digest_size
+
+    digest_size = utils.read_only_property("_digest_size")

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -161,3 +161,43 @@ class MD5(object):
     name = "md5"
     digest_size = 16
     block_size = 64
+
+
+@utils.register_interface(HashAlgorithm)
+class BLAKE2b(object):
+    name = "blake2b"
+    digest_size = None
+    _max_digest_size = 64
+    _min_digest_size = 1
+    block_size = 128
+
+    def __init__(self, digest_size):
+        if (
+            digest_size > self._max_digest_size or
+            digest_size < self._min_digest_size
+        ):
+            raise ValueError("Digest size must be {0}-{1}".format(
+                self._min_digest_size, self._max_digest_size)
+            )
+
+        self.digest_size = digest_size
+
+
+@utils.register_interface(HashAlgorithm)
+class BLAKE2s(object):
+    name = "blake2s"
+    block_size = 64
+    digest_size = None
+    _max_digest_size = 32
+    _min_digest_size = 1
+
+    def __init__(self, digest_size):
+        if (
+            digest_size > self._max_digest_size or
+            digest_size < self._min_digest_size
+        ):
+            raise ValueError("Digest size must be {0}-{1}".format(
+                self._min_digest_size, self._max_digest_size)
+            )
+
+        self.digest_size = digest_size

--- a/tests/hazmat/primitives/test_hash_vectors.py
+++ b/tests/hazmat/primitives/test_hash_vectors.py
@@ -158,3 +158,37 @@ class TestMD5(object):
         ],
         hashes.MD5(),
     )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.hash_supported(
+        hashes.BLAKE2b(digest_size=64)),
+    skip_message="Does not support BLAKE2b",
+)
+@pytest.mark.requires_backend_interface(interface=HashBackend)
+class TestBLAKE2b(object):
+    test_b2b = generate_hash_test(
+        load_hash_vectors,
+        os.path.join("hashes", "blake2"),
+        [
+            "blake2b.txt",
+        ],
+        hashes.BLAKE2b(digest_size=64),
+    )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.hash_supported(
+        hashes.BLAKE2s(digest_size=32)),
+    skip_message="Does not support BLAKE2s",
+)
+@pytest.mark.requires_backend_interface(interface=HashBackend)
+class TestBLAKE2s256(object):
+    test_b2s = generate_hash_test(
+        load_hash_vectors,
+        os.path.join("hashes", "blake2"),
+        [
+            "blake2s.txt",
+        ],
+        hashes.BLAKE2s(digest_size=32),
+    )

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -159,6 +159,54 @@ class TestMD5(object):
     )
 
 
+@pytest.mark.supported(
+    only_if=lambda backend: backend.hash_supported(
+        hashes.BLAKE2b(digest_size=64)),
+    skip_message="Does not support BLAKE2b",
+)
+@pytest.mark.requires_backend_interface(interface=HashBackend)
+class TestBLAKE2b(object):
+    test_BLAKE2b = generate_base_hash_test(
+        hashes.BLAKE2b(digest_size=64),
+        digest_size=64,
+        block_size=128,
+    )
+
+    def test_invalid_digest_size(self, backend):
+        with pytest.raises(ValueError):
+            hashes.BLAKE2b(digest_size=65)
+
+        with pytest.raises(ValueError):
+            hashes.BLAKE2b(digest_size=0)
+
+        with pytest.raises(ValueError):
+            hashes.BLAKE2b(digest_size=-1)
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.hash_supported(
+        hashes.BLAKE2s(digest_size=32)),
+    skip_message="Does not support BLAKE2s",
+)
+@pytest.mark.requires_backend_interface(interface=HashBackend)
+class TestBLAKE2s(object):
+    test_BLAKE2s = generate_base_hash_test(
+        hashes.BLAKE2s(digest_size=32),
+        digest_size=32,
+        block_size=64,
+    )
+
+    def test_invalid_digest_size(self, backend):
+        with pytest.raises(ValueError):
+            hashes.BLAKE2s(digest_size=33)
+
+        with pytest.raises(ValueError):
+            hashes.BLAKE2s(digest_size=0)
+
+        with pytest.raises(ValueError):
+            hashes.BLAKE2s(digest_size=-1)
+
+
 def test_invalid_backend():
     pretend_backend = object()
 


### PR DESCRIPTION
Doesn't support keying, personalization, salting, or tree hashes so the API is pretty simple right now.

Two outstanding questions:

`BLAKE2` supports configurable digest sizes. However, our interface for `HashAlgorithm` requires the presence of a `digest_size`, which needs to be provided in the constructor for `BLAKE2` (either that or we'll need to generate 96 different classes).  At the moment OpenSSL does not currently support anything other than the blake2b 64 byte out put and the blake2s 32 byte output, but it will likely support changing this in the future. I am inclined to say we should remove `digest_size` from the interface rather than the filthy `digest_size = None` workaround that's currently in this PR.

Do we want to add `personalization`, `salt`, and `key` to the API now and just error if any of them are passed to the openssl backend? Or do we want to add them later.

I'll add the rest of the tests for coverage once we decide on these issues.