### PR TITLE
Don't skip DH tests when dhx unsupported and no dhx is required

### DIFF
--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -18,8 +18,8 @@ from ...doubles import DummyKeySerializationEncryption
 from ...utils import load_nist_vectors, load_vectors_from_file
 
 
-def _skip_dhx_unsupported(backend, key_path):
-    if "rfc5114" not in key_path:
+def _skip_dhx_unsupported(backend, is_dhx):
+    if not is_dhx:
         return
     if not backend.dh_x942_serialization_supported():
         pytest.skip(
@@ -400,30 +400,34 @@ class TestDHPrivateKeySerialization(object):
         assert loaded_priv_num == priv_num
 
     @pytest.mark.parametrize(
-        ("key_path", "loader_func", "encoding"),
+        ("key_path", "loader_func", "encoding", "is_dhx"),
         [
             (
                 os.path.join("asymmetric", "DH", "dhkey.pem"),
                 serialization.load_pem_private_key,
                 serialization.Encoding.PEM,
+                False,
             ), (
                 os.path.join("asymmetric", "DH", "dhkey.der"),
                 serialization.load_der_private_key,
                 serialization.Encoding.DER,
+                False,
             ), (
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.pem"),
                 serialization.load_pem_private_key,
                 serialization.Encoding.PEM,
+                True,
             ), (
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.der"),
                 serialization.load_der_private_key,
                 serialization.Encoding.DER,
+                True,
             )
         ]
     )
     def test_private_bytes_match(self, key_path, loader_func,
-                                 encoding, backend):
-        _skip_dhx_unsupported(backend, key_path)
+                                 encoding, is_dhx, backend):
+        _skip_dhx_unsupported(backend, is_dhx)
         key_bytes = load_vectors_from_file(
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"
@@ -436,30 +440,34 @@ class TestDHPrivateKeySerialization(object):
         assert serialized == key_bytes
 
     @pytest.mark.parametrize(
-        ("key_path", "loader_func", "vec_path"),
+        ("key_path", "loader_func", "vec_path", "is_dhx"),
         [
             (
                 os.path.join("asymmetric", "DH", "dhkey.pem"),
                 serialization.load_pem_private_key,
-                os.path.join("asymmetric", "DH", "dhkey.txt")
+                os.path.join("asymmetric", "DH", "dhkey.txt"),
+                False,
             ), (
                 os.path.join("asymmetric", "DH", "dhkey.der"),
                 serialization.load_der_private_key,
-                os.path.join("asymmetric", "DH", "dhkey.txt")
+                os.path.join("asymmetric", "DH", "dhkey.txt"),
+                False,
             ), (
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.pem"),
                 serialization.load_pem_private_key,
-                os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt")
+                os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt"),
+                True,
             ), (
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.der"),
                 serialization.load_der_private_key,
-                os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt")
+                os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt"),
+                True,
             )
         ]
     )
     def test_private_bytes_values(self, key_path, loader_func,
-                                  vec_path, backend):
-        _skip_dhx_unsupported(backend, key_path)
+                                  vec_path, is_dhx, backend):
+        _skip_dhx_unsupported(backend, is_dhx)
         key_bytes = load_vectors_from_file(
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"
@@ -560,30 +568,34 @@ class TestDHPublicKeySerialization(object):
         assert loaded_pub_num == pub_num
 
     @pytest.mark.parametrize(
-        ("key_path", "loader_func", "encoding"),
+        ("key_path", "loader_func", "encoding", "is_dhx"),
         [
             (
                 os.path.join("asymmetric", "DH", "dhpub.pem"),
                 serialization.load_pem_public_key,
                 serialization.Encoding.PEM,
+                False,
             ), (
                 os.path.join("asymmetric", "DH", "dhpub.der"),
                 serialization.load_der_public_key,
                 serialization.Encoding.DER,
+                False,
             ), (
                 os.path.join("asymmetric", "DH", "dhpub_rfc5114_2.pem"),
                 serialization.load_pem_public_key,
                 serialization.Encoding.PEM,
+                True,
             ), (
                 os.path.join("asymmetric", "DH", "dhpub_rfc5114_2.der"),
                 serialization.load_der_public_key,
                 serialization.Encoding.DER,
+                True,
             )
         ]
     )
     def test_public_bytes_match(self, key_path, loader_func,
-                                encoding, backend):
-        _skip_dhx_unsupported(backend, key_path)
+                                encoding, is_dhx, backend):
+        _skip_dhx_unsupported(backend, is_dhx)
         key_bytes = load_vectors_from_file(
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"
@@ -596,30 +608,34 @@ class TestDHPublicKeySerialization(object):
         assert serialized == key_bytes
 
     @pytest.mark.parametrize(
-        ("key_path", "loader_func", "vec_path"),
+        ("key_path", "loader_func", "vec_path", "is_dhx"),
         [
             (
                 os.path.join("asymmetric", "DH", "dhpub.pem"),
                 serialization.load_pem_public_key,
                 os.path.join("asymmetric", "DH", "dhkey.txt"),
+                False,
             ), (
                 os.path.join("asymmetric", "DH", "dhpub.der"),
                 serialization.load_der_public_key,
                 os.path.join("asymmetric", "DH", "dhkey.txt"),
+                False,
             ), (
                 os.path.join("asymmetric", "DH", "dhpub_rfc5114_2.pem"),
                 serialization.load_pem_public_key,
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt"),
+                True,
             ), (
                 os.path.join("asymmetric", "DH", "dhpub_rfc5114_2.der"),
                 serialization.load_der_public_key,
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt"),
+                True,
             )
         ]
     )
     def test_public_bytes_values(self, key_path, loader_func,
-                                 vec_path, backend):
-        _skip_dhx_unsupported(backend, key_path)
+                                 vec_path, is_dhx, backend):
+        _skip_dhx_unsupported(backend, is_dhx)
         key_bytes = load_vectors_from_file(
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -18,7 +18,9 @@ from ...doubles import DummyKeySerializationEncryption
 from ...utils import load_nist_vectors, load_vectors_from_file
 
 
-def _skip_dhx_unsupported(backend):
+def _skip_dhx_unsupported(backend, key_path):
+    if "rfc5114" not in key_path:
+        return
     if not backend.dh_x942_serialization_supported():
         pytest.skip(
             "DH x9.42 serialization is not supported"
@@ -421,7 +423,7 @@ class TestDHPrivateKeySerialization(object):
     )
     def test_private_bytes_match(self, key_path, loader_func,
                                  encoding, backend):
-        _skip_dhx_unsupported(backend)
+        _skip_dhx_unsupported(backend, key_path)
         key_bytes = load_vectors_from_file(
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"
@@ -457,7 +459,7 @@ class TestDHPrivateKeySerialization(object):
     )
     def test_private_bytes_values(self, key_path, loader_func,
                                   vec_path, backend):
-        _skip_dhx_unsupported(backend)
+        _skip_dhx_unsupported(backend, key_path)
         key_bytes = load_vectors_from_file(
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"
@@ -581,7 +583,7 @@ class TestDHPublicKeySerialization(object):
     )
     def test_public_bytes_match(self, key_path, loader_func,
                                 encoding, backend):
-        _skip_dhx_unsupported(backend)
+        _skip_dhx_unsupported(backend, key_path)
         key_bytes = load_vectors_from_file(
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"
@@ -617,7 +619,7 @@ class TestDHPublicKeySerialization(object):
     )
     def test_public_bytes_values(self, key_path, loader_func,
                                  vec_path, backend):
-        _skip_dhx_unsupported(backend)
+        _skip_dhx_unsupported(backend, key_path)
         key_bytes = load_vectors_from_file(
             key_path,
             lambda pemfile: pemfile.read(), mode="rb"


### PR DESCRIPTION
I noticed that in commit c10aa1bc85fcd4ea35aabafd200e9e3873b8b308 I changed the skipping and made a mistake. Now tests that don't need dhx will be executed even when not supported.