### PR TITLE
Use static callbacks with Python 3.x again

### DIFF
--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import sys
-
 import cffi
 
 INCLUDES = """

--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -50,9 +50,8 @@ CUSTOMIZATIONS = """
 static const long Cryptography_STATIC_CALLBACKS = 1;
 """
 
-if cffi.__version_info__ < (1, 4, 0) or sys.version_info >= (3, 5):
+if cffi.__version_info__ < (1, 4, 0):
     # backwards compatibility for old cffi version on PyPy
-    # and Python >=3.5 (https://github.com/pyca/cryptography/issues/2970)
     TYPES = "static const long Cryptography_STATIC_CALLBACKS;"
     CUSTOMIZATIONS = """static const long Cryptography_STATIC_CALLBACKS = 0;
 """


### PR DESCRIPTION
Static callbacks were disabled for Python 3.5+ to work around an issue
with subinterpreters, locking callbacks and osrandom engine. Locking
callback and osrandom engine were replaced with a C implementations in
version 1.6 and 1.7.

https://github.com/pyca/cryptography/issues/2970

Closes: #3348
Signed-off-by: Christian Heimes <christian@python.org>