### PR TITLE
Add binding to DTLSv1's timeout handling functions

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -730,8 +730,13 @@ long DTLSv1_get_timeout_wrapped(
     int r = DTLSv1_get_timeout(ssl, &tv);
 
     if (r == 1) {
-        if (ptv_sec) *ptv_sec = tv.tv_sec;
-        if (ptv_usec) *ptv_usec = tv.tv_usec;
+        if (ptv_sec) {
+            *ptv_sec = tv.tv_sec;
+        }
+
+        if (ptv_usec) {
+            *ptv_usec = tv.tv_usec;
+        }
     }
 
     return r;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -725,7 +725,11 @@ static const long Cryptography_HAS_NPN_NEGOTIATED = 0;
 #endif
 
 /* Wrap DTLSv1_get_timeout to avoid cffi to handle a 'struct timeval'. */
-long DTLSv1_get_timeout_wrapped(SSL *ssl, time_t *ptv_sec, long int *ptv_usec) {
+long DTLSv1_get_timeout_wrapped(
+                                SSL *ssl,
+                                time_t *ptv_sec,
+                                long int *ptv_usec)
+{
     struct timeval tv = { 0 };
     int r = DTLSv1_get_timeout(ssl, &tv);
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -332,10 +332,6 @@ const SSL_METHOD *DTLSv1_method(void);
 const SSL_METHOD *DTLSv1_server_method(void);
 const SSL_METHOD *DTLSv1_client_method(void);
 
-const SSL_METHOD *DTLSv1_2_method(void);
-const SSL_METHOD *DTLSv1_2_server_method(void);
-const SSL_METHOD *DTLSv1_2_client_method(void);
-
 const SSL_METHOD *SSLv23_method(void);
 const SSL_METHOD *SSLv23_server_method(void);
 const SSL_METHOD *SSLv23_client_method(void);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -438,6 +438,10 @@ long SSL_CTX_sess_cb_hits(SSL_CTX *);
 long SSL_CTX_sess_misses(SSL_CTX *);
 long SSL_CTX_sess_timeouts(SSL_CTX *);
 long SSL_CTX_sess_cache_full(SSL_CTX *);
+
+/* DTLS support */
+long DTLSv1_get_timeout_wrapped(SSL *, time_t *, long int *);
+long DTLSv1_handle_timeout(SSL *);
 """
 
 CUSTOMIZATIONS = """
@@ -719,4 +723,19 @@ static const long Cryptography_HAS_NPN_NEGOTIATED = 1;
 static const long OPENSSL_NPN_NEGOTIATED = -1;
 static const long Cryptography_HAS_NPN_NEGOTIATED = 0;
 #endif
+
+/* Wrap DTLSv1_get_timeout to avoid cffi to handle a 'struct timeval'. */
+long DTLSv1_get_timeout_wrapped(SSL *ssl, time_t *ptv_sec, long int *ptv_usec) {
+    struct timeval tv = { 0 };
+    int r = DTLSv1_get_timeout(ssl, &tv);
+
+    if (r == 1) {
+        if (ptv_sec) *ptv_sec = tv.tv_sec;
+        if (ptv_usec) *ptv_usec = tv.tv_usec;
+    }
+
+    return r;
+}
+
+
 """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -436,7 +436,7 @@ long SSL_CTX_sess_timeouts(SSL_CTX *);
 long SSL_CTX_sess_cache_full(SSL_CTX *);
 
 /* DTLS support */
-long DTLSv1_get_timeout_wrapped(SSL *, time_t *, long int *);
+long DTLSv1_get_timeout_wrapped(SSL *, time_t *, long *);
 long DTLSv1_handle_timeout(SSL *);
 """
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -332,6 +332,10 @@ const SSL_METHOD *DTLSv1_method(void);
 const SSL_METHOD *DTLSv1_server_method(void);
 const SSL_METHOD *DTLSv1_client_method(void);
 
+const SSL_METHOD *DTLSv1_2_method(void);
+const SSL_METHOD *DTLSv1_2_server_method(void);
+const SSL_METHOD *DTLSv1_2_client_method(void);
+
 const SSL_METHOD *SSLv23_method(void);
 const SSL_METHOD *SSLv23_server_method(void);
 const SSL_METHOD *SSLv23_client_method(void);


### PR DESCRIPTION
2 patches to:

- ~~add the bindings of `DTLSv1_2_method()`, `DTLSv1_2_server_method()` and `DTLSv1_2_client_method()`.~~
- add the binding of `DTLSv1_get_timeout()` and `DTLSv1_handle_timeout()`.

Note that `DTLSv1_get_timeout()` is wrapped via `DTLSv1_get_timeout_wrapped()` to avoid `cffi` to manipulate a `struct timeval`. Pointers to the variables `tv_sec` and `tv_usec` are directly passed via the function's arguments.

Please let me know if you have any feedback which would help for this PR to be merged.

Thanks.

EDIT: as seen in https://github.com/pyca/cryptography/pull/3286#issuecomment-263015946 , this PR is now only about the DTLSv1.x timeout handling functions.