### PR TITLE
Attempted workaround for intermittent coverage issues

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,12 @@ coverage:
         project:
             default:
                 target: '100'
+
+# Workaround for
+# https://bitbucket.org/ned/coveragepy/issues/578/incomplete-file-path-in-xml-report
+fixes:
+    # Label all the files with a `tests/` prefix.
+    - "::tests/"
+    # Move things with a `tests/src/cryptography` prefix back to
+    # `src/cryptography/`
+    - "tests/src/cryptography/::src/cryptography/"


### PR DESCRIPTION
The root cause is https://bitbucket.org/ned/coveragepy/issues/578/incomplete-file-path-in-xml-report