### PR TITLE
Add API for retrieving the seconds-to-expiry for the token, given a TTL.

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -91,7 +91,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
         :raises cryptography.fernet.InvalidToken: If the ``token``'s signature
                                                   is invalid, this exception
                                                   is raised.
-        :raises TypeError: This exception is raised if ``data`` is not
+        :raises TypeError: This exception is raised if ``token`` is not
                            ``bytes``.
 
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -80,6 +80,20 @@ has support for implementing key rotation via :class:`MultiFernet`.
         :raises TypeError: This exception is raised if ``token`` is not
                            ``bytes``.
 
+    .. method:: age(token)
+
+        Computes the age of the token. The caller can then decide if the token
+        is about to expire and for example reissue a new token.
+
+        :param bytes token: The Fernet token. This is the result of calling
+                            :meth:`encrypt`.
+        :returns int: The token's age in seconds.
+        :raises cryptography.fernet.InvalidToken: If the ``token``'s signature
+                                                  is way invalid, this
+                                                  exception is raised.
+        :raises TypeError: This exception is raised if ``data`` is not
+                           ``bytes``.
+
 
 .. class:: MultiFernet(fernets)
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -89,8 +89,8 @@ has support for implementing key rotation via :class:`MultiFernet`.
                             :meth:`encrypt`.
         :returns int: The token's age in seconds.
         :raises cryptography.fernet.InvalidToken: If the ``token``'s signature
-                                                  is way invalid, this
-                                                  exception is raised.
+                                                  is invalid, this exception
+                                                  is raised.
         :raises TypeError: This exception is raised if ``data`` is not
                            ``bytes``.
 

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -74,6 +74,13 @@ class Fernet(object):
         timestamp, data = Fernet._get_unverified_token_data(token)
         return self._decrypt_data(data, timestamp, ttl)
 
+    def ttl(self, token, ttl):
+        current_time = int(time.time())
+        timestamp, data = Fernet._get_unverified_token_data(token)
+        # Verify the token was not tampered with, but do not fail on expiry.
+        self._decrypt_data(data, timestamp, None)
+        return ttl - (current_time - timestamp)
+
     @staticmethod
     def _get_unverified_token_data(token):
         if not isinstance(token, bytes):

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -122,21 +122,6 @@ class TestFernet(object):
         with pytest.raises(ValueError):
             Fernet(base64.urlsafe_b64encode(b"abc"), backend=backend)
 
-    def test_timestamp_ttl_overdue(self, monkeypatch, backend):
-        f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
-        # Create the token some time in the past.
-        ts = "1985-10-26T01:20:01"
-        current_time = calendar.timegm(iso8601.parse_date(ts).utctimetuple())
-        monkeypatch.setattr(time, "time", lambda: current_time)
-        token = f.encrypt(b'encrypt me')
-        # A minute later we check, but we declare the TTL to be 59 seconds so
-        # the token has expired.
-        ts = "1985-10-26T01:21:01"
-        current_time = calendar.timegm(iso8601.parse_date(ts).utctimetuple())
-        monkeypatch.setattr(time, "time", lambda: current_time)
-        with pytest.raises(InvalidToken):
-            f.decrypt(token, ttl=59)
-
     def test_timestamp_age(self, monkeypatch, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         # Create the token some time in the past.

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -9,7 +9,6 @@ import calendar
 import datetime
 import json
 import os
-import struct
 import time
 
 import iso8601


### PR DESCRIPTION
As discussed in issue #4091 perhaps there could be an API to check the number of seconds before the token expires (against a given TTL). This PR is still work in progress. I'd like to know if the implementation is anywhere near acceptable. If it is, I'll add TTL support to MultiFernet and add documentation. Thanks in advance for your feedback.