### PR TITLE
fix wheel building with parameters

### DIFF
--- a/release.py
+++ b/release.py
@@ -123,7 +123,7 @@ def release(version):
 
     token = getpass.getpass("Input the Jenkins token: ")
     response = session.get(
-        "{0}/build".format(JENKINS_URL),
+        "{0}/buildWithParameters".format(JENKINS_URL),
         params={
             "token": token,
             "BUILD_VERSION": version,


### PR DESCRIPTION
refs #3646 

yes, Jenkins really does require you to hit a different endpoint if you have parameters.