### PR TITLE
explicitly pull the latest docker image in jenkins

### DIFF
--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -167,7 +167,7 @@ for (config in configs) {
             builders[combinedName] = {
                 node(label) {
                     stage(combinedName) {
-                        buildImage = docker.image(imageName)
+                        def buildImage = docker.image(imageName)
                         buildImage.pull()
                         buildImage.inside("-u root") {
                             build(version, label, imageName)

--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -167,7 +167,9 @@ for (config in configs) {
             builders[combinedName] = {
                 node(label) {
                     stage(combinedName) {
-                        docker.image(imageName).inside("-u root") {
+                        buildImage = docker.image(imageName)
+                        buildImage.pull()
+                        buildImage.inside("-u root") {
                             build(version, label, imageName)
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -306,7 +306,7 @@ for (config in configs) {
             builders[combinedName] = {
                 node(label) {
                     stage(combinedName) {
-                        buildImage = docker.image(imageName)
+                        def buildImage = docker.image(imageName)
                         buildImage.pull()
                         buildImage.inside {
                             build(toxenv, label, imageName, artifacts, artifactExcludes)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -306,7 +306,9 @@ for (config in configs) {
             builders[combinedName] = {
                 node(label) {
                     stage(combinedName) {
-                        docker.image(imageName).inside {
+                        buildImage = docker.image(imageName)
+                        buildImage.pull()
+                        buildImage.inside {
                             build(toxenv, label, imageName, artifacts, artifactExcludes)
                         }
                     }


### PR DESCRIPTION
Right now we don't need to do this since the same jenkins instance that builds the images and tags them also pushes them, so it is guaranteed to always have the latest. However, if we want to add another docker builder that is no longer true, so let's always pull.