### PR TITLE
Adding one more exported function for DSA

### DIFF
--- a/src/_cffi_src/openssl/dsa.py
+++ b/src/_cffi_src/openssl/dsa.py
@@ -23,6 +23,9 @@ int DSA_sign(int, const unsigned char *, int, unsigned char *, unsigned int *,
 int DSA_verify(int, const unsigned char *, int, const unsigned char *, int,
                DSA *);
 
+/* added in 1.0.2 */
+DH *DSA_dup_DH(const DSA *r);
+
 /* added in 1.1.0 to access the opaque struct */
 void DSA_get0_pqg(const DSA *, const BIGNUM **, const BIGNUM **,
                   const BIGNUM **);
@@ -37,6 +40,11 @@ int DSA_generate_parameters_ex(DSA *, int, unsigned char *, int,
 """
 
 CUSTOMIZATIONS = """
+/* These functions were added in OpenSSL 1.0.2 */
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
+DH *(*DSA_dup_DH)(const DSA *r) = null;
+#endif
+
 /* These functions were added in OpenSSL 1.1.0-pre5 (beta2) */
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110PRE5
 void DSA_get0_pqg(const DSA *d,


### PR DESCRIPTION
Hello,
I had made a PR long ago to add 2 functions that I'm using in a product.
Essentially, I want to have a way to generate dhparams file for apache. So I looked at the code inside openssl and came up with the following python code:

def generate_dh_file():
    filename = join(fwcontrol.get_certs_folder_path(), 'dhparams.pem')
    if os.path.exists(filename):
        print("File %s already present" % filename)
        return

    print("Generating DSA parameters, 2048 bit long prime...")
    from cryptography.hazmat.backends.openssl.backend import Backend
    b = Backend()

    dsa = b.generate_dsa_parameters(2048)
    dh = b._ffi.gc(b._lib.DSA_dup_DH(dsa._dsa_cdata), b._lib.DH_free)

    q_list = b._ffi.new("BIGNUM *[1]")
    p_list = b._ffi.new("BIGNUM *[1]")
    b._lib.DH_get0_pqg(dh, p_list, q_list, b._ffi.NULL)
    func = b._lib.PEM_write_bio_DHxparams if q_list[0] == 0 else b._lib.PEM_write_bio_DHparams
    out = b._create_mem_bio_gc()
    if  func(out, dh) == 0:
        raise Exception(b._lib.ERR_GET_REASON(b._lib.ERR_get_error()))
    open(filename, 'wb').write(b._read_mem_bio(out))
    print("written file to %s" % filename)


So basically I needed to add DSA_dup_DH.
Disclaimer: I'm not a security expert and I really just copied what openssl is doing.