### PR TITLE
don't allow GeneralNames to be an empty list

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -1160,6 +1160,9 @@ class Extension(object):
 class GeneralNames(object):
     def __init__(self, general_names):
         general_names = list(general_names)
+        if len(general_names) == 0:
+            raise ValueError("Must supply at least one general name")
+
         if not all(isinstance(x, GeneralName) for x in general_names):
             raise TypeError(
                 "Every item in the general_names list must be an "

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -2052,6 +2052,10 @@ class TestGeneralNames(object):
                 [x509.DNSName(u"cryptography.io"), "invalid"]
             )
 
+    def test_does_not_allow_empty_list(self):
+        with pytest.raises(ValueError):
+            x509.GeneralNames([])
+
     def test_repr(self):
         gns = x509.GeneralNames(
             [
@@ -2217,12 +2221,6 @@ class TestCRLNumber(object):
         c3 = x509.CRLNumber(2)
         assert hash(c1) == hash(c2)
         assert hash(c1) != hash(c3)
-
-
-class TestGeneralNames(object):
-    def test_does_not_allow_empty_list(self):
-        with pytest.raises(ValueError):
-            x509.GeneralNames([])
 
 
 class TestSubjectAlternativeName(object):

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -2219,6 +2219,12 @@ class TestCRLNumber(object):
         assert hash(c1) != hash(c3)
 
 
+class TestGeneralNames(object):
+    def test_does_not_allow_empty_list(self):
+        with pytest.raises(ValueError):
+            x509.GeneralNames([])
+
+
 class TestSubjectAlternativeName(object):
     def test_get_values_for_type(self):
         san = x509.SubjectAlternativeName(


### PR DESCRIPTION
It doesn't make logical sense (at least in our higher level APIs) to allow empty GeneralNames.

fixes #4102 