### PR TITLE
simplify Jenkins test run for aws-encryption-sdk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,9 +158,9 @@ def downstreams = [
             virtualenv .venv
             source .venv/bin/activate
             pip install ../cryptography
-            pip install pytest pytest-mock mock
+            pip install -r test/requirements.txt
             pip install -e .
-            AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID="arn:aws:kms:us-west-2:nonsense" pytest -m local -l
+            pytest -m local -l
         """
     ],
     [


### PR DESCRIPTION
As of https://github.com/awslabs/aws-encryption-sdk-python/pull/46 we have improved the experience for tests running outside tox and for only running local tests. This change takes advantage of those improvements to simplify your downstream test setup and avoid breaking if/when we change our test dependencies in the future.