### PR TITLE
Remove ECDSA_sign_setup and *sign_ex bindings.

### DIFF
--- a/src/_cffi_src/openssl/ecdsa.py
+++ b/src/_cffi_src/openssl/ecdsa.py
@@ -24,14 +24,9 @@ void ECDSA_SIG_free(ECDSA_SIG *);
 int i2d_ECDSA_SIG(const ECDSA_SIG *, unsigned char **);
 ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **s, const unsigned char **, long);
 ECDSA_SIG *ECDSA_do_sign(const unsigned char *, int, EC_KEY *);
-ECDSA_SIG *ECDSA_do_sign_ex(const unsigned char *, int, const BIGNUM *,
-                            const BIGNUM *, EC_KEY *);
 int ECDSA_do_verify(const unsigned char *, int, const ECDSA_SIG *, EC_KEY *);
-int ECDSA_sign_setup(EC_KEY *, BN_CTX *, BIGNUM **, BIGNUM **);
 int ECDSA_sign(int, const unsigned char *, int, unsigned char *,
                unsigned int *, EC_KEY *);
-int ECDSA_sign_ex(int, const unsigned char *, int dgstlen, unsigned char *,
-                  unsigned int *, const BIGNUM *, const BIGNUM *, EC_KEY *);
 int ECDSA_verify(int, const unsigned char *, int, const unsigned char *, int,
                  EC_KEY *);
 int ECDSA_size(const EC_KEY *);


### PR DESCRIPTION
They are unused.

These functions have two purposes. They can be used to pass your own
value of k, or to amoritize the cost of generating k. Messing up k is
catastrophic to ECDSA, so best not to expose that one. ECDSA signing is
also quite fast, so there isn't much point in the latter. (The API comes
from DSA, which is a bit slower.) Moreover, ECDSA_sign is not the same
as ECDSA_sign_setup + ECDSA_sign_ex. OpenSSL has some nonce hardening
features that have to get skipped when doing this.