### PR TITLE
The HKDF limit is actually 255 * digest_length_in_bytes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changelog
 .. note:: This version is not yet released and is under active development.
 
 * **BACKWARDS INCOMPATIBLE:** Support for Python 2.6 has been dropped.
+* Resolved a bug in ``HKDF`` that incorrectly constrained output size.
 * Added token rotation support to :doc:`Fernet </fernet>` with
   :meth:`~cryptography.fernet.MultiFernet.rotate`.
 

--- a/src/cryptography/hazmat/primitives/kdf/hkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/hkdf.py
@@ -67,7 +67,7 @@ class HKDFExpand(object):
 
         self._backend = backend
 
-        max_length = 255 * (algorithm.digest_size // 8)
+        max_length = 255 * algorithm.digest_size
 
         if length > max_length:
             raise ValueError(

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -21,7 +21,7 @@ from ...utils import raises_unsupported_algorithm
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
 class TestHKDF(object):
     def test_length_limit(self, backend):
-        big_length = 255 * (hashes.SHA256().digest_size // 8) + 1
+        big_length = 255 * hashes.SHA256().digest_size + 1
 
         with pytest.raises(ValueError):
             HKDF(

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 import binascii
+import os
 
 import pytest
 
@@ -15,7 +16,9 @@ from cryptography.hazmat.backends.interfaces import HMACBackend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF, HKDFExpand
 
-from ...utils import raises_unsupported_algorithm
+from ...utils import (
+    load_nist_vectors, load_vectors_from_file, raises_unsupported_algorithm
+)
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
@@ -152,6 +155,21 @@ class TestHKDF(object):
         )
 
         assert hkdf.derive(b"\x01" * 16) == b"gJ\xfb{"
+
+    def test_derive_long_output(self, backend):
+        vector = load_vectors_from_file(
+            os.path.join("KDF", "hkdf-generated.txt"), load_nist_vectors
+        )[0]
+        hkdf = HKDF(
+            hashes.SHA256(),
+            int(vector["l"]),
+            salt=vector["salt"],
+            info=vector["info"],
+            backend=backend
+        )
+        ikm = binascii.unhexlify(vector["ikm"])
+
+        assert hkdf.derive(ikm) == binascii.unhexlify(vector["okm"])
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)


### PR DESCRIPTION
Previously we had a bug where we divided digest_size by 8...but HashAlgorithm.digest_size is already in bytes.

RFC 5869:
```
      L        length of output keying material in octets
               (<= 255*HashLen)
```

fixes #4032 