### PR TITLE
remove egd

### DIFF
--- a/src/_cffi_src/openssl/rand.py
+++ b/src/_cffi_src/openssl/rand.py
@@ -9,7 +9,6 @@ INCLUDES = """
 """
 
 TYPES = """
-static const long Cryptography_HAS_EGD;
 """
 
 FUNCTIONS = """
@@ -28,19 +27,7 @@ void ERR_load_RAND_strings(void);
 
 /* RAND_cleanup became a macro in 1.1.0 */
 void RAND_cleanup(void);
-
-int RAND_egd(const char *);
-int RAND_egd_bytes(const char *, int);
-int RAND_query_egd_bytes(const char *, unsigned char *, int);
 """
 
 CUSTOMIZATIONS = """
-#if CRYPTOGRAPHY_IS_LIBRESSL || CRYPTOGRAPHY_OPENSSL_110_OR_GREATER
-static const long Cryptography_HAS_EGD = 0;
-int (*RAND_egd)(const char *) = NULL;
-int (*RAND_egd_bytes)(const char *, int) = NULL;
-int (*RAND_query_egd_bytes)(const char *, unsigned char *, int) = NULL;
-#else
-static const long Cryptography_HAS_EGD = 1;
-#endif
 """

--- a/src/_cffi_src/openssl/rand.py
+++ b/src/_cffi_src/openssl/rand.py
@@ -9,6 +9,7 @@ INCLUDES = """
 """
 
 TYPES = """
+static const long Cryptography_HAS_EGD;
 """
 
 FUNCTIONS = """
@@ -30,4 +31,5 @@ void RAND_cleanup(void);
 """
 
 CUSTOMIZATIONS = """
+static const long Cryptography_HAS_EGD = 0;
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -75,14 +75,6 @@ def cryptography_has_rsa_r_pkcs_decoding_error():
     ]
 
 
-def cryptography_has_egd():
-    return [
-        "RAND_egd",
-        "RAND_egd_bytes",
-        "RAND_query_egd_bytes",
-    ]
-
-
 def cryptography_has_rsa_oaep_md():
     return [
         "EVP_PKEY_CTX_set_rsa_oaep_md",

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -257,7 +257,6 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR": (
         cryptography_has_rsa_r_pkcs_decoding_error
     ),
-    "Cryptography_HAS_EGD": cryptography_has_egd,
     "Cryptography_HAS_RSA_OAEP_MD": cryptography_has_rsa_oaep_md,
     "Cryptography_HAS_SSL3_METHOD": cryptography_has_ssl3_method,
     "Cryptography_HAS_ALPN": cryptography_has_alpn,


### PR DESCRIPTION
EGD is bad and old and we removed it from pyOpenSSL in 16.0.