### PR TITLE
tox 2.4 has new syntax for specifying extras

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ clint
 coverage
 invoke
 requests
-tox
+tox >= 2.4.1
 twine
 -e .[test,docstest,pep8test]
 -e vectors

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,10 @@
 envlist = py26,py27,pypy,py33,py34,py35,docs,pep8,py3pep8
 
 [testenv]
+extras =
+   test
 deps =
     coverage
-    .[test]
     ./vectors
 passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH USERNAME
 commands =
@@ -17,8 +18,8 @@ commands =
     coverage report -m
 
 [testenv:docs]
-deps =
-    .[docstest]
+extras =
+    docstest
 basepython = python2.7
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
@@ -44,15 +45,15 @@ commands =
     py.test --capture=no --strict {posargs}
 
 [testenv:pep8]
-deps =
-    .[pep8test]
+extras =
+    pep8test
 commands =
     flake8 .
 
 [testenv:py3pep8]
 basepython = python3
-deps =
-    .[pep8test]
+extras =
+   pep8test
 commands =
     flake8 .
 


### PR DESCRIPTION
The new [syntax](http://tox.readthedocs.io/en/latest/config.html?highlight=extras#confval-extras=MULTI-LINE-LIST) makes it a bit easier to distinguish extra dependencies from other test dependencies.
