### PR TITLE
bind GENERAL_NAME_free and move GENERAL_NAME_new to macros...

### DIFF
--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -176,7 +176,6 @@ typedef struct {
 FUNCTIONS = """
 int X509V3_EXT_add_alias(int, int);
 void X509V3_set_ctx(X509V3_CTX *, X509 *, X509 *, X509_REQ *, X509_CRL *, int);
-GENERAL_NAME *GENERAL_NAME_new(void);
 int GENERAL_NAME_print(BIO *, GENERAL_NAME *);
 GENERAL_NAMES *GENERAL_NAMES_new(void);
 void GENERAL_NAMES_free(GENERAL_NAMES *);
@@ -290,6 +289,8 @@ void DIST_POINT_free(DIST_POINT *);
 DIST_POINT_NAME *DIST_POINT_NAME_new(void);
 void DIST_POINT_NAME_free(DIST_POINT_NAME *);
 
+GENERAL_NAME *GENERAL_NAME_new(void);
+void GENERAL_NAME_free(GENERAL_NAME *);
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
GENERAL_NAME_new is a macro (both _new and _free are defined by DECLARE_ASN1_FUNCTIONS), so I don't know why we had it in functions...

refs #3248 