### PR TITLE
Travis mac updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,38 +46,43 @@ matrix:
           env: TOXENV=py3pep8
         - language: generic
           os: osx
-          # 7.1 is OS X 10.10.x
-          # see: https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
-          osx_image: xcode7.1
+          # 8 is planned to be macOS 10.12.x
+          # see: https://blog.travis-ci.com/2016-09-15-new-default-osx-image-coming/
+          osx_image: xcode8
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx
-          osx_image: xcode7.1
+          osx_image: xcode8
           env: TOXENV=py33 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx
-          osx_image: xcode7.1
+          osx_image: xcode8
           env: TOXENV=py34 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx
-          osx_image: xcode7.1
+          osx_image: xcode8
           env: TOXENV=py35 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx
-          osx_image: xcode7.1
+          osx_image: xcode8
           env: TOXENV=pypy-nocoverage CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1 PYPY_VERSION=5.1
         - language: generic
           os: osx
-          osx_image: xcode7.1
+          osx_image: xcode8
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=0
         - language: generic
           os: osx
-          # 7.2 is OS X 10.11.x
-          osx_image: xcode7.2
+          # 6.4 is OS X 10.10.x
+          osx_image: xcode6.4
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx
-          osx_image: xcode7.2
+          # 7.3 is OS X 10.11.x
+          osx_image: xcode7.3
+          env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+        - language: generic
+          os: osx
+          osx_image: xcode8
           env: TOXENV=docs CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,13 +72,13 @@ matrix:
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=0
         - language: generic
           os: osx
-          # 6.4 is OS X 10.10.x
-          osx_image: xcode6.4
+          # 7.3 is OS X 10.11.x
+          osx_image: xcode7.3
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx
-          # 7.3 is OS X 10.11.x
-          osx_image: xcode7.3
+          # 6.4 is OS X 10.10.x
+          osx_image: xcode6.4
           env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
         - language: generic
           os: osx

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -4,6 +4,7 @@ set -e
 set -x
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
+    sw_vers
     brew update || brew update
 
     brew outdated openssl || brew upgrade openssl


### PR DESCRIPTION
Update our travis config to run against 10.10, 10.11, and 10.12 (eventually). Drops 10.9.

Also adds `sw_vers` output so we can look at build output to see what OS it's on.