### PR TITLE
fix warnings in cffi 1.8.3 due to wrong buffer types

### DIFF
--- a/src/cryptography/hazmat/backends/commoncrypto/backend.py
+++ b/src/cryptography/hazmat/backends/commoncrypto/backend.py
@@ -133,7 +133,7 @@ class Backend(object):
     def derive_pbkdf2_hmac(self, algorithm, length, salt, iterations,
                            key_material):
         alg_enum = self._supported_pbkdf2_hmac_algorithms[algorithm.name]
-        buf = self._ffi.new("char[]", length)
+        buf = self._ffi.new("uint8_t[]", length)
         res = self._lib.CCKeyDerivationPBKDF(
             self._lib.kCCPBKDF2,
             key_material,

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -307,7 +307,7 @@ class Backend(object):
 
     def derive_pbkdf2_hmac(self, algorithm, length, salt, iterations,
                            key_material):
-        buf = self._ffi.new("char[]", length)
+        buf = self._ffi.new("unsigned char[]", length)
         evp_md = self._lib.EVP_get_digestbyname(
             algorithm.name.encode("ascii"))
         self.openssl_assert(evp_md != self._ffi.NULL)

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -102,7 +102,7 @@ class _ECDSASignatureContext(object):
         max_size = self._backend._lib.ECDSA_size(ec_key)
         self._backend.openssl_assert(max_size > 0)
 
-        sigbuf = self._backend._ffi.new("char[]", max_size)
+        sigbuf = self._backend._ffi.new("unsigned char[]", max_size)
         siglen_ptr = self._backend._ffi.new("unsigned int[]", 1)
         res = self._backend._lib.ECDSA_sign(
             0,

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -103,7 +103,7 @@ def _enc_dec_rsa_pkey_ctx(backend, key, data, padding_enum, padding):
         backend.openssl_assert(res > 0)
 
     outlen = backend._ffi.new("size_t *", buf_size)
-    buf = backend._ffi.new("char[]", buf_size)
+    buf = backend._ffi.new("unsigned char[]", buf_size)
     res = crypt(pkey_ctx, buf, outlen, data, len(data))
     if res <= 0:
         _handle_rsa_enc_dec_error(backend, key)

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -182,7 +182,7 @@ class TestOpenSSL(object):
             assert size == length
             return sample_data
         monkeypatch.setattr(os, "urandom", notrandom)
-        buf = backend._ffi.new("char[]", length)
+        buf = backend._ffi.new("unsigned char[]", length)
         backend._lib.RAND_bytes(buf, length)
         assert backend._ffi.buffer(buf)[0:length] == sample_data
 
@@ -247,7 +247,7 @@ class TestOpenSSLRandomEngine(object):
 
     def test_osrandom_sanity_check(self):
         # This test serves as a check against catastrophic failure.
-        buf = backend._ffi.new("char[]", 500)
+        buf = backend._ffi.new("unsigned char[]", 500)
         res = backend._lib.RAND_bytes(buf, 500)
         assert res == 1
         assert backend._ffi.buffer(buf)[:] != "\x00" * 500


### PR DESCRIPTION
cffi 1.8.3 cares about the distinction between char and unsigned char and raises a warning now. This PR fixes all the warnings that popped up when running the test suite and matches the buffer to the actual type as defined in the bindings.