### PR TITLE
Bind TLSEXT_STATUSTYPE_ocsp.

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -141,6 +141,7 @@ typedef ... SSL_SESSION;
 typedef ... SSL;
 
 static const long TLSEXT_NAMETYPE_host_name;
+static const long TLSEXT_STATUSTYPE_ocsp;
 
 typedef ... SSL_CIPHER;
 typedef ... Cryptography_STACK_OF_SSL_CIPHER;


### PR DESCRIPTION
This was missing from the earlier OCSP bindings, and is necessary for correctly-functioning client-side OCSP. Specifically, this is the only valid argument to `SSL_set_tlsext_status_type()`. PyOpenSSL can of course just hard-code the value, but given that we need to depend on the next version of Cryptography to get `OPENSSL_malloc` we may as well just do this properly.