### PR TITLE
Don't use whirlpool as an example

### DIFF
--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -175,7 +175,7 @@ Interfaces
         :type: str
 
         The standard name for the hash algorithm, for example: ``"sha256"`` or
-        ``"whirlpool"``.
+        ``"blake2b"``.
 
     .. attribute:: digest_size
 


### PR DESCRIPTION
Both because it's weirdo crypto, but also because we don't even support it.

Adhere to our documented policy of using good crypto for all examples