### PR TITLE
Fix some callback type signatures.

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -738,7 +738,7 @@ void (*SSL_CTX_set_psk_server_callback)(SSL_CTX *,
                                             SSL *,
                                             const char *,
                                             unsigned char *,
-                                            int
+                                            unsigned int
                                         )) = NULL;
 void (*SSL_CTX_set_psk_client_callback)(SSL_CTX *,
                                         unsigned int (*)(

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -252,7 +252,7 @@ void SSL_CTX_set_psk_server_callback(SSL_CTX *,
                                          SSL *,
                                          const char *,
                                          unsigned char *,
-                                         int
+                                         unsigned int
                                      ));
 void SSL_CTX_set_psk_client_callback(SSL_CTX *,
                                      unsigned int (*)(
@@ -401,7 +401,7 @@ void *SSL_get_ex_data(const SSL *, int);
 void SSL_set_tlsext_host_name(SSL *, char *);
 void SSL_CTX_set_tlsext_servername_callback(
     SSL_CTX *,
-    int (*)(const SSL *, int *, void *));
+    int (*)(SSL *, int *, void *));
 void SSL_CTX_set_tlsext_servername_arg(
     SSL_CTX *, void *);
 


### PR DESCRIPTION
Hopefully this PR is even less complicated. :-)

SSL_CTX_set_psk_server_callback:
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_psk_server_callback.html
https://github.com/openssl/openssl/blob/OpenSSL_1_0_2/ssl/ssl.h#L1355
https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/include/openssl/ssl.h#L734

SSL_CTX_set_tlsext_servername_callback:
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_tlsext_servername_callback.html
https://github.com/openssl/openssl/blob/OpenSSL_1_0_2/ssl/s3_lib.c#L3964
https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/ssl/s3_lib.c#L3499