### PR TITLE
Add binding for SSL_get_certificate

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -179,6 +179,7 @@ int SSL_pending(const SSL *);
 int SSL_write(SSL *, const void *, int);
 int SSL_read(SSL *, void *, int);
 int SSL_peek(SSL *, void *, int);
+X509 *SSL_get_certificate(const SSL *);
 X509 *SSL_get_peer_certificate(const SSL *);
 int SSL_get_ex_data_X509_STORE_CTX_idx(void);
 


### PR DESCRIPTION
Currently we only expose SSL_get_peer_certificate, which allows you
to retrieve the remote party's certificate. This adds the symetrical
binding to retrieve the local party's certificate.

The motivation for this additional binding is to make it possible to
query the local certificate regardless of the method which was used to
load the certificate into the SSL connection (from a file, from an
in-memory object). An example where this is useful is when negotiating
a DTLS-SRTP connection, the fingerprint of the local certificate needs
to be communicated to the remote party out-of-band via SDP.

This binding can be exposed in pyopenssl as Connection.get_certificate().