### PR TITLE
revert codecov.yml workaround and pin coverage to 4.3.4

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -89,4 +89,4 @@ fi
 
 python -m virtualenv ~/.venv
 source ~/.venv/bin/activate
-pip install tox codecov
+pip install tox codecov coverage==4.3.4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,6 +238,7 @@ def build(toxenv, label, imageName, artifacts, artifactExcludes) {
                             IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
                             virtualenv .codecov
                             call .codecov/Scripts/activate
+                            pip install coverage==4.3.4
                             pip install codecov
                             codecov -e JOB_BASE_NAME,LABEL
                         """
@@ -255,7 +256,7 @@ def build(toxenv, label, imageName, artifacts, artifactExcludes) {
                                     tox -r --  --color=yes
                                 virtualenv .venv
                                 source .venv/bin/activate
-                                pip install coverage
+                                pip install coverage==4.3.4
                                 bash <(curl -s https://codecov.io/bash) -e JOB_BASE_NAME,LABEL
                             """
                         }
@@ -274,7 +275,7 @@ def build(toxenv, label, imageName, artifacts, artifactExcludes) {
                                 fi
                                 virtualenv .venv
                                 source .venv/bin/activate
-                                pip install coverage
+                                pip install coverage==4.3.4
                                 bash <(curl -s https://codecov.io/bash) -e JOB_BASE_NAME,LABEL
                             """
                         }

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,12 +7,3 @@ coverage:
         project:
             default:
                 target: '100'
-
-# Workaround for
-# https://bitbucket.org/ned/coveragepy/issues/578/incomplete-file-path-in-xml-report
-fixes:
-    # Label all the files with a `tests/` prefix.
-    - "::tests/"
-    # Move things with a `tests/src/cryptography` prefix back to
-    # `src/cryptography/`
-    - "tests/src/cryptography/::src/cryptography/"


### PR DESCRIPTION
The 4.3.4 pins should be removed when https://bitbucket.org/ned/coveragepy/issues/578/incomplete-file-path-in-xml-report is resolved.