### PR TITLE
Add bindings for SRTP support

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -405,6 +405,9 @@ long SSL_set_tlsext_status_type(SSL *, long);
 long SSL_CTX_set_tlsext_status_cb(SSL_CTX *, int(*)(SSL *, void *));
 long SSL_CTX_set_tlsext_status_arg(SSL_CTX *, void *);
 
+int SSL_CTX_set_tlsext_use_srtp(SSL_CTX *, const char *);
+int SSL_set_tlsext_use_srtp(SSL *, const char *);
+
 long SSL_session_reused(SSL *);
 
 void SSL_CTX_set_next_protos_advertised_cb(SSL_CTX *,


### PR DESCRIPTION
I spotted a number of new bindings being added to support DTLS, which is great!

One useful application is negotiating SRTP keys using DTLS, for instance for use with WebRTC:

https://tools.ietf.org/html/rfc5764

To do so, you need bindings for SSL_set_tlsext_use_srtp and/or SSL_CTX_set_tlsext_use_srtp, which this pull request provides.