### PR TITLE
Make our locking setup function compy with our style guide

### DIFF
--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -33,7 +33,7 @@ typedef struct {
 """
 
 FUNCTIONS = """
-int _setup_ssl_threads(void);
+int Cryptography_setup_ssl_threads(void);
 int Cryptography_pem_password_cb(char *, int, int, void *);
 """
 
@@ -120,7 +120,7 @@ static void init_mutexes(void) {
 }
 
 
-int _setup_ssl_threads(void) {
+int Cryptography_setup_ssl_threads(void) {
     if (_ssl_locks == NULL) {
         _ssl_locks_count = CRYPTO_num_locks();
         _ssl_locks = calloc(_ssl_locks_count, sizeof(Cryptography_mutex));

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -145,7 +145,7 @@ class Binding(object):
 
             # If nothing else has setup a locking callback already, we set up
             # our own
-            res = lib._setup_ssl_threads()
+            res = lib.Cryptography_setup_ssl_threads()
             _openssl_assert(cls.lib, res == 1)
 
 


### PR DESCRIPTION
And not expose an unprefixed name to anyone who dlopens us.