### PR TITLE
Refs #3461 -- added the OID for the SCT x.509 extension

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -2607,6 +2607,8 @@ instances. The following common OIDs are available as constants.
 
     .. attribute:: PRECERT_SIGNED_CERTIFICATE_TIMESTAMPS
 
+        .. versionadded:: 1.9
+
         Corresponds to the dotted string ``"1.3.6.1.4.1.11129.2.4.2"``.
 
     .. attribute:: POLICY_CONSTRAINTS

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -2605,6 +2605,10 @@ instances. The following common OIDs are available as constants.
         the ``CRLNumber`` extension type. This extension only has meaning
         for certificate revocation lists.
 
+    .. attribute:: PRECERT_SIGNED_CERTIFICATE_TIMESTAMPS
+
+        Corresponds to the dotted string ``"1.3.6.1.4.1.11129.2.4.2"``.
+
     .. attribute:: POLICY_CONSTRAINTS
 
         Corresponds to the dotted string ``"2.5.29.36"``. The identifier for the

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -86,6 +86,9 @@ class ExtensionOID(object):
     SUBJECT_INFORMATION_ACCESS = ObjectIdentifier("1.3.6.1.5.5.7.1.11")
     OCSP_NO_CHECK = ObjectIdentifier("1.3.6.1.5.5.7.48.1.5")
     CRL_NUMBER = ObjectIdentifier("2.5.29.20")
+    PRECERT_SIGNED_CERTIFICATE_TIMESTAMPS = (
+        ObjectIdentifier("1.3.6.1.4.1.11129.2.4.2")
+    )
 
 
 class CRLEntryExtensionOID(object):


### PR DESCRIPTION
Just to get everybody's brain juice flowing:

- There's a distinct OID for embedding SCTs in an OCSP response
- This OID does not appear to have an associated name, so I didn't put it in the names dict.