### PR TITLE
Revert "don't allow GeneralNames to be an empty list (#4128)"

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -1160,9 +1160,6 @@ class Extension(object):
 class GeneralNames(object):
     def __init__(self, general_names):
         general_names = list(general_names)
-        if len(general_names) == 0:
-            raise ValueError("Must supply at least one general name")
-
         if not all(isinstance(x, GeneralName) for x in general_names):
             raise TypeError(
                 "Every item in the general_names list must be an "

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -2052,10 +2052,6 @@ class TestGeneralNames(object):
                 [x509.DNSName(u"cryptography.io"), "invalid"]
             )
 
-    def test_does_not_allow_empty_list(self):
-        with pytest.raises(ValueError):
-            x509.GeneralNames([])
-
     def test_repr(self):
         gns = x509.GeneralNames(
             [


### PR DESCRIPTION
This breaks the urllib3 tests, as well as several in-the-wild certs

This reverts commit 388d1bd3e9cd953fcc948edbc152d5d140c87eb8.