### PR TITLE
when you :%s/\:/=/g sometimes there's a colon you shouldn't have touched

### DIFF
--- a/vectors/cryptography_vectors/ciphers/ChaCha20Poly1305/boringssl.txt
+++ b/vectors/cryptography_vectors/ciphers/ChaCha20Poly1305/boringssl.txt
@@ -3,7 +3,7 @@
 COUNT = 1
 KEY= 808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f
 NONCE= 070000004041424344454647
-IN= "Ladies and Gentlemen of the class of '99= If I could offer you only one tip for the future, sunscreen would be it."
+IN= "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it."
 AD= 50515253c0c1c2c3c4c5c6c7
 CT= d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d63dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b3692ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc3ff4def08e4b7a9de576d26586cec64b6116
 TAG= 1ae10b594f09e26a7e902ecbd0600691


### PR DESCRIPTION
I had this fixed on another branch but didn't port it back to the vectors PR.