### PR TITLE
Make AuthorityKeyIdentifier docs reflect reality

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1713,7 +1713,7 @@ X.509 Extensions
 
     .. attribute:: authority_cert_issuer
 
-        :type: :class:`Name` or None
+        :type: A list of :class:`GeneralName` instances or None
 
         The :class:`Name` of the issuer's issuer.
 


### PR DESCRIPTION
The `AuthorityKeyIdentifier.authority_cert_issuer` docs state that it returns a `Name` instance, but it [actually returns a list of `GeneralName` instances or `None`](https://github.com/pyca/cryptography/blob/master/src/cryptography/x509/extensions.py#L157).