### PR TITLE
pyopenssl needs pretend for its tests now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ def downstreams = [
             source .venv/bin/activate
             pip install ../cryptography
             pip install -e .
-            pip install pytest
+            pip install pytest pretend
             pytest tests
         """
     ],


### PR DESCRIPTION
And since pyopenssl doesn't have a place it tracks test deps we have to add it here.