### PR TITLE
Fix the docs-linkcheck tox target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ commands =
     python setup.py check --restructuredtext --strict
 
 [testenv:docs-linkcheck]
+extras =
 deps =
     sphinx
 basepython = python2.7


### PR DESCRIPTION
The docs-linkcheck tox target was broken when we started using the new `extras` config. This is because `testenv` is the parent environment that cascades down to `testenv:docs-linkcheck`. Previously we overrode the `[test]` extra because it was in `deps` and the `docs-linkcheck` target specifies `deps = sphinx`. When extras became separate that was no longer the case so vector install was failing (despite the fact that we didn't need the vectors). This PR resolves the issue by specifying an empty `extras`.

Fixes #3220 