### PR TITLE
Revert the const bits of #4220.

### DIFF
--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -24,7 +24,7 @@ int BIO_write(BIO *, const void *, int);
 /* Added in 1.1.0 */
 int BIO_up_ref(BIO *);
 
-BIO *BIO_new(const BIO_METHOD *);
+BIO *BIO_new(BIO_METHOD *);
 BIO_METHOD *BIO_s_mem(void);
 BIO_METHOD *BIO_s_datagram(void);
 BIO *BIO_new_mem_buf(const void *, int);


### PR DESCRIPTION
In #4220, I switched BIO_new to take a const pointer (true in 1.1.0, but
not 1.0.2) on grounds that:

    This also folds in the const bits from 1.1.0, on the assumption that,
    now that the function pointer check is gone, it will just cause cffi to
    generate more conservative pointer types that work for 1.0.2 as well.

But I got this backwards. If the bindings say BIO_METHOD*, cffi will
pass a BIO_METHOD* to BIO_new, which works in both OpenSSL versions. If
it says const BIO_METHOD*, cffi will pass const BIO_METHD* to BIO_new,
which does not work in 1.0.2.

(Although cryptography.io's build ignores all these warnings anyway, so
it's kind of moot.)