### PR TITLE
(mostly) revert wheel builder config change

### DIFF
--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -111,10 +111,8 @@ def build(version, label, imageName) {
                         virtualenv .venv -p ${pythonPath[version]}
                         source .venv/bin/activate
                         pip install -U wheel # upgrade wheel to latest before we use it to build the wheel
-                        CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1"
-                            LDFLAGS="/usr/local/opt/openssl@1.1/lib/libcrypto.a /usr/local/opt/openssl@1.1/lib/libssl.a"
-                            CFLAGS="-I/usr/local/opt/openssl@1.1/include -mmacosx-version-min=10.9"
-                            pip wheel cryptography==$BUILD_VERSION --wheel-dir=wheelhouse --no-binary cryptography
+                        # -mmacosx-version-min=10.9 can be remove when https://github.com/pyca/cryptography/issues/3635 is resolved
+                        CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1" LDFLAGS="/usr/local/opt/openssl@1.1/lib/libcrypto.a /usr/local/opt/openssl@1.1/lib/libssl.a" CFLAGS="-I/usr/local/opt/openssl@1.1/include -mmacosx-version-min=10.9" pip wheel cryptography==$BUILD_VERSION --wheel-dir=wheelhouse --no-binary cryptography
                         pip install -f wheelhouse cryptography --no-index
                         python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"
                         otool -L `find .venv -name '_openssl*.so'`

--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -111,7 +111,6 @@ def build(version, label, imageName) {
                         virtualenv .venv -p ${pythonPath[version]}
                         source .venv/bin/activate
                         pip install -U wheel # upgrade wheel to latest before we use it to build the wheel
-                        # -mmacosx-version-min=10.9 can be remove when https://github.com/pyca/cryptography/issues/3635 is resolved
                         CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1" LDFLAGS="/usr/local/opt/openssl@1.1/lib/libcrypto.a /usr/local/opt/openssl@1.1/lib/libssl.a" CFLAGS="-I/usr/local/opt/openssl@1.1/include -mmacosx-version-min=10.9" pip wheel cryptography==$BUILD_VERSION --wheel-dir=wheelhouse --no-binary cryptography
                         pip install -f wheelhouse cryptography --no-index
                         python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"


### PR DESCRIPTION
This reverts the wheel builder config change that broke our 2.0.3 release. It is not safe to add linebreaks like this. However, that comment is still wrong so we'll still remove it.