### PR TITLE
remove arbitrary rc4 key size limitations

### DIFF
--- a/src/cryptography/hazmat/primitives/ciphers/algorithms.py
+++ b/src/cryptography/hazmat/primitives/ciphers/algorithms.py
@@ -103,10 +103,9 @@ class CAST5(object):
 @utils.register_interface(CipherAlgorithm)
 class ARC4(object):
     name = "RC4"
-    key_sizes = frozenset([40, 56, 64, 80, 128, 160, 192, 256])
 
     def __init__(self, key):
-        self.key = _verify_key_size(self, key)
+        self.key = key
 
     @property
     def key_size(self):


### PR DESCRIPTION
What's the reasoning behind a limited set of possible key sizes for `ARC4` (https://github.com/pyca/cryptography/blob/master/src/cryptography/hazmat/primitives/ciphers/algorithms.py#L106) when the OpenSSL backend can take any key size up to 256 bytes (https://github.com/openssl/openssl/blob/master/crypto/rc4/rc4_skey.c#L45)?
Note that `PyCrypto` also doesn't have this limitation.
No additional unit tests are included (sorry), but the existing ones should still work.