### PR TITLE
Write a memory leak test for X.509 extensions

### DIFF
--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -34,15 +34,6 @@ static const int CRYPTO_LOCK_SSL;
 
 FUNCTIONS = """
 int CRYPTO_mem_ctrl(int);
-
-void Cryptography_CRYPTO_get_mem_functions(
-    void *(**)(size_t, const char *, int),
-    void *(**)(void *, size_t, const char *, int),
-    void (**)(void *, const char *, int));
-int Cryptography_CRYPTO_set_mem_functions(
-    void *(*)(size_t, const char *, int),
-    void *(*)(void *, size_t, const char *, int),
-    void (*)(void *, const char *, int));
 """
 
 MACROS = """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -35,12 +35,14 @@ static const int CRYPTO_LOCK_SSL;
 FUNCTIONS = """
 int CRYPTO_mem_ctrl(int);
 
-void CRYPTO_get_mem_functions(void *(**)(size_t, const char *, int),
-                              void *(**)(void *, size_t, const char *, int),
-                              void (**)(void *, const char *, int));
-int CRYPTO_set_mem_functions(void *(*)(size_t, const char *, int),
-                             void *(*)(void *, size_t, const char *, int),
-                             void (*)(void *, const char *, int));
+void Cryptography_CRYPTO_get_mem_functions(
+    void *(**)(size_t, const char *, int),
+    void *(**)(void *, size_t, const char *, int),
+    void (**)(void *, const char *, int));
+int Cryptography_CRYPTO_set_mem_functions(
+    void *(*)(size_t, const char *, int),
+    void *(*)(void *, size_t, const char *, int),
+    void (*)(void *, const char *, int));
 """
 
 MACROS = """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -34,6 +34,13 @@ static const int CRYPTO_LOCK_SSL;
 
 FUNCTIONS = """
 int CRYPTO_mem_ctrl(int);
+
+void CRYPTO_get_mem_functions(void *(**)(size_t, const char *, int),
+                              void *(**)(void *, size_t, const char *, int),
+                              void (**)(void *, const char *, int));
+int CRYPTO_set_mem_functions(void *(*)(size_t, const char *, int),
+                             void *(*)(void *, size_t, const char *, int),
+                             void (*)(void *, const char *, int));
 """
 
 MACROS = """

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -125,7 +125,6 @@ def skip_if_memtesting_not_supported():
     return pytest.mark.skipif(
         not Binding().lib.Cryptography_HAS_MEM_FUNCTIONS,
         reason="Requires OpenSSL memory functions (>=1.1.0)"
-    )
 
 
 @skip_if_memtesting_not_supported()

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -23,32 +23,14 @@ def main(argv):
     import gc
     import json
 
-    import cffi
-
     from cryptography.hazmat.bindings._openssl import ffi, lib
 
-    libc_ffi = cffi.FFI()
-    libc_ffi.cdef('''
-    void free(void *);
-    int backtrace(void **, int);
-    char **backtrace_symbols(void *const *, int);
-    ''')
-    libc_lib = libc_ffi.dlopen(None)
-
     heap = {}
-
-    def _backtrace():
-        buf = libc_ffi.new("void *[]", 64)
-        result = libc_lib.backtrace(buf, len(buf))
-        strings = libc_lib.backtrace_symbols(buf, result)
-        stack = [libc_ffi.string(strings[i]) for i in range(result)]
-        libc_lib.free(strings)
-        return stack
 
     @ffi.callback("void *(size_t, const char *, int)")
     def malloc(size, path, line):
         ptr = lib.Cryptography_malloc_wrapper(size, path, line)
-        heap[ptr] = (size, path, line, _backtrace())
+        heap[ptr] = (size, path, line)
         return ptr
 
     @ffi.callback("void *(void *, size_t, const char *, int)")
@@ -56,7 +38,7 @@ def main(argv):
         if ptr != ffi.NULL:
             del heap[ptr]
         new_ptr = lib.Cryptography_realloc_wrapper(ptr, size, path, line)
-        heap[new_ptr] = (size, path, line, _backtrace())
+        heap[new_ptr] = (size, path, line)
         return new_ptr
 
     @ffi.callback("void(void *, const char *, int)")

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -35,13 +35,13 @@ def main(argv):
 
     heap = {}
 
-    @ffi.callback("void *(size_t, const char *, int)")
+    @libc_ffi.callback("void *(size_t, const char *, int)")
     def malloc(size, path, line):
         ptr = lib.Cryptography_malloc_wrapper(size, path, line)
         heap[ptr] = (size, path, line)
         return ptr
 
-    @ffi.callback("void *(void *, size_t, const char *, int)")
+    @libc_ffi.callback("void *(void *, size_t, const char *, int)")
     def realloc(ptr, size, path, line):
         if ptr != ffi.NULL:
             del heap[ptr]
@@ -49,7 +49,7 @@ def main(argv):
         heap[new_ptr] = (size, path, line)
         return new_ptr
 
-    @ffi.callback("void(void *, const char *, int)")
+    @libc_ffi.callback("void(void *, const char *, int)")
     def free(ptr, path, line):
         if ptr != ffi.NULL:
             del heap[ptr]

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -96,9 +96,6 @@ def assert_no_memory_leaks(s, argv=[]):
     ] + argv
     # Shell out to a fresh Python process because OpenSSL does not allow you to
     # install new memory hooks after the first malloc/free occurs.
-    argv = [
-        sys.executable, "-c", "{0}\n\n{1}".format(s, MEMORY_LEAK_SCRIPT)
-    ] + argv
     proc = subprocess.Popen(
         argv,
         env=env,
@@ -127,13 +124,13 @@ def skip_if_memtesting_not_supported():
 class TestAssertNoMemoryLeaks(object):
     def test_no_leak_no_malloc(self):
         assert_no_memory_leaks(textwrap.dedent("""
-        def func(argv):
+        def func():
             pass
         """))
 
     def test_no_leak_free(self):
         assert_no_memory_leaks(textwrap.dedent("""
-        def func(argv):
+        def func():
             from cryptography.hazmat.bindings.openssl.binding import Binding
             b = Binding()
             name = b.lib.X509_NAME_new()
@@ -142,7 +139,7 @@ class TestAssertNoMemoryLeaks(object):
 
     def test_no_leak_gc(self):
         assert_no_memory_leaks(textwrap.dedent("""
-        def func(argv):
+        def func():
             from cryptography.hazmat.bindings.openssl.binding import Binding
             b = Binding()
             name = b.lib.X509_NAME_new()
@@ -152,7 +149,7 @@ class TestAssertNoMemoryLeaks(object):
     def test_leak(self):
         with pytest.raises(AssertionError):
             assert_no_memory_leaks(textwrap.dedent("""
-            def func(argv):
+            def func():
                 from cryptography.hazmat.bindings.openssl.binding import (
                     Binding
                 )
@@ -163,7 +160,7 @@ class TestAssertNoMemoryLeaks(object):
     def test_errors(self):
         with pytest.raises(ValueError):
             assert_no_memory_leaks(textwrap.dedent("""
-            def func(argv):
+            def func():
                 raise ZeroDivisionError
             """))
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -31,7 +31,7 @@ def main(argv):
     void *realloc(void *, size_t);
     void free(void *);
     ''')
-    libc_lib = libc_ffi.dlopen(None)
+    libc_lib = libc_ffi.dlopen(ctypes.util.find_library("c"))
 
     heap = {}
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -31,7 +31,7 @@ def main(argv):
     void *realloc(void *, size_t);
     void free(void *);
     ''')
-    libc_lib = libc_ffi.dlopen("c")
+    libc_lib = libc_ffi.dlopen(None)
 
     heap = {}
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -172,15 +172,15 @@ class TestOpenSSLMemoryLeaks(object):
     ])
     def test_x509_extensions(self, path):
         assert_no_memory_leaks(textwrap.dedent("""
-        def func(argv):
+        def func(path):
             from cryptography import x509
-            from cryptography.hazmat.backends import default_backend
+            from cryptography.hazmat.backends.openssl import backend
 
             import cryptography_vectors
 
-            with cryptography_vectors.open_vector_file(argv[0], "rb") as f:
+            with cryptography_vectors.open_vector_file(path, "rb") as f:
                 cert = x509.load_der_x509_certificate(
-                    f.read(), default_backend()
+                    f.read(), backend
                 )
 
             cert.extensions

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -31,7 +31,7 @@ def main(argv):
     void *realloc(void *, size_t);
     void free(void *);
     ''')
-    libc_lib = libc_ffi.dlopen("libc")
+    libc_lib = libc_ffi.dlopen("c")
 
     heap = {}
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -25,17 +25,15 @@ def main(argv):
 
     from cryptography.hazmat.bindings._openssl import ffi, lib
 
-    libc_ffi = cffi.FFI()
-
     heap = {}
 
-    @libc_ffi.callback("void *(size_t, const char *, int)")
+    @ffi.callback("void *(size_t, const char *, int)")
     def malloc(size, path, line):
         ptr = lib.Cryptography_malloc_wrapper(size, path, line)
         heap[ptr] = (size, path, line)
         return ptr
 
-    @libc_ffi.callback("void *(void *, size_t, const char *, int)")
+    @ffi.callback("void *(void *, size_t, const char *, int)")
     def realloc(ptr, size, path, line):
         if ptr != ffi.NULL:
             del heap[ptr]
@@ -43,7 +41,7 @@ def main(argv):
         heap[new_ptr] = (size, path, line)
         return new_ptr
 
-    @libc_ffi.callback("void(void *, const char *, int)")
+    @ffi.callback("void(void *, const char *, int)")
     def free(ptr, path, line):
         if ptr != ffi.NULL:
             del heap[ptr]

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -25,6 +25,14 @@ def main(argv):
 
     from cryptography.hazmat.bindings._openssl import ffi, lib
 
+    libc_ffi = cffi.FFI()
+    libc_ffi.cdef('''
+    void *malloc(size_t);
+    void *realloc(void *, size_t);
+    void free(void *);
+    ''')
+    libc_lib = libc_ffi.dlopen("libc")
+
     heap = {}
 
     @ffi.callback("void *(size_t, const char *, int)")

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -31,6 +31,7 @@ def main(argv):
     void *realloc(void *, size_t);
     void free(void *);
     ''')
+    raise ValueError(ctypes.util.find_library("c"))
     libc_lib = libc_ffi.dlopen(ctypes.util.find_library("c"))
 
     heap = {}

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -135,6 +135,7 @@ def skip_if_memtesting_not_supported():
     return pytest.mark.skipif(
         not Binding().lib.Cryptography_HAS_MEM_FUNCTIONS,
         reason="Requires OpenSSL memory functions (>=1.1.0)"
+    )
 
 
 @skip_if_memtesting_not_supported()

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -58,17 +58,6 @@ def main(argv):
     result = lib.Cryptography_CRYPTO_set_mem_functions(malloc, realloc, free)
     assert result == 1
 
-    # Make sure these functions aren't free, this avoids the following
-    # scenario:
-    #   * We set up these pointers
-    #   * This function returns, and they're freed by ref-counting
-    #   * The whole program exits and OpenSSL's atexit handler is invoked
-    #   * OpenSSL tries to free things, and uses our callback which is a
-    #     dangling ptr
-    keepalive.append(malloc)
-    keepalive.append(realloc)
-    keepalive.append(free)
-
     # Trigger a bunch of initialization stuff.
     import cryptography.hazmat.backends.openssl
 

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -26,13 +26,6 @@ def main(argv):
     from cryptography.hazmat.bindings._openssl import ffi, lib
 
     libc_ffi = cffi.FFI()
-    libc_ffi.cdef('''
-    void *malloc(size_t);
-    void *realloc(void *, size_t);
-    void free(void *);
-    ''')
-    raise ValueError(ctypes.util.find_library("c"))
-    libc_lib = libc_ffi.dlopen(ctypes.util.find_library("c"))
 
     heap = {}
 


### PR DESCRIPTION
It's currently failing, and I can't figure out from where the memory is being allocated, because my `_backtrace()` hack has a single `??` frame.