### PR TITLE
Refactor binding initialization to clear error queue at startup

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -109,7 +109,12 @@ class Binding(object):
 
     @classmethod
     def _register_osrandom_engine(cls):
-        _openssl_assert(cls.lib, cls.lib.ERR_peek_error() == 0)
+        # Clear any errors extant in the queue before we start. In many
+        # scenarios other things may be interacting with OpenSSL in the same
+        # process space and it has proven untenable to assume that they will
+        # reliably clear the error queue. Once we clear it here we will
+        # error on any subsequent unexpected item in the stack.
+        cls.lib.ERR_clear_error()
         cls._osrandom_engine_id = cls.lib.Cryptography_osrandom_engine_id
         cls._osrandom_engine_name = cls.lib.Cryptography_osrandom_engine_name
         result = cls.lib.Cryptography_add_osrandom_engine()

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -8,7 +8,7 @@ import pytest
 
 from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings.openssl.binding import (
-    Binding, _OpenSSLErrorWithText, _openssl_assert
+    Binding, _OpenSSLErrorWithText, _consume_errors, _openssl_assert
 )
 
 
@@ -110,3 +110,15 @@ class TestOpenSSL(object):
                 b'ex:data not multiple of block length'
             )
         )]
+
+    def test_check_startup_errors_are_allowed(self):
+        b = Binding()
+        b.lib.ERR_put_error(
+            b.lib.ERR_LIB_EVP,
+            b.lib.EVP_F_EVP_ENCRYPTFINAL_EX,
+            b.lib.EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH,
+            b"",
+            -1
+        )
+        b._register_osrandom_engine()
+        assert _consume_errors(b.lib) == []


### PR DESCRIPTION
If pyca/cryptography sees any errors on the error stack during its own initialization it immediately raises InternalError and refuses to proceed. This is a safety measure since we don't know if OpenSSL is safe to use. However, there is a subset of errors that may be resident on the stack that we can safely clear and proceed. This PR covers the error that has resulted in almost all the issues we've had filed, PEM_R_NO_START_LINE in PEM_F_PEM_READ_BIO.

refs #3275, #3174, #3089, #2699, #2471, #2468, and probably more.

Update: this PR has been changed to simply clear the error queue. Heavy sigh