### PR TITLE
pytest 3.3.0 has an issue with parametrized null bytes again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ else:
     setup_requirements.append("cffi>=1.7")
 
 test_requirements = [
-    "pytest>=3.2.1",
+    "pytest>=3.2.1,!=3.3.0",
     "pretend",
     "iso8601",
     "pytz",


### PR DESCRIPTION
refs https://github.com/pytest-dev/pytest/issues/2957

Blacklisting 3.3.0 for now.