### PR TITLE
Add latest error to FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -27,6 +27,18 @@ If you are using PyPy, we do not currently ship ``cryptography`` wheels for
 PyPy. You will need to install your own copy of OpenSSL -- we recommend using
 Homebrew.
 
+Compiling ``cryptography`` on macOS produces a ``fatal error: 'openssl/opensslv.h' file not found`` error
+---------------------------------------------------------------------------------------------------------
+
+You may get this message with the newest version of pip and a version of Python
+that can't install from wheels (like PyPy). Install OpenSSL using Homebrew
+(``brew install openssl``) and then link against Homebrew's OpenSSL when
+installing cryptography by running
+
+.. code-block::
+
+    pip install cryptography --global-option=build_ext --global-option="-L$(brew --prefix)/opt/openssl/lib" --global-option="-I$(brew --prefix)/opt/openssl/include"
+
 Starting ``cryptography`` using ``mod_wsgi`` produces an ``InternalError`` during a call in ``_register_osrandom_engine``
 -------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I matched on the exact error string I got when compiling, so hopefully
users will land on the FAQ first when searching for the error message
(instead of e.g. closed Github issues).

Includes the installation instructions you need to link against the
Homebrew OpenSSL while installing modules from pip, if your pip/Python
aren't installed by Homebrew.