### PR TITLE
implement __hash__ on all GeneralName types

### DIFF
--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -123,7 +123,7 @@ class RFC822Name(object):
         return not self == other
 
     def __hash__(self):
-        return hash(self.value)
+        return hash(self.bytes_value)
 
 
 def _idna_encode(value):
@@ -204,6 +204,9 @@ class DNSName(object):
 
     def __ne__(self, other):
         return not self == other
+
+    def __hash__(self):
+        return hash(self.bytes_value)
 
 
 @utils.register_interface(GeneralName)
@@ -306,7 +309,7 @@ class UniformResourceIdentifier(object):
         return not self == other
 
     def __hash__(self):
-        return hash(self.value)
+        return hash(self.bytes_value)
 
 
 @utils.register_interface(GeneralName)
@@ -331,6 +334,9 @@ class DirectoryName(object):
     def __ne__(self, other):
         return not self == other
 
+    def __hash__(self):
+        return hash(self.value)
+
 
 @utils.register_interface(GeneralName)
 class RegisteredID(object):
@@ -353,6 +359,9 @@ class RegisteredID(object):
 
     def __ne__(self, other):
         return not self == other
+
+    def __hash__(self):
+        return hash(self.value)
 
 
 @utils.register_interface(GeneralName)
@@ -389,6 +398,9 @@ class IPAddress(object):
     def __ne__(self, other):
         return not self == other
 
+    def __hash__(self):
+        return hash(self.value)
+
 
 @utils.register_interface(GeneralName)
 class OtherName(object):
@@ -416,3 +428,6 @@ class OtherName(object):
 
     def __ne__(self, other):
         return not self == other
+
+    def __hash__(self):
+        return hash((self.type_id, self.value))

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -1525,6 +1525,13 @@ class TestDNSName(object):
         assert n1 != n2
         assert not (n2 != n3)
 
+    def test_hash(self):
+        n1 = x509.DNSName(b"test1")
+        n2 = x509.DNSName(b"test2")
+        n3 = x509.DNSName(b"test2")
+        assert hash(n1) != hash(n2)
+        assert hash(n2) == hash(n3)
+
 
 class TestDirectoryName(object):
     def test_not_name(self):
@@ -1570,6 +1577,19 @@ class TestDirectoryName(object):
         gn2 = x509.DirectoryName(name2)
         assert gn != gn2
         assert gn != object()
+
+    def test_hash(self):
+        name = x509.Name([
+            x509.NameAttribute(x509.ObjectIdentifier('2.999.1'), u'value1')
+        ])
+        name2 = x509.Name([
+            x509.NameAttribute(x509.ObjectIdentifier('2.999.2'), u'value2')
+        ])
+        gn = x509.DirectoryName(name)
+        gn2 = x509.DirectoryName(name)
+        gn3 = x509.DirectoryName(name2)
+        assert hash(gn) == hash(gn2)
+        assert hash(gn) != hash(gn3)
 
 
 class TestRFC822Name(object):
@@ -1728,6 +1748,13 @@ class TestRegisteredID(object):
         assert gn != gn2
         assert gn != object()
 
+    def test_hash(self):
+        gn = x509.RegisteredID(NameOID.COMMON_NAME)
+        gn2 = x509.RegisteredID(NameOID.COMMON_NAME)
+        gn3 = x509.RegisteredID(ExtensionOID.BASIC_CONSTRAINTS)
+        assert hash(gn) == hash(gn2)
+        assert hash(gn) != hash(gn3)
+
 
 class TestIPAddress(object):
     def test_not_ipaddress(self):
@@ -1760,6 +1787,13 @@ class TestIPAddress(object):
         gn2 = x509.IPAddress(ipaddress.IPv4Address(u"127.0.0.2"))
         assert gn != gn2
         assert gn != object()
+
+    def test_hash(self):
+        gn = x509.IPAddress(ipaddress.IPv4Address(u"127.0.0.1"))
+        gn2 = x509.IPAddress(ipaddress.IPv4Address(u"127.0.0.1"))
+        gn3 = x509.IPAddress(ipaddress.IPv4Address(u"127.0.0.2"))
+        assert hash(gn) == hash(gn2)
+        assert hash(gn) != hash(gn3)
 
 
 class TestOtherName(object):
@@ -1809,6 +1843,13 @@ class TestOtherName(object):
 
         gn2 = x509.OtherName(x509.ObjectIdentifier("1.2.3.5"), b"derdata")
         assert gn != gn2
+
+    def test_hash(self):
+        gn = x509.OtherName(x509.ObjectIdentifier("1.2.3.4"), b"derdata")
+        gn2 = x509.OtherName(x509.ObjectIdentifier("1.2.3.4"), b"derdata")
+        gn3 = x509.OtherName(x509.ObjectIdentifier("1.2.3.5"), b"derdata")
+        assert hash(gn) == hash(gn2)
+        assert hash(gn) != hash(gn3)
 
 
 class TestGeneralNames(object):


### PR DESCRIPTION
Needed to implement `__hash__` on AuthorityKeyIdentifier

I also noticed that some of our hash implementations are just hashing a single byte string, which means a trivial hash collision is possible if, for whatever reason, a user puts an instance of that object in a dict with the byte string itself. I've gone ahead and made the hash a tuple of `(type(self), self.value)` here -- should we do that everywhere or back it out on this PR?