### PR TITLE
add X509_NAME_print_ex

### DIFF
--- a/src/_cffi_src/openssl/x509name.py
+++ b/src/_cffi_src/openssl/x509name.py
@@ -39,7 +39,10 @@ int Cryptography_X509_NAME_ENTRY_set(X509_NAME_ENTRY *);
 /* These became const X509_NAME * in 1.1.0 */
 int X509_NAME_entry_count(X509_NAME *);
 X509_NAME_ENTRY *X509_NAME_get_entry(X509_NAME *, int);
+/* manual for X509_NAME_PRINT_EX ``strongly discourages'' the use of
+   X509_NAME_oneline */
 char *X509_NAME_oneline(X509_NAME *, char *, int);
+int X509_NAME_print_ex(BIO *, X509_NAME *, int, unsigned long);
 
 /* These became const X509_NAME_ENTRY * in 1.1.0 */
 ASN1_OBJECT *X509_NAME_ENTRY_get_object(X509_NAME_ENTRY *);

--- a/src/_cffi_src/openssl/x509name.py
+++ b/src/_cffi_src/openssl/x509name.py
@@ -39,8 +39,6 @@ int Cryptography_X509_NAME_ENTRY_set(X509_NAME_ENTRY *);
 /* These became const X509_NAME * in 1.1.0 */
 int X509_NAME_entry_count(X509_NAME *);
 X509_NAME_ENTRY *X509_NAME_get_entry(X509_NAME *, int);
-/* manual for X509_NAME_PRINT_EX ``strongly discourages'' the use of
-   X509_NAME_oneline */
 char *X509_NAME_oneline(X509_NAME *, char *, int);
 int X509_NAME_print_ex(BIO *, X509_NAME *, int, unsigned long);
 


### PR DESCRIPTION
As a prerequisite to fixing https://github.com/pyca/pyopenssl/issues/745, this project needs to provide one of the recommended name formatting functions.