### PR TITLE
Update Review Rules

### DIFF
--- a/docs/development/reviewing-patches.rst
+++ b/docs/development/reviewing-patches.rst
@@ -44,8 +44,9 @@ devastating, ``cryptography`` has a strict merge policy for committers:
 * Patches must *never* be pushed directly to ``master``, all changes (even the
   most trivial typo fixes!) must be submitted as a pull request.
 * A committer may only merge their own pull request if it has been approved
-  through the GitHub UI by a second party. If multiple people work on a pull
-  request, it must be approved by someone who did not work on it.
+  through the GitHub UI by a second party who is also a committer. If multiple
+  people work on a pull request, it must be approved by someone who did not
+  work on it.
 * A patch that breaks tests, or introduces regressions by changing or removing
   existing tests should not be merged. Tests must always be passing on
   ``master``.

--- a/docs/development/reviewing-patches.rst
+++ b/docs/development/reviewing-patches.rst
@@ -43,9 +43,9 @@ devastating, ``cryptography`` has a strict merge policy for committers:
 
 * Patches must *never* be pushed directly to ``master``, all changes (even the
   most trivial typo fixes!) must be submitted as a pull request.
-* A committer may *never* merge their own pull request, a second party must
-  merge their changes. If multiple people work on a pull request, it must be
-  merged by someone who did not work on it.
+* A committer may only merge their own pull request if it has been approved
+  through the GitHub UI by a second party. If multiple people work on a pull
+  request, it must be approved by someone who did not work on it.
 * A patch that breaks tests, or introduces regressions by changing or removing
   existing tests should not be merged. Tests must always be passing on
   ``master``.


### PR DESCRIPTION
GH's new review system has given us the ability to signify approval of a PR independent of merging. This lets us potentially allow authors to also merge if a second party has approved.

This PR is going to sit for a bit at @alex's request to see if a few more GH review features roll out in the next few weeks.