### PR TITLE
temporarily pin cffi to avoid bug related to virtualenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if platform.python_implementation() == "PyPy":
             "upgrade PyPy to use this library."
         )
 else:
-    setup_requirements.append("cffi>=1.7")
+    setup_requirements.append("cffi>=1.7,cffi!=1.11.3")
 
 test_requirements = [
     "pytest>=3.2.1,!=3.3.0",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if platform.python_implementation() == "PyPy":
             "upgrade PyPy to use this library."
         )
 else:
-    setup_requirements.append("cffi>=1.7,cffi!=1.11.3")
+    setup_requirements.append("cffi>=1.7,!=1.11.3")
 
 test_requirements = [
     "pytest>=3.2.1,!=3.3.0",


### PR DESCRIPTION
This isn't cffi's bug and they're likely to release a 1.11.4 shortly to resolve the issue, but if we want to unblock our CI we can merge this.

refs https://bitbucket.org/cffi/cffi/issues/355/importerror-dll-load-failed-on-windows