### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -61,7 +61,7 @@ automatically, so all you have to do is:
 
 .. code-block:: console
 
-    $ py.test
+    $ pytest
     ...
     62746 passed in 220.43 seconds
 

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ deps =
     {[testenv]deps}
     pytest-random
 commands =
-    py.test --capture=no --strict --random {posargs}
+    pytest --capture=no --strict --random {posargs}
 
 [flake8]
 exclude = .tox,*.egg,.git,_build,.hypothesis


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot