### PR TITLE
pypy3 compilation fix for locking callback

### DIFF
--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -60,10 +60,10 @@ static __inline void cryptography_mutex_unlock(Cryptography_mutex *mutex) {
 }
 #else
 typedef pthread_mutex_t Cryptography_mutex;
-#define ASSERT_STATUS(call)                                           \
-    if (call != 0) {                                                  \
-        perror("Fatal error in callback initialization: " #call);     \
-        abort();                                                      \
+#define ASSERT_STATUS(call)                                             \
+    if ((call) != 0) {                                                  \
+        perror("Fatal error in callback initialization: " #call);       \
+        abort();                                                        \
     }
 static inline void cryptography_mutex_init(Cryptography_mutex *mutex) {
 #if !defined(pthread_mutexattr_default)

--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -53,10 +53,10 @@ static inline void mutex1_unlock(mutex1_t *mutex) {
 #include <stdlib.h>
 #include <pthread.h>
 typedef pthread_mutex_t mutex1_t;
-#define ASSERT_STATUS(call)                             \
-    if (call != 0) {                                    \
-        perror("Fatal error in _cffi_ssl: " #call);     \
-        abort();                                        \
+#define ASSERT_STATUS(call)                                           \
+    if (call != 0) {                                                  \
+        perror("Fatal error in callback initialization: " #call);     \
+        abort();                                                      \
     }
 static inline void mutex1_init(mutex1_t *mutex) {
 #if !defined(pthread_mutexattr_default)
@@ -123,7 +123,7 @@ int _setup_ssl_threads(void) {
         if (_ssl_locks == NULL) {
             return 0;
         }
-        memset(_ssl_locks, 0, sizeof(PyThread_type_lock) * _ssl_locks_count);
+        memset(_ssl_locks, 0, sizeof(mutex1_t) * _ssl_locks_count);
         init_mutexes();
         CRYPTO_set_locking_callback(_ssl_thread_locking_function);
 #ifndef _WIN32

--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -123,7 +123,7 @@ static void init_mutexes(void) {
 int _setup_ssl_threads(void) {
     if (_ssl_locks == NULL) {
         _ssl_locks_count = CRYPTO_num_locks();
-        _ssl_locks = calloc(sizeof(Cryptography_mutex) * _ssl_locks_count);
+        _ssl_locks = calloc(_ssl_locks_count, sizeof(Cryptography_mutex));
         if (_ssl_locks == NULL) {
             return 0;
         }

--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -9,6 +9,14 @@ INCLUDES = """
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
 #include <openssl/crypto.h>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#endif
 """
 
 TYPES = """
@@ -34,24 +42,23 @@ CUSTOMIZATIONS = """
    locking callback for OpenSSL.
 
    Copyright 2001-2016 Python Software Foundation; All Rights Reserved.
+
+   It has been subsequently modified to use cross platform locking without
+   using CPython APIs by Armin Rigo of the PyPy project.
 */
 
 #ifdef _WIN32
-#include <Windows.h>
 typedef CRITICAL_SECTION mutex1_t;
-static inline void mutex1_init(mutex1_t *mutex) {
+static __inline void mutex1_init(mutex1_t *mutex) {
     InitializeCriticalSection(mutex);
 }
-static inline void mutex1_lock(mutex1_t *mutex) {
+static __inline void mutex1_lock(mutex1_t *mutex) {
     EnterCriticalSection(mutex);
 }
-static inline void mutex1_unlock(mutex1_t *mutex) {
+static __inline void mutex1_unlock(mutex1_t *mutex) {
     LeaveCriticalSection(mutex);
 }
 #else
-#include <stdio.h>
-#include <stdlib.h>
-#include <pthread.h>
 typedef pthread_mutex_t mutex1_t;
 #define ASSERT_STATUS(call)                                           \
     if (call != 0) {                                                  \

--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -122,8 +122,6 @@ static void init_mutexes(void)
 
 
 int _setup_ssl_threads(void) {
-    unsigned int i;
-
     if (_ssl_locks == NULL) {
         _ssl_locks_count = CRYPTO_num_locks();
         _ssl_locks = malloc(sizeof(mutex1_t) * _ssl_locks_count);


### PR DESCRIPTION
Fixes #3701, which will happen on any installation of cryptography in pypy3 that uses our locking callbacks. We're not seeing it on our linux pypy3 CI right now because it doesn't build against a custom OpenSSL so importing stdlib SSL has already registered locking callbacks and ours are bypassed. It is easily replicable in macOS though because we always build against a custom OpenSSL on that platform.

Here's a branch (https://github.com/pyca/cryptography/compare/master...reaperhulk:pypy3-fix) that incorporates the changes from https://bitbucket.org/pypy/pypy/commits/198dc138680f96c391802fa1e77b8b6d2e0134e6?at=py3.5 and passes all tests on macOS. I lack the C expertise to determine if this is a safe change that we can assume will result in functional cross-platform locking across every platform we'd expect to see cryptography compiled on (e.g. more unusual ones like the rarer BSDs, Solaris, etc).

@arigo would you expect this to work reliably pretty much everywhere? (And are there any licensing things we need to do to be able to incorporate it?) @alex what do you think?