### PR TITLE
Add testing support of Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
           env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
+        - python: 3.7
+          env: TOXENV=py37
+          dist: xenial
+          sudo: true
         - python: pypy-5.3
           env: TOXENV=pypy
         - python: pypy2.7-5.10.0


### PR DESCRIPTION
So pyca/cryptography's Python classifier already claims support
of Python 3.7, but there is no testing matrix for it. This patch
adds the recently released Python 3.7 to the matrix of testing.
It requires sudo:true and xenial to pass.

Fixes Issue #4301

Signed-off-by: Eric Brown <browne@vmware.com>