### PR TITLE
update wheel builder script for static linking on linux

### DIFF
--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -138,8 +138,7 @@ def build(version, label, imageName) {
                     LDFLAGS="-L/opt/pyca/cryptography/openssl/lib" \
                         CFLAGS="-I/opt/pyca/cryptography/openssl/include" \
                         $linux32 /opt/python/$version/bin/pip wheel cryptography==$BUILD_VERSION -w tmpwheelhouse/ --no-binary cryptography --no-deps
-                    LD_LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" \
-                        $linux32 auditwheel repair tmpwheelhouse/cryptography*.whl -w wheelhouse/
+                    $linux32 auditwheel repair tmpwheelhouse/cryptography*.whl -w wheelhouse/
                     $linux32 /opt/python/$version/bin/pip install cryptography==$BUILD_VERSION --no-index -f wheelhouse/
                     $linux32 /opt/python/$version/bin/python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"
                 """


### PR DESCRIPTION
We don't need to do an LD_LIBRARY_PATH when calling auditwheel because we're now statically linking OpenSSL.

This is blocked on:
* https://github.com/pyca/infra/pull/120
* https://github.com/pyca/infra/issues/121

We should consider doing a 2.0.1 for this probably.