### PR TITLE
Turns out we shouldn't call it uniqueIdentifier

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -2306,7 +2306,7 @@ instances. The following common OIDs are available as constants.
 
         Corresponds to the dotted string ``"2.5.4.44"``.
 
-    .. attribute:: UNIQUE_IDENTIFIER
+    .. attribute:: X500_UNIQUE_IDENTIFIER
 
         .. versionadded:: 1.6
 

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -107,7 +107,7 @@ class NameOID(object):
     GIVEN_NAME = ObjectIdentifier("2.5.4.42")
     TITLE = ObjectIdentifier("2.5.4.12")
     GENERATION_QUALIFIER = ObjectIdentifier("2.5.4.44")
-    UNIQUE_IDENTIFIER = ObjectIdentifier("2.5.4.45")
+    X500_UNIQUE_IDENTIFIER = ObjectIdentifier("2.5.4.45")
     DN_QUALIFIER = ObjectIdentifier("2.5.4.46")
     PSEUDONYM = ObjectIdentifier("2.5.4.65")
     DOMAIN_COMPONENT = ObjectIdentifier("0.9.2342.19200300.100.1.25")
@@ -189,7 +189,7 @@ _OID_NAMES = {
     NameOID.GIVEN_NAME: "givenName",
     NameOID.TITLE: "title",
     NameOID.GENERATION_QUALIFIER: "generationQualifier",
-    NameOID.UNIQUE_IDENTIFIER: "uniqueIdentifier",
+    NameOID.X500_UNIQUE_IDENTIFIER: "x500UniqueIdentifier",
     NameOID.DN_QUALIFIER: "dnQualifier",
     NameOID.PSEUDONYM: "pseudonym",
     NameOID.DOMAIN_COMPONENT: "domainComponent",


### PR DESCRIPTION
http://www.ca.com/us/services-support/ca-support/ca-support-online/knowledge-base-articles.tec465360.html

OpenSSL also uses this naming.