### PR TITLE
Expose FIPS funcs for OpenSSL.

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -76,6 +76,7 @@ ffi = build_ffi_for_binding(
         "engine",
         "err",
         "evp",
+        "fips",
         "hmac",
         "nid",
         "objects",

--- a/src/_cffi_src/openssl/fips.py
+++ b/src/_cffi_src/openssl/fips.py
@@ -1,0 +1,30 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+INCLUDES = """
+#include <openssl/crypto.h>
+"""
+
+TYPES = """
+static const long Cryptography_HAS_FIPS;
+"""
+
+FUNCTIONS = """
+int FIPS_mode_set(int);
+int FIPS_mode(void);
+void FIPS_selftest_check(void);
+"""
+
+CUSTOMIZATIONS = """
+#ifdef OPENSSL_FIPS
+static const long Cryptography_HAS_FIPS = 1;
+# else
+static const long Cryptography_HAS_FIPS = 0;
+int (*FIPS_mode_set)(int) = NULL;
+int (*FIPS_mode)(void) = NULL;
+void (*FIPS_selftest_check)(void) = NULL;
+#endif
+"""

--- a/src/_cffi_src/openssl/fips.py
+++ b/src/_cffi_src/openssl/fips.py
@@ -14,7 +14,6 @@ TYPES = """
 FUNCTIONS = """
 int FIPS_mode_set(int);
 int FIPS_mode(void);
-void FIPS_selftest_check(void);
 """
 
 CUSTOMIZATIONS = """

--- a/src/_cffi_src/openssl/fips.py
+++ b/src/_cffi_src/openssl/fips.py
@@ -9,6 +9,7 @@ INCLUDES = """
 """
 
 TYPES = """
+static const long Cryptography_HAS_FIPS;
 """
 
 FUNCTIONS = """
@@ -17,4 +18,11 @@ int FIPS_mode(void);
 """
 
 CUSTOMIZATIONS = """
+#if CRYPTOGRAPHY_IS_LIBRESSL
+static const long Cryptography_HAS_FIPS = 0;
+int (*FIPS_mode_set)(int) = NULL;
+int (*FIPS_mode)(void) = NULL;
+#else
+static const long Cryptography_HAS_FIPS = 1;
+#endif
 """

--- a/src/_cffi_src/openssl/fips.py
+++ b/src/_cffi_src/openssl/fips.py
@@ -9,7 +9,6 @@ INCLUDES = """
 """
 
 TYPES = """
-static const long Cryptography_HAS_FIPS;
 """
 
 FUNCTIONS = """
@@ -19,12 +18,4 @@ void FIPS_selftest_check(void);
 """
 
 CUSTOMIZATIONS = """
-#ifdef OPENSSL_FIPS
-static const long Cryptography_HAS_FIPS = 1;
-# else
-static const long Cryptography_HAS_FIPS = 0;
-int (*FIPS_mode_set)(int) = NULL;
-int (*FIPS_mode)(void) = NULL;
-void (*FIPS_selftest_check)(void) = NULL;
-#endif
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -243,6 +243,13 @@ def cryptography_has_evp_pkey_get_set_tls_encodedpoint():
     ]
 
 
+def cryptography_has_fips():
+    return [
+        "FIPS_set_mode",
+        "FIPS_mode",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -292,4 +299,5 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_EVP_PKEY_get_set_tls_encodedpoint": (
         cryptography_has_evp_pkey_get_set_tls_encodedpoint
     ),
+    "Cryptography_HAS_FIPS": cryptography_has_fips,
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -243,6 +243,14 @@ def cryptography_has_evp_pkey_get_set_tls_encodedpoint():
     ]
 
 
+def cryptography_has_fips():
+    return [
+        "FIPS_set_mode",
+        "FIPS_mode",
+        "FIPS_selftest_check",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -292,4 +300,5 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_EVP_PKEY_get_set_tls_encodedpoint": (
         cryptography_has_evp_pkey_get_set_tls_encodedpoint
     ),
+    "Cryptography_HAS_FIPS": cryptography_has_fips,
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -243,14 +243,6 @@ def cryptography_has_evp_pkey_get_set_tls_encodedpoint():
     ]
 
 
-def cryptography_has_fips():
-    return [
-        "FIPS_set_mode",
-        "FIPS_mode",
-        "FIPS_selftest_check",
-    ]
-
-
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -300,5 +292,4 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_EVP_PKEY_get_set_tls_encodedpoint": (
         cryptography_has_evp_pkey_get_set_tls_encodedpoint
     ),
-    "Cryptography_HAS_FIPS": cryptography_has_fips,
 }


### PR DESCRIPTION
While the merits of FIPS can certainly be debated, it would be nice if FIPS mode could be set if the backend library supports the option.  The following MR should enable that functionality.

If FIPS will never be accepted into the Cryptography library, is there a method that would enable this via some build-time parameters?