### PR TITLE
add support for prehashing in ECDSA sign/verify

### DIFF
--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -384,12 +384,16 @@ Key Interfaces
 .. class:: EllipticCurveSignatureAlgorithm
 
     .. versionadded:: 0.5
+    .. versionchanged:: 1.6
+        :class:`~cryptography.hazmat.primitives.asymmetric.utils.Prehashed`
+        can now be used as an ``algorithm``.
 
     A signature algorithm for use with elliptic curve keys.
 
     .. attribute:: algorithm
 
-        :type: :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+        :type: :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm` or
+            :class:`~cryptography.hazmat.primitives.asymmetric.utils.Prehashed`
 
         The digest algorithm to be used with the signature scheme.
 


### PR DESCRIPTION
Same as #3266, to avoid merge conflicts between ECDSA and DSA PRs there will be one followup PR adding support information to the `Prehashed` docs + changelog entries.