### PR TITLE
Expose `BN_clear_free` in the OpenSSL backend

### DIFF
--- a/src/_cffi_src/openssl/bignum.py
+++ b/src/_cffi_src/openssl/bignum.py
@@ -17,6 +17,7 @@ typedef int... BN_ULONG;
 FUNCTIONS = """
 BIGNUM *BN_new(void);
 void BN_free(BIGNUM *);
+void BN_clear_free(BIGNUM *);
 
 BN_CTX *BN_CTX_new(void);
 void BN_CTX_free(BN_CTX *);

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -150,7 +150,7 @@ class TestOpenSSL(object):
         value = (2 ** 4242) - 4242
         bn = backend._int_to_bn(value)
         assert bn != backend._ffi.NULL
-        bn = backend._ffi.gc(bn, backend._lib.BN_free)
+        bn = backend._ffi.gc(bn, backend._lib.BN_clear_free)
 
         assert bn
         assert backend._bn_to_int(bn) == value


### PR DESCRIPTION
### What this does:
1. Exposes `BN_clear_free` in the OpenSSL backend. (See #4065)
2. Implements `BN_clear_free` in `tests.hazmat.backends.test_openssl.test_int_to_bn`.

### Guidance Requested:
This being my first patch to cryptography.io, I'm trying to figure out the best way to go about the test for this. As you can see, I have replaced the use of `BN_free` in `test_int_to_bn` and replaced it with `BN_clear_free`. I'm not sure if this is the best way to go about it, but this leaves one other test that uses `BN_free` -- `test_int_to_bn_inplace`.
  