### PR TITLE
Expose OpenSSL constant time bignum arithmetic

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,3 +40,4 @@ PGP key fingerprints are enclosed in parentheses.
 * Chris Wolfe <chriswwolfe@gmail.com>
 * Jeremy Lainé <jeremy.laine@m4x.org>
 * Denis Gladkikh <denis@gladkikh.email>
+* John Pacific <me@johnpacific.com> (2CF6 0381 B5EF 29B7 D48C 2020 7BB9 71A0 E891 44D9)

--- a/src/_cffi_src/openssl/bignum.py
+++ b/src/_cffi_src/openssl/bignum.py
@@ -10,11 +10,17 @@ INCLUDES = """
 
 TYPES = """
 typedef ... BN_CTX;
+typedef ... BN_MONT_CTX;
 typedef ... BIGNUM;
 typedef int... BN_ULONG;
 """
 
 FUNCTIONS = """
+#define BN_FLG_CONSTTIME ...
+
+void BN_set_flags(BIGNUM *, int);
+int BN_get_flags(const BIGNUM *, int);
+
 BIGNUM *BN_new(void);
 void BN_free(BIGNUM *);
 void BN_clear_free(BIGNUM *);
@@ -28,6 +34,10 @@ void BN_CTX_free(BN_CTX *);
 void BN_CTX_start(BN_CTX *);
 BIGNUM *BN_CTX_get(BN_CTX *);
 void BN_CTX_end(BN_CTX *);
+
+BN_MONT_CTX *BN_MONT_CTX_new(void);
+int BN_MONT_CTX_set(BN_MONT_CTX *, BIGNUM *, BN_CTX *);
+void BN_MONT_CTX_free(BN_MONT_CTX *);
 
 BIGNUM *BN_copy(BIGNUM *, const BIGNUM *);
 BIGNUM *BN_dup(const BIGNUM *);
@@ -63,6 +73,10 @@ int BN_mod_sqr(BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
 int BN_exp(BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
 int BN_mod_exp(BIGNUM *, const BIGNUM *, const BIGNUM *, const BIGNUM *,
                BN_CTX *);
+int BN_mod_exp_mont(BIGNUM *, const BIGNUM *, const BIGNUM *, const BIGNUM *,
+                    BN_CTX *, BN_MONT_CTX *);
+int BN_mod_exp_mont_consttime(BIGNUM *, const BIGNUM *, const BIGNUM *,
+                              const BIGNUM *, BN_CTX *, BN_MONT_CTX *);
 int BN_gcd(BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
 BIGNUM *BN_mod_inverse(BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
 


### PR DESCRIPTION
### What this does:
1. Exposes the following:
    1. `BN_set_flags` and `BN_get_flags`
    2. `BN_MONT_CTX_new`, `BN_MONT_CTX_set`, and `BN_MONT_CTX_free`
    3. `BN_mod_exp_mont`, `BN_mod_exp_mont_consttime`
    4. `BN_FLG_CONSTTIME` flag for setting BNs to use constant time operations in `BN_div`, `BN_mod_inverse`, and `BN_mod_exp_mont`.
2. Resolves #4199

### Notes:
1. When `BN_FLG_CONSTTIME` is set on an OpenSSL BN and `BN_mod_inverse`, `BN_div`, or `BN_mod_exp_mont` is called OpenSSL will, in turn, call `BN_mod_inverse_no_branch`, `BN_div_no_branch`, and `BN_mod_exp_mont_consttime` respectively.