### PR TITLE
Declare that 2.1 is the last version to support Python 2.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Python 2.6 support is deprecated, and will be removed in the next release of
+  ``cryptography``.
 * **BACKWARDS INCOMPATIBLE:** ``Whirlpool``, ``RIPEMD160``, and
   ``UnsupportedExtension`` have been removed in accordance with our
   :doc:`/api-stability` policy.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
-* Python 2.6 support is deprecated, and will be removed in the next release of
-  ``cryptography``.
+* **FINAL DEPRECATION** Python 2.6 support is deprecated, and will be removed
+  in the next release of ``cryptography``.
 * **BACKWARDS INCOMPATIBLE:** ``Whirlpool``, ``RIPEMD160``, and
   ``UnsupportedExtension`` have been removed in accordance with our
   :doc:`/api-stability` policy.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,8 +22,8 @@ PyPy 5.3+ on these operating systems.
 * 32-bit and 64-bit Python on 64-bit Windows Server 2012
 
 .. warning::
-    Python 2.6 is no longer supported by the Python core team. A future version
-    of cryptography will drop support for this version.
+    Python 2.6 is no longer supported by the Python core team. The next release
+    of ``cryptography`` will drop support for Python 2.6.
 
 We test compiling with ``clang`` as well as ``gcc`` and use the following
 OpenSSL releases:

--- a/src/cryptography/__init__.py
+++ b/src/cryptography/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 if sys.version_info[:2] == (2, 6):
     warnings.warn(
         "Python 2.6 is no longer supported by the Python core team, please "
-        "upgrade your Python. A future version of cryptography will drop "
+        "upgrade your Python. The next version of cryptography will drop "
         "support for Python 2.6",
         DeprecationWarning
     )


### PR DESCRIPTION
FYI: @bitprophet, @glyph, @hynek, @Lukasa, @abadger, @bmw

Our current plan is 3-fold:

1) 2.1 will be the last release of cryptography to support Python 2.6;
2) If there is a need for a security release, we will backport it to 2.1 through the end of 2017
3) We'll help the certbot team land https://github.com/certbot/certbot/issues/2208 which should remove the majority of our downloads from 2.6

This is based on the dwindling rate of 2.6 users, and an increasing maintenance burden.