### PR TITLE
add captions to the split toctrees

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,11 +56,9 @@ admonition at the top.
 We recommend using the recipes layer whenever possible, and falling back to the
 hazmat layer only when necessary.
 
-The recipes layer
-~~~~~~~~~~~~~~~~~
-
 .. toctree::
     :maxdepth: 2
+    :caption: The recipes layer
 
     fernet
     x509/index
@@ -69,21 +67,17 @@ The recipes layer
     faq
     glossary
 
-The hazardous materials layer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 .. toctree::
     :maxdepth: 2
+    :caption: The hazardous materials layer
 
     hazmat/primitives/index
     hazmat/backends/index
     hazmat/bindings/index
 
-The ``cryptography`` open source project
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 .. toctree::
     :maxdepth: 2
+    :caption: The ``cryptography`` open source project
 
     installation
     development/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,7 +77,7 @@ hazmat layer only when necessary.
 
 .. toctree::
     :maxdepth: 2
-    :caption: The ``cryptography`` open source project
+    :caption: The cryptography open source project
 
     installation
     development/index


### PR DESCRIPTION
this will render the table of contents with separators in the RTD
theme. right now, the table of contents is quite confusing on
the [RTD site][] - that is because there are 3 distinct `toctree`
directives, but no `:caption:` field. instead, there are headers in
the `index.rst` but those are not parsed by RTD.

[RTD site]: https://cryptography.io/en/latest/

by moving those headers in the `:caption:` field, we keep the heading,
but it will also be shown in the left table of contents on the RTD
site.

for an example of that pattern, see the [scrapy documentation][]. they
go even further by hiding the `toctree` elements completely and adding
explanations on every section, but this is out of scope here for now.

[scrapy documentation]: https://doc.scrapy.org/en/latest/index.html