### PR TITLE
since the generator order is 570 bits this should be 570

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -135,7 +135,7 @@ EllipticCurvePublicKeyWithSerialization = EllipticCurvePublicKey
 @utils.register_interface(EllipticCurve)
 class SECT571R1(object):
     name = "sect571r1"
-    key_size = 571
+    key_size = 570
 
 
 @utils.register_interface(EllipticCurve)


### PR DESCRIPTION
but key_size is nonsense and we'll deprecate it next

fixes #4271 