### PR TITLE
parallelize docs work and always give full traceback on exception

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,10 +40,10 @@ extras =
     docstest
 basepython = python2.7
 commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
-    sphinx-build -W -b latex -d {envtmpdir}/doctrees docs docs/_build/latex
-    sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
-    sphinx-build -W -b spelling docs docs/_build/html
+    sphinx-build -j4 -T -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
+    sphinx-build -j4 -T -W -b latex -d {envtmpdir}/doctrees docs docs/_build/latex
+    sphinx-build -j4 -T -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
+    sphinx-build -j4 -T -W -b spelling docs docs/_build/html
     doc8 --allow-long-titles README.rst CHANGELOG.rst docs/ --ignore-path docs/_build/
     python setup.py check --restructuredtext --strict
 


### PR DESCRIPTION
In local testing this didn't seem to gain much, but it also doesn't hurt so what the hell.

(On my touchbar MBP quad core skylake @2.7ghz this dropped runtime from 69s to 65s)

fixes #3885 