### PR TITLE
remove block size as a required part of HashAlgorithm

### DIFF
--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -183,12 +183,6 @@ Interfaces
 
         The size of the resulting digest in bytes.
 
-    .. attribute:: block_size
-
-        :type: int
-
-        The internal block size of the hash algorithm in bytes.
-
 
 .. class:: HashContext
 

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -29,12 +29,6 @@ class HashAlgorithm(object):
         The size of the resulting digest in bytes.
         """
 
-    @abc.abstractproperty
-    def block_size(self):
-        """
-        The internal block size of the hash algorithm in bytes.
-        """
-
 
 @six.add_metaclass(abc.ABCMeta)
 class HashContext(object):


### PR DESCRIPTION
Internal block size isn't a particularly useful piece of information and constructions like SHA3 make it even harder to determine what that really means. Accordingly, we're removing it from the interface (but
leaving it on all existing hashes)