### PR TITLE
allow p % 24 == 23 when generator == 2 in DH_check

### DIFF
--- a/src/_cffi_src/openssl/dh.py
+++ b/src/_cffi_src/openssl/dh.py
@@ -10,6 +10,8 @@ INCLUDES = """
 
 TYPES = """
 typedef ... DH;
+
+const long DH_NOT_SUITABLE_GENERATOR;
 """
 
 FUNCTIONS = """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1777,9 +1777,13 @@ class Backend(object):
         self.openssl_assert(res == 1)
 
         # DH_check will return DH_NOT_SUITABLE_GENERATOR if p % 24 does not
-        # equal 11 when the generator is 2. We want to ignore that error
-        # because p % 24 == 23 is also fine. See:
-        # https://crypto.stackexchange.com/questions/12961
+        # equal 11 when the generator is 2 (a quadratic nonresidue).
+        # We want to ignore that error because p % 24 == 23 is also fine.
+        # Specifically, it is a quadratic residue. Within the context of
+        # Diffie-Hellman this means it can only generate half the possible
+        # values. That sounds bad, but quadratic nonresidues leak a bit of
+        # the key to the attacker in exchange for having the full key space
+        # available. See: https://crypto.stackexchange.com/questions/12961
         if codes[0] != 0 and not (
             parameter_numbers.g == 2 and
             codes[0] ^ self._lib.DH_NOT_SUITABLE_GENERATOR == 0

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1779,7 +1779,7 @@ class Backend(object):
         # DH_check will return DH_NOT_SUITABLE_GENERATOR if p % 24 does not
         # equal 11 when the generator is 2 (a quadratic nonresidue).
         # We want to ignore that error because p % 24 == 23 is also fine.
-        # Specifically, it is a quadratic residue. Within the context of
+        # Specifically, g is then a quadratic residue. Within the context of
         # Diffie-Hellman this means it can only generate half the possible
         # values. That sounds bad, but quadratic nonresidues leak a bit of
         # the key to the attacker in exchange for having the full key space

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1779,8 +1779,7 @@ class Backend(object):
         # DH_check will return DH_NOT_SUITABLE_GENERATOR if p % 24 does not
         # equal 11 when the generator is 2. We want to ignore that error
         # because p % 24 == 23 is also fine. See:
-        # https://crypto.stackexchange.com/questions/12961/diffie-hellman-
-        # parameter-check-when-g-2-must-p-mod-24-11
+        # https://crypto.stackexchange.com/questions/12961
         if codes[0] != 0 and not (
             parameter_numbers.g == 2 and
             codes[0] ^ self._lib.DH_NOT_SUITABLE_GENERATOR == 0

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import binascii
 import os
 
 import pytest
@@ -161,6 +162,24 @@ class TestDH(object):
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(
+            os.path.join("asymmetric", "DH", "rfc3526.txt"),
+            load_nist_vectors
+        )
+    )
+    def test_dh_parameters_allows_rfc3526_groups(self, backend, vector):
+        p = int_from_bytes(binascii.unhexlify(vector["p"]), 'big')
+        params = dh.DHParameterNumbers(p, int(vector["g"]))
+        param = params.parameters(backend)
+        key = param.generate_private_key()
+        # This confirms that a key generated with this group
+        # will pass DH_check when we serialize and de-serialize it via
+        # the Numbers path.
+        roundtripped_key = key.private_numbers().private_key(backend)
+        assert key.private_numbers() == roundtripped_key.private_numbers()
+
+    @pytest.mark.parametrize(
+        "vector",
+        load_vectors_from_file(
             os.path.join("asymmetric", "DH", "RFC5114.txt"),
             load_nist_vectors))
     def test_dh_parameters_supported_with_q(self, backend, vector):
@@ -202,7 +221,7 @@ class TestDH(object):
                           dh.DHPrivateKeyWithSerialization)
 
     def test_numbers_unsupported_parameters(self, backend):
-        params = dh.DHParameterNumbers(23, 2)
+        params = dh.DHParameterNumbers(21, 2)
         public = dh.DHPublicNumbers(1, params)
         private = dh.DHPrivateNumbers(2, public)
 

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -221,6 +221,11 @@ class TestDH(object):
                           dh.DHPrivateKeyWithSerialization)
 
     def test_numbers_unsupported_parameters(self, backend):
+        # p is set to 21 because when calling private_key we want it to
+        # fail the DH_check call OpenSSL does. Originally this was 23, but
+        # we are allowing p % 24 to == 23 with this PR (see #3768 for more)
+        # By setting it to 21 it fails later in DH_check in a primality check
+        # which triggers the code path we want to test
         params = dh.DHParameterNumbers(21, 2)
         public = dh.DHPublicNumbers(1, params)
         private = dh.DHPrivateNumbers(2, public)


### PR DESCRIPTION
refs #3755 

Depends on #3767

https://crypto.stackexchange.com/questions/12961/diffie-hellman-parameter-check-when-g-2-must-p-mod-24-11

+ conversations with competent cryptographers have convinced me that it's reasonable to do this, but once #3767 merges we can cc lvh for a review :)