### PR TITLE
fix memory leak reported in #3134

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/encode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/encode_asn1.py
@@ -85,6 +85,10 @@ def _encode_name(backend, attributes):
     subject = backend._lib.X509_NAME_new()
     for attribute in attributes:
         name_entry = _encode_name_entry(backend, attribute)
+        # X509_NAME_add_entry dups the object so we need to gc this copy
+        name_entry = backend._ffi.gc(
+            name_entry, backend._lib.X509_NAME_ENTRY_free
+        )
         res = backend._lib.X509_NAME_add_entry(subject, name_entry, -1, 0)
         backend.openssl_assert(res == 1)
     return subject


### PR DESCRIPTION
We also use `_encode_name_entry` when adding items via `sk_X509_NAME_ENTRY_push`. Looking at `sk_X509_NAME_ENTRY_push` it ultimately calls `OPENSSL_sk_insert` which appears to take ownership. So the fix is to free in `_encode_name`. Fixes #3134 