### PR TITLE
fix a memory leak in ec derive_private_key

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1409,8 +1409,9 @@ class Backend(object):
 
         res = self._lib.EC_KEY_set_public_key(ec_cdata, point)
         self.openssl_assert(res == 1)
-        res = self._lib.EC_KEY_set_private_key(
-            ec_cdata, self._int_to_bn(private_value))
+        private = self._int_to_bn(private_value)
+        private = self._ffi.gc(private, self._lib.BN_clear_free)
+        res = self._lib.EC_KEY_set_private_key(ec_cdata, private)
         self.openssl_assert(res == 1)
 
         evp_pkey = self._ec_cdata_to_evp_pkey(ec_cdata)

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -219,6 +219,6 @@ class TestOpenSSLMemoryLeaks(object):
         assert_no_memory_leaks(textwrap.dedent("""
         def func():
             from cryptography.hazmat.backends.openssl import backend
-            from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, derive_private_key
-            derive_private_key(1, SECP256R1(), backend)
+            from cryptography.hazmat.primitives.asymmetric import ec
+            ec.derive_private_key(1, ec.SECP256R1(), backend)
         """))

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -214,3 +214,11 @@ class TestOpenSSLMemoryLeaks(object):
                 )
             ).private_key(backend)
         """))
+
+    def test_ec_derive_private_key(self):
+        assert_no_memory_leaks(textwrap.dedent("""
+        def func():
+            from cryptography.hazmat.backends.openssl import backend
+            from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, derive_private_key
+            derive_private_key(1, SECP256R1(), backend)
+        """))


### PR DESCRIPTION
fixes #4095 

We should separately put in a PR for a changelog entry. Just writing this here to help me remember.