### PR TITLE
disallow empty string for NameAttribute

### DIFF
--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -27,6 +27,9 @@ class NameAttribute(object):
                 "Country name must be a 2 character country code"
             )
 
+        if len(value) == 0:
+            raise ValueError("Value cannot be an empty string")
+
         self._oid = oid
         self._value = value
 

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -3624,6 +3624,10 @@ class TestNameAttribute(object):
                 u'\U0001F37A\U0001F37A'
             )
 
+    def test_init_empty_value(self):
+        with pytest.raises(ValueError):
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, u'')
+
     def test_eq(self):
         assert x509.NameAttribute(
             x509.ObjectIdentifier('2.999.1'), u'value'


### PR DESCRIPTION
fixes #3649 

This will disallow all empty string values for any name attribute. It seems like this is a reasonable thing to restrict, but if anyone knows a reason why this is a behavior we want to allow speak up. The error reported comes from `ASN1_mbstring_ncopy`, which takes a `minsize`. That `minsize` comes from an `ASN1_STRING_TABLE` that contains min/max values, but I haven't traced where those are coming from other than "a default conf".