### PR TITLE
Debian sid is python3.6 now (#3968)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ def configs = [
     [
         label: 'docker',
         imageName: 'pyca/cryptography-runner-sid',
-        toxenvs: ['py27', 'py35'],
+        toxenvs: ['py27', 'py36'],
     ],
     [
         label: 'docker',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -248,6 +248,9 @@ def load_pkcs1_vectors(vector_data):
             attr = None
 
         if private_key_vector is None or public_key_vector is None:
+            # Random garbage to defeat CPython's peephole optimizer so that
+            # coverage records correctly: https://bugs.python.org/issue2506
+            1 + 1
             continue
 
         if line.startswith("# Private key"):


### PR DESCRIPTION
* Debian sid is python3.6 now

* Workaround because apparently measuring coverage correctly isn't a legitimate use case