### PR TITLE
change chacha20poly1305_supported to aead_cipher_supported

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1934,7 +1934,11 @@ class Backend(object):
             self, b"chacha20-poly1305", key, nonce, data, associated_data, 16
         )
 
-    def chacha20poly1305_supported(self):
+    def aead_cipher_supported(self, cls):
+        from cryptography.hazmat.primitives.ciphers.aead import (
+            ChaCha20Poly1305
+        )
+        assert cls is ChaCha20Poly1305
         return (
             self._lib.EVP_get_cipherbyname(b"chacha20-poly1305") !=
             self._ffi.NULL

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -12,7 +12,7 @@ from cryptography.hazmat.backends.openssl.backend import backend
 
 class ChaCha20Poly1305(object):
     def __init__(self, key):
-        if not backend.chacha20poly1305_supported():
+        if not backend.aead_cipher_supported(type(self)):
             raise exceptions.UnsupportedAlgorithm(
                 "ChaCha20Poly1305 is not supported by this version of OpenSSL",
                 exceptions._Reasons.UNSUPPORTED_CIPHER

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -20,7 +20,7 @@ from ...utils import (
 
 @pytest.mark.supported(
     only_if=lambda backend: (
-        not backend.chacha20poly1305_supported()
+        not backend.aead_cipher_supported(ChaCha20Poly1305)
     ),
     skip_message="Requires OpenSSL without ChaCha20Poly1305 support"
 )
@@ -31,7 +31,7 @@ def test_chacha20poly1305_unsupported_on_older_openssl(backend):
 
 
 @pytest.mark.supported(
-    only_if=lambda backend: backend.chacha20poly1305_supported(),
+    only_if=lambda backend: backend.aead_cipher_supported(ChaCha20Poly1305),
     skip_message="Does not support ChaCha20Poly1305"
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)


### PR DESCRIPTION
The `cls` and apparently pointless assertion are because we'll use the `cls` in the CCM PR.

refs #3700 