### PR TITLE
add OCSP binding for obtaining information from CertID structure

### DIFF
--- a/src/_cffi_src/openssl/ocsp.py
+++ b/src/_cffi_src/openssl/ocsp.py
@@ -54,6 +54,8 @@ OCSP_REQUEST *OCSP_REQUEST_new(void);
 void OCSP_REQUEST_free(OCSP_REQUEST *);
 int OCSP_request_add1_nonce(OCSP_REQUEST *, unsigned char *, int);
 int OCSP_REQUEST_add1_ext_i2d(OCSP_REQUEST *, int, void *, int, unsigned long);
+int OCSP_id_get0_info(ASN1_OCTET_STRING **, ASN1_OBJECT **,
+                      ASN1_OCTET_STRING **, ASN1_INTEGER **, OCSP_CERTID *);
 OCSP_REQUEST *d2i_OCSP_REQUEST_bio(BIO *, OCSP_REQUEST **);
 OCSP_RESPONSE *d2i_OCSP_RESPONSE_bio(BIO *, OCSP_RESPONSE **);
 int i2d_OCSP_REQUEST_bio(BIO *, OCSP_REQUEST *);


### PR DESCRIPTION
refs #3887 

Needed to fully parse a request.