### PR TITLE
Backwards incompatible change to DNSName

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -611,7 +611,7 @@ X.509 Certificate Builder
         >>> builder = builder.public_key(public_key)
         >>> builder = builder.add_extension(
         ...     x509.SubjectAlternativeName(
-        ...         [x509.DNSName(b'cryptography.io')]
+        ...         [x509.DNSName(u'cryptography.io')]
         ...     ),
         ...     critical=False
         ... )

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -88,7 +88,10 @@ def _decode_general_names(backend, gns):
 
 def _decode_general_name(backend, gn):
     if gn.type == backend._lib.GEN_DNS:
-        data = _asn1_string_to_utf8(backend, gn.d.dNSName)
+        # Convert to bytes and then decode to utf8. We don't use
+        # asn1_string_to_utf8 here because it doesn't properly convert
+        # utf8 from ia5strings.
+        data = _asn1_string_to_bytes(backend, gn.d.dNSName).decode("utf8")
         # We don't use the constructor for DNSName so we can bypass validation
         # This allows us to create DNSName objects that have unicode chars
         # when a certificate (against the RFC) contains them.

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -88,8 +88,11 @@ def _decode_general_names(backend, gns):
 
 def _decode_general_name(backend, gn):
     if gn.type == backend._lib.GEN_DNS:
-        data = _asn1_string_to_bytes(backend, gn.d.dNSName)
-        return x509.DNSName(data)
+        data = _asn1_string_to_utf8(backend, gn.d.dNSName)
+        # We don't use the constructor for DNSName so we can bypass validation
+        # This allows us to create DNSName objects that have unicode chars
+        # when a certificate (against the RFC) contains them.
+        return x509.DNSName._init_without_validation(data)
     elif gn.type == backend._lib.GEN_URI:
         data = _asn1_string_to_bytes(backend, gn.d.uniformResourceIdentifier)
         return x509.UniformResourceIdentifier(data)

--- a/src/cryptography/hazmat/backends/openssl/encode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/encode_asn1.py
@@ -368,7 +368,8 @@ def _encode_general_name(backend, name):
 
         ia5 = backend._lib.ASN1_IA5STRING_new()
         backend.openssl_assert(ia5 != backend._ffi.NULL)
-        value = name.bytes_value
+        # TODO: do we want to allow RFC violating utf8 encodes?
+        value = name.value.encode("utf8")
 
         res = backend._lib.ASN1_STRING_set(ia5, value, len(value))
         backend.openssl_assert(res == 1)

--- a/src/cryptography/hazmat/backends/openssl/encode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/encode_asn1.py
@@ -368,7 +368,8 @@ def _encode_general_name(backend, name):
 
         ia5 = backend._lib.ASN1_IA5STRING_new()
         backend.openssl_assert(ia5 != backend._ffi.NULL)
-        # TODO: do we want to allow RFC violating utf8 encodes?
+        # ia5strings are supposed to be ITU T.50 but to allow round-tripping
+        # of broken certs that encode utf8 we'll encode utf8 here too.
         value = name.value.encode("utf8")
 
         res = backend._lib.ASN1_STRING_set(ia5, value, len(value))

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -131,8 +131,8 @@ def _idna_encode(value):
     for prefix in ['*.', '.']:
         if value.startswith(prefix):
             value = value[len(prefix):]
-            return prefix.encode('ascii') + idna.encode(value)
-    return idna.encode(value)
+            return prefix + idna.encode(value).decode("ascii")
+    return idna.encode(value).decode("ascii")
 
 
 @utils.register_interface(GeneralName)
@@ -140,73 +140,40 @@ class DNSName(object):
     def __init__(self, value):
         if isinstance(value, six.text_type):
             try:
-                value = value.encode("ascii")
+                value.encode("ascii")
             except UnicodeEncodeError:
                 value = _idna_encode(value)
                 warnings.warn(
-                    "DNSName values should be passed as idna-encoded bytes, "
-                    "not strings. Support for passing unicode strings will be "
-                    "removed in a future version.",
+                    "DNSName values should be passed as an A-label string. "
+                    "This means unicode characters should be encoded via "
+                    "idna. Support for passing unicode strings (aka U-label) "
+                    " will be removed in a future version.",
                     utils.DeprecatedIn21,
                     stacklevel=2,
                 )
-            else:
-                warnings.warn(
-                    "DNSName values should be passed as bytes, not strings. "
-                    "Support for passing unicode strings will be removed in a "
-                    "future version.",
-                    utils.DeprecatedIn21,
-                    stacklevel=2,
-                )
-        elif not isinstance(value, bytes):
-            raise TypeError("value must be bytes")
-
-        self._bytes_value = value
-
-    bytes_value = utils.read_only_property("_bytes_value")
-
-    @property
-    def value(self):
-        warnings.warn(
-            "DNSName.bytes_value should be used instead of DNSName.value; it "
-            "contains the DNS name as raw bytes, instead of as an idna-decoded"
-            " unicode string. DNSName.value will be removed in a future "
-            "version.",
-            utils.DeprecatedIn21,
-            stacklevel=2
-        )
-        data = self._bytes_value
-        if not data:
-            decoded = u""
-        elif data.startswith(b"*."):
-            # This is a wildcard name. We need to remove the leading wildcard,
-            # IDNA decode, then re-add the wildcard. Wildcard characters should
-            # always be left-most (RFC 2595 section 2.4).
-            decoded = u"*." + idna.decode(data[2:])
+        elif isinstance(value, six.binary_type):
+            value = value.decode("utf8")
         else:
-            # Not a wildcard, decode away. If the string has a * in it anywhere
-            # invalid this will raise an InvalidCodePoint
-            decoded = idna.decode(data)
-            if data.startswith(b"."):
-                # idna strips leading periods. Name constraints can have that
-                # so we need to re-add it. Sigh.
-                decoded = u"." + decoded
-        return decoded
+            raise TypeError("value must be string or bytes")
+
+        self._value = value
+
+    value = utils.read_only_property("_value")
 
     def __repr__(self):
-        return "<DNSName(bytes_value={0!r})>".format(self.bytes_value)
+        return "<DNSName(value={0!r})>".format(self.value)
 
     def __eq__(self, other):
         if not isinstance(other, DNSName):
             return NotImplemented
 
-        return self.bytes_value == other.bytes_value
+        return self.value == other.value
 
     def __ne__(self, other):
         return not self == other
 
     def __hash__(self):
-        return hash(self.bytes_value)
+        return hash(self.value)
 
 
 @utils.register_interface(GeneralName)

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -151,14 +151,18 @@ class DNSName(object):
                     utils.DeprecatedIn21,
                     stacklevel=2,
                 )
-        elif isinstance(value, six.binary_type):
-            value = value.decode("utf8")
         else:
-            raise TypeError("value must be string or bytes")
+            raise TypeError("value must be string")
 
         self._value = value
 
     value = utils.read_only_property("_value")
+
+    @classmethod
+    def _init_without_validation(cls, value):
+        instance = cls.__new__(cls)
+        instance._value = value
+        return instance
 
     def __repr__(self):
         return "<DNSName(value={0!r})>".format(self.value)

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -226,7 +226,7 @@ class TestCertificateRevocationList(object):
         assert aia.value == x509.AuthorityInformationAccess([
             x509.AccessDescription(
                 AuthorityInformationAccessOID.CA_ISSUERS,
-                x509.DNSName(b"cryptography.io")
+                x509.DNSName(u"cryptography.io")
             )
         ])
         assert ian.value == x509.IssuerAlternativeName([
@@ -1243,8 +1243,8 @@ class TestRSACertificateRequest(object):
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
         assert list(ext.value) == [
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"sub.cryptography.io"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"sub.cryptography.io"),
         ]
 
     def test_public_bytes_pem(self, backend):
@@ -1472,7 +1472,7 @@ class TestRSACertificateRequest(object):
         ).add_extension(
             x509.BasicConstraints(ca=False, path_length=None), True,
         ).add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(b"cryptography.io")]),
+            x509.SubjectAlternativeName([x509.DNSName(u"cryptography.io")]),
             critical=False,
         ).not_valid_before(
             not_valid_before
@@ -1494,7 +1494,7 @@ class TestRSACertificateRequest(object):
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
         assert list(subject_alternative_name.value) == [
-            x509.DNSName(b"cryptography.io"),
+            x509.DNSName(u"cryptography.io"),
         ]
 
     def test_build_cert_private_type_encoding(self, backend):
@@ -2122,7 +2122,7 @@ class TestCertificateBuilder(object):
         ).add_extension(
             x509.BasicConstraints(ca=False, path_length=None), True,
         ).add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(b"cryptography.io")]),
+            x509.SubjectAlternativeName([x509.DNSName(u"cryptography.io")]),
             critical=False,
         ).not_valid_before(
             not_valid_before
@@ -2144,7 +2144,7 @@ class TestCertificateBuilder(object):
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
         assert list(subject_alternative_name.value) == [
-            x509.DNSName(b"cryptography.io"),
+            x509.DNSName(u"cryptography.io"),
         ]
 
     @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
@@ -2168,7 +2168,7 @@ class TestCertificateBuilder(object):
         ).add_extension(
             x509.BasicConstraints(ca=False, path_length=None), True,
         ).add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(b"cryptography.io")]),
+            x509.SubjectAlternativeName([x509.DNSName(u"cryptography.io")]),
             critical=False,
         ).not_valid_before(
             not_valid_before
@@ -2190,7 +2190,7 @@ class TestCertificateBuilder(object):
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
         assert list(subject_alternative_name.value) == [
-            x509.DNSName(b"cryptography.io"),
+            x509.DNSName(u"cryptography.io"),
         ]
 
     @pytest.mark.requires_backend_interface(interface=RSABackend)
@@ -2279,7 +2279,7 @@ class TestCertificateBuilder(object):
                 )
             ]),
             x509.IssuerAlternativeName([
-                x509.DNSName(b"myissuer"),
+                x509.DNSName(u"myissuer"),
                 x509.RFC822Name(u"email@domain.com"),
             ]),
             x509.ExtendedKeyUsage([
@@ -2308,7 +2308,7 @@ class TestCertificateBuilder(object):
                         ipaddress.IPv6Network(u"FF:FF:0:0:0:0:0:0/128")
                     ),
                 ],
-                excluded_subtrees=[x509.DNSName(b"name.local")]
+                excluded_subtrees=[x509.DNSName(u"name.local")]
             ),
             x509.NameConstraints(
                 permitted_subtrees=[
@@ -2318,7 +2318,7 @@ class TestCertificateBuilder(object):
             ),
             x509.NameConstraints(
                 permitted_subtrees=None,
-                excluded_subtrees=[x509.DNSName(b"name.local")]
+                excluded_subtrees=[x509.DNSName(u"name.local")]
             ),
             x509.PolicyConstraints(
                 require_explicit_policy=None,
@@ -2847,7 +2847,7 @@ class TestCertificateSigningRequestBuilder(object):
                 x509.NameAttribute(NameOID.COUNTRY_NAME, u'US'),
             ])
         ).add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(b"cryptography.io")]),
+            x509.SubjectAlternativeName([x509.DNSName(u"cryptography.io")]),
             critical=False,
         ).add_extension(
             DummyExtension(), False
@@ -2933,7 +2933,7 @@ class TestCertificateSigningRequestBuilder(object):
         request = builder.subject_name(
             x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, u'US')])
         ).add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(b"cryptography.io")]),
+            x509.SubjectAlternativeName([x509.DNSName(u"cryptography.io")]),
             critical=False,
         ).add_extension(
             x509.BasicConstraints(ca=True, path_length=2), critical=True
@@ -2950,7 +2950,7 @@ class TestCertificateSigningRequestBuilder(object):
         ext = request.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
-        assert list(ext.value) == [x509.DNSName(b"cryptography.io")]
+        assert list(ext.value) == [x509.DNSName(u"cryptography.io")]
 
     def test_set_subject_twice(self):
         builder = x509.CertificateSigningRequestBuilder()
@@ -2970,8 +2970,8 @@ class TestCertificateSigningRequestBuilder(object):
         private_key = RSA_KEY_2048.private_key(backend)
 
         san = x509.SubjectAlternativeName([
-            x509.DNSName(b"example.com"),
-            x509.DNSName(b"*.example.com"),
+            x509.DNSName(u"example.com"),
+            x509.DNSName(u"*.example.com"),
             x509.RegisteredID(x509.ObjectIdentifier("1.2.3.4.5.6.7")),
             x509.DirectoryName(x509.Name([
                 x509.NameAttribute(NameOID.COMMON_NAME, u'PyCA'),

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -777,6 +777,24 @@ class TestRSACertificate(object):
             )
         ]
 
+    def test_non_ascii_dns_name(self, backend):
+        cert = _load_cert(
+            os.path.join("x509", "utf8-dnsname.pem"),
+            x509.load_pem_x509_certificate,
+            backend
+        )
+        san = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        ).value
+
+        names = san.get_values_for_type(x509.DNSName)
+
+        assert names == [
+            u'partner.biztositas.hu', u'biztositas.hu', u'*.biztositas.hu',
+            u'biztos\xedt\xe1s.hu', u'*.biztos\xedt\xe1s.hu',
+            u'xn--biztosts-fza2j.hu', u'*.xn--biztosts-fza2j.hu'
+        ]
+
     def test_all_subject_name_types(self, backend):
         cert = _load_cert(
             os.path.join(
@@ -2224,6 +2242,9 @@ class TestCertificateBuilder(object):
     @pytest.mark.parametrize(
         "add_ext",
         [
+            x509.SubjectAlternativeName(
+                [x509.DNSName._init_without_validation(u'a\xedt\xe1s.test')]
+            ),
             x509.CertificatePolicies([
                 x509.PolicyInformation(
                     x509.ObjectIdentifier("2.16.840.1.12345.1.2.3.4.1"),

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -1662,8 +1662,8 @@ class TestKeyUsageExtension(object):
 
 class TestDNSName(object):
     def test_init(self):
-        name = x509.DNSName(u".xn--4ca7aey.example.com")
-        assert name.value == u".xn--4ca7aey.example.com"
+        name = x509.DNSName(u"*.xn--4ca7aey.example.com")
+        assert name.value == u"*.xn--4ca7aey.example.com"
 
         with pytest.warns(utils.DeprecatedIn21):
             name = x509.DNSName(u".\xf5\xe4\xf6\xfc.example.com")

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -1669,6 +1669,10 @@ class TestDNSName(object):
             name = x509.DNSName(u".\xf5\xe4\xf6\xfc.example.com")
         assert name.value == u".xn--4ca7aey.example.com"
 
+        with pytest.warns(utils.DeprecatedIn21):
+            name = x509.DNSName(u"\xf5\xe4\xf6\xfc.example.com")
+        assert name.value == u"xn--4ca7aey.example.com"
+
         name = x509.DNSName(
             u"\xf5\xe4\xf6\xfc.example.com".encode("utf8")
         )

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -234,20 +234,20 @@ class TestUnrecognizedExtension(object):
 class TestCertificateIssuer(object):
     def test_iter_names(self):
         ci = x509.CertificateIssuer([
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ])
         assert len(ci) == 2
         assert list(ci) == [
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ]
 
     def test_indexing(self):
         ci = x509.CertificateIssuer([
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
-            x509.DNSName(b"another.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
+            x509.DNSName(u"another.local"),
             x509.RFC822Name(b"email@another.local"),
             x509.UniformResourceIdentifier(b"http://another.local"),
         ])
@@ -255,18 +255,18 @@ class TestCertificateIssuer(object):
         assert ci[2:6:2] == [ci[2], ci[4]]
 
     def test_eq(self):
-        ci1 = x509.CertificateIssuer([x509.DNSName(b"cryptography.io")])
-        ci2 = x509.CertificateIssuer([x509.DNSName(b"cryptography.io")])
+        ci1 = x509.CertificateIssuer([x509.DNSName(u"cryptography.io")])
+        ci2 = x509.CertificateIssuer([x509.DNSName(u"cryptography.io")])
         assert ci1 == ci2
 
     def test_ne(self):
-        ci1 = x509.CertificateIssuer([x509.DNSName(b"cryptography.io")])
-        ci2 = x509.CertificateIssuer([x509.DNSName(b"somethingelse.tld")])
+        ci1 = x509.CertificateIssuer([x509.DNSName(u"cryptography.io")])
+        ci2 = x509.CertificateIssuer([x509.DNSName(u"somethingelse.tld")])
         assert ci1 != ci2
         assert ci1 != object()
 
     def test_repr(self):
-        ci = x509.CertificateIssuer([x509.DNSName(b"cryptography.io")])
+        ci = x509.CertificateIssuer([x509.DNSName(u"cryptography.io")])
         if six.PY3:
             assert repr(ci) == (
                 "<CertificateIssuer(<GeneralNames([<DNSName(value="
@@ -280,14 +280,14 @@ class TestCertificateIssuer(object):
 
     def test_get_values_for_type(self):
         ci = x509.CertificateIssuer(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         names = ci.get_values_for_type(x509.DNSName)
         assert names == [u"cryptography.io"]
 
     def test_hash(self):
-        ci1 = x509.CertificateIssuer([x509.DNSName(b"cryptography.io")])
-        ci2 = x509.CertificateIssuer([x509.DNSName(b"cryptography.io")])
+        ci1 = x509.CertificateIssuer([x509.DNSName(u"cryptography.io")])
+        ci2 = x509.CertificateIssuer([x509.DNSName(u"cryptography.io")])
         ci3 = x509.CertificateIssuer(
             [x509.UniformResourceIdentifier(b"http://something")]
         )
@@ -1099,7 +1099,7 @@ class TestAuthorityKeyIdentifier(object):
         assert aki.authority_cert_serial_number is None
 
     def test_authority_cert_serial_zero(self):
-        dns = x509.DNSName(b"SomeIssuer")
+        dns = x509.DNSName(u"SomeIssuer")
         aki = x509.AuthorityKeyIdentifier(b"id", [dns], 0)
         assert aki.key_identifier == b"id"
         assert aki.authority_cert_issuer == [dns]
@@ -1673,13 +1673,11 @@ class TestDNSName(object):
             name = x509.DNSName(u"\xf5\xe4\xf6\xfc.example.com")
         assert name.value == u"xn--4ca7aey.example.com"
 
-        name = x509.DNSName(
-            u"\xf5\xe4\xf6\xfc.example.com".encode("utf8")
-        )
-        assert name.value == u"\xf5\xe4\xf6\xfc.example.com"
-
         with pytest.raises(TypeError):
             x509.DNSName(1.3)
+
+        with pytest.raises(TypeError):
+            x509.DNSName(b"bytes not allowed")
 
     def test_ne(self):
         n1 = x509.DNSName(u"test1")
@@ -2019,35 +2017,35 @@ class TestOtherName(object):
 class TestGeneralNames(object):
     def test_get_values_for_type(self):
         gns = x509.GeneralNames(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         names = gns.get_values_for_type(x509.DNSName)
         assert names == [u"cryptography.io"]
 
     def test_iter_names(self):
         gns = x509.GeneralNames([
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ])
         assert len(gns) == 2
         assert list(gns) == [
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ]
 
     def test_iter_input(self):
         names = [
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ]
         gns = x509.GeneralNames(iter(names))
         assert list(gns) == names
 
     def test_indexing(self):
         gn = x509.GeneralNames([
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
-            x509.DNSName(b"another.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
+            x509.DNSName(u"another.local"),
             x509.RFC822Name(b"email@another.local"),
             x509.UniformResourceIdentifier(b"http://another.local"),
         ])
@@ -2057,13 +2055,13 @@ class TestGeneralNames(object):
     def test_invalid_general_names(self):
         with pytest.raises(TypeError):
             x509.GeneralNames(
-                [x509.DNSName(b"cryptography.io"), "invalid"]
+                [x509.DNSName(u"cryptography.io"), "invalid"]
             )
 
     def test_repr(self):
         gns = x509.GeneralNames(
             [
-                x509.DNSName(b"cryptography.io")
+                x509.DNSName(u"cryptography.io")
             ]
         )
         if six.PY3:
@@ -2077,16 +2075,16 @@ class TestGeneralNames(object):
 
     def test_eq(self):
         gns = x509.GeneralNames(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         gns2 = x509.GeneralNames(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         assert gns == gns2
 
     def test_ne(self):
         gns = x509.GeneralNames(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         gns2 = x509.GeneralNames(
             [x509.RFC822Name(b"admin@cryptography.io")]
@@ -2095,8 +2093,8 @@ class TestGeneralNames(object):
         assert gns != object()
 
     def test_hash(self):
-        gns = x509.GeneralNames([x509.DNSName(b"cryptography.io")])
-        gns2 = x509.GeneralNames([x509.DNSName(b"cryptography.io")])
+        gns = x509.GeneralNames([x509.DNSName(u"cryptography.io")])
+        gns2 = x509.GeneralNames([x509.DNSName(u"cryptography.io")])
         gns3 = x509.GeneralNames([x509.RFC822Name(b"admin@cryptography.io")])
         assert hash(gns) == hash(gns2)
         assert hash(gns) != hash(gns3)
@@ -2105,27 +2103,27 @@ class TestGeneralNames(object):
 class TestIssuerAlternativeName(object):
     def test_get_values_for_type(self):
         san = x509.IssuerAlternativeName(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         names = san.get_values_for_type(x509.DNSName)
         assert names == [u"cryptography.io"]
 
     def test_iter_names(self):
         san = x509.IssuerAlternativeName([
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ])
         assert len(san) == 2
         assert list(san) == [
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ]
 
     def test_indexing(self):
         ian = x509.IssuerAlternativeName([
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
-            x509.DNSName(b"another.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
+            x509.DNSName(u"another.local"),
             x509.RFC822Name(b"email@another.local"),
             x509.UniformResourceIdentifier(b"http://another.local"),
         ])
@@ -2135,13 +2133,13 @@ class TestIssuerAlternativeName(object):
     def test_invalid_general_names(self):
         with pytest.raises(TypeError):
             x509.IssuerAlternativeName(
-                [x509.DNSName(b"cryptography.io"), "invalid"]
+                [x509.DNSName(u"cryptography.io"), "invalid"]
             )
 
     def test_repr(self):
         san = x509.IssuerAlternativeName(
             [
-                x509.DNSName(b"cryptography.io")
+                x509.DNSName(u"cryptography.io")
             ]
         )
         if six.PY3:
@@ -2157,16 +2155,16 @@ class TestIssuerAlternativeName(object):
 
     def test_eq(self):
         san = x509.IssuerAlternativeName(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         san2 = x509.IssuerAlternativeName(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         assert san == san2
 
     def test_ne(self):
         san = x509.IssuerAlternativeName(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         san2 = x509.IssuerAlternativeName(
             [x509.RFC822Name(b"admin@cryptography.io")]
@@ -2175,8 +2173,8 @@ class TestIssuerAlternativeName(object):
         assert san != object()
 
     def test_hash(self):
-        ian = x509.IssuerAlternativeName([x509.DNSName(b"cryptography.io")])
-        ian2 = x509.IssuerAlternativeName([x509.DNSName(b"cryptography.io")])
+        ian = x509.IssuerAlternativeName([x509.DNSName(u"cryptography.io")])
+        ian2 = x509.IssuerAlternativeName([x509.DNSName(u"cryptography.io")])
         ian3 = x509.IssuerAlternativeName(
             [x509.RFC822Name(b"admin@cryptography.io")]
         )
@@ -2230,27 +2228,27 @@ class TestCRLNumber(object):
 class TestSubjectAlternativeName(object):
     def test_get_values_for_type(self):
         san = x509.SubjectAlternativeName(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         names = san.get_values_for_type(x509.DNSName)
         assert names == [u"cryptography.io"]
 
     def test_iter_names(self):
         san = x509.SubjectAlternativeName([
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ])
         assert len(san) == 2
         assert list(san) == [
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
         ]
 
     def test_indexing(self):
         san = x509.SubjectAlternativeName([
-            x509.DNSName(b"cryptography.io"),
-            x509.DNSName(b"crypto.local"),
-            x509.DNSName(b"another.local"),
+            x509.DNSName(u"cryptography.io"),
+            x509.DNSName(u"crypto.local"),
+            x509.DNSName(u"another.local"),
             x509.RFC822Name(b"email@another.local"),
             x509.UniformResourceIdentifier(b"http://another.local"),
         ])
@@ -2260,13 +2258,13 @@ class TestSubjectAlternativeName(object):
     def test_invalid_general_names(self):
         with pytest.raises(TypeError):
             x509.SubjectAlternativeName(
-                [x509.DNSName(b"cryptography.io"), "invalid"]
+                [x509.DNSName(u"cryptography.io"), "invalid"]
             )
 
     def test_repr(self):
         san = x509.SubjectAlternativeName(
             [
-                x509.DNSName(b"cryptography.io")
+                x509.DNSName(u"cryptography.io")
             ]
         )
         if six.PY3:
@@ -2282,16 +2280,16 @@ class TestSubjectAlternativeName(object):
 
     def test_eq(self):
         san = x509.SubjectAlternativeName(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         san2 = x509.SubjectAlternativeName(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         assert san == san2
 
     def test_ne(self):
         san = x509.SubjectAlternativeName(
-            [x509.DNSName(b"cryptography.io")]
+            [x509.DNSName(u"cryptography.io")]
         )
         san2 = x509.SubjectAlternativeName(
             [x509.RFC822Name(b"admin@cryptography.io")]
@@ -2300,8 +2298,8 @@ class TestSubjectAlternativeName(object):
         assert san != object()
 
     def test_hash(self):
-        san = x509.SubjectAlternativeName([x509.DNSName(b"cryptography.io")])
-        san2 = x509.SubjectAlternativeName([x509.DNSName(b"cryptography.io")])
+        san = x509.SubjectAlternativeName([x509.DNSName(u"cryptography.io")])
+        san2 = x509.SubjectAlternativeName([x509.DNSName(u"cryptography.io")])
         san3 = x509.SubjectAlternativeName(
             [x509.RFC822Name(b"admin@cryptography.io")]
         )
@@ -2649,7 +2647,7 @@ class TestExtendedKeyUsageExtension(object):
 class TestAccessDescription(object):
     def test_invalid_access_method(self):
         with pytest.raises(TypeError):
-            x509.AccessDescription("notanoid", x509.DNSName(b"test"))
+            x509.AccessDescription("notanoid", x509.DNSName(u"test"))
 
     def test_invalid_access_location(self):
         with pytest.raises(TypeError):
@@ -3243,7 +3241,7 @@ class TestNameConstraints(object):
             x509.NameConstraints(None, None)
 
     def test_permitted_none(self):
-        excluded = [x509.DNSName(b"name.local")]
+        excluded = [x509.DNSName(u"name.local")]
         nc = x509.NameConstraints(
             permitted_subtrees=None, excluded_subtrees=excluded
         )
@@ -3251,7 +3249,7 @@ class TestNameConstraints(object):
         assert nc.excluded_subtrees is not None
 
     def test_excluded_none(self):
-        permitted = [x509.DNSName(b"name.local")]
+        permitted = [x509.DNSName(u"name.local")]
         nc = x509.NameConstraints(
             permitted_subtrees=permitted, excluded_subtrees=None
         )
@@ -3265,7 +3263,7 @@ class TestNameConstraints(object):
         assert list(nc.excluded_subtrees) == subtrees
 
     def test_repr(self):
-        permitted = [x509.DNSName(b"name.local"), x509.DNSName(b"name2.local")]
+        permitted = [x509.DNSName(u"name.local"), x509.DNSName(u"name2.local")]
         nc = x509.NameConstraints(
             permitted_subtrees=permitted,
             excluded_subtrees=None
@@ -3296,16 +3294,16 @@ class TestNameConstraints(object):
 
     def test_ne(self):
         nc = x509.NameConstraints(
-            permitted_subtrees=[x509.DNSName(b"name.local")],
-            excluded_subtrees=[x509.DNSName(b"name2.local")]
+            permitted_subtrees=[x509.DNSName(u"name.local")],
+            excluded_subtrees=[x509.DNSName(u"name2.local")]
         )
         nc2 = x509.NameConstraints(
-            permitted_subtrees=[x509.DNSName(b"name.local")],
+            permitted_subtrees=[x509.DNSName(u"name.local")],
             excluded_subtrees=None
         )
         nc3 = x509.NameConstraints(
             permitted_subtrees=None,
-            excluded_subtrees=[x509.DNSName(b"name2.local")]
+            excluded_subtrees=[x509.DNSName(u"name2.local")]
         )
 
         assert nc != nc2
@@ -3314,20 +3312,20 @@ class TestNameConstraints(object):
 
     def test_hash(self):
         nc = x509.NameConstraints(
-            permitted_subtrees=[x509.DNSName(b"name.local")],
-            excluded_subtrees=[x509.DNSName(b"name2.local")]
+            permitted_subtrees=[x509.DNSName(u"name.local")],
+            excluded_subtrees=[x509.DNSName(u"name2.local")]
         )
         nc2 = x509.NameConstraints(
-            permitted_subtrees=[x509.DNSName(b"name.local")],
-            excluded_subtrees=[x509.DNSName(b"name2.local")]
+            permitted_subtrees=[x509.DNSName(u"name.local")],
+            excluded_subtrees=[x509.DNSName(u"name2.local")]
         )
         nc3 = x509.NameConstraints(
-            permitted_subtrees=[x509.DNSName(b"name.local")],
+            permitted_subtrees=[x509.DNSName(u"name.local")],
             excluded_subtrees=None
         )
         nc4 = x509.NameConstraints(
             permitted_subtrees=None,
-            excluded_subtrees=[x509.DNSName(b"name.local")]
+            excluded_subtrees=[x509.DNSName(u"name.local")]
         )
         assert hash(nc) == hash(nc2)
         assert hash(nc) != hash(nc3)
@@ -3350,7 +3348,7 @@ class TestNameConstraintsExtension(object):
         ).value
         assert nc == x509.NameConstraints(
             permitted_subtrees=[
-                x509.DNSName(b"zombo.local"),
+                x509.DNSName(u"zombo.local"),
             ],
             excluded_subtrees=[
                 x509.DirectoryName(x509.Name([
@@ -3372,7 +3370,7 @@ class TestNameConstraintsExtension(object):
         ).value
         assert nc == x509.NameConstraints(
             permitted_subtrees=[
-                x509.DNSName(b"zombo.local"),
+                x509.DNSName(u"zombo.local"),
             ],
             excluded_subtrees=None
         )
@@ -3390,7 +3388,7 @@ class TestNameConstraintsExtension(object):
         ).value
         assert nc == x509.NameConstraints(
             permitted_subtrees=[
-                x509.DNSName(b".cryptography.io"),
+                x509.DNSName(u".cryptography.io"),
                 x509.UniformResourceIdentifier(b"ftp://cryptography.test")
             ],
             excluded_subtrees=None
@@ -3410,7 +3408,7 @@ class TestNameConstraintsExtension(object):
         assert nc == x509.NameConstraints(
             permitted_subtrees=None,
             excluded_subtrees=[
-                x509.DNSName(b".cryptography.io"),
+                x509.DNSName(u".cryptography.io"),
                 x509.UniformResourceIdentifier(b"gopher://cryptography.test")
             ]
         )
@@ -3432,7 +3430,7 @@ class TestNameConstraintsExtension(object):
                 x509.IPAddress(ipaddress.IPv6Network(u"FF:0:0:0:0:0:0:0/96")),
             ],
             excluded_subtrees=[
-                x509.DNSName(b".domain.com"),
+                x509.DNSName(u".domain.com"),
                 x509.UniformResourceIdentifier(b"http://test.local"),
             ]
         )

--- a/tests/x509/test_x509_revokedcertbuilder.py
+++ b/tests/x509/test_x509_revokedcertbuilder.py
@@ -146,7 +146,7 @@ class TestRevokedCertificateBuilder(object):
             x509.InvalidityDate(datetime.datetime(2015, 1, 1, 0, 0)),
             x509.CRLReason(x509.ReasonFlags.ca_compromise),
             x509.CertificateIssuer([
-                x509.DNSName(b"cryptography.io"),
+                x509.DNSName(u"cryptography.io"),
             ])
         ]
     )
@@ -180,7 +180,7 @@ class TestRevokedCertificateBuilder(object):
             datetime.datetime(2015, 1, 1, 0, 0)
         )
         certificate_issuer = x509.CertificateIssuer([
-            x509.DNSName(b"cryptography.io"),
+            x509.DNSName(u"cryptography.io"),
         ])
         crl_reason = x509.CRLReason(x509.ReasonFlags.aa_compromise)
         builder = x509.RevokedCertificateBuilder().serial_number(


### PR DESCRIPTION
During this release cycle we decided to officially deprecate passing U-labels to our GeneralName constructors. At first we tried changing this in a purely backwards compatible way, but get_values_for_type made that untenable. This PR modifies DNSName to take three different types. U-label strings (which raises a deprecation warning), A-label strings (the new preferred type), and bytes (which are assumed to be decodable to unicode strings). The latter, while supported, is primarily intended for use by our parser and allows us to return the actual encoded data in a certificate even if it has not been properly encoded to A-label before the certificate is created. (Of course, if the certificate contains invalid utf8 sequences this will still fail, but let's handle one catastrophic failure at a time).

Note that this change is only backwards incompatible in the case where the user is passing a string that contains an internationalized domain name U-label. In that scenario the user will pass a string containing unicode characters and receive back a string encoded to A-label when calling `value`.

refs #3943 

Once URI and RFC822Name are complete we'll also need to update the changelog.