### PR TITLE
support defining which windows libraries to link with an env var

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,20 +52,20 @@ release infrastructure (`openssl-release`_). Be sure to download the proper
 version for your architecture and Python (2010 works for Python 2.6, 2.7, 3.3,
 and 3.4 while 2015 is required for 3.5 and above). Wherever you place your copy
 of OpenSSL you'll need to set the ``LIB`` and ``INCLUDE`` environment variables
-to include the proper locations. Finally, you'll want to supply the names of
-your OpenSSL libraries. For example:
+to include the proper locations. For example:
 
 .. code-block:: console
 
     C:\> \path\to\vcvarsall.bat x86_amd64
     C:\> set LIB=C:\OpenSSL-win64\lib;%LIB%
     C:\> set INCLUDE=C:\OpenSSL-win64\include;%INCLUDE%
-    C:\> set CRYPTOGRAPHY_WINDOWS_LIBRARIES=libeay32 ssleay32
+    C:\> set CRYPTOGRAPHY_WINDOWS_LINK_OPENSSL110=1
     C:\> pip install cryptography
 
 As of OpenSSL 1.1.0 the library names have changed from ``libeay32`` and
 ``ssleay32`` to ``libcrypto`` and ``libssl`` (matching their names on all other
-platforms).
+platforms). Due to this change when linking against 1.1.0 you **must** set
+``CRYPTOGRAPHY_WINDOWS_LINK_OPENSSL110`` or else installation will fail.
 
 If you need to rebuild ``cryptography`` for any reason be sure to clear the
 local `wheel cache`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -50,16 +50,22 @@ If you prefer to compile it yourself you'll need to have OpenSSL installed.
 You can compile OpenSSL yourself as well or use the binaries we build for our
 release infrastructure (`openssl-release`_). Be sure to download the proper
 version for your architecture and Python (2010 works for Python 2.6, 2.7, 3.3,
-and 3.4 while 2015 is required for 3.5). Wherever you place your copy
+and 3.4 while 2015 is required for 3.5 and above). Wherever you place your copy
 of OpenSSL you'll need to set the ``LIB`` and ``INCLUDE`` environment variables
-to include the proper locations. For example:
+to include the proper locations. Finally, you'll want to supply the names of
+your OpenSSL libraries. For example:
 
 .. code-block:: console
 
     C:\> \path\to\vcvarsall.bat x86_amd64
     C:\> set LIB=C:\OpenSSL-win64\lib;%LIB%
     C:\> set INCLUDE=C:\OpenSSL-win64\include;%INCLUDE%
+    C:\> set CRYPTOGRAPHY_WINDOWS_LIBRARIES=libeay32 ssleay32
     C:\> pip install cryptography
+
+As of OpenSSL 1.1.0 the library names have changed from ``libeay32`` and
+``ssleay32`` to ``libcrypto`` and ``libssl`` (matching their names on all other
+platforms).
 
 If you need to rebuild ``cryptography`` for any reason be sure to clear the
 local `wheel cache`_.

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -22,12 +22,15 @@ def _get_openssl_libraries(platform):
         windows_link_openssl110 = os.environ.get(
             "CRYPTOGRAPHY_WINDOWS_LINK_OPENSSL110", None
         )
-        if compiler_type() == "msvc" and windows_link_openssl110 is None:
-            # These lib names are only accurate for OpenSSL < 1.1.0
-            # If linking against 1.1.0+ you'll need to use the
-            # CRYPTOGRAPHY_WINDOWS_LIBRARIES environment variable
-            libs = ["libeay32", "ssleay32"]
+        if compiler_type() == "msvc":
+            if windows_link_openssl110 is not None:
+                # Link against the 1.1.0 names
+                libs = ["libssl", "libcrypto"]
+            else:
+                # Link against the 1.0.2 and lower names
+                libs = ["libeay32", "ssleay32"]
         else:
+            # Support mingw, which behaves unix-like and prefixes "lib"
             libs = ["ssl", "crypto"]
         return libs + ["advapi32", "crypt32", "gdi32", "user32", "ws2_32"]
     else:

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -19,20 +19,16 @@ def _get_openssl_libraries(platform):
             os.environ.get("CRYPTOGRAPHY_OSX_NO_LINK_FLAGS")
         )
     elif platform == "win32":
-        # A space separated list of libraries to link against. With MSVC this
-        # needs to be the full name of the lib, e.g. libcrypto, not crypto
-        lib_names = os.environ.get("CRYPTOGRAPHY_WINDOWS_LIBRARIES", None)
-        if lib_names is not None:
-            libs = lib_names.split(" ")
+        windows_link_openssl110 = os.environ.get(
+            "CRYPTOGRAPHY_WINDOWS_LINK_OPENSSL110", None
+        )
+        if compiler_type() == "msvc" and windows_link_openssl110 is None:
+            # These lib names are only accurate for OpenSSL < 1.1.0
+            # If linking against 1.1.0+ you'll need to use the
+            # CRYPTOGRAPHY_WINDOWS_LIBRARIES environment variable
+            libs = ["libeay32", "ssleay32"]
         else:
-            # Preserve the behavior of cryptography releases < 1.8
-            if compiler_type() == "msvc":
-                # These lib names are only accurate for OpenSSL < 1.1.0
-                # If linking against 1.1.0+ you'll need to use the
-                # CRYPTOGRAPHY_WINDOWS_LIBRARIES environment variable
-                libs = ["libeay32", "ssleay32"]
-            else:
-                libs = ["ssl", "crypto"]
+            libs = ["ssl", "crypto"]
         return libs + ["advapi32", "crypt32", "gdi32", "user32", "ws2_32"]
     else:
         # In some circumstances, the order in which these libs are

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -19,10 +19,20 @@ def _get_openssl_libraries(platform):
             os.environ.get("CRYPTOGRAPHY_OSX_NO_LINK_FLAGS")
         )
     elif platform == "win32":
-        if compiler_type() == "msvc":
-            libs = ["libeay32", "ssleay32"]
+        # A space separated list of libraries to link against. With MSVC this
+        # needs to be the full name of the lib, e.g. libcrypto, not crypto
+        lib_names = os.environ.get("CRYPTOGRAPHY_WINDOWS_LIBRARIES", None)
+        if lib_names is not None:
+            libs = lib_names.split(" ")
         else:
-            libs = ["ssl", "crypto"]
+            # Preserve the behavior of cryptography releases < 1.8
+            if compiler_type() == "msvc":
+                # These lib names are only accurate for OpenSSL < 1.1.0
+                # If linking against 1.1.0+ you'll need to use the
+                # CRYPTOGRAPHY_WINDOWS_LIBRARIES environment variable
+                libs = ["libeay32", "ssleay32"]
+            else:
+                libs = ["ssl", "crypto"]
         return libs + ["advapi32", "crypt32", "gdi32", "user32", "ws2_32"]
     else:
         # In some circumstances, the order in which these libs are


### PR DESCRIPTION
`CRYPTOGRAPHY_WINDOWS_LIBRARIES` is your new friend.

refs #3306 