### PR TITLE
cffi bindings additions for pypy's _hashlib module

### DIFF
--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -156,6 +156,7 @@ int EVP_PKEY_assign_EC_KEY(EVP_PKEY *, EC_KEY *);
 EC_KEY *EVP_PKEY_get1_EC_KEY(EVP_PKEY *);
 int EVP_PKEY_set1_EC_KEY(EVP_PKEY *, EC_KEY *);
 
+int EVP_MD_CTX_block_size(const EVP_MD_CTX *md);
 int EVP_CIPHER_CTX_block_size(const EVP_CIPHER_CTX *);
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *, int, int, void *);
 

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -156,7 +156,7 @@ int EVP_PKEY_assign_EC_KEY(EVP_PKEY *, EC_KEY *);
 EC_KEY *EVP_PKEY_get1_EC_KEY(EVP_PKEY *);
 int EVP_PKEY_set1_EC_KEY(EVP_PKEY *, EC_KEY *);
 
-int EVP_MD_CTX_block_size(const EVP_MD_CTX *md);
+int EVP_MD_CTX_block_size(const EVP_MD_CTX *);
 int EVP_CIPHER_CTX_block_size(const EVP_CIPHER_CTX *);
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *, int, int, void *);
 

--- a/src/_cffi_src/openssl/objects.py
+++ b/src/_cffi_src/openssl/objects.py
@@ -15,6 +15,8 @@ typedef struct {
     const char *name;
     const char *data;
 } OBJ_NAME;
+
+static const long OBJ_NAME_TYPE_MD_METH;
 """
 
 FUNCTIONS = """
@@ -36,8 +38,6 @@ void OBJ_NAME_do_all(int, void (*) (const OBJ_NAME *, void *), void *);
 MACROS = """
 /* OBJ_cleanup became a macro in 1.1.0 */
 void OBJ_cleanup(void);
-
-#define OBJ_NAME_TYPE_MD_METH ...
 """
 
 CUSTOMIZATIONS = """

--- a/src/_cffi_src/openssl/objects.py
+++ b/src/_cffi_src/openssl/objects.py
@@ -9,6 +9,12 @@ INCLUDES = """
 """
 
 TYPES = """
+typedef struct {
+    int type;
+    int alias;
+    const char *name;
+    const char *data;
+} OBJ_NAME;
 """
 
 FUNCTIONS = """
@@ -24,11 +30,14 @@ int OBJ_obj2txt(char *, int, const ASN1_OBJECT *, int);
 int OBJ_cmp(const ASN1_OBJECT *, const ASN1_OBJECT *);
 ASN1_OBJECT *OBJ_dup(const ASN1_OBJECT *);
 int OBJ_create(const char *, const char *, const char *);
+void OBJ_NAME_do_all(int, void (*) (const OBJ_NAME *, void *), void *);
 """
 
 MACROS = """
 /* OBJ_cleanup became a macro in 1.1.0 */
 void OBJ_cleanup(void);
+
+#define OBJ_NAME_TYPE_MD_METH ...
 """
 
 CUSTOMIZATIONS = """


### PR DESCRIPTION
There are some more bindings I used in the stdlib module. Unsure about OBJ_NAME, I found no OpenSSL functions that could access the fields, so I assume it is meant to be used directly?