### PR TITLE
Pass the right length of null bytes when no salt is provided to HKDF

### DIFF
--- a/src/cryptography/hazmat/primitives/kdf/hkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/hkdf.py
@@ -30,7 +30,7 @@ class HKDF(object):
             raise TypeError("salt must be bytes.")
 
         if salt is None:
-            salt = b"\x00" * (self._algorithm.digest_size // 8)
+            salt = b"\x00" * self._algorithm.digest_size
 
         self._salt = salt
 


### PR DESCRIPTION
This bug looks bad but ends up being benign because HMAC is specified to pad null bytes if a key is too short. So we passed too few bytes and then OpenSSL obligingly padded it out to the correct length. However, we should still do the right thing obviously.

refs #4032 