### PR TITLE
1.3.6.1.4.1.11129.2.4.2 is no longer an 'Unknown OID'

### DIFF
--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -241,6 +241,9 @@ _OID_NAMES = {
     ExtensionOID.SUBJECT_ALTERNATIVE_NAME: "subjectAltName",
     ExtensionOID.ISSUER_ALTERNATIVE_NAME: "issuerAltName",
     ExtensionOID.BASIC_CONSTRAINTS: "basicConstraints",
+    ExtensionOID.PRECERT_SIGNED_CERTIFICATE_TIMESTAMPS: (
+        "signedCertificateTimestampList"
+    ),
     CRLEntryExtensionOID.CRL_REASON: "cRLReason",
     CRLEntryExtensionOID.INVALIDITY_DATE: "invalidityDate",
     CRLEntryExtensionOID.CERTIFICATE_ISSUER: "certificateIssuer",


### PR DESCRIPTION
We already have 1.3.6.1.4.1.11129.2.4.2 in the ExtensionOID class, and we already have a method in hazmat/backends/openssl/decode_asn1 for decoding it, but because it wasn't in the _OID_Name dictionary, it showed up as an 'Unknown OID' when processed.

This PR just adds the name `signedCertificateTimestampList` since that's how it's referred to on page 13 of [Laurie et al.](https://tools.ietf.org/html/rfc6962)