### PR TITLE
allow global suppression of link flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,45 +44,45 @@ matrix:
           # 8.3 is macOS 10.12.x
           # see: https://docs.travis-ci.com/user/osx-ci-environment/
           osx_image: xcode8.3
-          env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+          env: TOXENV=py27 CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=py33 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+          env: TOXENV=py33 CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=py34 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+          env: TOXENV=py34 CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=py35 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+          env: TOXENV=py35 CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=py36 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+          env: TOXENV=py36 CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=pypy CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1 PYPY_VERSION=5.7.1
+          env: TOXENV=pypy CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1 PYPY_VERSION=5.7.1
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=0
+          env: TOXENV=py27 CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=0
         - language: generic
           os: osx
           # 7.3 is OS X 10.11.x
           osx_image: xcode7.3
-          env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+          env: TOXENV=py27 CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1
         - language: generic
           os: osx
           # 6.4 is OS X 10.10.x
           osx_image: xcode6.4
-          env: TOXENV=py27 CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+          env: TOXENV=py27 CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1
         - language: generic
           os: osx
           osx_image: xcode8.3
-          env: TOXENV=docs CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1
+          env: TOXENV=docs CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1
 
 install:
     - ./.travis/install.sh

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -11,7 +11,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
 
     # set our flags to use homebrew openssl
     # if the build is static we need different LDFLAGS
-    if [[ "${CRYPTOGRAPHY_OSX_NO_LINK_FLAGS}" == "1" ]]; then
+    if [[ "${CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS}" == "1" ]]; then
         export LDFLAGS="/usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a"
     else
         export LDFLAGS="-L/usr/local/opt/openssl/lib"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,7 +223,6 @@ def build(toxenv, label, imageName, artifacts, artifactExcludes) {
                         bat """
                             cd cryptography
                             @set PATH="C:\\Python27";"C:\\Python27\\Scripts";%PATH%
-                            @set CRYPTOGRAPHY_WINDOWS_LINK_OPENSSL110=1
                             @set PYTHON="${pythonPath[toxenv]}"
 
                             @set INCLUDE="${opensslPaths[label]['include']}";%INCLUDE%
@@ -243,7 +242,7 @@ def build(toxenv, label, imageName, artifacts, artifactExcludes) {
                                 export PATH="/usr/local/bin:\${PATH}"
                                 export PATH="/Users/jenkins/.pyenv/shims:\${PATH}"
                                 cd cryptography
-                                CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1 \
+                                CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1 \
                                     LDFLAGS="/usr/local/opt/openssl\\@1.1/lib/libcrypto.a /usr/local/opt/openssl\\@1.1/lib/libssl.a" \
                                     CFLAGS="-I/usr/local/opt/openssl\\@1.1/include -Werror -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types -Wno-error=unused-function -Wno-error=unused-command-line-argument" \
                                     tox -r --  --color=yes

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -46,7 +46,7 @@ For example, with `Homebrew`_:
         pip install --requirement ./dev-requirements.txt
 
 Alternatively for a static build you can specify
-``CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1`` and ensure ``LDFLAGS`` points to the
+``CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1`` and ensure ``LDFLAGS`` points to the
 absolute path for the `OpenSSL`_ libraries before calling pip.
 
 .. tip::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,13 +60,13 @@ to include the proper locations. For example:
     C:\> \path\to\vcvarsall.bat x86_amd64
     C:\> set LIB=C:\OpenSSL-win64\lib;%LIB%
     C:\> set INCLUDE=C:\OpenSSL-win64\include;%INCLUDE%
-    C:\> set CRYPTOGRAPHY_WINDOWS_LINK_OPENSSL110=1
     C:\> pip install cryptography
 
 As of OpenSSL 1.1.0 the library names have changed from ``libeay32`` and
 ``ssleay32`` to ``libcrypto`` and ``libssl`` (matching their names on all other
-platforms). Due to this change when linking against 1.1.0 you **must** set
-``CRYPTOGRAPHY_WINDOWS_LINK_OPENSSL110`` or else installation will fail.
+platforms). ``cryptography`` links against the new 1.1.0 names by default. If
+you need to compile ``cryptography`` against an older version then you **must**
+set ``CRYPTOGRAPHY_WINDOWS_LINK_LEGACY_OPENSSL`` or else installation will fail.
 
 If you need to rebuild ``cryptography`` for any reason be sure to clear the
 local `wheel cache`_.
@@ -237,14 +237,14 @@ You can also build cryptography statically:
 .. code-block:: console
 
     $ brew install openssl@1.1
-    $ env CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1 LDFLAGS="$(brew --prefix openssl@1.1)/lib/libssl.a $(brew --prefix openssl@1.1)/lib/libcrypto.a" CFLAGS="-I$(brew --prefix openssl@1.1)/include" pip install cryptography
+    $ env CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1 LDFLAGS="$(brew --prefix openssl@1.1)/lib/libssl.a $(brew --prefix openssl@1.1)/lib/libcrypto.a" CFLAGS="-I$(brew --prefix openssl@1.1)/include" pip install cryptography
 
 `MacPorts`_:
 
 .. code-block:: console
 
     $ sudo port install openssl
-    $ env CRYPTOGRAPHY_OSX_NO_LINK_FLAGS=1 LDFLAGS="/opt/local/lib/libssl.a /opt/local/lib/libcrypto.a" CFLAGS="-I/opt/local/include" pip install cryptography
+    $ env CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1 LDFLAGS="/opt/local/lib/libssl.a /opt/local/lib/libcrypto.a" CFLAGS="-I/opt/local/include" pip install cryptography
 
 If you need to rebuild ``cryptography`` for any reason be sure to clear the
 local `wheel cache`_.


### PR DESCRIPTION
CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS will now suppress link flags regardless
of platform. Additionally, CRYPTOGRAPHY_WINDOWS_LINK_LEGACY_OPENSSL is
now the flag you need if you want to link against < 1.1.0 on windows.

fixes #3403 