### PR TITLE
Expose BN_rand operations

### DIFF
--- a/src/_cffi_src/openssl/bignum.py
+++ b/src/_cffi_src/openssl/bignum.py
@@ -19,6 +19,9 @@ BIGNUM *BN_new(void);
 void BN_free(BIGNUM *);
 void BN_clear_free(BIGNUM *);
 
+int BN_rand(BIGNUM *, int, int, int);
+int BN_rand_range(BIGNUM *, BIGNUM *);
+
 BN_CTX *BN_CTX_new(void);
 void BN_CTX_free(BN_CTX *);
 


### PR DESCRIPTION
### What this does:
1. Exposes `BN_rand` and `BN_rand_range` in the OpenSSL backend.
2. Solves #4109  