### PR TITLE
Fixed build errors on HP-UX.

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -46,7 +46,7 @@ def _extra_compile_args(platform):
     When we drop support for CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 we can
     revisit this.
     """
-    if platform not in [ "win32", "hp-ux11" ]:
+    if platform not in ["win32", "hp-ux11"]:
         return ["-Wconversion", "-Wno-error=sign-conversion"]
     else:
         return []

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -46,7 +46,7 @@ def _extra_compile_args(platform):
     When we drop support for CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 we can
     revisit this.
     """
-    if not platform in [ "win32", "hp-ux11" ]:
+    if platform not in [ "win32", "hp-ux11" ]:
         return ["-Wconversion", "-Wno-error=sign-conversion"]
     else:
         return []

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -46,7 +46,7 @@ def _extra_compile_args(platform):
     When we drop support for CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 we can
     revisit this.
     """
-    if platform != "win32":
+    if not platform in [ "win32", "hp-ux11" ]:
         return ["-Wconversion", "-Wno-error=sign-conversion"]
     else:
         return []

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -143,6 +143,7 @@ void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *path,
 }
 
 void Cryptography_free_wrapper(void *ptr, const char *path, int line) {
-    return free(ptr);
+    free(ptr);
+    return;
 }
 """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -144,6 +144,5 @@ void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *path,
 
 void Cryptography_free_wrapper(void *ptr, const char *path, int line) {
     free(ptr);
-    return;
 }
 """


### PR DESCRIPTION
Thanks for `cryptography`! We package it with https://github.com/chevah/python-package on a number of OS'es. 

In latest revisions we are using `cryptography` 2.2.2 on HP-UX with these minor changes, required for building with the proprietary compiler on HP-UX 11i v3.

