### PR TITLE
add aki hash

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -216,7 +216,7 @@ class AuthorityKeyIdentifier(object):
     def __hash__(self):
         return hash((
             self.key_identifier,
-            self.authority_cert_issuer,
+            str(self.authority_cert_issuer),
             self.authority_cert_serial_number
         ))
 

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -213,6 +213,13 @@ class AuthorityKeyIdentifier(object):
     def __ne__(self, other):
         return not self == other
 
+    def __hash__(self):
+        return hash((
+            self.key_identifier,
+            self.authority_cert_issuer,
+            self.authority_cert_serial_number
+        ))
+
     key_identifier = utils.read_only_property("_key_identifier")
     authority_cert_issuer = utils.read_only_property("_authority_cert_issuer")
     authority_cert_serial_number = utils.read_only_property(

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -214,10 +214,12 @@ class AuthorityKeyIdentifier(object):
         return not self == other
 
     def __hash__(self):
+        if self.authority_cert_issuer is None:
+            aci = None
+        else:
+            aci = tuple(self.authority_cert_issuer)
         return hash((
-            self.key_identifier,
-            str(self.authority_cert_issuer),
-            self.authority_cert_serial_number
+            self.key_identifier, aci, self.authority_cert_serial_number
         ))
 
     key_identifier = utils.read_only_property("_key_identifier")

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -1025,6 +1025,9 @@ class TestAuthorityKeyIdentifier(object):
         assert aki != object()
 
     def test_hash(self):
+        dirname = x509.DirectoryName(
+            x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, u'myCN')])
+        )
         aki1 = x509.AuthorityKeyIdentifier(b"digest", [dirname], 1234)
         aki2 = x509.AuthorityKeyIdentifier(b"digest", [dirname], 1234)
         aki3 = x509.AuthorityKeyIdentifier(b"digest", None, None)

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -907,7 +907,6 @@ class TestSubjectKeyIdentifier(object):
         ski3 = x509.SubjectKeyIdentifier(
             binascii.unhexlify(b"aa8098456f6ff7ff3ac9092384932230498bc980")
         )
-
         assert hash(ski1) == hash(ski2)
         assert hash(ski1) != hash(ski3)
 
@@ -1024,6 +1023,13 @@ class TestAuthorityKeyIdentifier(object):
         assert aki != aki4
         assert aki != aki5
         assert aki != object()
+
+    def test_hash(self):
+        aki1 = x509.AuthorityKeyIdentifier(b"digest", [dirname], 1234)
+        aki2 = x509.AuthorityKeyIdentifier(b"digest", [dirname], 1234)
+        aki3 = x509.AuthorityKeyIdentifier(b"digest", None, None)
+        assert hash(aki1) == hash(aki2)
+        assert hash(aki1) != hash(aki3)
 
 
 class TestBasicConstraints(object):


### PR DESCRIPTION
This is #3655 but for some reason rebasing and force pushing to that branch closed the PR. Here it is now that all general names have `__hash__`