### PR TITLE
Remove DH generator size constraint

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -87,9 +87,6 @@ class DHParameterNumbers(object):
         if q is not None and not isinstance(q, six.integer_types):
             raise TypeError("q must be integer or None")
 
-        if q is None and g not in (2, 5):
-            raise ValueError("DH generator must be 2 or 5")
-
         self._p = p
         self._g = g
         self._q = q

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -87,6 +87,9 @@ class DHParameterNumbers(object):
         if q is not None and not isinstance(q, six.integer_types):
             raise TypeError("q must be integer or None")
 
+        if g < 2:
+            raise ValueError("DH generator must be 2 or greater")
+
         self._p = p
         self._g = g
         self._q = q

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -51,6 +51,11 @@ def test_dh_parameternumbers():
             None, None
         )
 
+    with pytest.raises(ValueError):
+        dh.DHParameterNumbers(
+            65537, 1
+        )
+
     params = dh.DHParameterNumbers(
         65537, 7, 1245
     )

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -51,11 +51,6 @@ def test_dh_parameternumbers():
             None, None
         )
 
-    with pytest.raises(ValueError):
-        dh.DHParameterNumbers(
-            65537, 7
-        )
-
     params = dh.DHParameterNumbers(
         65537, 7, 1245
     )


### PR DESCRIPTION
I've been working on a `cryptography` based TLS module for Scapy (see PR [https://github.com/secdev/scapy/pull/476](https://github.com/secdev/scapy/pull/476)).

During test handshakes with `openssl`, I came across this limitation on the generator size of DH groups. Default DH group parameters with `openssl` are currently 2048-bit order with a 2048-bit generator. While we could debate on the impact of choosing a long generator over a value of 2 or 5, it does not seem appropriate to keep this constraint in the library.