### PR TITLE
minor int_to_bytes performance increase

### DIFF
--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -58,7 +58,7 @@ if hasattr(int, "to_bytes"):
         )
 else:
     def int_to_bytes(integer, length=None):
-        hexed = '{:x}'.format(integer)
+        hexed = '{0:x}'.format(integer)
 
         # Handle odd-length hex strings.
         if len(hexed) & 1:

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -51,13 +51,26 @@ else:
         return int(bytes(data).encode('hex'), 16)
 
 
-def int_to_bytes(integer, length=None):
-    hex_string = '%x' % integer
-    if length is None:
-        n = len(hex_string)
-    else:
-        n = length * 2
-    return binascii.unhexlify(hex_string.zfill(n + (n & 1)))
+if hasattr(int, "to_bytes"):
+    def int_to_bytes(integer, length=None):
+        return integer.to_bytes(
+            length or (integer.bit_length() + 7) // 8 or 1, 'big'
+        )
+else:
+    def int_to_bytes(integer, length=None):
+        hexed = '{:x}'.format(integer)
+
+        # Handle odd-length hex strings.
+        if len(hexed) & 1:
+            hexed = '0' + hexed
+
+        bytestr = binascii.unhexlify(hexed)
+
+        if not length:
+            return bytestr
+
+        # Pad bytes assuming big-endian.
+        return (b'\x00' * (length - len(bytestr))) + bytestr
 
 
 class InterfaceNotImplemented(Exception):

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -58,19 +58,12 @@ if hasattr(int, "to_bytes"):
         )
 else:
     def int_to_bytes(integer, length=None):
-        hexed = '{0:x}'.format(integer)
-
-        # Handle odd-length hex strings.
-        if len(hexed) & 1:
-            hexed = '0' + hexed
-
-        bytestr = binascii.unhexlify(hexed)
-
-        if not length:
-            return bytestr
-
-        # Pad bytes assuming big-endian.
-        return (b'\x00' * (length - len(bytestr))) + bytestr
+        hex_string = '%x' % integer
+        if length is None:
+            n = len(hex_string)
+        else:
+            n = length * 2
+        return binascii.unhexlify(hex_string.zfill(n + (n & 1)))
 
 
 class InterfaceNotImplemented(Exception):


### PR DESCRIPTION
Also cleaner code.

```bash
$ python -m timeit -s "from cryptography.utils import int_to_bytes" "int_to_bytes(87993618360805341115891506172036624893404292644470266399436498750715784469187)"
1000000 loops, best of 3: 1.62 usec per loop
$ python -m timeit -s "from binascii import unhexlify" "unhexlify('{:x}'.format(87993618360805341115891506172036624893404292644470266399436498750715784469187))"
1000000 loops, best of 3: 0.838 usec per loop
$ python -m timeit -s "def int_to_bytes(num):return num.to_bytes((num.bit_length() + 7) // 8, 'big')" "int_to_bytes(87993618360805341115891506172036624893404292644470266399436498750715784469187)"
1000000 loops, best of 3: 0.629 usec per loop
```