### PR TITLE
Validate the public/private halves of EC keys on import.

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1355,14 +1355,15 @@ class Backend(object):
         self.openssl_assert(ec_cdata != self._ffi.NULL)
         ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
 
-        ec_cdata = self._ec_key_set_public_key_affine_coordinates(
-            ec_cdata, public.x, public.y)
-
         private_value = self._ffi.gc(
             self._int_to_bn(numbers.private_value), self._lib.BN_clear_free
         )
         res = self._lib.EC_KEY_set_private_key(ec_cdata, private_value)
         self.openssl_assert(res == 1)
+
+        ec_cdata = self._ec_key_set_public_key_affine_coordinates(
+            ec_cdata, public.x, public.y)
+
         evp_pkey = self._ec_cdata_to_evp_pkey(ec_cdata)
 
         return _EllipticCurvePrivateKey(self, ec_cdata, evp_pkey)

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -1068,8 +1068,8 @@ class TestECDH(object):
                 ec._CURVE_TYPES[vector['curve']]()
             )
         )
-        # Errno 5-7 indicates a bad public or private key, this doesn't test the
-        # ECDH code at all
+        # Errno 5-7 indicates a bad public or private key, this doesn't test
+        # the ECDH code at all
         if vector['fail'] and vector['errno'] in [5, 6, 7]:
             with pytest.raises(ValueError):
                 private_numbers.private_key(backend)

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -1068,9 +1068,9 @@ class TestECDH(object):
                 ec._CURVE_TYPES[vector['curve']]()
             )
         )
-        # Errno 5 and 6 indicates a bad public key, this doesn't test the ECDH
-        # code at all
-        if vector['fail'] and vector['errno'] in [5, 6]:
+        # Errno 5-7 indicates a bad public or private key, this doesn't test the
+        # ECDH code at all
+        if vector['fail'] and vector['errno'] in [5, 6, 7]:
             with pytest.raises(ValueError):
                 private_numbers.private_key(backend)
             return


### PR DESCRIPTION
OpenSSL's API is a little finicky. If one sets the public key before the
private key, it does not validate that they match. If set in the other
order, it does validate this.

In particular, KASValidityTest_ECCStaticUnified_NOKC_ZZOnly_init.fax
describes error code 7 as:

  Result = F (7 - IUT's Static private key d changed-prikey validity)

Reordering the two operations makes those tests to fail on key import,
which is what CAVP appears to have intended.