### PR TITLE
some wconversion fixes

### DIFF
--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -99,7 +99,7 @@ BIO_METHOD *BIO_f_null(void);
 BIO_METHOD *BIO_f_buffer(void);
 /* BIO_new_mem_buf became const void * in 1.0.2g */
 BIO *BIO_new_mem_buf(void *, int);
-long BIO_set_fd(BIO *, long, int);
+long BIO_set_fd(BIO *, int, long);
 long BIO_get_fd(BIO *, char *);
 long BIO_set_mem_eof_return(BIO *, int);
 long BIO_get_mem_data(BIO *, char **);

--- a/src/_cffi_src/openssl/src/osrandom_engine.c
+++ b/src/_cffi_src/openssl/src/osrandom_engine.c
@@ -205,7 +205,7 @@ static int osrandom_init(ENGINE *e) {
 #if !defined(__APPLE__)
     getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_WORKS;
 #else
-    if (getentropy != NULL) {
+    if (&getentropy != NULL) {
         getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_WORKS;
     } else {
         getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_FALLBACK;
@@ -219,7 +219,8 @@ static int osrandom_init(ENGINE *e) {
 }
 
 static int osrandom_rand_bytes(unsigned char *buffer, int size) {
-    int len, res;
+    size_t len;
+    int res;
 
     switch(getentropy_works) {
     case CRYPTOGRAPHY_OSRANDOM_GETENTROPY_FALLBACK:
@@ -227,7 +228,7 @@ static int osrandom_rand_bytes(unsigned char *buffer, int size) {
     case CRYPTOGRAPHY_OSRANDOM_GETENTROPY_WORKS:
         while (size > 0) {
             /* OpenBSD and macOS restrict maximum buffer size to 256. */
-            len = size > 256 ? 256 : size;
+            len = size > 256 ? 256 : (size_t)size;
             res = getentropy(buffer, len);
             if (res < 0) {
                 ERR_Cryptography_OSRandom_error(
@@ -476,7 +477,7 @@ static int osrandom_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void)) 
         len = strlen(name);
         if ((p == NULL) && (i == 0)) {
             /* return required buffer len */
-            return len;
+            return (int)len;
         }
         if ((p == NULL) || i < 0 || ((size_t)i <= len)) {
             /* no buffer or buffer too small */
@@ -484,7 +485,7 @@ static int osrandom_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void)) 
             return 0;
         }
         strncpy((char *)p, name, len);
-        return len;
+        return (int)len;
     default:
         ENGINEerr(ENGINE_F_ENGINE_CTRL, ENGINE_R_CTRL_COMMAND_NOT_IMPLEMENTED);
         return 0;

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -296,7 +296,7 @@ int i2d_RSAPrivateKey(RSA *, unsigned char **);
 int i2d_DSAPublicKey(DSA *, unsigned char **);
 int i2d_DSAPrivateKey(DSA *, unsigned char **);
 
-int X509_CRL_get_version(X509_CRL *);
+long X509_CRL_get_version(X509_CRL *);
 ASN1_TIME *X509_CRL_get_lastUpdate(X509_CRL *);
 ASN1_TIME *X509_CRL_get_nextUpdate(X509_CRL *);
 X509_NAME *X509_CRL_get_issuer(X509_CRL *);


### PR DESCRIPTION
refs #3695 

This is the set of -Wconversion fixes that should just be bug fixes. There is one other fix, which resolves a warning related to the weaklink symbol check with `getentropy` (passing the address of the function is apparently how you're supposed to do it)