### PR TITLE
Add Multifernet.rotate method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,3 +37,4 @@ PGP key fingerprints are enclosed in parentheses.
 * Ofek Lev <ofekmeister@gmail.com> (FFB6 B92B 30B1 7848 546E 9912 972F E913 DAD5 A46E)
 * Erik Daguerre <fallenwolf@wolfthefallen.com>
 * Aviv Palivoda <palaviv@gmail.com>
+* Chris Wolfe <chriswwolfe@gmail.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Changelog
 .. note:: This version is not yet released and is under active development.
 
 * **BACKWARDS INCOMPATIBLE:** Support for Python 2.6 has been dropped.
+* Added token rotation support to :doc:`Fernet </fernet>` with
+  :meth:`~cryptography.fernet.MultiFernet.rotate`.
 
 .. _v2-1-1:
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -137,25 +137,20 @@ has support for implementing key rotation via :class:`MultiFernet`.
 
         :param bytes msg: The token to re-encrypt.
         :param int ttl: Optionally, the number of seconds old a message may be
-                        for it to be valid. If the message is older than
-                        ``ttl`` seconds (from the time it was originally
-                        created) an exception will be raised. If ``ttl`` is not
-                        provided (or is ``None``), the age of the message is
-                        not considered. If any token is older than the ``ttl``
-                        then an exception will be raised.
+           for it to be valid. If the message is older than ``ttl`` seconds
+           (from the time it was originally created) an exception will be
+           raised. If ``ttl`` is not provided (or is ``None``), the age of the
+           message is not considered. If any token is older than the ``ttl``
+           then an exception will be raised.
         :returns bytes: A secure message that cannot be read or altered without
-                        the key. This is URL-safe base64-encoded. This is
-                        referred to as a "Fernet token".
+           the key. This is URL-safe base64-encoded. This is referred to as a
+           "Fernet token".
         :raises cryptography.fernet.InvalidToken: If a ``token`` is in any
-                                                  way invalid, this exception
-                                                  is raised. A token may be
-                                                  invalid for a number of
-                                                  reasons: it is older than the
-                                                  ``ttl``, it is malformed, or
-                                                  it does not have a valid
-                                                  signature.
-        :raises TypeError: This exception is raised if the ```msg`` is not
-                           ``bytes``.
+           way invalid, this exception is raised. A token may be invalid for a
+           number of reasons: it is older than the ``ttl``, it is malformed, or
+           it does not have a valid signature.
+        :raises TypeError: This exception is raised if the ``msg`` is not
+           ``bytes``.
 
 
 .. class:: InvalidToken

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -113,9 +113,10 @@ has support for implementing key rotation via :class:`MultiFernet`.
     Token rotation as offered by :meth:`MultiFernet.rotate` is a best practice
     and manner of cryptographic hygiene designed to limit damage in the event of
     an undetected event and to increase the difficulty of attacks. For example,
-    it would be necessary to rotate all fernet tokens in the event of an
-    employee leaving who previously had access to the fernet key used to
-    encrypt/decrypt fernet tokens.
+    if an employee who had access to your company's fernet keys leaves, you'll
+    want to generate new fernet key, rotate all of the tokens currently deployed
+    using that new key, and then retire the old fernet key(s) to which the
+    employee had access.
 
     .. method:: rotate(msg)
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -102,7 +102,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
         'Secret message!'
         >>> key3 = Fernet(Fernet.generate_key())
         >>> f2 = MultiFernet([key3, key1, key2])
-        >>> rotated = f2.rotate([token])[0]
+        >>> rotated = f2.rotate(token)
         >>> f2.decrypt(rotated)
         'Secret message!'
 
@@ -115,16 +115,13 @@ has support for implementing key rotation via :class:`MultiFernet`.
     the front of the list to start encrypting new messages, and remove old keys
     as they are no longer needed.
 
-    .. method:: rotate(msgs, ttl=None)
+    .. method:: rotate(msg, ttl=None)
 
-        Re-encrypts the provided fernet tokens. If all tokens have successfully
-        been re-encrypted, then the list of re-encrypted tokens will be
-        returned. In the event of re-encryption failing, an exception will be
-        raised for the first token to fail.
+        Re-encrypts the provided fernet token. If the token has successfully
+        been re-encrypted, then the re-encrypted token will be returned. This
+        will raise an exception if re-encryption fails.
 
-        :param list(bytes) msgs: The Fernet tokens to re-encrypt. Each token is the
-                                result of calling :meth:`Fernet.encrypt` with a given
-                                message.
+        :param bytes msg: The token to re-encrypt.
         :param int ttl: Optionally, the number of seconds old a message may be
                         for it to be valid. If the message is older than
                         ``ttl`` seconds (from the time it was originally
@@ -132,9 +129,9 @@ has support for implementing key rotation via :class:`MultiFernet`.
                         provided (or is ``None``), the age of the message is
                         not considered. If any token is older than the ``ttl``
                         then an exception will be raised.
-        :returns list(bytes): A list of secure messages that cannot be read or
-                        altered without the key. Each is URL-safe base64-encoded.
-                        Each is referred to as a "Fernet token".
+        :returns bytes: A secure message that cannot be read or altered without
+                        the key. This is URL-safe base64-encoded. This is
+                        referred to as a "Fernet token".
         :raises cryptography.fernet.InvalidToken: If a ``token`` is in any
                                                   way invalid, this exception
                                                   is raised. A token may be
@@ -143,7 +140,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
                                                   ``ttl``, it is malformed, or
                                                   it does not have a valid
                                                   signature.
-        :raises TypeError: This exception is raised if any of the ```msgs`` are not
+        :raises TypeError: This exception is raised if the ```msg`` is not
                            ``bytes``.
 
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -110,14 +110,15 @@ has support for implementing key rotation via :class:`MultiFernet`.
     the front of the list to start encrypting new messages, and remove old keys
     as they are no longer needed.
 
-    .. method:: rotate(msg, ttl=None)
+    .. method:: rotate(msg)
 
         .. versionadded:: 2.2
 
         Rotating tokens is necessary when any of the fernet keys of a
         :class:`MultiFernet` instance have been compromised. This decrypts the
         token `msg` using any of the keys attached to the :class:`MultiFernet`
-        instance and then re-encrypts the token using the primary key.
+        instance and then re-encrypts the token using the primary key. This
+        preserves the timestamp that was originally saved with the message.
 
         If a token has successfully been rotated, then the rotated token will be
         returned. If rotation fails, this will raise an exception.
@@ -140,19 +141,13 @@ has support for implementing key rotation via :class:`MultiFernet`.
            'Secret message!'
 
         :param bytes msg: The token to re-encrypt.
-        :param int ttl: Optionally, the number of seconds old a message may be
-           for it to be valid. If the message is older than ``ttl`` seconds
-           (from the time it was originally created) an exception will be
-           raised. If ``ttl`` is not provided (or is ``None``), the age of the
-           message is not considered. If any token is older than the ``ttl``
-           then an exception will be raised.
         :returns bytes: A secure message that cannot be read or altered without
            the key. This is URL-safe base64-encoded. This is referred to as a
            "Fernet token".
         :raises cryptography.fernet.InvalidToken: If a ``token`` is in any
            way invalid, this exception is raised. A token may be invalid for a
-           number of reasons: it is older than the ``ttl``, it is malformed, or
-           it does not have a valid signature.
+           number of reasons: it is malformed, or it does not have a valid
+           signature.
         :raises TypeError: This exception is raised if the ``msg`` is not
            ``bytes``.
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -86,7 +86,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
     .. versionadded:: 0.7
 
     This class implements key rotation for Fernet. It takes a ``list`` of
-    :class:`Fernet` instances, and implements the same API with the exception
+    :class:`Fernet` instances and implements the same API with the exception
     of one additional method: :meth:`MultiFernet.rotate`:
 
     .. doctest::
@@ -114,14 +114,18 @@ has support for implementing key rotation via :class:`MultiFernet`.
 
         .. versionadded:: 2.2
 
-        Rotating tokens is necessary when any of the fernet keys of a
-        :class:`MultiFernet` instance have been compromised. This decrypts the
-        token `msg` using any of the keys attached to the :class:`MultiFernet`
-        instance and then re-encrypts the token using the primary key. This
-        preserves the timestamp that was originally saved with the token.
+        Rotates a token by re-encrypting it under the :class:`MultiFernet`
+        instance's primary key. This preserves the timestamp that was originally
+        saved with the token. If a token has successfully been rotated then the
+        rotated token will be returned. If rotation fails this will raise an
+        exception.
 
-        If a token has successfully been rotated, then the rotated token will be
-        returned. If rotation fails, this will raise an exception.
+        Token rotation is a best practice and manner of cryptographic hygiene
+        designed to limit damage in the event of an undetected event and to
+        increase the difficulty of attacks. For example, it would be necessary
+        to rotate all fernet tokens in the event of an employee leaving who
+        previously had access to the fernet key used to encrypt/decrypt fernet
+        tokens.
 
         .. doctest::
 
@@ -145,9 +149,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
            the key. This is URL-safe base64-encoded. This is referred to as a
            "Fernet token".
         :raises cryptography.fernet.InvalidToken: If a ``token`` is in any
-           way invalid, this exception is raised. A token may be invalid for a
-           number of reasons: it is malformed, or it does not have a valid
-           signature.
+           way invalid this exception is raised.
         :raises TypeError: This exception is raised if the ``msg`` is not
            ``bytes``.
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -118,6 +118,23 @@ has support for implementing key rotation via :class:`MultiFernet`.
         been re-encrypted, then the re-encrypted token will be returned. This
         will raise an exception if re-encryption fails.
 
+        .. doctest::
+
+           >>> from cryptography.fernet import Fernet, MultiFernet
+           >>> key1 = Fernet(Fernet.generate_key())
+           >>> key2 = Fernet(Fernet.generate_key())
+           >>> f = MultiFernet([key1, key2])
+           >>> token = f.encrypt(b"Secret message!")
+           >>> token
+           '...'
+           >>> f.decrypt(token)
+           'Secret message!'
+           >>> key3 = Fernet(Fernet.generate_key())
+           >>> f2 = MultiFernet([key3, key1, key2])
+           >>> rotated = f2.rotate(token)
+           >>> f2.decrypt(rotated)
+           'Secret message!'
+
         :param bytes msg: The token to re-encrypt.
         :param int ttl: Optionally, the number of seconds old a message may be
                         for it to be valid. If the message is older than

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -115,13 +115,12 @@ has support for implementing key rotation via :class:`MultiFernet`.
         .. versionadded:: 2.2
 
         Rotating tokens is necessary when any of the fernet keys of a
-        :class:`MultiFernet` instance have been compromised. This method
-        re-encrypts the token, `msg`, under the new primary key. Once all tokens
-        have been successfully rotated under the new primary key, the
-        compromised key can be removed from the :class`MultiFernet` instance. If
-        the token has successfully been re-encrypted, then the re-encrypted
-        token will be returned. This will raise an exception if re-encryption
-        fails.
+        :class:`MultiFernet` instance have been compromised. This decrypts the
+        token `msg` using any of the keys attached to the :class:`MultiFernet`
+        instance and then re-encrypts the token using the primary key.
+
+        If a token has successfully been rotated, then the rotated token will be
+        returned. If rotation fails, this will raise an exception.
 
         .. doctest::
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -100,11 +100,6 @@ has support for implementing key rotation via :class:`MultiFernet`.
         '...'
         >>> f.decrypt(token)
         'Secret message!'
-        >>> key3 = Fernet(Fernet.generate_key())
-        >>> f2 = MultiFernet([key3, key1, key2])
-        >>> rotated = f2.rotate(token)
-        >>> f2.decrypt(rotated)
-        'Secret message!'
 
     MultiFernet performs all encryption options using the *first* key in the
     ``list`` provided. MultiFernet attempts to decrypt tokens with each key in
@@ -116,6 +111,8 @@ has support for implementing key rotation via :class:`MultiFernet`.
     as they are no longer needed.
 
     .. method:: rotate(msg, ttl=None)
+
+        .. versionadded:: 2.2
 
         Re-encrypts the provided fernet token. If the token has successfully
         been re-encrypted, then the re-encrypted token will be returned. This

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -110,6 +110,13 @@ has support for implementing key rotation via :class:`MultiFernet`.
     the front of the list to start encrypting new messages, and remove old keys
     as they are no longer needed.
 
+    Token rotation as offered by :meth:`MultiFernet.rotate` is a best practice
+    and manner of cryptographic hygiene designed to limit damage in the event of
+    an undetected event and to increase the difficulty of attacks. For example,
+    it would be necessary to rotate all fernet tokens in the event of an
+    employee leaving who previously had access to the fernet key used to
+    encrypt/decrypt fernet tokens.
+
     .. method:: rotate(msg)
 
         .. versionadded:: 2.2
@@ -119,13 +126,6 @@ has support for implementing key rotation via :class:`MultiFernet`.
         saved with the token. If a token has successfully been rotated then the
         rotated token will be returned. If rotation fails this will raise an
         exception.
-
-        Token rotation is a best practice and manner of cryptographic hygiene
-        designed to limit damage in the event of an undetected event and to
-        increase the difficulty of attacks. For example, it would be necessary
-        to rotate all fernet tokens in the event of an employee leaving who
-        previously had access to the fernet key used to encrypt/decrypt fernet
-        tokens.
 
         .. doctest::
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -114,9 +114,14 @@ has support for implementing key rotation via :class:`MultiFernet`.
 
         .. versionadded:: 2.2
 
-        Re-encrypts the provided fernet token. If the token has successfully
-        been re-encrypted, then the re-encrypted token will be returned. This
-        will raise an exception if re-encryption fails.
+        Rotating tokens is necessary when any of the fernet keys of a
+        :class:`MultiFernet` instance have been compromised. This method
+        re-encrypts the token, `msg`, under the new primary key. Once all tokens
+        have been successfully rotated under the new primary key, the
+        compromised key can be removed from the :class`MultiFernet` instance. If
+        the token has successfully been re-encrypted, then the re-encrypted
+        token will be returned. This will raise an exception if re-encryption
+        fails.
 
         .. doctest::
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -118,7 +118,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
         :class:`MultiFernet` instance have been compromised. This decrypts the
         token `msg` using any of the keys attached to the :class:`MultiFernet`
         instance and then re-encrypts the token using the primary key. This
-        preserves the timestamp that was originally saved with the message.
+        preserves the timestamp that was originally saved with the token.
 
         If a token has successfully been rotated, then the rotated token will be
         returned. If rotation fails, this will raise an exception.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -21,6 +21,7 @@ cryptographic
 cryptographically
 Debian
 decrypt
+decrypts
 Decrypts
 decrypted
 decrypting

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -134,8 +134,8 @@ class MultiFernet(object):
     def encrypt(self, msg):
         return self._fernets[0].encrypt(msg)
 
-    def rotate(self, msgs, ttl=None):
-        return [self.encrypt(self.decrypt(m, ttl)) for m in msgs]
+    def rotate(self, msg, ttl=None):
+        return self.encrypt(self.decrypt(msg, ttl))
 
     def decrypt(self, msg, ttl=None):
         for f in self._fernets:

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -71,10 +71,13 @@ class Fernet(object):
         return base64.urlsafe_b64encode(basic_parts + hmac)
 
     def decrypt(self, token, ttl=None):
+        timestamp, data = self._get_token_data(token)
+        return self._decrypt_data(data, timestamp, ttl)
+
+    @staticmethod
+    def _get_token_data(token):
         if not isinstance(token, bytes):
             raise TypeError("token must be bytes.")
-
-        current_time = int(time.time())
 
         try:
             data = base64.urlsafe_b64decode(token)
@@ -88,6 +91,10 @@ class Fernet(object):
             timestamp, = struct.unpack(">Q", data[1:9])
         except struct.error:
             raise InvalidToken
+        return timestamp, data
+
+    def _decrypt_data(self, data, timestamp, ttl):
+        current_time = int(time.time())
         if ttl is not None:
             if timestamp + ttl < current_time:
                 raise InvalidToken

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -71,7 +71,7 @@ class Fernet(object):
         return base64.urlsafe_b64encode(basic_parts + hmac)
 
     def decrypt(self, token, ttl=None):
-        timestamp, data = self._get_unverified_token_data(token)
+        timestamp, data = Fernet._get_unverified_token_data(token)
         return self._decrypt_data(data, timestamp, ttl)
 
     @staticmethod
@@ -142,7 +142,7 @@ class MultiFernet(object):
         return self._fernets[0].encrypt(msg)
 
     def rotate(self, msg):
-        timestamp, data = self._fernets[0]._get_unverified_token_data(msg)
+        timestamp, data = Fernet._get_unverified_token_data(msg)
         for f in self._fernets:
             try:
                 p = f._decrypt_data(data, timestamp, None)

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -134,11 +134,8 @@ class MultiFernet(object):
     def encrypt(self, msg):
         return self._fernets[0].encrypt(msg)
 
-    def rotate(self, messages, ttl=None):
-        return [
-            self.encrypt(self.decrypt(m, ttl))
-            for m in messages
-        ]
+    def rotate(self, msgs, ttl=None):
+        return [self.encrypt(self.decrypt(m, ttl)) for m in msgs]
 
     def decrypt(self, msg, ttl=None):
         for f in self._fernets:

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -71,11 +71,11 @@ class Fernet(object):
         return base64.urlsafe_b64encode(basic_parts + hmac)
 
     def decrypt(self, token, ttl=None):
-        timestamp, data = self._get_token_data(token)
+        timestamp, data = self._get_unverified_token_data(token)
         return self._decrypt_data(data, timestamp, ttl)
 
     @staticmethod
-    def _get_token_data(token):
+    def _get_unverified_token_data(token):
         if not isinstance(token, bytes):
             raise TypeError("token must be bytes.")
 
@@ -142,7 +142,7 @@ class MultiFernet(object):
         return self._fernets[0].encrypt(msg)
 
     def rotate(self, msg):
-        timestamp, data = self._fernets[0]._get_token_data(msg)
+        timestamp, data = self._fernets[0]._get_unverified_token_data(msg)
         for f in self._fernets:
             try:
                 p = f._decrypt_data(data, timestamp, None)

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -134,6 +134,12 @@ class MultiFernet(object):
     def encrypt(self, msg):
         return self._fernets[0].encrypt(msg)
 
+    def rotate(self, messages, ttl=None):
+        return [
+            self.encrypt(self.decrypt(m, ttl))
+            for m in messages
+        ]
+
     def decrypt(self, msg, ttl=None):
         for f in self._fernets:
             try:

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -170,7 +170,7 @@ class TestMultiFernet(object):
 
         assert mf2.decrypt(mf1_ciphertext) == plaintext
 
-        rotated = mf2.rotate([mf1_ciphertext])[0]
+        rotated = mf2.rotate(mf1_ciphertext)
 
         assert rotated != mf1_ciphertext
         assert mf2.decrypt(rotated) == plaintext
@@ -190,7 +190,7 @@ class TestMultiFernet(object):
         monkeypatch.setattr(time, "time", lambda: later_time)
 
         with pytest.raises(InvalidToken):
-            mf2.rotate([mf1_ciphertext], ttl=10)
+            mf2.rotate(mf1_ciphertext, ttl=10)
 
     def test_rotate_decrypt_no_shared_keys(self, backend):
         f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
@@ -200,4 +200,4 @@ class TestMultiFernet(object):
         mf2 = MultiFernet([f2])
 
         with pytest.raises(InvalidToken):
-            mf2.rotate([mf1.encrypt(b"abc")])
+            mf2.rotate(mf1.encrypt(b"abc"))

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -187,8 +187,10 @@ class TestMultiFernet(object):
         plaintext = b"abc"
         mf1_ciphertext = mf1.encrypt(plaintext)
 
-        original_time, _ = Fernet._get_token_data(mf1_ciphertext)
-        rotated_time, _ = Fernet._get_token_data(mf2.rotate(mf1_ciphertext))
+        original_time, _ = Fernet._get_unverified_token_data(mf1_ciphertext)
+        rotated_time, _ = Fernet._get_unverified_token_data(
+            mf2.rotate(mf1_ciphertext)
+        )
 
         assert original_time == rotated_time
 

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import base64
 import calendar
-import datetime
 import json
 import os
 import time
@@ -189,7 +188,7 @@ class TestMultiFernet(object):
         mf1_ciphertext = mf1.encrypt(plaintext)
 
         original_time, _ = Fernet._get_token_data(mf1_ciphertext)
-        rotated_time, _ =  Fernet._get_token_data(mf2.rotate(mf1_ciphertext))
+        rotated_time, _ = Fernet._get_token_data(mf2.rotate(mf1_ciphertext))
 
         assert original_time == rotated_time
 

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -175,6 +175,9 @@ class TestMultiFernet(object):
         assert rotated != mf1_ciphertext
         assert mf2.decrypt(rotated) == plaintext
 
+        with pytest.raises(InvalidToken):
+            mf1.decrypt(rotated)
+
     def test_rotate_ttl_failure(self, backend, monkeypatch):
         f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         f2 = Fernet(base64.urlsafe_b64encode(b"\x01" * 32), backend=backend)

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -182,29 +182,22 @@ class TestMultiFernet(object):
         f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         f2 = Fernet(base64.urlsafe_b64encode(b"\x01" * 32), backend=backend)
 
-        earlier = datetime.datetime.now() - datetime.timedelta(minutes=1)
-        later = datetime.datetime.now() + datetime.timedelta(minutes=1)
-
-        t1 = time.mktime(earlier.timetuple())
-        t2 = time.mktime(later.timetuple())
-
-        assert t1 < t2
-
         mf1 = MultiFernet([f1])
         mf2 = MultiFernet([f2, f1])
 
         plaintext = b"abc"
-
-        monkeypatch.setattr(time, "time", lambda: t1)
         mf1_ciphertext = mf1.encrypt(plaintext)
 
-        monkeypatch.setattr(time, "time", lambda: t2)
+        later = datetime.datetime.now() + datetime.timedelta(minutes=5)
+        later_time = time.mktime(later.timetuple())
+        monkeypatch.setattr(time, "time", lambda: later_time)
+
         original_time, _ = Fernet._get_unverified_token_data(mf1_ciphertext)
         rotated_time, _ = Fernet._get_unverified_token_data(
             mf2.rotate(mf1_ciphertext)
         )
 
-        assert original_time == t1
+        assert later_time != rotated_time
         assert original_time == rotated_time
 
     def test_rotate_decrypt_no_shared_keys(self, backend):

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -170,7 +170,7 @@ class TestMultiFernet(object):
 
         assert mf2.decrypt(mf1_ciphertext) == plaintext
 
-        rotated = mf2.rotate([mf1.encrypt(plaintext)])[0]
+        rotated = mf2.rotate([mf1_ciphertext])[0]
 
         assert rotated != mf1_ciphertext
         assert mf2.decrypt(rotated) == plaintext


### PR DESCRIPTION
This addresses #3882.

Adds a `rotate(msgs, ttl)` method to `Multifernet` to make it a easier to re-encrypt old tokens under a new primary key. 

Thanks!