### PR TITLE
add blake2b/blake2s support for hmac

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,9 @@ Changelog
   raw value.
 * Added :meth:`~cryptography.x509.CertificateRevocationList.is_signature_valid`
   to :class:`~cryptography.x509.CertificateRevocationList`.
+* Support :class:`~cryptography.hazmat.primitives.hashes.BLAKE2b` and
+  :class:`~cryptography.hazmat.primitives.hashes.BLAKE2s` with
+  :class:`~cryptography.hazmat.primitives.hmac.HMAC`.
 
 
 .. _v2-0-3:

--- a/src/cryptography/hazmat/backends/openssl/hmac.py
+++ b/src/cryptography/hazmat/backends/openssl/hmac.py
@@ -25,12 +25,11 @@ class _HMACContext(object):
             ctx = self._backend._ffi.gc(
                 ctx, self._backend._lib.Cryptography_HMAC_CTX_free
             )
-            evp_md = self._backend._lib.EVP_get_digestbyname(
-                algorithm.name.encode('ascii'))
+            name = self._backend._build_openssl_digest_name(algorithm)
+            evp_md = self._backend._lib.EVP_get_digestbyname(name)
             if evp_md == self._backend._ffi.NULL:
                 raise UnsupportedAlgorithm(
-                    "{0} is not a supported hash on this backend.".format(
-                        algorithm.name),
+                    "{0} is not a supported hash on this backend".format(name),
                     _Reasons.UNSUPPORTED_HASH
                 )
             res = self._backend._lib.HMAC_Init_ex(

--- a/tests/hazmat/primitives/test_hmac_vectors.py
+++ b/tests/hazmat/primitives/test_hmac_vectors.py
@@ -123,7 +123,7 @@ class TestHMACBLAKE2(object):
         h = hmac.HMAC(b"0" * 64, hashes.BLAKE2b(digest_size=64), backend)
         h.update(b"test")
         digest = h.finalize()
-        digest == binascii.unhexlify(
+        assert digest == binascii.unhexlify(
             b"b5319122f8a24ba134a0c9851922448104e25be5d1b91265c0c68b22722f0f29"
             b"87dba4aeaa69e6bed7edc44f48d6b1be493a3ce583f9c737c53d6bacc09e2f32"
         )
@@ -132,6 +132,6 @@ class TestHMACBLAKE2(object):
         h = hmac.HMAC(b"0" * 32, hashes.BLAKE2s(digest_size=32), backend)
         h.update(b"test")
         digest = h.finalize()
-        digest == binascii.unhexlify(
+        assert digest == binascii.unhexlify(
             b"51477cc5bdf1faf952cf97bb934ee936de1f4d5d7448a84eeb6f98d23b392166"
         )

--- a/tests/hazmat/primitives/test_hmac_vectors.py
+++ b/tests/hazmat/primitives/test_hmac_vectors.py
@@ -4,10 +4,12 @@
 
 from __future__ import absolute_import, division, print_function
 
+import binascii
+
 import pytest
 
 from cryptography.hazmat.backends.interfaces import HMACBackend
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, hmac
 
 from .utils import generate_hmac_test
 from ...utils import load_hash_vectors
@@ -107,3 +109,29 @@ class TestHMACSHA512(object):
         ],
         hashes.SHA512(),
     )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.hmac_supported(hashes.BLAKE2b(
+        digest_size=64
+    )),
+    skip_message="Does not support BLAKE2",
+)
+@pytest.mark.requires_backend_interface(interface=HMACBackend)
+class TestHMACBLAKE2(object):
+    def test_blake2b(self, backend):
+        h = hmac.HMAC(b"0" * 64, hashes.BLAKE2b(digest_size=64), backend)
+        h.update(b"test")
+        digest = h.finalize()
+        digest == binascii.unhexlify(
+            b"b5319122f8a24ba134a0c9851922448104e25be5d1b91265c0c68b22722f0f29"
+            b"87dba4aeaa69e6bed7edc44f48d6b1be493a3ce583f9c737c53d6bacc09e2f32"
+        )
+
+    def test_blake2s(self, backend):
+        h = hmac.HMAC(b"0" * 32, hashes.BLAKE2s(digest_size=32), backend)
+        h.update(b"test")
+        digest = h.finalize()
+        digest == binascii.unhexlify(
+            b"51477cc5bdf1faf952cf97bb934ee936de1f4d5d7448a84eeb6f98d23b392166"
+        )


### PR DESCRIPTION
This was a bug, but it turns out the noise protocol suggests using the HMAC construction with BLAKE2 (rather than BLAKE2's own keyed functionality) for a few reasons, so we should support it.

Fixes #3869 