### PR TITLE
backport wheel builder fixes

### DIFF
--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -8,11 +8,11 @@ properties([
 def configs = [
     [
         label: 'windows',
-        versions: ['py26', 'py27', 'py33', 'py34', 'py35', 'py36'],
+        versions: ['py26', 'py27', 'py34', 'py35', 'py36'],
     ],
     [
         label: 'windows64',
-        versions: ['py26', 'py27', 'py33', 'py34', 'py35', 'py36'],
+        versions: ['py26', 'py27', 'py34', 'py35', 'py36'],
     ],
     [
         label: 'sierra',
@@ -46,7 +46,6 @@ def build(version, label, imageName) {
                 def pythonPath = [
                     py26: "C:\\Python26\\python.exe",
                     py27: "C:\\Python27\\python.exe",
-                    py33: "C:\\Python33\\python.exe",
                     py34: "C:\\Python34\\python.exe",
                     py35: "C:\\Python35\\python.exe",
                     py36: "C:\\Python36\\python.exe"

--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -139,8 +139,7 @@ def build(version, label, imageName) {
                     LDFLAGS="-L/opt/pyca/cryptography/openssl/lib" \
                         CFLAGS="-I/opt/pyca/cryptography/openssl/include" \
                         $linux32 /opt/python/$version/bin/pip wheel cryptography==$BUILD_VERSION -w tmpwheelhouse/ --no-binary cryptography --no-deps
-                    LD_LIBRARY_PATH="/opt/pyca/cryptography/openssl/lib" \
-                        $linux32 auditwheel repair tmpwheelhouse/cryptography*.whl -w wheelhouse/
+                    $linux32 auditwheel repair tmpwheelhouse/cryptography*.whl -w wheelhouse/
                     $linux32 /opt/python/$version/bin/pip install cryptography==$BUILD_VERSION --no-index -f wheelhouse/
                     $linux32 /opt/python/$version/bin/python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"
                 """


### PR DESCRIPTION
remove things no longer needed since we're static linking and no longer build py33 wheels