### PR TITLE
revert a change to our exceptions for asymmetric key loading

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1209,23 +1209,6 @@ class Backend(object):
                 _Reasons.UNSUPPORTED_CIPHER
             )
 
-        elif errors[0][1:] in (
-            (
-                self._lib.ERR_LIB_ASN1,
-                self._lib.ASN1_F_ASN1_CHECK_TLEN,
-                self._lib.ASN1_R_WRONG_TAG
-            ),
-            (
-                self._lib.ERR_LIB_PEM,
-                self._lib.PEM_F_PEM_READ_BIO,
-                self._lib.PEM_R_NO_START_LINE
-            ),
-        ):
-            raise UnsupportedAlgorithm(
-                "Unsupported public key algorithm.",
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
-            )
-
         elif any(
             error[1:] == (
                 self._lib.ERR_LIB_EVP,
@@ -1234,10 +1217,7 @@ class Backend(object):
             )
             for error in errors
         ):
-            raise UnsupportedAlgorithm(
-                "Unsupported public key algorithm.",
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
-            )
+            raise ValueError("Unsupported public key algorithm.")
 
         else:
             assert errors[0][1] in (

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -617,7 +617,7 @@ class TestGOSTCertificate(object):
 
 @pytest.mark.skipif(
     backend._lib.Cryptography_HAS_EVP_PKEY_DHX == 1,
-    reason="Requires OpenSSL without EVP_PKEY_DHX (1.0.2-)")
+    reason="Requires OpenSSL without EVP_PKEY_DHX (< 1.0.2)")
 @pytest.mark.requires_backend_interface(interface=DHBackend)
 class TestOpenSSLDHSerialization(object):
 
@@ -662,8 +662,7 @@ class TestOpenSSLDHSerialization(object):
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"
         )
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             loader_func(key_bytes, None, backend)
 
     @pytest.mark.parametrize(
@@ -685,6 +684,5 @@ class TestOpenSSLDHSerialization(object):
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"
         )
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             loader_func(key_bytes, backend)

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -236,12 +236,10 @@ class TestDERSerialization(object):
         """).encode()
         bad_der = base64.b64decode(b"".join(key_data.splitlines()))
 
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             load_pem_private_key(bad_der, None, backend)
 
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             load_pem_private_key(
                 bad_der, b"this password will not be used", backend
             )
@@ -577,14 +575,12 @@ class TestPEMSerialization(object):
     def test_wrong_private_format(self, backend):
         key_data = b"---- NOT A KEY ----\n"
 
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             load_pem_private_key(
                 key_data, None, backend
             )
 
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             load_pem_private_key(
                 key_data, b"this password will not be used", backend
             )
@@ -592,8 +588,7 @@ class TestPEMSerialization(object):
     def test_wrong_public_format(self, backend):
         key_data = b"---- NOT A KEY ----\n"
 
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             load_pem_public_key(key_data, backend)
 
     def test_corrupt_traditional_format(self, backend):
@@ -725,14 +720,12 @@ class TestPEMSerialization(object):
 
         password = b"this password is wrong"
 
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             load_pem_private_key(
                 key_data, None, backend
             )
 
-        with raises_unsupported_algorithm(
-                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM):
+        with pytest.raises(ValueError):
             load_pem_private_key(
                 key_data, password, backend
             )
@@ -852,9 +845,7 @@ class TestPEMSerialization(object):
         ]
     )
     def test_load_bad_oid_key(self, key_file, password, backend):
-        with raises_unsupported_algorithm(
-            _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
-        ):
+        with pytest.raises(ValueError):
             load_vectors_from_file(
                 os.path.join(
                     "asymmetric", "PKCS8", key_file),


### PR DESCRIPTION
Previously when bad data was passed we'd raise ValuError. In the DH PR (#3369) we modified it so under some scenarios (that were too broad) it would raise UnsupportedAlgorithm. Since this was unnecessary this PR reverts it.