### PR TITLE
make cryptography fallback to /dev/urandom on mac on macOS < 10.12 even if SYS_getentropy is in the headers

### DIFF
--- a/src/_cffi_src/openssl/src/osrandom_engine.h
+++ b/src/_cffi_src/openssl/src/osrandom_engine.h
@@ -13,6 +13,7 @@
 
   #ifdef __APPLE__
     #include <sys/random.h>
+    #include <AvailabilityMacros.h>
   #endif
 
   #ifdef __linux__
@@ -33,8 +34,11 @@
   #if defined(_WIN32)
     /* Windows */
     #define CRYPTOGRAPHY_OSRANDOM_ENGINE CRYPTOGRAPHY_OSRANDOM_ENGINE_CRYPTGENRANDOM
-  #elif defined(BSD) && defined(SYS_getentropy)
-    /* OpenBSD 5.6+ or macOS 10.12+ */
+  #elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+    /* macOS 10.12+ */
+    #define CRYPTOGRAPHY_OSRANDOM_ENGINE CRYPTOGRAPHY_OSRANDOM_ENGINE_GETENTROPY
+  #elif defined(BSD) && defined(SYS_getentropy) && !defined(__APPLE__)
+    /* OpenBSD 5.6+ */
     #define CRYPTOGRAPHY_OSRANDOM_ENGINE CRYPTOGRAPHY_OSRANDOM_ENGINE_GETENTROPY
   #elif defined(__linux__) && defined(SYS_getrandom)
     /* Linux 3.4.17+ */


### PR DESCRIPTION
This will fix #3332 

However, the correct longterm approach is to do runtime detection of whether `SYS_getentropy` is available during `osrandom_init` like we do for the `getrandom` engine. Then we could revert this check entirely, as well as be able to generate wheels that would use the getentropy path when available on mac (right now all our wheels use /dev/urandom).

@tiran would you be interested in potentially adapting the getrandom code so that we can do the same thing in getentropy?