### PR TITLE
bind EVP_CTRL_AEAD even when on < 1.1.0

### DIFF
--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -22,9 +22,9 @@ static const int EVP_PKEY_DH;
 static const int EVP_PKEY_DHX;
 static const int EVP_PKEY_EC;
 static const int EVP_MAX_MD_SIZE;
-static const int EVP_CTRL_GCM_SET_IVLEN;
-static const int EVP_CTRL_GCM_GET_TAG;
-static const int EVP_CTRL_GCM_SET_TAG;
+static const int EVP_CTRL_AEAD_SET_IVLEN;
+static const int EVP_CTRL_AEAD_GET_TAG;
+static const int EVP_CTRL_AEAD_SET_TAG;
 
 static const int Cryptography_HAS_GCM;
 static const int Cryptography_HAS_PBKDF2_HMAC;
@@ -210,5 +210,16 @@ int (*EVP_PBE_scrypt)(const char *, size_t, const unsigned char *, size_t,
                       size_t) = NULL;
 #else
 static const long Cryptography_HAS_SCRYPT = 1;
+#endif
+
+/* OpenSSL 1.1.0+ does this define for us, but if not present we'll do it */
+#if !defined(EVP_CTRL_AEAD_SET_IVLEN)
+# define EVP_CTRL_AEAD_SET_IVLEN EVP_CTRL_GCM_SET_IVLEN
+#endif
+#if !defined(EVP_CTRL_AEAD_GET_TAG)
+# define EVP_CTRL_AEAD_GET_TAG EVP_CTRL_GCM_GET_TAG
+#endif
+#if !defined(EVP_CTRL_AEAD_SET_TAG)
+# define EVP_CTRL_AEAD_SET_TAG EVP_CTRL_GCM_SET_TAG
 #endif
 """

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -75,13 +75,13 @@ class _CipherContext(object):
         self._backend.openssl_assert(res != 0)
         if isinstance(mode, modes.GCM):
             res = self._backend._lib.EVP_CIPHER_CTX_ctrl(
-                ctx, self._backend._lib.EVP_CTRL_GCM_SET_IVLEN,
+                ctx, self._backend._lib.EVP_CTRL_AEAD_SET_IVLEN,
                 len(iv_nonce), self._backend._ffi.NULL
             )
             self._backend.openssl_assert(res != 0)
             if mode.tag is not None:
                 res = self._backend._lib.EVP_CIPHER_CTX_ctrl(
-                    ctx, self._backend._lib.EVP_CTRL_GCM_SET_TAG,
+                    ctx, self._backend._lib.EVP_CTRL_AEAD_SET_TAG,
                     len(mode.tag), mode.tag
                 )
                 self._backend.openssl_assert(res != 0)
@@ -179,7 +179,7 @@ class _CipherContext(object):
                 "unsigned char[]", self._block_size_bytes
             )
             res = self._backend._lib.EVP_CIPHER_CTX_ctrl(
-                self._ctx, self._backend._lib.EVP_CTRL_GCM_GET_TAG,
+                self._ctx, self._backend._lib.EVP_CTRL_AEAD_GET_TAG,
                 self._block_size_bytes, tag_buf
             )
             self._backend.openssl_assert(res != 0)
@@ -199,7 +199,7 @@ class _CipherContext(object):
                 "method please update OpenSSL"
             )
         res = self._backend._lib.EVP_CIPHER_CTX_ctrl(
-            self._ctx, self._backend._lib.EVP_CTRL_GCM_SET_TAG,
+            self._ctx, self._backend._lib.EVP_CTRL_AEAD_SET_TAG,
             len(tag), tag
         )
         self._backend.openssl_assert(res != 0)


### PR DESCRIPTION
In earlier versions of OpenSSL the `EVP_CTRL_GCM_*` defines are set to the following:

```
  # define         EVP_CTRL_GCM_SET_IVLEN         0x9
  # define         EVP_CTRL_GCM_GET_TAG           0x10
  # define         EVP_CTRL_GCM_SET_TAG           0x11
```
In 1.1.0 these were redefined to be:

```
  # define         EVP_CTRL_AEAD_SET_IVLEN         0x9
  # define         EVP_CTRL_AEAD_GET_TAG           0x10
  # define         EVP_CTRL_AEAD_SET_TAG           0x11
  # define         EVP_CTRL_GCM_SET_IVLEN          EVP_CTRL_AEAD_SET_IVLEN
  # define         EVP_CTRL_GCM_GET_TAG            EVP_CTRL_AEAD_GET_TAG
  # define         EVP_CTRL_GCM_SET_TAG            EVP_CTRL_AEAD_SET_TAG
```

This PR makes it so we can just use `EVP_CTLR_AEAD_*` in all versions. This will make it less confusing when I submit the chacha20poly1305 PR.