### PR TITLE
remove key check

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1271,9 +1271,6 @@ class Backend(object):
             res = self._lib.EC_KEY_generate_key(ec_cdata)
             self.openssl_assert(res == 1)
 
-            res = self._lib.EC_KEY_check_key(ec_cdata)
-            self.openssl_assert(res == 1)
-
             evp_pkey = self._ec_cdata_to_evp_pkey(ec_cdata)
 
             return _EllipticCurvePrivateKey(self, ec_cdata, evp_pkey)


### PR DESCRIPTION
Fixes #3472.

@lvh Is this safe? [EC_KEY_generate_key](https://github.com/openssl/openssl/blob/master/crypto/ec/ec_key.c#L185) would never generate an invalid key right?