### PR TITLE
do downstream builds as part of our normal parallel jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -363,15 +363,12 @@ builders["setup.py-test"] = {
     }
 }
 
-parallel builders
-
-def downstreamBuilders = [:]
 for (downstream in downstreams) {
     def downstreamName = downstream["downstreamName"]
     def imageName = downstream["imageName"]
     def label = downstream["label"]
     def script = downstream["script"]
-    downstreamBuilders[downstreamName] = {
+    builders[downstreamName] = {
         node(label) {
             docker.image(imageName).inside {
                 try {
@@ -387,6 +384,5 @@ for (downstream in downstreams) {
     }
 }
 
-stage("Downstreams") {
-    parallel downstreamBuilders
-}
+parallel builders
+


### PR DESCRIPTION
When we originally added our Jenkinsfile we decided to be fancy with our downstreams where we only execute them after all the other tests pass. However, it turns out that was a bad choice and just slows us down. When we have a lot of jobs we end up waiting a long time because the downstream jobs get added to the end of the queue, and when we have only one job we pointlessly leave capacity unused. So, let's stop doing that!