### PR TITLE
Add some ASN1_TIME related functions for the relevant PyOpenSSL patch.

### DIFF
--- a/src/_cffi_src/openssl/asn1.py
+++ b/src/_cffi_src/openssl/asn1.py
@@ -80,6 +80,8 @@ void ASN1_TIME_free(ASN1_TIME *);
 ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *,
                                                    ASN1_GENERALIZEDTIME **);
 ASN1_TIME *ASN1_TIME_set(ASN1_TIME *, time_t);
+int ASN1_TIME_set_string(ASN1_TIME *, const char *);
+int ASN1_TIME_check(ASN1_TIME *);
 
 /*  ASN1 UTCTIME */
 ASN1_UTCTIME *ASN1_UTCTIME_new(void);

--- a/src/_cffi_src/openssl/asn1.py
+++ b/src/_cffi_src/openssl/asn1.py
@@ -81,7 +81,6 @@ ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(ASN1_TIME *,
                                                    ASN1_GENERALIZEDTIME **);
 ASN1_TIME *ASN1_TIME_set(ASN1_TIME *, time_t);
 int ASN1_TIME_set_string(ASN1_TIME *, const char *);
-int ASN1_TIME_check(ASN1_TIME *);
 
 /*  ASN1 UTCTIME */
 ASN1_UTCTIME *ASN1_UTCTIME_new(void);
@@ -148,6 +147,7 @@ ASN1_INTEGER *BN_to_ASN1_INTEGER(BIGNUM *, ASN1_INTEGER *);
 /* These isn't a macro the arg is const on openssl 1.0.2+ */
 int ASN1_GENERALIZEDTIME_check(ASN1_GENERALIZEDTIME *);
 int ASN1_UTCTIME_check(ASN1_UTCTIME *);
+int ASN1_TIME_check(ASN1_TIME *);
 
 /* Not a macro, const on openssl 1.0 */
 int ASN1_STRING_set_default_mask_asc(char *);


### PR DESCRIPTION
This patch adds the signatures for the following functions:

*  `ASN1_TIME_set_string`
* `ASN1_TIME_check`

These are necssary in the PyOpenSSL patch which will be submitted shortly.