### PR TITLE
disable smart quotes in sphinx to workaround a spellchecker issue

### DIFF
--- a/docs/docutils.conf
+++ b/docs/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+smart_quotes: no

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ setup(
             "doc8",
             "pyenchant >= 1.6.11",
             "readme_renderer >= 16.0",
-            "sphinx != 1.6.1, != 1.6.2, != 1.6.3, != 1.6.4",
+            "sphinx",
             "sphinx_rtd_theme",
             "sphinxcontrib-spelling",
         ],


### PR DESCRIPTION
This makes it so we don't have to pin sphinx while we wait for sphinxcontrib-spelling to handle smart quotes.

Refs https://github.com/sphinx-contrib/spelling/issues/1

Obviates #3545 