### PR TITLE
add AESGCM AEAD support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ Changelog
   :class:`~cryptography.hazmat.primitives.ciphers.aead.ChaCha20Poly1305`.
 * Added support for
   :class:`~cryptography.hazmat.primitives.ciphers.aead.AESCCM`.
+* Added
+  :class:`~cryptography.hazmat.primitives.ciphers.aead.AESGCM`, a "one shot"
+  API for AES GCM encryption.
 * Added support for :doc:`/hazmat/primitives/asymmetric/x25519`.
 * Added support for serializing and deserializing Diffie-Hellman parameters
   with

--- a/docs/hazmat/primitives/aead.rst
+++ b/docs/hazmat/primitives/aead.rst
@@ -161,3 +161,74 @@ also support providing integrity for associated data which is not encrypted.
             doesn't validate this exception will be raised. This will occur
             when the ciphertext has been changed, but will also occur when the
             key, nonce, or associated data are wrong.
+
+.. class:: AESGCM(key)
+
+    .. versionadded:: 2.0
+
+    The AES-GCM construction is composed of the
+    :class:`~cryptography.hazmat.primitives.ciphers.algorithms.AES` block
+    cipher utilizing Galois Counter Mode (GCM).
+
+    :param bytes key: A 128, 192, or 256-bit key. This **must** be kept secret.
+
+    .. doctest::
+
+        >>> import os
+        >>> from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        >>> data = b"a secret message"
+        >>> aad = b"authenticated but unencrypted data"
+        >>> key = AESGCM.generate_key(bit_length=128)
+        >>> aesgcm = AESGCM(key)
+        >>> nonce = os.urandom(12)
+        >>> ct = aesgcm.encrypt(nonce, data, aad)
+        >>> aesgcm.decrypt(nonce, ct, aad)
+        'a secret message'
+
+    .. classmethod:: generate_key(bit_length)
+
+        Securely generates a random AES-GCM key.
+
+        :param bit_length: The bit length of the key to generate. Must be
+            128, 192, or 256.
+
+        :returns bytes: The generated key.
+
+    .. method:: encrypt(nonce, data, associated_data)
+
+        .. warning::
+
+            Reuse of a ``nonce`` with a given ``key`` compromises the security
+            of any message with that ``nonce`` and ``key`` pair.
+
+        Encrypts and authenticates the ``data`` provided as well as
+        authenticating the ``associated_data``.  The output of this can be
+        passed directly to the ``decrypt`` method.
+
+        :param bytes nonce: NIST `recommends a 96-bit IV length`_ for best
+            performance but it can be up to 2\ :sup:`64` - 1 bits.
+            **NEVER REUSE A NONCE** with a key.
+        :param bytes data: The data to encrypt.
+        :param bytes associated_data: Additional data that should be
+            authenticated with the key, but is not encrypted. Can be ``None``.
+        :returns bytes: The ciphertext bytes with the 16 byte tag appended.
+
+    .. method:: decrypt(nonce, data, associated_data)
+
+        Decrypts the ``data`` and authenticates the ``associated_data``. If you
+        called encrypt with ``associated_data`` you must pass the same
+        ``associated_data`` in decrypt or the integrity check will fail.
+
+        :param bytes nonce: NIST `recommends a 96-bit IV length`_ for best
+            performance but it can be up to 2\ :sup:`64` - 1 bits.
+            **NEVER REUSE A NONCE** with a key.
+        :param bytes data: The data to decrypt (with tag appended).
+        :param bytes associated_data: Additional data to authenticate. Can be
+            ``None`` if none was passed during encryption.
+        :returns bytes: The original plaintext.
+        :raises cryptography.exceptions.InvalidTag: If the authentication tag
+            doesn't validate this exception will be raised. This will occur
+            when the ciphertext has been changed, but will also occur when the
+            key, nonce, or associated data are wrong.
+
+.. _`recommends a 96-bit IV length`: http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf

--- a/docs/hazmat/primitives/aead.rst
+++ b/docs/hazmat/primitives/aead.rst
@@ -78,6 +78,75 @@ also support providing integrity for associated data which is not encrypted.
             when the ciphertext has been changed, but will also occur when the
             key, nonce, or associated data are wrong.
 
+.. class:: AESGCM(key)
+
+    .. versionadded:: 2.0
+
+    The AES-GCM construction is composed of the
+    :class:`~cryptography.hazmat.primitives.ciphers.algorithms.AES` block
+    cipher utilizing Galois Counter Mode (GCM).
+
+    :param bytes key: A 128, 192, or 256-bit key. This **must** be kept secret.
+
+    .. doctest::
+
+        >>> import os
+        >>> from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        >>> data = b"a secret message"
+        >>> aad = b"authenticated but unencrypted data"
+        >>> key = AESGCM.generate_key(bit_length=128)
+        >>> aesgcm = AESGCM(key)
+        >>> nonce = os.urandom(12)
+        >>> ct = aesgcm.encrypt(nonce, data, aad)
+        >>> aesgcm.decrypt(nonce, ct, aad)
+        'a secret message'
+
+    .. classmethod:: generate_key(bit_length)
+
+        Securely generates a random AES-GCM key.
+
+        :param bit_length: The bit length of the key to generate. Must be
+            128, 192, or 256.
+
+        :returns bytes: The generated key.
+
+    .. method:: encrypt(nonce, data, associated_data)
+
+        .. warning::
+
+            Reuse of a ``nonce`` with a given ``key`` compromises the security
+            of any message with that ``nonce`` and ``key`` pair.
+
+        Encrypts and authenticates the ``data`` provided as well as
+        authenticating the ``associated_data``.  The output of this can be
+        passed directly to the ``decrypt`` method.
+
+        :param bytes nonce: NIST `recommends a 96-bit IV length`_ for best
+            performance but it can be up to 2\ :sup:`64` - 1 bits.
+            **NEVER REUSE A NONCE** with a key.
+        :param bytes data: The data to encrypt.
+        :param bytes associated_data: Additional data that should be
+            authenticated with the key, but is not encrypted. Can be ``None``.
+        :returns bytes: The ciphertext bytes with the 16 byte tag appended.
+
+    .. method:: decrypt(nonce, data, associated_data)
+
+        Decrypts the ``data`` and authenticates the ``associated_data``. If you
+        called encrypt with ``associated_data`` you must pass the same
+        ``associated_data`` in decrypt or the integrity check will fail.
+
+        :param bytes nonce: NIST `recommends a 96-bit IV length`_ for best
+            performance but it can be up to 2\ :sup:`64` - 1 bits.
+            **NEVER REUSE A NONCE** with a key.
+        :param bytes data: The data to decrypt (with tag appended).
+        :param bytes associated_data: Additional data to authenticate. Can be
+            ``None`` if none was passed during encryption.
+        :returns bytes: The original plaintext.
+        :raises cryptography.exceptions.InvalidTag: If the authentication tag
+            doesn't validate this exception will be raised. This will occur
+            when the ciphertext has been changed, but will also occur when the
+            key, nonce, or associated data are wrong.
+
 .. class:: AESCCM(key, tag_length=16)
 
     .. versionadded:: 2.0
@@ -152,75 +221,6 @@ also support providing integrity for associated data which is not encrypted.
 
         :param bytes nonce: A value of between 7 and 13 bytes. This
             is the same value used when you originally called encrypt.
-            **NEVER REUSE A NONCE** with a key.
-        :param bytes data: The data to decrypt (with tag appended).
-        :param bytes associated_data: Additional data to authenticate. Can be
-            ``None`` if none was passed during encryption.
-        :returns bytes: The original plaintext.
-        :raises cryptography.exceptions.InvalidTag: If the authentication tag
-            doesn't validate this exception will be raised. This will occur
-            when the ciphertext has been changed, but will also occur when the
-            key, nonce, or associated data are wrong.
-
-.. class:: AESGCM(key)
-
-    .. versionadded:: 2.0
-
-    The AES-GCM construction is composed of the
-    :class:`~cryptography.hazmat.primitives.ciphers.algorithms.AES` block
-    cipher utilizing Galois Counter Mode (GCM).
-
-    :param bytes key: A 128, 192, or 256-bit key. This **must** be kept secret.
-
-    .. doctest::
-
-        >>> import os
-        >>> from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-        >>> data = b"a secret message"
-        >>> aad = b"authenticated but unencrypted data"
-        >>> key = AESGCM.generate_key(bit_length=128)
-        >>> aesgcm = AESGCM(key)
-        >>> nonce = os.urandom(12)
-        >>> ct = aesgcm.encrypt(nonce, data, aad)
-        >>> aesgcm.decrypt(nonce, ct, aad)
-        'a secret message'
-
-    .. classmethod:: generate_key(bit_length)
-
-        Securely generates a random AES-GCM key.
-
-        :param bit_length: The bit length of the key to generate. Must be
-            128, 192, or 256.
-
-        :returns bytes: The generated key.
-
-    .. method:: encrypt(nonce, data, associated_data)
-
-        .. warning::
-
-            Reuse of a ``nonce`` with a given ``key`` compromises the security
-            of any message with that ``nonce`` and ``key`` pair.
-
-        Encrypts and authenticates the ``data`` provided as well as
-        authenticating the ``associated_data``.  The output of this can be
-        passed directly to the ``decrypt`` method.
-
-        :param bytes nonce: NIST `recommends a 96-bit IV length`_ for best
-            performance but it can be up to 2\ :sup:`64` - 1 bits.
-            **NEVER REUSE A NONCE** with a key.
-        :param bytes data: The data to encrypt.
-        :param bytes associated_data: Additional data that should be
-            authenticated with the key, but is not encrypted. Can be ``None``.
-        :returns bytes: The ciphertext bytes with the 16 byte tag appended.
-
-    .. method:: decrypt(nonce, data, associated_data)
-
-        Decrypts the ``data`` and authenticates the ``associated_data``. If you
-        called encrypt with ``associated_data`` you must pass the same
-        ``associated_data`` in decrypt or the integrity check will fail.
-
-        :param bytes nonce: NIST `recommends a 96-bit IV length`_ for best
-            performance but it can be up to 2\ :sup:`64` - 1 bits.
             **NEVER REUSE A NONCE** with a key.
         :param bytes data: The data to decrypt (with tag appended).
         :param bytes associated_data: Additional data to authenticate. Can be

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -294,6 +294,11 @@ Modes
 
     .. danger::
 
+        If you are encrypting data that can fit into memory you should strongly
+        consider using
+        :class:`~cryptography.hazmat.primitives.ciphers.aead.AESGCM` instead
+        of this.
+
         When using this mode you **must** not use the decrypted data until
         the appropriate finalization method
         (:meth:`~cryptography.hazmat.primitives.ciphers.CipherContext.finalize`
@@ -301,6 +306,7 @@ Modes
         :meth:`~cryptography.hazmat.primitives.ciphers.AEADDecryptionContext.finalize_with_tag`)
         has been called. GCM provides **no** guarantees of ciphertext integrity
         until decryption is complete.
+
 
     GCM (Galois Counter Mode) is a mode of operation for block ciphers. An
     AEAD (authenticated encryption with additional data) mode is a type of

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -307,7 +307,6 @@ Modes
         has been called. GCM provides **no** guarantees of ciphertext integrity
         until decryption is complete.
 
-
     GCM (Galois Counter Mode) is a mode of operation for block ciphers. An
     AEAD (authenticated encryption with additional data) mode is a type of
     block cipher mode that simultaneously encrypts the message as well as

--- a/src/cryptography/hazmat/backends/openssl/aead.py
+++ b/src/cryptography/hazmat/backends/openssl/aead.py
@@ -13,13 +13,15 @@ _DECRYPT = 0
 
 def _aead_cipher_name(cipher):
     from cryptography.hazmat.primitives.ciphers.aead import (
-        AESCCM, ChaCha20Poly1305
+        AESCCM, AESGCM, ChaCha20Poly1305
     )
     if isinstance(cipher, ChaCha20Poly1305):
         return b"chacha20-poly1305"
-    else:
-        assert isinstance(cipher, AESCCM)
+    elif isinstance(cipher, AESCCM):
         return "aes-{0}-ccm".format(len(cipher._key) * 8).encode("ascii")
+    else:
+        assert isinstance(cipher, AESGCM)
+        return "aes-{0}-gcm".format(len(cipher._key) * 8).encode("ascii")
 
 
 def _aead_setup(backend, cipher_name, key, nonce, tag, tag_len, operation):

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -118,3 +118,45 @@ class AESCCM(object):
         utils._check_bytes("associated_data", associated_data)
         if not 7 <= len(nonce) <= 13:
             raise ValueError("Nonce must be between 7 and 13 bytes")
+
+
+class AESGCM(object):
+    def __init__(self, key):
+        utils._check_bytes("key", key)
+        if len(key) not in (16, 24, 32):
+            raise ValueError("AESGCM key must be 128, 192, or 256 bits.")
+
+        self._key = key
+
+    @classmethod
+    def generate_key(cls, bit_length):
+        if not isinstance(bit_length, int):
+            raise TypeError("bit_length must be an integer")
+
+        if bit_length not in (128, 192, 256):
+            raise ValueError("bit_length must be 128, 192, or 256")
+
+        return os.urandom(bit_length // 8)
+
+    def encrypt(self, nonce, data, associated_data):
+        if associated_data is None:
+            associated_data = b""
+
+        self._check_params(nonce, data, associated_data)
+        return aead._encrypt(
+            backend, self, nonce, data, associated_data, 16
+        )
+
+    def decrypt(self, nonce, data, associated_data):
+        if associated_data is None:
+            associated_data = b""
+
+        self._check_params(nonce, data, associated_data)
+        return aead._decrypt(
+            backend, self, nonce, data, associated_data, 16
+        )
+
+    def _check_params(self, nonce, data, associated_data):
+        utils._check_bytes("nonce", nonce)
+        utils._check_bytes("data", data)
+        utils._check_bytes("associated_data", associated_data)


### PR DESCRIPTION
Fixes #3784 

I decided to name it `nonce` this time. This makes us inconsistent with the arg naming on the `GCM` mode itself, but I think we should call it a `nonce` since that's what it is. NIST's own GCM document calls it an initialization vector but then ALSO says it is synonymous with nonce.