### PR TITLE
fix symmetric encryption interfaces heading

### DIFF
--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -435,7 +435,7 @@ Insecure modes
     **Padding is required when using this mode.**
 
 Interfaces
-----------
+~~~~~~~~~~
 
 .. currentmodule:: cryptography.hazmat.primitives.ciphers
 


### PR DESCRIPTION
Previously it was considered a subheading of Modes, which is definitely not right.