### PR TITLE
add ec.private_key_from_secret_and_curve

### DIFF
--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -422,6 +422,15 @@ A specific ``backend`` may provide one or more of these interfaces.
         :returns: An instance of
             :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey`.
 
+    .. method:: derive_elliptic_curve_public_point(private_value, curve)
+
+        :param private_value: A secret scalar value.
+
+        :param curve: An instance of
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`.
+
+        :returns: A tuple (x, y).
+
 .. class:: PEMSerializationBackend
 
     .. versionadded:: 0.6

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -26,7 +26,7 @@ Elliptic curve cryptography
 
     Derive a private key from ``secret`` on ``curve`` for use with ``backend``.
 
-    :param secret: An instance of :class:`int`.
+    :param int secret: The secret scalar value
 
     :param curve: An instance of :class:`EllipticCurve`.
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -20,6 +20,22 @@ Elliptic curve cryptography
     :returns: A new instance of :class:`EllipticCurvePrivateKey`.
 
 
+.. function:: private_key_from_secret_and_curve(secret, curve, backend)
+
+    .. versionadded:: 1.5.4
+
+    Derive a private key from ``secret`` on ``curve`` for use with ``backend``.
+
+    :param secret: An instance of :class:`int`.
+
+    :param curve: An instance of :class:`EllipticCurve`.
+
+    :param backend: An instance of
+        :class:`~cryptography.hazmat.backends.interfaces.EllipticCurveBackend`.
+
+    :returns: A new instance of :class:`EllipticCurvePrivateKey`.
+
+
 Elliptic Curve Signature Algorithms
 -----------------------------------
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -20,7 +20,7 @@ Elliptic curve cryptography
     :returns: A new instance of :class:`EllipticCurvePrivateKey`.
 
 
-.. function:: private_key_from_secret_and_curve(secret, curve, backend)
+.. function:: derive_private_key(secret, curve, backend)
 
     .. versionadded:: 1.5.4
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -22,7 +22,7 @@ Elliptic curve cryptography
 
 .. function:: derive_private_key(secret, curve, backend)
 
-    .. versionadded:: 1.5.4
+    .. versionadded:: 1.6
 
     Derive a private key from ``secret`` on ``curve`` for use with ``backend``.
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -26,7 +26,7 @@ Elliptic curve cryptography
 
     Derive a private key from ``secret`` on ``curve`` for use with ``backend``.
 
-    :param int secret: The secret scalar value
+    :param int secret: The secret scalar value.
 
     :param curve: An instance of :class:`EllipticCurve`.
 

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -221,6 +221,12 @@ class EllipticCurveBackend(object):
         Returns whether the exchange algorithm is supported by this backend.
         """
 
+    @abc.abstractmethod
+    def derive_elliptic_curve_public_point(self, private_value, curve):
+        """
+        Compute the public key point (x, y) given the private value and curve.
+        """
+
 
 @six.add_metaclass(abc.ABCMeta)
 class PEMSerializationBackend(object):

--- a/src/cryptography/hazmat/backends/multibackend.py
+++ b/src/cryptography/hazmat/backends/multibackend.py
@@ -279,6 +279,19 @@ class MultiBackend(object):
             _Reasons.UNSUPPORTED_ELLIPTIC_CURVE
         )
 
+    def derive_elliptic_curve_public_point(self, private_value, curve):
+        for b in self._filtered_backends(EllipticCurveBackend):
+            try:
+                return b.derive_elliptic_curve_public_point(private_value,
+                                                            curve)
+            except UnsupportedAlgorithm:
+                continue
+
+        raise UnsupportedAlgorithm(
+            "This backend does not support this elliptic curve.",
+            _Reasons.UNSUPPORTED_ELLIPTIC_CURVE
+        )
+
     def elliptic_curve_exchange_algorithm_supported(self, algorithm, curve):
         return any(
             b.elliptic_curve_exchange_algorithm_supported(algorithm, curve)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1386,6 +1386,40 @@ class Backend(object):
 
         return _EllipticCurvePublicKey(self, ec_cdata, evp_pkey)
 
+    def derive_elliptic_curve_public_point(self, private_value, curve):
+        curve_nid = self._elliptic_curve_to_nid(curve)
+
+        ec_cdata = self._lib.EC_KEY_new_by_curve_name(curve_nid)
+        assert ec_cdata != self._ffi.NULL
+        ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
+
+        set_func, get_func, group = (
+            self._ec_key_determine_group_get_set_funcs(ec_cdata)
+        )
+
+        point = self._lib.EC_POINT_new(group)
+        assert point != self._ffi.NULL
+        point = self._ffi.gc(point, self._lib.EC_POINT_free)
+
+        value = self._int_to_bn(private_value)
+        value = self._ffi.gc(value, self._lib.BN_free)
+
+        with self._tmp_bn_ctx() as bn_ctx:
+            res = self._lib.EC_POINT_mul(group, point, value, self._ffi.NULL,
+                                         self._ffi.NULL, bn_ctx)
+            assert res == 1
+
+            bn_x = self._lib.BN_CTX_get(bn_ctx)
+            bn_y = self._lib.BN_CTX_get(bn_ctx)
+
+            res = get_func(group, point, bn_x, bn_y, bn_ctx)
+            assert res == 1
+
+            point_x = self._bn_to_int(bn_x)
+            point_y = self._bn_to_int(bn_y)
+
+        return point_x, point_y
+
     def elliptic_curve_exchange_algorithm_supported(self, algorithm, curve):
         return (
             self.elliptic_curve_supported(curve) and

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1390,6 +1390,7 @@ class Backend(object):
         curve_nid = self._elliptic_curve_to_nid(curve)
 
         ec_cdata = self._lib.EC_KEY_new_by_curve_name(curve_nid)
+        self.openssl_assert(ec_cdata != self._ffi.NULL)
         ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
 
         set_func, get_func, group = (
@@ -1397,6 +1398,7 @@ class Backend(object):
         )
 
         point = self._lib.EC_POINT_new(group)
+        self.openssl_assert(point != self._ffi.NULL)
         point = self._ffi.gc(point, self._lib.EC_POINT_free)
 
         value = self._int_to_bn(private_value)
@@ -1405,11 +1407,13 @@ class Backend(object):
         with self._tmp_bn_ctx() as bn_ctx:
             res = self._lib.EC_POINT_mul(group, point, value, self._ffi.NULL,
                                          self._ffi.NULL, bn_ctx)
+            self.openssl_assert(res == 1)
 
             bn_x = self._lib.BN_CTX_get(bn_ctx)
             bn_y = self._lib.BN_CTX_get(bn_ctx)
 
             res = get_func(group, point, bn_x, bn_y, bn_ctx)
+            self.openssl_assert(res == 1)
 
             point_x = self._bn_to_int(bn_x)
             point_y = self._bn_to_int(bn_y)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1390,7 +1390,6 @@ class Backend(object):
         curve_nid = self._elliptic_curve_to_nid(curve)
 
         ec_cdata = self._lib.EC_KEY_new_by_curve_name(curve_nid)
-        assert ec_cdata != self._ffi.NULL
         ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
 
         set_func, get_func, group = (
@@ -1398,7 +1397,6 @@ class Backend(object):
         )
 
         point = self._lib.EC_POINT_new(group)
-        assert point != self._ffi.NULL
         point = self._ffi.gc(point, self._lib.EC_POINT_free)
 
         value = self._int_to_bn(private_value)
@@ -1407,13 +1405,11 @@ class Backend(object):
         with self._tmp_bn_ctx() as bn_ctx:
             res = self._lib.EC_POINT_mul(group, point, value, self._ffi.NULL,
                                          self._ffi.NULL, bn_ctx)
-            assert res == 1
 
             bn_x = self._lib.BN_CTX_get(bn_ctx)
             bn_y = self._lib.BN_CTX_get(bn_ctx)
 
             res = get_func(group, point, bn_x, bn_y, bn_ctx)
-            assert res == 1
 
             point_x = self._bn_to_int(bn_x)
             point_y = self._bn_to_int(bn_y)

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -253,15 +253,17 @@ def generate_private_key(curve, backend):
     return backend.generate_elliptic_curve_private_key(curve)
 
 
-def derive_from_private_value_and_curve(cls, private_value, curve, backend):
-    if not isinstance(private_value, six.integer_types):
+def private_key_from_secret_and_curve(secret, curve, backend):
+    if not isinstance(secret, six.integer_types):
         raise TypeError("private_value must be an integer.")
 
     if not isinstance(curve, EllipticCurve):
         raise TypeError("curve must provide the EllipticCurve interface.")
 
-    x, y = backend.derive_elliptic_curve_public_point(private_value, curve)
-    return EllipticCurvePublicNumbers(x, y, curve)
+    x, y = backend.derive_elliptic_curve_public_point(secret, curve)
+    public_numbers = EllipticCurvePublicNumbers(x, y, curve)
+    private_numbers = EllipticCurvePrivateNumbers(secret, public_numbers)
+    return private_numbers.private_key(backend)
 
 
 class EllipticCurvePublicNumbers(object):

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -253,9 +253,9 @@ def generate_private_key(curve, backend):
     return backend.generate_elliptic_curve_private_key(curve)
 
 
-def private_key_from_secret_and_curve(secret, curve, backend):
+def derive_private_key(secret, curve, backend):
     if not isinstance(secret, six.integer_types):
-        raise TypeError("private_value must be an integer.")
+        raise TypeError("secret must be an integer type.")
 
     if not isinstance(curve, EllipticCurve):
         raise TypeError("curve must provide the EllipticCurve interface.")

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -253,6 +253,17 @@ def generate_private_key(curve, backend):
     return backend.generate_elliptic_curve_private_key(curve)
 
 
+def derive_from_private_value_and_curve(cls, private_value, curve, backend):
+    if not isinstance(private_value, six.integer_types):
+        raise TypeError("private_value must be an integer.")
+
+    if not isinstance(curve, EllipticCurve):
+        raise TypeError("curve must provide the EllipticCurve interface.")
+
+    x, y = backend.derive_elliptic_curve_public_point(private_value, curve)
+    return EllipticCurvePublicNumbers(x, y, curve)
+
+
 class EllipticCurvePublicNumbers(object):
     def __init__(self, x, y, curve):
         if (

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -27,6 +27,12 @@ class DummyBackend(object):
     pass
 
 
+@utils.register_interface(ec.EllipticCurve)
+class DummyCurve(object):
+    name = "dummy-curve"
+    key_size = 1
+
+
 @utils.register_interface(CipherBackend)
 class DummyCipherBackend(object):
     def __init__(self, supported_ciphers):
@@ -504,6 +510,9 @@ class TestMultiBackend(object):
         assert not backend2.elliptic_curve_exchange_algorithm_supported(
             ec.ECDH(), ec.SECT163K1()
         )
+
+        with pytest.raises(UnsupportedAlgorithm):
+            backend.derive_elliptic_curve_public_point(123, DummyCurve())
 
     def test_pem_serialization_backend(self):
         backend = MultiBackend([DummyPEMSerializationBackend()])

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -514,6 +514,9 @@ class TestMultiBackend(object):
         with pytest.raises(UnsupportedAlgorithm):
             backend.derive_elliptic_curve_public_point(123, DummyCurve())
 
+        assert backend.derive_elliptic_curve_public_point(
+            123, ec.SECP256K1()) is None
+
     def test_pem_serialization_backend(self):
         backend = MultiBackend([DummyPEMSerializationBackend()])
 

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -179,6 +179,10 @@ class DummyEllipticCurveBackend(object):
             self.elliptic_curve_supported(curve)
         )
 
+    def derive_elliptic_curve_public_point(self, private_value, curve):
+        if not self.elliptic_curve_supported(curve):
+            raise UnsupportedAlgorithm(_Reasons.UNSUPPORTED_ELLIPTIC_CURVE)
+
 
 @utils.register_interface(PEMSerializationBackend)
 class DummyPEMSerializationBackend(object):

--- a/tests/hazmat/backends/test_multibackend.py
+++ b/tests/hazmat/backends/test_multibackend.py
@@ -515,7 +515,7 @@ class TestMultiBackend(object):
             backend.derive_elliptic_curve_public_point(123, DummyCurve())
 
         assert backend.derive_elliptic_curve_public_point(
-            123, ec.SECP256K1()) is None
+            123, ec.SECT283K1()) is None
 
     def test_pem_serialization_backend(self):
         backend = MultiBackend([DummyPEMSerializationBackend()])

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -100,6 +100,32 @@ def test_skip_ecdsa_vector(backend):
         _skip_ecdsa_vector(backend, DummyCurve, hashes.SHA256)
 
 
+@pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
+def test_private_key_from_secret_and_curve(backend):
+    curve = ec.SECP256K1()
+    private_key = ec.generate_private_key(curve, backend)
+    private_numbers = private_key.private_numbers()
+    public_numbers = private_numbers.public_numbers()
+
+    generated_private_value = private_numbers.private_value
+    generated_x = public_numbers.x
+    generated_y = public_numbers.y
+
+    private_key = ec.private_key_from_secret_and_curve(
+        generated_private_value, curve, backend
+    )
+    private_numbers = private_key.private_numbers()
+    public_numbers = private_numbers.public_numbers()
+
+    derived_private_value = private_numbers.private_value
+    derived_x = public_numbers.x
+    derived_y = public_numbers.y
+
+    assert generated_private_value == derived_private_value
+    assert generated_x == derived_x
+    assert generated_y == derived_y
+
+
 def test_ec_numbers():
     numbers = ec.EllipticCurvePrivateNumbers(
         1,

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECP256R1()
+    curve = ec.SECP521R1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -105,25 +105,13 @@ def test_derive_private_key_success(backend):
     curve = ec.SECP256K1()
     _skip_curve_unsupported(backend, curve)
 
-    private_key = ec.generate_private_key(curve, backend)
-    public_numbers = private_key.public_key().public_numbers()
+    private_numbers = ec.generate_private_key(curve, backend).private_numbers()
 
-    generated_private_value = private_key.private_numbers().private_value
-    generated_x = public_numbers.x
-    generated_y = public_numbers.y
-
-    private_key = ec.derive_private_key(
-        generated_private_value, curve, backend
+    derived_key = ec.derive_private_key(
+        private_numbers.private_value, curve, backend
     )
-    public_numbers = private_key.public_key().public_numbers()
 
-    derived_private_value = private_key.private_numbers().private_value
-    derived_x = public_numbers.x
-    derived_y = public_numbers.y
-
-    assert generated_private_value == derived_private_value
-    assert generated_x == derived_x
-    assert generated_y == derived_y
+    assert private_numbers == derived_key.private_numbers()
 
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT571K1()
+    curve = ec.SECT409K1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECP256K1()
+    curve = ec.SECP384R1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT233R1()
+    curve = ec.SECT163R2()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT283R1()
+    curve = ec.SECT233R1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT283K1()
+    curve = ec.SECT233K1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT163R2()
+    curve = ec.SECP521R1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT409K1()
+    curve = ec.SECT283K1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT233K1()
+    curve = ec.SECT163K1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT163K1()
+    curve = ec.SECT571R1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT571R1()
+    curve = ec.SECT409R1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECP384R1()
+    curve = ec.SECT283K1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECP521R1()
+    curve = ec.SECP256R1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,9 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECP521R1()
+    curve = ec.SECP256K1()
+    _skip_curve_unsupported(backend, curve)
+
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -104,20 +104,18 @@ def test_skip_ecdsa_vector(backend):
 def test_private_key_from_secret_and_curve(backend):
     curve = ec.SECP256K1()
     private_key = ec.generate_private_key(curve, backend)
-    private_numbers = private_key.private_numbers()
-    public_numbers = private_numbers.public_numbers()
+    public_numbers = private_key.public_key().public_numbers()
 
-    generated_private_value = private_numbers.private_value
+    generated_private_value = private_key.private_numbers().private_value
     generated_x = public_numbers.x
     generated_y = public_numbers.y
 
     private_key = ec.private_key_from_secret_and_curve(
         generated_private_value, curve, backend
     )
-    private_numbers = private_key.private_numbers()
-    public_numbers = private_numbers.public_numbers()
+    public_numbers = private_key.public_key().public_numbers()
 
-    derived_private_value = private_numbers.private_value
+    derived_private_value = private_key.private_numbers().private_value
     derived_x = public_numbers.x
     derived_y = public_numbers.y
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -112,7 +112,7 @@ def test_private_key_from_secret_and_curve(backend):
     generated_x = public_numbers.x
     generated_y = public_numbers.y
 
-    private_key = ec.private_key_from_secret_and_curve(
+    private_key = ec.derive_private_key(
         generated_private_value, curve, backend
     )
     public_numbers = private_key.public_key().public_numbers()
@@ -126,10 +126,10 @@ def test_private_key_from_secret_and_curve(backend):
     assert generated_y == derived_y
 
     with pytest.raises(TypeError):
-        ec.private_key_from_secret_and_curve('one', curve, backend)
+        ec.derive_private_key('one', curve, backend)
 
     with pytest.raises(TypeError):
-        ec.private_key_from_secret_and_curve(10, 'five', backend)
+        ec.derive_private_key(10, 'five', backend)
 
 
 def test_ec_numbers():

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT283K1()
+    curve = ec.SECT571K1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -102,7 +102,7 @@ def test_skip_ecdsa_vector(backend):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 def test_private_key_from_secret_and_curve(backend):
-    curve = ec.SECT409R1()
+    curve = ec.SECT283R1()
     private_key = ec.generate_private_key(curve, backend)
     public_numbers = private_key.public_key().public_numbers()
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -101,7 +101,7 @@ def test_skip_ecdsa_vector(backend):
 
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
-def test_private_key_from_secret_and_curve(backend):
+def test_derive_private_key_success(backend):
     curve = ec.SECP256K1()
     _skip_curve_unsupported(backend, curve)
 
@@ -124,6 +124,12 @@ def test_private_key_from_secret_and_curve(backend):
     assert generated_private_value == derived_private_value
     assert generated_x == derived_x
     assert generated_y == derived_y
+
+
+@pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
+def test_derive_private_key_errors(backend):
+    curve = ec.SECP256K1()
+    _skip_curve_unsupported(backend, curve)
 
     with pytest.raises(TypeError):
         ec.derive_private_key('one', curve, backend)

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -123,6 +123,12 @@ def test_private_key_from_secret_and_curve(backend):
     assert generated_x == derived_x
     assert generated_y == derived_y
 
+    with pytest.raises(TypeError):
+        ec.private_key_from_secret_and_curve('one', curve, backend)
+
+    with pytest.raises(TypeError):
+        ec.private_key_from_secret_and_curve(10, 'five', backend)
+
 
 def test_ec_numbers():
     numbers = ec.EllipticCurvePrivateNumbers(


### PR DESCRIPTION
Added test & doc for https://github.com/pyca/cryptography/pull/1973 . Changed implementation to return an EllipticCurvePrivateKey instead of EllipticCurvePublicNumbers as users only wanted the latter to instantiate the former.