### PR TITLE
Memleak tests

### DIFF
--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -33,6 +33,13 @@ static const int CRYPTO_LOCK_SSL;
 
 FUNCTIONS = """
 int CRYPTO_mem_ctrl(int);
+
+void CRYPTO_get_mem_functions(void *(**)(size_t, const char *, int),
+                              void *(**)(void *, size_t, const char *, int),
+                              void (**)(void *, const char *, int));
+int CRYPTO_set_mem_functions(void *(*)(size_t, const char *, int),
+                             void *(*)(void *, size_t, const char *, int),
+                             void (*)(void *, const char *, int));
 """
 
 MACROS = """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -34,15 +34,6 @@ static const int CRYPTO_LOCK_SSL;
 
 FUNCTIONS = """
 int CRYPTO_mem_ctrl(int);
-
-void Cryptography_CRYPTO_get_mem_functions(
-    void *(**)(size_t, const char *, int),
-    void *(**)(void *, size_t, const char *, int),
-    void (**)(void *, const char *, int));
-int Cryptography_CRYPTO_set_mem_functions(
-    void *(*)(size_t, const char *, int),
-    void *(*)(void *, size_t, const char *, int),
-    void (*)(void *, const char *, int));
 """
 
 MACROS = """
@@ -68,6 +59,16 @@ void OPENSSL_free(void *);
 
 /* This was removed in 1.1.0 */
 void CRYPTO_lock(int, int, const char *, int);
+
+/* Signature changed significantly in 1.1.0, only expose there for sanity */
+void Cryptography_CRYPTO_get_mem_functions(
+    void *(**)(size_t, const char *, int),
+    void *(**)(void *, size_t, const char *, int),
+    void (**)(void *, const char *, int));
+int Cryptography_CRYPTO_set_mem_functions(
+    void *(*)(size_t, const char *, int),
+    void *(*)(void *, size_t, const char *, int),
+    void (*)(void *, const char *, int));
 """
 
 CUSTOMIZATIONS = """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -65,6 +65,10 @@ int Cryptography_CRYPTO_set_mem_functions(
     void *(*)(size_t, const char *, int),
     void *(*)(void *, size_t, const char *, int),
     void (*)(void *, const char *, int));
+
+void *Cryptography_malloc_wrapper(size_t, const char *, int);
+void *Cryptography_realloc_wrapper(void *, size_t, const char *, int);
+void Cryptography_free_wrapper(void *, const char *, int);
 """
 
 CUSTOMIZATIONS = """
@@ -131,4 +135,16 @@ int Cryptography_CRYPTO_set_mem_functions(
     return CRYPTO_set_mem_functions(m, r, f);
 }
 #endif
+
+void *Cryptography_malloc_wrapper(size_t size, const char *file, int line) {
+    return malloc(size);
+}
+
+void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *file, int line) {
+    return realloc(ptr, size);
+}
+
+void Cryptography_free_wrapper(void *ptr, const char *file, int line) {
+    return free(ptr);
+}
 """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -10,6 +10,7 @@ INCLUDES = """
 
 TYPES = """
 static const long Cryptography_HAS_LOCKING_CALLBACKS;
+static const long Cryptography_HAS_MEM_FUNCTIONS;
 
 static const int SSLEAY_VERSION;
 static const int SSLEAY_CFLAGS;
@@ -108,5 +109,18 @@ static const long CRYPTO_READ = 0;
 static const long CRYPTO_LOCK_SSL = 0;
 #endif
 void (*CRYPTO_lock)(int, int, const char *, int) = NULL;
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+static const long Cryptography_HAS_MEM_FUNCTIONS = 0;
+void (*CRYPTO_get_mem_functions)(void *(**)(size_t, const char *, int),
+                                 void *(**)(void *, size_t, const char *, int),
+                                 void (**)(void *, const char *, int)) = NULL;
+int (*CRYPTO_set_mem_functions)(void *(*)(size_t, const char *, int),
+                                void *(*)(void *, size_t, const char *, int),
+                                void (*)(void *, const char *, int)) = NULL;
+
+#else
+static const long Cryptography_HAS_MEM_FUNCTIONS = 1;
 #endif
 """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -136,7 +136,7 @@ void Cryptography_CRYPTO_get_mem_functions(
     void *(**r)(void *, size_t, const char *, int),
     void (**f)(void *, const char *, int)
 ) {
-    CRYPTO_get_memfunctions(m, r, f);
+    CRYPTO_get_mem_functions(m, r, f);
 }
 
 int Cryptography_CRYPTO_set_mem_functions(

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -140,7 +140,8 @@ void *Cryptography_malloc_wrapper(size_t size, const char *file, int line) {
     return malloc(size);
 }
 
-void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *file, int line) {
+void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *file,
+                                   int line) {
     return realloc(ptr, size);
 }
 

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -61,10 +61,6 @@ void OPENSSL_free(void *);
 void CRYPTO_lock(int, int, const char *, int);
 
 /* Signature changed significantly in 1.1.0, only expose there for sanity */
-void Cryptography_CRYPTO_get_mem_functions(
-    void *(**)(size_t, const char *, int),
-    void *(**)(void *, size_t, const char *, int),
-    void (**)(void *, const char *, int));
 int Cryptography_CRYPTO_set_mem_functions(
     void *(*)(size_t, const char *, int),
     void *(*)(void *, size_t, const char *, int),
@@ -115,14 +111,10 @@ void (*CRYPTO_lock)(int, int, const char *, int) = NULL;
 #endif
 
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 || defined(LIBRESSL_VERSION_NUMBER)
-/* These functions have a significantly different signature pre-1.1.0. since
- * they are for testing only, we don't bother to expose them on older OpenSSLs.
+/* This function has a significantly different signature pre-1.1.0. since it is
+ * for testing only, we don't bother to expose it on older OpenSSLs.
  */
 static const long Cryptography_HAS_MEM_FUNCTIONS = 0;
-void (*Cryptography_CRYPTO_get_mem_functions)(
-    void *(**)(size_t, const char *, int),
-    void *(**)(void *, size_t, const char *, int),
-    void (**)(void *, const char *, int)) = NULL;
 int (*Cryptography_CRYPTO_set_mem_functions)(
     void *(*)(size_t, const char *, int),
     void *(*)(void *, size_t, const char *, int),
@@ -130,14 +122,6 @@ int (*Cryptography_CRYPTO_set_mem_functions)(
 
 #else
 static const long Cryptography_HAS_MEM_FUNCTIONS = 1;
-
-void Cryptography_CRYPTO_get_mem_functions(
-    void *(**m)(size_t, const char *, int),
-    void *(**r)(void *, size_t, const char *, int),
-    void (**f)(void *, const char *, int)
-) {
-    CRYPTO_get_mem_functions(m, r, f);
-}
 
 int Cryptography_CRYPTO_set_mem_functions(
     void *(*m)(size_t, const char *, int),

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -114,7 +114,7 @@ static const long CRYPTO_LOCK_SSL = 0;
 void (*CRYPTO_lock)(int, int, const char *, int) = NULL;
 #endif
 
-#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 || defined(LIBRESSL_VERSION_NUMBER)
 /* These functions have a significantly different signature pre-1.1.0. since
  * they are for testing only, we don't bother to expose them on older OpenSSLs.
  */

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -136,16 +136,16 @@ int Cryptography_CRYPTO_set_mem_functions(
 }
 #endif
 
-void *Cryptography_malloc_wrapper(size_t size, const char *file, int line) {
+void *Cryptography_malloc_wrapper(size_t size, const char *path, int line) {
     return malloc(size);
 }
 
-void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *file,
+void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *path,
                                    int line) {
     return realloc(ptr, size);
 }
 
-void Cryptography_free_wrapper(void *ptr, const char *file, int line) {
+void Cryptography_free_wrapper(void *ptr, const char *path, int line) {
     return free(ptr);
 }
 """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -35,12 +35,14 @@ static const int CRYPTO_LOCK_SSL;
 FUNCTIONS = """
 int CRYPTO_mem_ctrl(int);
 
-void CRYPTO_get_mem_functions(void *(**)(size_t, const char *, int),
-                              void *(**)(void *, size_t, const char *, int),
-                              void (**)(void *, const char *, int));
-int CRYPTO_set_mem_functions(void *(*)(size_t, const char *, int),
-                             void *(*)(void *, size_t, const char *, int),
-                             void (*)(void *, const char *, int));
+void Cryptography_CRYPTO_get_mem_functions(
+    void *(**)(size_t, const char *, int),
+    void *(**)(void *, size_t, const char *, int),
+    void (**)(void *, const char *, int));
+int Cryptography_CRYPTO_set_mem_functions(
+    void *(*)(size_t, const char *, int),
+    void *(*)(void *, size_t, const char *, int),
+    void (*)(void *, const char *, int));
 """
 
 MACROS = """
@@ -112,15 +114,36 @@ void (*CRYPTO_lock)(int, int, const char *, int) = NULL;
 #endif
 
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+/* These functions have a significantly different signature pre-1.1.0. since
+ * they are for testing only, we don't bother to expose them on older OpenSSLs.
+ */
 static const long Cryptography_HAS_MEM_FUNCTIONS = 0;
-void (*CRYPTO_get_mem_functions)(void *(**)(size_t, const char *, int),
-                                 void *(**)(void *, size_t, const char *, int),
-                                 void (**)(void *, const char *, int)) = NULL;
-int (*CRYPTO_set_mem_functions)(void *(*)(size_t, const char *, int),
-                                void *(*)(void *, size_t, const char *, int),
-                                void (*)(void *, const char *, int)) = NULL;
+void (*Cryptography_CRYPTO_get_mem_functions)(
+    void *(**)(size_t, const char *, int),
+    void *(**)(void *, size_t, const char *, int),
+    void (**)(void *, const char *, int)) = NULL;
+int (*Cryptography_CRYPTO_set_mem_functions)(
+    void *(*)(size_t, const char *, int),
+    void *(*)(void *, size_t, const char *, int),
+    void (*)(void *, const char *, int)) = NULL;
 
 #else
 static const long Cryptography_HAS_MEM_FUNCTIONS = 1;
+
+void Cryptography_CRYPTO_get_mem_functions(
+    void *(**m)(size_t, const char *, int),
+    void *(**r)(void *, size_t, const char *, int),
+    void (**f)(void *, const char *, int)
+) {
+    CRYPTO_get_memfunctions(m, r, f);
+}
+
+int Cryptography_CRYPTO_set_mem_functions(
+    void *(*m)(size_t, const char *, int),
+    void *(*r)(void *, size_t, const char *, int),
+    void (*f)(void *, const char *, int)
+) {
+    return CRYPTO_set_mem_functions(m, r, f);
+}
 #endif
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -310,4 +310,8 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_EVP_PKEY_DHX": [
         "EVP_PKEY_DHX",
     ],
+    "Cryptography_HAS_MEM_FUNCTIONS": [
+        "CRYPTO_get_mem_functions",
+        "CRYPTO_set_mem_functions",
+    ],
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -311,7 +311,7 @@ CONDITIONAL_NAMES = {
         "EVP_PKEY_DHX",
     ],
     "Cryptography_HAS_MEM_FUNCTIONS": [
-        "CRYPTO_get_mem_functions",
-        "CRYPTO_set_mem_functions",
+        "Cryptography_CRYPTO_get_mem_functions",
+        "Cryptography_CRYPTO_set_mem_functions",
     ],
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -311,7 +311,6 @@ CONDITIONAL_NAMES = {
         "EVP_PKEY_DHX",
     ],
     "Cryptography_HAS_MEM_FUNCTIONS": [
-        "Cryptography_CRYPTO_get_mem_functions",
         "Cryptography_CRYPTO_set_mem_functions",
     ],
 }

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -79,6 +79,7 @@ def main():
             })
             for ptr in remaining
         )))
+        sys.stderr.flush()
         sys.exit(1)
 
 main()

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -45,14 +45,9 @@ def main():
         orig_free[0](ptr, path, line)
 
     result = lib.Cryptography_CRYPTO_set_mem_functions(malloc, realloc, free)
-    assert result == 1, "x1"
-    try:
-        func()
-    finally:
-        result = lib.Cryptography_CRYPTO_set_mem_functions(
-            orig_malloc, orig_realloc, orig_free
-        )
-        assert result == 1, "x2"
+    assert result == 1
+
+    func()
 
     assert not heap, "x3"
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -32,6 +32,7 @@ def main():
     void *realloc(void *, size_t);
     void free(void *);
     ''')
+    raise ValueError(ctypes.util.find_library("c"))
     libc_lib = libc_ffi.dlopen(ctypes.util.find_library("c"))
 
     heap = {}

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -90,7 +90,7 @@ def assert_no_memory_leaks(s):
     env = os.environ.copy()
     env["PYTHONPATH"] = os.pathsep.join(sys.path)
     proc = subprocess.Popen(
-        [sys.executable, "-c", "{}\n\n{}".format(s, MEMORY_LEAK_SCRIPT)],
+        [sys.executable, "-c", "{0}\n\n{0}".format(s, MEMORY_LEAK_SCRIPT)],
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -90,7 +90,7 @@ def assert_no_memory_leaks(s):
     env = os.environ.copy()
     env["PYTHONPATH"] = os.pathsep.join(sys.path)
     proc = subprocess.Popen(
-        [sys.executable, "-c", "{0}\n\n{0}".format(s, MEMORY_LEAK_SCRIPT)],
+        [sys.executable, "-c", "{0}\n\n{1}".format(s, MEMORY_LEAK_SCRIPT)],
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -1,0 +1,104 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+MEMORY_LEAK_SCRIPT = """
+def main():
+    from cryptography.hazmat.bindings.openssl.binding import Binding
+
+    b = Binding()
+    heap = {}
+
+    orig_malloc = b.ffi.new("void *(**)(size_t, const char *, int)")
+    orig_realloc = b.ffi.new("void *(**)(void *, size_t, const char *, int)")
+    orig_free = b.ffi.new("void(**)(void *, const char *, int)")
+    b.lib.Cryptography_CRYPTO_get_mem_functions(
+        orig_malloc, orig_realloc, orig_free
+    )
+
+    @b.ffi.callback("void *(size_t, const char *, int)")
+    def malloc(size, path, line):
+        ptr = orig_malloc[0](size, path, line)
+        heap[ptr] = (size, path, line)
+        return ptr
+
+    @b.ffi.callback("void *(void *, size_t, const char *, int)")
+    def realloc(ptr, size, path, line):
+        # TODO: this may need to be `heap.pop(ptr)`
+        del heap[ptr]
+        new_ptr = orig_realloc[0](ptr, size, path, line)
+        heap[new_ptr] = (size, path, line)
+        return new_ptr
+
+    @b.ffi.callback("void(void *, const char *, int)")
+    def free(ptr, path, line):
+        del heap[ptr]
+        orig_free[0](ptr, path, line)
+
+    result = b.lib.Cryptography_CRYPTO_set_mem_functions(malloc, realloc, free)
+    assert result == 1, "x1"
+    try:
+        func()
+    finally:
+        result = b.lib.Cryptography_CRYPTO_set_mem_functions(
+            orig_malloc, orig_realloc, orig_free
+        )
+        assert result == 1, "x2"
+
+    assert not heap, "x3"
+
+main()
+"""
+
+def assert_no_memory_leaks(s):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    subprocess.check_call(
+        [sys.executable, "-c", "{}\n\n{}".format(s, MEMORY_LEAK_SCRIPT)],
+        env=env,
+    )
+
+
+class TestAssertNoMemoryLeaks(object):
+    def test_no_leak_no_malloc(self):
+        assert_no_memory_leaks(textwrap.dedent("""
+        def func():
+            pass
+        """))
+
+    def test_no_leak_free(self):
+        assert_no_memory_leaks(textwrap.dedent("""
+        def func():
+            from cryptography.hazmat.bindings.openssl.binding import Binding
+            b = Binding()
+            name = b.lib.X509_NAME_new()
+            b.lib.X509_NAME_free(name)
+        """))
+
+    def test_no_leak_gc(self):
+        assert_no_memory_leaks(textwrap.dedent("""
+        def func():
+            from cryptography.hazmat.bindings.openssl.binding import Binding
+            b = Binding()
+            name = b.lib.X509_NAME_new()
+            b.ffi.gc(name, b.lib.X509_NAME_free)
+        """))
+
+    def test_leak(self):
+        with pytest.raises(AssertionError):
+            assert_no_memory_leaks(textwrap.dedent("""
+            def func():
+                from cryptography.hazmat.bindings.openssl.binding import Binding
+                b = Binding()
+                b.lib.X509_NAME_new()
+            """))

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.bindings.openssl.binding import Binding
 
 MEMORY_LEAK_SCRIPT = """
 def main():
+    import ctypes.util
     import gc
     import json
     import sys
@@ -31,7 +32,7 @@ def main():
     void *realloc(void *, size_t);
     void free(void *);
     ''')
-    libc_lib = libc_ffi.dlopen(None)
+    libc_lib = libc_ffi.dlopen(ctypes.util.find_library("c"))
 
     heap = {}
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -84,7 +84,7 @@ def main():
         sys.stderr.write(json.dumps(dict(
             (int(libc_ffi.cast("size_t", ptr)), {
                 "size": heap[ptr][0],
-                "path": libc_ffi.string(heap[ptr][1]),
+                "path": libc_ffi.string(heap[ptr][1]).decode(),
                 "line": heap[ptr][2]
             })
             for ptr in remaining

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -16,7 +16,7 @@ from cryptography.hazmat.bindings.openssl.binding import Binding
 
 
 MEMORY_LEAK_SCRIPT = """
-def main(keepalive):
+def main():
     import gc
     import json
     import sys
@@ -57,17 +57,6 @@ def main(keepalive):
     result = lib.Cryptography_CRYPTO_set_mem_functions(malloc, realloc, free)
     assert result == 1
 
-    # Make sure these functions aren't free, this avoids the following
-    # scenario:
-    #   * We set up these pointers
-    #   * This function returns, and they're freed by ref-counting
-    #   * The whole program exits and OpenSSL's atexit handler is invoked
-    #   * OpenSSL tries to free things, and uses our callback which is a
-    #     dangling ptr
-    keepalive.append(malloc)
-    keepalive.append(realloc)
-    keepalive.append(free)
-
     # Trigger a bunch of initialization stuff.
     from cryptography.hazmat.bindings.openssl.binding import Binding
     Binding()
@@ -93,8 +82,7 @@ def main(keepalive):
         sys.stderr.flush()
         sys.exit(1)
 
-_keepalive = []
-main(_keepalive)
+main()
 """
 
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -107,7 +107,7 @@ def assert_no_memory_leaks(s):
     )
     proc.wait()
     if proc.returncode != 0:
-        out = json.load(proc.stdout)
+        out = json.loads(proc.stdout.read().decode())
         raise AssertionError(out)
 
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -47,6 +47,7 @@ def main():
 main()
 """
 
+
 def assert_no_memory_leaks(s):
     env = os.environ.copy()
     env["PYTHONPATH"] = os.pathsep.join(sys.path)
@@ -85,7 +86,9 @@ class TestAssertNoMemoryLeaks(object):
         with pytest.raises(AssertionError):
             assert_no_memory_leaks(textwrap.dedent("""
             def func():
-                from cryptography.hazmat.bindings.openssl.binding import Binding
+                from cryptography.hazmat.bindings.openssl.binding import (
+                    Binding
+                )
                 b = Binding()
                 b.lib.X509_NAME_new()
             """))

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -81,7 +81,7 @@ def main():
     remaining = set(heap) - start_heap
 
     if remaining:
-        sys.stderr.write(json.dumps(dict(
+        sys.stdout.write(json.dumps(dict(
             (int(libc_ffi.cast("size_t", ptr)), {
                 "size": heap[ptr][0],
                 "path": libc_ffi.string(heap[ptr][1]).decode(),
@@ -89,7 +89,7 @@ def main():
             })
             for ptr in remaining
         )))
-        sys.stderr.flush()
+        sys.stdout.flush()
         sys.exit(1)
 
 main()
@@ -103,7 +103,7 @@ def assert_no_memory_leaks(s):
         [sys.executable, "-c", "{0}\n\n{1}".format(s, MEMORY_LEAK_SCRIPT)],
         env=env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
     )
     proc.wait()
     if proc.returncode != 0:

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -31,7 +31,7 @@ def main():
     void *realloc(void *, size_t);
     void free(void *);
     ''')
-    libc_lib = libc_ffi.dlopen("c")
+    libc_lib = libc_ffi.dlopen(None)
 
     heap = {}
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -21,30 +21,26 @@ def main():
     import json
     import sys
 
-    import cffi
-
     from cryptography.hazmat.bindings._openssl import ffi, lib
-
-    libc_ffi = cffi.FFI()
 
     heap = {}
 
-    @libc_ffi.callback("void *(size_t, const char *, int)")
+    @ffi.callback("void *(size_t, const char *, int)")
     def malloc(size, path, line):
         ptr = lib.Cryptography_malloc_wrapper(size, path, line)
         heap[ptr] = (size, path, line)
         return ptr
 
-    @libc_ffi.callback("void *(void *, size_t, const char *, int)")
+    @ffi.callback("void *(void *, size_t, const char *, int)")
     def realloc(ptr, size, path, line):
         del heap[ptr]
         new_ptr = lib.Cryptography_realloc_wrapper(ptr, size, path, line)
         heap[new_ptr] = (size, path, line)
         return new_ptr
 
-    @libc_ffi.callback("void(void *, const char *, int)")
+    @ffi.callback("void(void *, const char *, int)")
     def free(ptr, path, line):
-        if ptr != libc_ffi.NULL:
+        if ptr != ffi.NULL:
             del heap[ptr]
             lib.Cryptography_free_wrapper(ptr, path, line)
 
@@ -76,9 +72,9 @@ def main():
 
     if remaining:
         sys.stdout.write(json.dumps(dict(
-            (int(libc_ffi.cast("size_t", ptr)), {
+            (int(ffi.cast("size_t", ptr)), {
                 "size": heap[ptr][0],
-                "path": libc_ffi.string(heap[ptr][1]).decode(),
+                "path": ffi.string(heap[ptr][1]).decode(),
                 "line": heap[ptr][2]
             })
             for ptr in remaining

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -29,7 +29,7 @@ def main():
     void *realloc(void *, size_t);
     void free(void *);
     ''')
-    libc_lib = libc_ffi.dlopen("libc")
+    libc_lib = libc_ffi.dlopen("c")
 
     heap = {}
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -12,6 +12,8 @@ import textwrap
 
 import pytest
 
+from cryptography.hazmat.bindings.openssl.binding import Binding
+
 
 MEMORY_LEAK_SCRIPT = """
 def main():
@@ -98,6 +100,14 @@ def assert_no_memory_leaks(s):
         raise AssertionError(out)
 
 
+def skip_if_memtesting_not_supported():
+    return pytest.mark.skipif(
+        not Binding().lib.Cryptography_HAS_MEM_FUNCTIONS,
+        reason="Requires OpenSSL memory functions (>=1.1.0)"
+    )
+
+
+@skip_if_memtesting_not_supported()
 class TestAssertNoMemoryLeaks(object):
     def test_no_leak_no_malloc(self):
         assert_no_memory_leaks(textwrap.dedent("""


### PR DESCRIPTION
They don't work,  because something calls `OpenSSL_malloc` in the subprocess before we initialize it. I assume this comes from the `Binding` init process
