### PR TITLE
x509: Add support for literal IPv6 in URI GeneralNames

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -93,11 +93,8 @@ def _decode_general_name(backend, gn):
         data = _asn1_string_to_ascii(backend, gn.d.uniformResourceIdentifier)
         parsed = urllib_parse.urlparse(data)
         if parsed.hostname:
-            if parsed.netloc[0] == '[' and ']' in parsed.netloc:
-                # TODO: support optional "vX." prefix ?
-                # ...or just ignore the content and assume it to be non-hostname (so non-idna) anyway ?
-                ipaddress.IPv6Address(parsed.hostname.decode('ascii'))
-                hostname = '[' + parsed.hostname + ']'
+            if parsed.netloc[0] == u'[' and u']' in parsed.netloc:
+                hostname = u'[' + parsed.hostname + u']'
             else:
                 try:
                     ipaddress.IPv4Address(six.text_type(parsed.hostname))

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -93,7 +93,18 @@ def _decode_general_name(backend, gn):
         data = _asn1_string_to_ascii(backend, gn.d.uniformResourceIdentifier)
         parsed = urllib_parse.urlparse(data)
         if parsed.hostname:
-            hostname = idna.decode(parsed.hostname)
+            if parsed.netloc[0] == '[' and ']' in parsed.netloc:
+                # TODO: support optional "vX." prefix ?
+                # ...or just ignore the content and assume it to be non-hostname (so non-idna) anyway ?
+                ipaddress.IPv6Address(parsed.hostname.decode('ascii'))
+                hostname = '[' + parsed.hostname + ']'
+            else:
+                try:
+                    ipaddress.IPv4Address(six.text_type(parsed.hostname))
+                except ValueError:
+                    hostname = idna.decode(parsed.hostname)
+                else:
+                    hostname = parsed.hostname
         else:
             hostname = ""
         if parsed.port:

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -300,7 +300,7 @@ class UniformResourceIdentifier(object):
         if not isinstance(other, UniformResourceIdentifier):
             return NotImplemented
 
-        return self.value == other.value
+        return self.bytes_value == other.bytes_value
 
     def __ne__(self, other):
         return not self == other

--- a/tests/test_x509_ext.py
+++ b/tests/test_x509_ext.py
@@ -1571,6 +1571,11 @@ class TestUniformResourceIdentifier(object):
         assert gn != gn2
         assert gn != object()
         assert gn == gn3
+        # Also deprecated value property
+        with pytest.warns(utils.DeprecatedIn21):
+            assert gn.value != gn2.value
+            assert gn.value != object()
+            assert gn.value == gn3.value
 
     def test_not_text_or_bytes(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes #3863 .

Note: `x509.UniformResourceIdentifier.value` duplicates hostname parsing, making test fail. As `value` is marked as deprecated and, in test context, only accessed from `__eq__`, I work around this limitation by accessing the non-deprecated `bytes_value` property. Should I also fix `value` ?