### PR TITLE
change our manylinux1 and macos wheel builders to build limited api

### DIFF
--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -16,14 +16,13 @@ def configs = [
     ],
     [
         label: 'sierra',
-        versions: ['py27', 'py34', 'py35', 'py36'],
+        versions: ['py27', 'py34'],
     ],
     [
         label: 'docker',
         imageName: 'pyca/cryptography-manylinux1:i686',
         versions: [
             'cp27-cp27m', 'cp27-cp27mu', 'cp34-cp34m',
-            'cp35-cp35m', 'cp36-cp36m'
         ],
     ],
     [
@@ -31,7 +30,6 @@ def configs = [
         imageName: 'pyca/cryptography-manylinux1:x86_64',
         versions: [
             'cp27-cp27m', 'cp27-cp27mu', 'cp34-cp34m',
-            'cp35-cp35m', 'cp36-cp36m'
         ],
     ],
 ]
@@ -88,8 +86,6 @@ def build(version, label, imageName) {
                 def pythonPath = [
                     py27: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7",
                     py34: "/Library/Frameworks/Python.framework/Versions/3.4/bin/python3.4",
-                    py35: "/Library/Frameworks/Python.framework/Versions/3.5/bin/python3.5",
-                    py36: "/Library/Frameworks/Python.framework/Versions/3.6/bin/python3.6",
                 ]
                 ansiColor {
                     sh """#!/usr/bin/env bash
@@ -107,7 +103,15 @@ def build(version, label, imageName) {
                         virtualenv .venv -p ${pythonPath[version]}
                         source .venv/bin/activate
                         pip install -U wheel # upgrade wheel to latest before we use it to build the wheel
-                        CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1" LDFLAGS="/usr/local/opt/openssl@1.1/lib/libcrypto.a /usr/local/opt/openssl@1.1/lib/libssl.a" CFLAGS="-I/usr/local/opt/openssl@1.1/include -mmacosx-version-min=10.9" pip wheel cryptography==$BUILD_VERSION --wheel-dir=wheelhouse --no-binary cryptography
+                        pip install cffi six idna asn1crypto ipaddress enum34
+                        pip download cryptography==$BUILD_VERSION --no-binary cryptography --no-deps
+                        tar zxf cryptography*
+                        cd cryptography*
+                        if [[ "${version}" == "py34" ]]; then
+                            PY_LIMITED_API='--py-limited-api=cp34'
+                        fi
+                        CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1" LDFLAGS="/usr/local/opt/openssl@1.1/lib/libcrypto.a /usr/local/opt/openssl@1.1/lib/libssl.a" CFLAGS="-I/usr/local/opt/openssl@1.1/include -mmacosx-version-min=10.9" python setup.py bdist_wheel --dist-dir=../wheelhouse \$PY_LIMITED_API
+                        cd ..
                         pip install -f wheelhouse cryptography --no-index
                         python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"
                         otool -L `find .venv -name '_openssl*.so'`
@@ -122,6 +126,10 @@ def build(version, label, imageName) {
                 }
                 sh """#!/usr/bin/env bash
                     set -x -e
+
+                    $linux32 /opt/python/$version/bin/pip install cffi six idna asn1crypto ipaddress enum34
+                    $linux32 /opt/python/$version/bin/pip download cryptography==$BUILD_VERSION --no-binary cryptography --no-deps
+                    tar zxf cryptography*
                     # Because we are doing this as root in the container, but we write to a mounted dir that is outside the container
                     # we need to make sure we set these files writable such that the jenkins user can delete them afterwards
                     mkdir -p tmpwheelhouse
@@ -129,10 +137,15 @@ def build(version, label, imageName) {
                     chmod -R 777 tmpwheelhouse
                     chmod -R 777 wheelhouse
 
-                    $linux32 /opt/python/$version/bin/pip install cffi six idna asn1crypto ipaddress enum34
+                    cd cryptography*
+                    if [[ "${version}" == "cp34-cp34m" ]]; then
+                        PY_LIMITED_API='--py-limited-api=cp34'
+                    fi
                     LDFLAGS="-L/opt/pyca/cryptography/openssl/lib" \
                         CFLAGS="-I/opt/pyca/cryptography/openssl/include -Wl,--exclude-libs,ALL" \
-                        $linux32 /opt/python/$version/bin/pip wheel cryptography==$BUILD_VERSION -w tmpwheelhouse/ --no-binary cryptography --no-deps
+                        $linux32 /opt/python/$version/bin/python setup.py bdist_wheel --dist-dir=../tmpwheelhouse \$PY_LIMITED_API
+                    cd ..
+                    chmod -R 777 cryptography*
                     $linux32 auditwheel repair tmpwheelhouse/cryptography*.whl -w wheelhouse/
                     unzip wheelhouse/*.whl -d execstack.check
                     chmod -R 777 execstack.check

--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -110,7 +110,10 @@ def build(version, label, imageName) {
                         if [[ "${version}" == "py34" ]]; then
                             PY_LIMITED_API='--py-limited-api=cp34'
                         fi
-                        CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1" LDFLAGS="/usr/local/opt/openssl@1.1/lib/libcrypto.a /usr/local/opt/openssl@1.1/lib/libssl.a" CFLAGS="-I/usr/local/opt/openssl@1.1/include -mmacosx-version-min=10.9" python setup.py bdist_wheel --dist-dir=../wheelhouse \$PY_LIMITED_API
+                        CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1" \
+                            LDFLAGS="/usr/local/opt/openssl@1.1/lib/libcrypto.a /usr/local/opt/openssl@1.1/lib/libssl.a" \
+                            CFLAGS="-I/usr/local/opt/openssl@1.1/include -mmacosx-version-min=10.9" \
+                            python setup.py bdist_wheel --dist-dir=../wheelhouse \$PY_LIMITED_API
                         cd ..
                         pip install -f wheelhouse cryptography --no-index
                         python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"

--- a/.jenkins/Jenkinsfile-cryptography-wheel-builder
+++ b/.jenkins/Jenkinsfile-cryptography-wheel-builder
@@ -16,11 +16,15 @@ def configs = [
     ],
     [
         label: 'sierra',
+        # The py3x version listed here corresponds to the minimum ABI version
+        # the wheels will support. e.g. py34 supports py34+
         versions: ['py27', 'py34'],
     ],
     [
         label: 'docker',
         imageName: 'pyca/cryptography-manylinux1:i686',
+        # The py3x version listed here corresponds to the minimum ABI version
+        # the wheels will support. e.g. cp34-cp34m supports py34+
         versions: [
             'cp27-cp27m', 'cp27-cp27mu', 'cp34-cp34m',
         ],
@@ -28,6 +32,8 @@ def configs = [
     [
         label: 'docker',
         imageName: 'pyca/cryptography-manylinux1:x86_64',
+        # The py3x version listed here corresponds to the minimum ABI version
+        # the wheels will support. e.g. cp34-cp34m supports py34+
         versions: [
             'cp27-cp27m', 'cp27-cp27mu', 'cp34-cp34m',
         ],
@@ -106,15 +112,16 @@ def build(version, label, imageName) {
                         pip install cffi six idna asn1crypto ipaddress enum34
                         pip download cryptography==$BUILD_VERSION --no-binary cryptography --no-deps
                         tar zxf cryptography*
-                        cd cryptography*
-                        if [[ "${version}" == "py34" ]]; then
-                            PY_LIMITED_API='--py-limited-api=cp34'
+                        pushd cryptography*
+                        REGEX="cp3([0-9])*"
+                        if [[ "${version}" =~ $REGEX ]]; then
+                            PY_LIMITED_API="--py-limited-api=cp3${BASH_REMATCH[1]}"
                         fi
                         CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1" \
                             LDFLAGS="/usr/local/opt/openssl@1.1/lib/libcrypto.a /usr/local/opt/openssl@1.1/lib/libssl.a" \
                             CFLAGS="-I/usr/local/opt/openssl@1.1/include -mmacosx-version-min=10.9" \
                             python setup.py bdist_wheel --dist-dir=../wheelhouse \$PY_LIMITED_API
-                        cd ..
+                        popd
                         pip install -f wheelhouse cryptography --no-index
                         python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"
                         otool -L `find .venv -name '_openssl*.so'`
@@ -140,14 +147,15 @@ def build(version, label, imageName) {
                     chmod -R 777 tmpwheelhouse
                     chmod -R 777 wheelhouse
 
-                    cd cryptography*
-                    if [[ "${version}" == "cp34-cp34m" ]]; then
-                        PY_LIMITED_API='--py-limited-api=cp34'
+                    pushd cryptography*
+                    REGEX="cp3([0-9])*"
+                    if [[ "${version}" =~ $REGEX ]]; then
+                        PY_LIMITED_API="--py-limited-api=cp3${BASH_REMATCH[1]}"
                     fi
                     LDFLAGS="-L/opt/pyca/cryptography/openssl/lib" \
                         CFLAGS="-I/opt/pyca/cryptography/openssl/include -Wl,--exclude-libs,ALL" \
                         $linux32 /opt/python/$version/bin/python setup.py bdist_wheel --dist-dir=../tmpwheelhouse \$PY_LIMITED_API
-                    cd ..
+                    popd
                     chmod -R 777 cryptography*
                     $linux32 auditwheel repair tmpwheelhouse/cryptography*.whl -w wheelhouse/
                     unzip wheelhouse/*.whl -d execstack.check


### PR DESCRIPTION
pip does not currently support --py-limited-api so we have to switch to downloading and then building via setup.py bdist_wheel for now. However, we can get rid of everything but the py34 builder on mac/linux/linux32, saving us 6 wheels now (and soon 9 with the release of python 3.7).

This addresses #3307.