### PR TITLE
re-add setuptools resolve vs load workaround

### DIFF
--- a/src/cryptography/hazmat/backends/__init__.py
+++ b/src/cryptography/hazmat/backends/__init__.py
@@ -17,7 +17,12 @@ def _available_backends():
 
     if _available_backends_list is None:
         _available_backends_list = [
-            ep.resolve()
+            # setuptools 11.3 deprecated support for the require parameter to
+            # load(), and introduced the new resolve() method instead.
+            # We previously removed this fallback, but users are having issues
+            # where Python loads an older setuptools due to various syspath
+            # weirdness.
+            ep.resolve() if hasattr(ep, "resolve") else ep.load(require=False)
             for ep in pkg_resources.iter_entry_points(
                 "cryptography.backends"
             )

--- a/src/cryptography/hazmat/backends/__init__.py
+++ b/src/cryptography/hazmat/backends/__init__.py
@@ -17,6 +17,7 @@ def _available_backends():
 
     if _available_backends_list is None:
         _available_backends_list = [
+            # DeprecatedIn16
             # setuptools 11.3 deprecated support for the require parameter to
             # load(), and introduced the new resolve() method instead.
             # We previously removed this fallback, but users are having issues


### PR DESCRIPTION
After discussion in IRC it was agreed that re-adding this workaround is probably appropriate given the issues users keep having with python pathing loading an older version.

See #3149 and #2838 