### PR TITLE
set an OPENSSL_API_COMPAT level

### DIFF
--- a/src/_cffi_src/openssl/cryptography.py
+++ b/src/_cffi_src/openssl/cryptography.py
@@ -5,6 +5,11 @@
 from __future__ import absolute_import, division, print_function
 
 INCLUDES = """
+/* define our OpenSSL API compatibility level to 1.0.0. Any symbols older than
+   that will raise an error during compilation. We can raise this number again
+   after we drop 1.0.2 support in the distant future */
+#define OPENSSL_API_COMPAT 0x10000000L
+
 #include <openssl/opensslv.h>
 
 

--- a/src/_cffi_src/openssl/cryptography.py
+++ b/src/_cffi_src/openssl/cryptography.py
@@ -5,10 +5,10 @@
 from __future__ import absolute_import, division, print_function
 
 INCLUDES = """
-/* define our OpenSSL API compatibility level to 1.0.0. Any symbols older than
+/* define our OpenSSL API compatibility level to 1.0.1. Any symbols older than
    that will raise an error during compilation. We can raise this number again
-   after we drop 1.0.2 support in the distant future */
-#define OPENSSL_API_COMPAT 0x10000000L
+   after we drop 1.0.2 support in the distant future.  */
+#define OPENSSL_API_COMPAT 0x10001000L
 
 #include <openssl/opensslv.h>
 


### PR DESCRIPTION
This helps prevent adding deprecated functions and will let us see what we need to/can prune in the distant future when we support only 1.1.0+.

from a side discussion in #3460