### PR TITLE
Add minversion to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 2.4
 envlist = py26,py27,pypy,py33,py34,py35,docs,pep8,py3pep8
 
 [testenv]


### PR DESCRIPTION
Cryptography uses new features from tox 2.4. Tox 2.3 happily ignores the
new config stanzes and doesn't install dependency. This can lead to strange
test failures.

With minversion=2.4, tox 2.3 fails to run properly:
$ tox
ERROR: tox version is 2.3.1, required is at least 2.4

Signed-off-by: Christian Heimes <christian@python.org>