### PR TITLE
Bind OPENSSL_malloc.

### DIFF
--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -53,6 +53,7 @@ unsigned long OpenSSL_version_num(void);
 const char *OpenSSL_version(int);
 
 /* this is a macro in 1.1.0 */
+void *OPENSSL_malloc(size_t);
 void OPENSSL_free(void *);
 
 /* This was removed in 1.1.0 */


### PR DESCRIPTION
Annoyingly we need this for OCSP. 