### PR TITLE
Add a Versioning section to the API stability docs

### DIFF
--- a/docs/api-stability.rst
+++ b/docs/api-stability.rst
@@ -34,18 +34,34 @@ One exception to our API stability policy is for security. We will violate this
 policy as necessary in order to resolve a security issue or harden
 ``cryptography`` against a possible attack.
 
+Versioning
+----------
+
+This project uses a custom versioning scheme as described below.
+
+Given a version ``cryptography X.Y.Z``,
+
+* ``X.Y`` is a decimal number that is incremented for
+  potentially-backwards-incompatible releases.
+
+  * This increases like a standard decimal.
+    In other words, 0.9 is the ninth release, and 1.0 is the tenth (not 0.10).
+    The dividing decimal point can effectively be ignored.
+
+* ``Z`` is an integer that is incremented for backward-compatible releases.
+
 Deprecation
------------
+~~~~~~~~~~~
 
 From time to time we will want to change the behavior of an API or remove it
 entirely. In that case, here's how the process will work:
 
 * In ``cryptography X.Y`` the feature exists.
-* In ``cryptography X.Y+1`` using that feature will emit a
+* In ``cryptography X.Y + 0.1`` using that feature will emit a
   ``UserWarning``.
-* In ``cryptography X.Y+2`` using that feature will emit a
+* In ``cryptography X.Y + 0.2`` using that feature will emit a
   ``UserWarning``.
-* In ``cryptography X.Y+3`` the feature will be removed or changed.
+* In ``cryptography X.Y + 0.3`` the feature will be removed or changed.
 
 In short, code that runs without warnings will always continue to work for a
 period of two releases.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -100,6 +100,7 @@ unpadding
 verifier
 Verifier
 Verisign
+versioning
 wildcard
 WoSign
 Xcode


### PR DESCRIPTION
This patch aims to articulate the versioning/tagging scheme used by the project.