### PR TITLE
update to new CI server for wheels + switch to using a job token

### DIFF
--- a/release.py
+++ b/release.py
@@ -17,7 +17,10 @@ from clint.textui.progress import Bar as ProgressBar
 import requests
 
 
-JENKINS_URL = "https://jenkins.cryptography.io/job/cryptography-wheel-builder"
+JENKINS_URL = (
+    "https://ci.cryptography.io/job/cryptography-support-jobs/"
+    "job/wheel-builder/"
+)
 
 
 def run(*args, **kwargs):
@@ -128,14 +131,11 @@ def release(version):
     )
     response.raise_for_status()
 
-    username = getpass.getpass("Input the GitHub/Jenkins username: ")
     token = getpass.getpass("Input the Jenkins token: ")
-    response = session.post(
+    response = session.get(
         "{0}/build".format(JENKINS_URL),
-        auth=requests.auth.HTTPBasicAuth(
-            username, token
-        ),
         params={
+            "token": token,
             "cause": "Building wheels for {0}".format(version)
         }
     )

--- a/release.py
+++ b/release.py
@@ -19,7 +19,7 @@ import requests
 
 JENKINS_URL = (
     "https://ci.cryptography.io/job/cryptography-support-jobs/"
-    "job/wheel-builder/"
+    "job/wheel-builder"
 )
 
 


### PR DESCRIPTION
Fixes #3637 depends on #3636 

This switches back to using a job token instead of username/token because a job token makes more sense. Unfortunately you can't POST for that so we also switch to a GET.