### PR TITLE
change x509 validation to allow parsing of some "bad" certs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changelog
 * Added support for :class:`~cryptography.hazmat.primitives.hashes.SHAKE128`
   and :class:`~cryptography.hazmat.primitives.hashes.SHAKE256` when using
   OpenSSL 1.1.1.
+* Allow parsing of more certificates that are not :rfc:`5280` compliant.
 * Added initial support for parsing PKCS12 files with
   :func:`~cryptography.hazmat.primitives.serialization.pkcs12.load_key_and_certificates`.
 * Added support for :class:`~cryptography.x509.IssuingDistributionPoint`.

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -403,6 +403,8 @@ class CertificateSigningRequestBuilder(object):
             raise TypeError('Expecting x509.Name object.')
         if self._subject_name is not None:
             raise ValueError('The subject name may only be set once.')
+
+        name._validate()
         return CertificateSigningRequestBuilder(name, self._extensions)
 
     def add_extension(self, extension, critical):
@@ -414,6 +416,7 @@ class CertificateSigningRequestBuilder(object):
 
         extension = Extension(extension.oid, critical, extension)
         _reject_duplicate_extension(extension, self._extensions)
+        extension._validate()
 
         return CertificateSigningRequestBuilder(
             self._subject_name, self._extensions + [extension]
@@ -449,6 +452,8 @@ class CertificateBuilder(object):
             raise TypeError('Expecting x509.Name object.')
         if self._issuer_name is not None:
             raise ValueError('The issuer name may only be set once.')
+
+        name._validate()
         return CertificateBuilder(
             name, self._subject_name, self._public_key,
             self._serial_number, self._not_valid_before,
@@ -463,6 +468,8 @@ class CertificateBuilder(object):
             raise TypeError('Expecting x509.Name object.')
         if self._subject_name is not None:
             raise ValueError('The subject name may only be set once.')
+
+        name._validate()
         return CertificateBuilder(
             self._issuer_name, name, self._public_key,
             self._serial_number, self._not_valid_before,
@@ -563,6 +570,7 @@ class CertificateBuilder(object):
 
         extension = Extension(extension.oid, critical, extension)
         _reject_duplicate_extension(extension, self._extensions)
+        extension._validate()
 
         return CertificateBuilder(
             self._issuer_name, self._subject_name,
@@ -609,6 +617,8 @@ class CertificateRevocationListBuilder(object):
             raise TypeError('Expecting x509.Name object.')
         if self._issuer_name is not None:
             raise ValueError('The issuer name may only be set once.')
+
+        issuer_name._validate()
         return CertificateRevocationListBuilder(
             issuer_name, self._last_update, self._next_update,
             self._extensions, self._revoked_certificates
@@ -659,6 +669,8 @@ class CertificateRevocationListBuilder(object):
 
         extension = Extension(extension.oid, critical, extension)
         _reject_duplicate_extension(extension, self._extensions)
+        extension._validate()
+
         return CertificateRevocationListBuilder(
             self._issuer_name, self._last_update, self._next_update,
             self._extensions + [extension], self._revoked_certificates
@@ -733,6 +745,8 @@ class RevokedCertificateBuilder(object):
 
         extension = Extension(extension.oid, critical, extension)
         _reject_duplicate_extension(extension, self._extensions)
+        extension._validate()
+
         return RevokedCertificateBuilder(
             self._serial_number, self._revocation_date,
             self._extensions + [extension]

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -84,12 +84,6 @@ class NameAttribute(object):
                 "value argument must be a text type."
             )
 
-        if (
-            oid in (NameOID.COUNTRY_NAME, NameOID.JURISDICTION_COUNTRY_NAME)
-            and _type == _SENTINEL
-        ):
-            _type = _ASN1Type.PrintableString
-
         # The appropriate ASN1 string type varies by OID and is defined across
         # multiple RFCs including 2459, 3280, and 5280. In general UTF8String
         # is preferred (2459), but 3280 and 5280 specify several OIDs with

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -85,16 +85,10 @@ class NameAttribute(object):
             )
 
         if (
-            oid == NameOID.COUNTRY_NAME or
-            oid == NameOID.JURISDICTION_COUNTRY_NAME
+            oid in (NameOID.COUNTRY_NAME, NameOID.JURISDICTION_COUNTRY_NAME)
+            and _type == _SENTINEL
         ):
-            if len(value.encode("utf8")) != 2:
-                raise ValueError(
-                    "Country name must be a 2 character country code"
-                )
-
-        if len(value) == 0:
-            raise ValueError("Value cannot be an empty string")
+            _type = _ASN1Type.PrintableString
 
         # The appropriate ASN1 string type varies by OID and is defined across
         # multiple RFCs including 2459, 3280, and 5280. In general UTF8String
@@ -124,6 +118,21 @@ class NameAttribute(object):
         """
         key = _NAMEOID_TO_NAME.get(self.oid, self.oid.dotted_string)
         return '%s=%s' % (key, _escape_dn_value(self.value))
+
+    def _validate(self):
+        if len(self.value) == 0:
+            raise ValueError(
+                "Value cannot be an empty string. OID: "
+                "{0}".format(self.oid)
+            )
+
+        if (
+            self.oid == NameOID.COUNTRY_NAME and
+            len(self.value.encode("utf8")) != 2
+        ):
+            raise ValueError(
+                "Country name must be a 2 character country code"
+            )
 
     def __eq__(self, other):
         if not isinstance(other, NameAttribute):
@@ -229,6 +238,11 @@ class Name(object):
 
     def public_bytes(self, backend):
         return backend.x509_name_bytes(self)
+
+    def _validate(self):
+        for rdn in self._attributes:
+            for name_attribute in rdn:
+                name_attribute._validate()
 
     def __eq__(self, other):
         if not isinstance(other, Name):

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -41,6 +41,26 @@ class TestCertificateRevocationListBuilder(object):
 
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)
+    def test_calls_validators(self, backend):
+        builder = x509.CertificateRevocationListBuilder()
+        with pytest.raises(ValueError):
+            builder.issuer_name(x509.Name([
+                x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u'Texas'),
+                x509.NameAttribute(NameOID.COUNTRY_NAME, u'United States'),
+            ]))
+
+        with pytest.raises(ValueError):
+            builder.issuer_name(x509.Name([
+                x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u''),
+            ]))
+
+        with pytest.raises(ValueError):
+            builder.add_extension(
+                x509.BasicConstraints(ca=False, path_length=1), True,
+            )
+
+    @pytest.mark.requires_backend_interface(interface=RSABackend)
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
     def test_aware_last_update(self, backend):
         last_time = datetime.datetime(2012, 1, 16, 22, 43)
         tz = pytz.timezone("US/Pacific")

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -1191,8 +1191,9 @@ class TestBasicConstraints(object):
             x509.BasicConstraints(ca="notbool", path_length=None)
 
     def test_path_length_not_ca(self):
+        bc = x509.BasicConstraints(ca=False, path_length=0)
         with pytest.raises(ValueError):
-            x509.BasicConstraints(ca=False, path_length=0)
+            bc._validate()
 
     def test_path_length_not_int(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
We now validate on these fields when adding the objects to the CertificateBuilder.

This PR does not attempt to migrate all validation logic. Each extension has logic that may be specific to Python or enforcement of an RFC restriction. Before migrating more logic I'd like to see examples of certificates that encode things in that specific invalid way.

Fixes #3857 and #3856 