### PR TITLE
Clean up unused EC bindings.

### DIFF
--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -27,34 +27,16 @@ typedef struct {
 typedef enum {
     POINT_CONVERSION_COMPRESSED,
     POINT_CONVERSION_UNCOMPRESSED,
-    POINT_CONVERSION_HYBRID,
     ...
 } point_conversion_form_t;
 """
 
 FUNCTIONS = """
-EC_GROUP *EC_GROUP_new(const EC_METHOD *);
 void EC_GROUP_free(EC_GROUP *);
-void EC_GROUP_clear_free(EC_GROUP *);
 
-EC_GROUP *EC_GROUP_new_curve_GFp(
-    const BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
-EC_GROUP *EC_GROUP_new_curve_GF2m(
-    const BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
 EC_GROUP *EC_GROUP_new_by_curve_name(int);
 
-int EC_GROUP_set_curve_GFp(
-    EC_GROUP *, const BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
-int EC_GROUP_get_curve_GFp(
-    const EC_GROUP *, BIGNUM *, BIGNUM *, BIGNUM *, BN_CTX *);
-int EC_GROUP_set_curve_GF2m(
-    EC_GROUP *, const BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
-int EC_GROUP_get_curve_GF2m(
-    const EC_GROUP *, BIGNUM *, BIGNUM *, BIGNUM *, BN_CTX *);
-
 int EC_GROUP_get_degree(const EC_GROUP *);
-void EC_GROUP_set_asn1_flag(EC_GROUP *, int);
-void EC_GROUP_set_point_conversion_form(EC_GROUP *, point_conversion_form_t);
 
 const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *);
 const EC_POINT *EC_GROUP_get0_generator(const EC_GROUP *);
@@ -65,13 +47,7 @@ size_t EC_get_builtin_curves(EC_builtin_curve *, size_t);
 EC_KEY *EC_KEY_new(void);
 void EC_KEY_free(EC_KEY *);
 
-int EC_KEY_get_flags(const EC_KEY *);
-void EC_KEY_set_flags(EC_KEY *, int);
-void EC_KEY_clear_flags(EC_KEY *, int);
 EC_KEY *EC_KEY_new_by_curve_name(int);
-EC_KEY *EC_KEY_copy(EC_KEY *, EC_KEY *);
-EC_KEY *EC_KEY_dup(EC_KEY *);
-int EC_KEY_up_ref(EC_KEY *);
 const EC_GROUP *EC_KEY_get0_group(const EC_KEY *);
 int EC_GROUP_get_order(const EC_GROUP *, BIGNUM *, BN_CTX *);
 int EC_KEY_set_group(EC_KEY *, const EC_GROUP *);
@@ -79,30 +55,14 @@ const BIGNUM *EC_KEY_get0_private_key(const EC_KEY *);
 int EC_KEY_set_private_key(EC_KEY *, const BIGNUM *);
 const EC_POINT *EC_KEY_get0_public_key(const EC_KEY *);
 int EC_KEY_set_public_key(EC_KEY *, const EC_POINT *);
-unsigned int EC_KEY_get_enc_flags(const EC_KEY *);
-void EC_KEY_set_enc_flags(EC_KEY *eckey, unsigned int);
-point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *);
-void EC_KEY_set_conv_form(EC_KEY *, point_conversion_form_t);
 void EC_KEY_set_asn1_flag(EC_KEY *, int);
-int EC_KEY_precompute_mult(EC_KEY *, BN_CTX *);
 int EC_KEY_generate_key(EC_KEY *);
-int EC_KEY_check_key(const EC_KEY *);
 int EC_KEY_set_public_key_affine_coordinates(EC_KEY *, BIGNUM *, BIGNUM *);
 
 EC_POINT *EC_POINT_new(const EC_GROUP *);
 void EC_POINT_free(EC_POINT *);
 void EC_POINT_clear_free(EC_POINT *);
-int EC_POINT_copy(EC_POINT *, const EC_POINT *);
 EC_POINT *EC_POINT_dup(const EC_POINT *, const EC_GROUP *);
-const EC_METHOD *EC_POINT_method_of(const EC_POINT *);
-
-int EC_POINT_set_to_infinity(const EC_GROUP *, EC_POINT *);
-
-int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *, EC_POINT *,
-    const BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
-
-int EC_POINT_get_Jprojective_coordinates_GFp(const EC_GROUP *,
-    const EC_POINT *, BIGNUM *, BIGNUM *, BIGNUM *, BN_CTX *);
 
 int EC_POINT_set_affine_coordinates_GFp(const EC_GROUP *, EC_POINT *,
     const BIGNUM *, const BIGNUM *, BN_CTX *);
@@ -129,18 +89,6 @@ size_t EC_POINT_point2oct(const EC_GROUP *, const EC_POINT *,
 int EC_POINT_oct2point(const EC_GROUP *, EC_POINT *,
     const unsigned char *, size_t, BN_CTX *);
 
-BIGNUM *EC_POINT_point2bn(const EC_GROUP *, const EC_POINT *,
-    point_conversion_form_t form, BIGNUM *, BN_CTX *);
-
-EC_POINT *EC_POINT_bn2point(const EC_GROUP *, const BIGNUM *,
-    EC_POINT *, BN_CTX *);
-
-char *EC_POINT_point2hex(const EC_GROUP *, const EC_POINT *,
-    point_conversion_form_t form, BN_CTX *);
-
-EC_POINT *EC_POINT_hex2point(const EC_GROUP *, const char *,
-    EC_POINT *, BN_CTX *);
-
 int EC_POINT_add(const EC_GROUP *, EC_POINT *, const EC_POINT *,
     const EC_POINT *, BN_CTX *);
 
@@ -152,24 +100,8 @@ int EC_POINT_is_on_curve(const EC_GROUP *, const EC_POINT *, BN_CTX *);
 int EC_POINT_cmp(
     const EC_GROUP *, const EC_POINT *, const EC_POINT *, BN_CTX *);
 
-int EC_POINT_make_affine(const EC_GROUP *, EC_POINT *, BN_CTX *);
-int EC_POINTs_make_affine(const EC_GROUP *, size_t, EC_POINT *[], BN_CTX *);
-
-int EC_POINTs_mul(
-    const EC_GROUP *, EC_POINT *, const BIGNUM *,
-    size_t, const EC_POINT *[], const BIGNUM *[], BN_CTX *);
-
 int EC_POINT_mul(const EC_GROUP *, EC_POINT *, const BIGNUM *,
     const EC_POINT *, const BIGNUM *, BN_CTX *);
-
-int EC_GROUP_precompute_mult(EC_GROUP *, BN_CTX *);
-int EC_GROUP_have_precompute_mult(const EC_GROUP *);
-
-const EC_METHOD *EC_GFp_simple_method();
-const EC_METHOD *EC_GFp_mont_method();
-const EC_METHOD *EC_GFp_nist_method();
-
-const EC_METHOD *EC_GF2m_simple_method();
 
 int EC_METHOD_get_field_type(const EC_METHOD *);
 
@@ -182,25 +114,8 @@ static const long Cryptography_HAS_EC = 1;
 #if defined(OPENSSL_NO_EC2M)
 static const long Cryptography_HAS_EC2M = 0;
 
-const EC_METHOD *(*EC_GF2m_simple_method)() = NULL;
-
-int (*EC_POINT_set_affine_coordinates_GF2m)(const EC_GROUP *, EC_POINT *,
-    const BIGNUM *, const BIGNUM *, BN_CTX *) = NULL;
-
 int (*EC_POINT_get_affine_coordinates_GF2m)(const EC_GROUP *,
     const EC_POINT *, BIGNUM *, BIGNUM *, BN_CTX *) = NULL;
-
-int (*EC_POINT_set_compressed_coordinates_GF2m)(const EC_GROUP *, EC_POINT *,
-    const BIGNUM *, int, BN_CTX *) = NULL;
-
-int (*EC_GROUP_set_curve_GF2m)(
-    EC_GROUP *, const BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
-
-int (*EC_GROUP_get_curve_GF2m)(
-    const EC_GROUP *, BIGNUM *, BIGNUM *, BIGNUM *, BN_CTX *);
-
-EC_GROUP *(*EC_GROUP_new_curve_GF2m)(
-    const BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
 #else
 static const long Cryptography_HAS_EC2M = 1;
 #endif

--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -114,8 +114,14 @@ static const long Cryptography_HAS_EC = 1;
 #if defined(OPENSSL_NO_EC2M)
 static const long Cryptography_HAS_EC2M = 0;
 
+int (*EC_POINT_set_affine_coordinates_GF2m)(const EC_GROUP *, EC_POINT *,
+    const BIGNUM *, const BIGNUM *, BN_CTX *) = NULL;
+
 int (*EC_POINT_get_affine_coordinates_GF2m)(const EC_GROUP *,
     const EC_POINT *, BIGNUM *, BIGNUM *, BN_CTX *) = NULL;
+
+int (*EC_POINT_set_compressed_coordinates_GF2m)(const EC_GROUP *, EC_POINT *,
+    const BIGNUM *, int, BN_CTX *) = NULL;
 #else
 static const long Cryptography_HAS_EC2M = 1;
 #endif

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -7,13 +7,9 @@ from __future__ import absolute_import, division, print_function
 
 def cryptography_has_ec2m():
     return [
-        "EC_GF2m_simple_method",
         "EC_POINT_set_affine_coordinates_GF2m",
         "EC_POINT_get_affine_coordinates_GF2m",
         "EC_POINT_set_compressed_coordinates_GF2m",
-        "EC_GROUP_set_curve_GF2m",
-        "EC_GROUP_get_curve_GF2m",
-        "EC_GROUP_new_curve_GF2m",
     ]
 
 


### PR DESCRIPTION
Hopefully this one is less complicated than BIO.

A lot of these are really OpenSSL internals, like the EC_METHOD
business, support for custom curves which are a bad idea, and weird
non-standard serializations like taking the usual point serialization
and treating it as a single BIGNUM.

I also didn't remove things when they're arguably part of a set. E.g.
EC_POINT_add is used, but EC_POINT_dbl isn't. However, they both set at
the same abstraction level (basic point operations), so it's strange to
have one without the other.

I also kept EC_POINT_is_on_curve because, although it is not used,
OpenSSL prior to 1.1.0 doesn't perform this important check in
EC_POINT_set_affine_coordinates_GFp (though it does in some of the
functions which ultimately call it, like
EC_KEY_set_public_key_affine_coordinates, what cryptography.io actually
uses), so one should not expose the latter without the former.