### PR TITLE
bump minimum setuptools version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requirements = [
     "asn1crypto>=0.21.0",
     "packaging",
     "six>=1.4.1",
-    "setuptools>=11.3",
+    "setuptools>=20.5",
 ]
 setup_requirements = []
 


### PR DESCRIPTION
This is sort of a pre-req for #3508 (but not really, because setuptools needs to be this version before setup.py even runs for that PR). Because we still support older setuptools versions in our pkg_resources code, this is mostly a gentle nudge to the ecosystem.