### PR TITLE
fix a bug with URI value when parsing a string with no hostname

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -102,7 +102,8 @@ def _decode_general_name(backend, gn):
         if parsed.hostname:
             hostname = idna.decode(parsed.hostname)
         else:
-            hostname = ""
+            # There's no IDNA so we can immediately return
+            return x509.UniformResourceIdentifier(data)
         if parsed.port:
             netloc = hostname + u":" + six.text_type(parsed.port)
         else:

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -271,7 +271,8 @@ class UniformResourceIdentifier(object):
         )
         parsed = urllib_parse.urlparse(self.bytes_value)
         if not parsed.hostname:
-            netloc = ""
+            # There's no idna here so we can immediately return
+            return self.bytes_value.decode("utf-8")
         elif parsed.port:
             netloc = idna.decode(parsed.hostname) + ":{0}".format(parsed.port)
         else:

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -1669,10 +1669,11 @@ class TestUniformResourceIdentifier(object):
             b"gopher://xn--80ato2c.cryptography:70/some/path"
         )
 
-    def test_empty_string(self):
-        gn = x509.UniformResourceIdentifier(b"")
+    def test_empty_hostname(self):
+        gn = x509.UniformResourceIdentifier(b"ldap:///some-nonsense")
+        assert gn.bytes_value == b"ldap:///some-nonsense"
         with pytest.warns(utils.DeprecatedIn21):
-            assert gn.value == u""
+            assert gn.value == "ldap:///some-nonsense"
 
     def test_query_and_fragment(self):
         gn = x509.UniformResourceIdentifier(
@@ -3778,7 +3779,7 @@ class TestCRLDistributionPointsExtension(object):
         assert cdps == x509.CRLDistributionPoints([
             x509.DistributionPoint(
                 full_name=[x509.UniformResourceIdentifier(
-                    u"ldap:/CN=A,OU=B,dc=C,DC=D?E?F?G?H=I"
+                    b"ldap:///CN=A,OU=B,dc=C,DC=D?E?F?G?H=I"
                 )],
                 relative_name=None,
                 reasons=None,


### PR DESCRIPTION
strings of the form "scheme:///anything" would incorrectly have two slashes dropped. This is fixed in two code paths in this PR but one of those code paths will be entirely removed in a followup PR.

#3905 found this bug in combination with the switch to comparing against `bytes_value` rather than parsing it first and then comparing the parsed version thereafter.