### PR TITLE
Fixes #3821 -- improve output during release.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -25,13 +25,8 @@ JENKINS_URL = (
 
 
 def run(*args, **kwargs):
-    kwargs.setdefault("stderr", subprocess.STDOUT)
-    try:
-        subprocess.check_output(list(args), **kwargs)
-    except subprocess.CalledProcessError as e:
-        # Reraise this with a different type so that str(e) is something with
-        # stdout in it.
-        raise Exception(e.cmd, e.returncode, e.output)
+    print("[running] {0}".format(list(args)))
+    subprocess.check_call(list(args), **kwargs)
 
 
 def wait_for_build_completed(session):


### PR DESCRIPTION
This should cause stdout/stderr for command we run to be displayed, and also print which commands we're running