### PR TITLE
Fix weak linking of getentropy when compiling on older macOS

### DIFF
--- a/src/_cffi_src/openssl/src/osrandom_engine.h
+++ b/src/_cffi_src/openssl/src/osrandom_engine.h
@@ -13,6 +13,9 @@
 
   #ifdef __APPLE__
     #include <sys/random.h>
+    /* To support weak linking we need to declare this as a weak import even if
+     * it's not present in sys/random. */
+    extern int getentropy(void* buffer, size_t size) __attribute((weak_import));
   #endif
 
   #ifdef __linux__

--- a/src/_cffi_src/openssl/src/osrandom_engine.h
+++ b/src/_cffi_src/openssl/src/osrandom_engine.h
@@ -14,8 +14,8 @@
   #ifdef __APPLE__
     #include <sys/random.h>
     /* To support weak linking we need to declare this as a weak import even if
-     * it's not present in sys/random. */
-    extern int getentropy(void* buffer, size_t size) __attribute((weak_import));
+     * it's not present in sys/random (e.g. macOS < 10.12). */
+    extern int getentropy(void *buffer, size_t size) __attribute((weak_import));
   #endif
 
   #ifdef __linux__


### PR DESCRIPTION
We use weak linking in macOS to determine if the getentropy symbol is
available. However, to do that we need to have a declaration that states
the function is __attribute((weak_import)) at compile time. On macOS
10.12 this is provided in sys/random.h, but on older macOS the
declaration doesn't exist at all, so we need to forward declare it
ourselves.

refs #3332