### PR TITLE
Fix `load_rsa_public_numbers` documentation

### DIFF
--- a/docs/hazmat/backends/interfaces.rst
+++ b/docs/hazmat/backends/interfaces.rst
@@ -266,7 +266,7 @@ A specific ``backend`` may provide one or more of these interfaces.
     .. method:: load_rsa_public_numbers(numbers)
 
         :param numbers: An instance of
-            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`.
+            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicNumbers`.
 
         :returns: An instance of
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`.


### PR DESCRIPTION
`load_rsa_public_numbers` takes an `RSAPublicNumbers` object as the name implies, not an `RSAPrivateNumbers`.