### PR TITLE
DSA parameters should support 224 for q length

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -130,8 +130,8 @@ def generate_private_key(key_size, backend):
 def _check_dsa_parameters(parameters):
     if parameters.p.bit_length() not in [1024, 2048, 3072]:
         raise ValueError("p must be exactly 1024, 2048, or 3072 bits long")
-    if parameters.q.bit_length() not in [160, 256]:
-        raise ValueError("q must be exactly 160 or 256 bits long")
+    if parameters.q.bit_length() not in [160, 224, 256]:
+        raise ValueError("q must be exactly 160, 224 or 256 bits long")
 
     if not (1 < parameters.g < parameters.p):
         raise ValueError("g, p don't satisfy 1 < g < p.")


### PR DESCRIPTION
I am trying to make Golang to talk to Python and using this library.
In golang keys are generated with `L2048N224` (https://golang.org/pkg/crypto/dsa/#ParameterSizes) and after making this small fix I do not see any issue - I can load my parameters and work with my keys.