### PR TITLE
Don't compare cffi version using strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ VECTORS_DEPENDENCY = "cryptography_vectors=={0}".format(about['__version__'])
 requirements = [
     "idna>=2.1",
     "asn1crypto>=0.21.0",
-    "packaging",
     "six>=1.4.1",
     "setuptools>=20.5",
 ]

--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -147,7 +147,7 @@ class _CipherContext(object):
 
     # cffi 1.7 supports from_buffer on bytearray, which is required. We can
     # remove this check in the future when we raise our minimum PyPy version.
-    if utils._version_check(cffi.__version__, "1.7"):
+    if cffi.__version_info__ >= (1, 7):
         def update_into(self, data, buf):
             if self._ctx is None:
                 raise AlreadyFinalized("Context was already finalized.")
@@ -195,7 +195,7 @@ class _AEADCipherContext(object):
 
     # cffi 1.7 supports from_buffer on bytearray, which is required. We can
     # remove this check in the future when we raise our minimum PyPy version.
-    if utils._version_check(cffi.__version__, "1.7"):
+    if cffi.__version_info__ >= (1, 7):
         def update_into(self, data, buf):
             self._check_limit(len(data))
             return self._ctx.update_into(data, buf)

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -10,8 +10,6 @@ import inspect
 import sys
 import warnings
 
-from packaging.version import parse
-
 
 # Several APIs were deprecated with no specific end-of-life date because of the
 # ubiquity of their use. They should not be removed until we agree on when that
@@ -102,11 +100,6 @@ if sys.version_info >= (2, 7):
 else:
     def bit_length(x):
         return len(bin(x)) - (2 + (x <= 0))
-
-
-def _version_check(version, required_version):
-    # This is used to check if we support update_into on CipherContext.
-    return parse(version) >= parse(required_version)
 
 
 class _DeprecatedValue(object):

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -17,7 +17,6 @@ from cryptography.hazmat.backends.interfaces import CipherBackend
 from cryptography.hazmat.primitives.ciphers import (
     Cipher, algorithms, base, modes
 )
-from cryptography.utils import _version_check
 
 from .utils import (
     generate_aead_exception_test, generate_aead_tag_exception_test
@@ -74,7 +73,7 @@ class TestCipherContext(object):
             decryptor.finalize()
 
     @pytest.mark.skipif(
-        not _version_check(cffi.__version__, '1.7'),
+        cffi.__version_info__ < (1, 7),
         reason="cffi version too old"
     )
     def test_use_update_into_after_finalize(self, backend):

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -18,7 +18,6 @@ from cryptography.hazmat.primitives.ciphers import modes
 from cryptography.hazmat.primitives.ciphers.algorithms import (
     AES, ARC4, Blowfish, CAST5, Camellia, IDEA, SEED, TripleDES
 )
-from cryptography.utils import _version_check
 
 from ...utils import (
     load_nist_vectors, load_vectors_from_file, raises_unsupported_algorithm
@@ -143,7 +142,7 @@ def test_invalid_backend():
 
 
 @pytest.mark.skipif(
-    not _version_check(cffi.__version__, '1.7'),
+    cffi.__version_info__ < (1, 7),
     reason="cffi version too old"
 )
 @pytest.mark.supported(
@@ -241,7 +240,7 @@ class TestCipherUpdateInto(object):
 
 
 @pytest.mark.skipif(
-    _version_check(cffi.__version__, '1.7'),
+    cffi.__version_info__ >= (1, 7),
     reason="cffi version too new"
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)


### PR DESCRIPTION
This makes the code simpler, shorter, and lets us remove a dependecy.