### PR TITLE
Add Session functions, necessary to implement new features in Python 3.6

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -306,6 +306,10 @@ int SSL_CTX_set_ex_data(SSL_CTX *, int, void *);
 
 SSL_SESSION *SSL_get_session(const SSL *);
 const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *, unsigned int *);
+long SSL_SESSION_get_time(const SSL_SESSION *);
+long SSL_SESSION_get_timeout(const SSL_SESSION *);
+int SSL_SESSION_has_ticket(const SSL_SESSION *);
+long SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *);
 
 /* not a macro, but older OpenSSLs don't pass the args as const */
 char *SSL_CIPHER_description(const SSL_CIPHER *, char *, int);
@@ -569,6 +573,16 @@ size_t SSL_SESSION_get_master_key(const SSL_SESSION *session,
         outlen = session->master_key_length;
     memcpy(out, session->master_key, outlen);
     return outlen;
+}
+/* from ssl/ssl_sess.c */
+int SSL_SESSION_has_ticket(const SSL_SESSION *s)
+{
+    return (s->tlsext_ticklen > 0) ? 1 : 0;
+}
+/* from ssl/ssl_sess.c */
+unsigned long SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *s)
+{
+    return s->tlsext_tick_lifetime_hint;
 }
 #endif
 


### PR DESCRIPTION
This change was already applied in the PyPy repository, and test_ssl passes.