### PR TITLE
AIA hashing

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -284,6 +284,9 @@ class AuthorityInformationAccess(object):
     def __getitem__(self, idx):
         return self._descriptions[idx]
 
+    def __hash__(self):
+        return hash(tuple(self._descriptions))
+
 
 class AccessDescription(object):
     def __init__(self, access_method, access_location):

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -2749,6 +2749,40 @@ class TestAuthorityInformationAccess(object):
         assert aia[-1] == aia[4]
         assert aia[2:6:2] == [aia[2], aia[4]]
 
+    def test_hash(self):
+        aia = x509.AuthorityInformationAccess([
+            x509.AccessDescription(
+                AuthorityInformationAccessOID.OCSP,
+                x509.UniformResourceIdentifier(b"http://ocsp.domain.com")
+            ),
+            x509.AccessDescription(
+                AuthorityInformationAccessOID.CA_ISSUERS,
+                x509.UniformResourceIdentifier(b"http://domain.com/ca.crt")
+            )
+        ])
+        aia2 = x509.AuthorityInformationAccess([
+            x509.AccessDescription(
+                AuthorityInformationAccessOID.OCSP,
+                x509.UniformResourceIdentifier(b"http://ocsp.domain.com")
+            ),
+            x509.AccessDescription(
+                AuthorityInformationAccessOID.CA_ISSUERS,
+                x509.UniformResourceIdentifier(b"http://domain.com/ca.crt")
+            )
+        ])
+        aia3 = x509.AuthorityInformationAccess([
+            x509.AccessDescription(
+                AuthorityInformationAccessOID.OCSP,
+                x509.UniformResourceIdentifier(b"http://ocsp.other.com")
+            ),
+            x509.AccessDescription(
+                AuthorityInformationAccessOID.CA_ISSUERS,
+                x509.UniformResourceIdentifier(b"http://domain.com/ca.crt")
+            )
+        ])
+        assert hash(aia) == hash(aia2)
+        assert hash(aia) != hash(aia3)
+
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)


### PR DESCRIPTION
refs #2578

(I'm tired of that issue sitting there)

descriptions must be a list of AccessDescription objects, which already have `__hash__`.