### PR TITLE
document that an ECPublicNumbers object has some unexpected properties

### DIFF
--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -154,7 +154,10 @@ Elliptic Curve Signature Algorithms
 
     .. warning::
         The point represented by this object is not validated in any way until
-        :meth:`EllipticCurvePublicNumbers.public_key` is called.
+        :meth:`EllipticCurvePublicNumbers.public_key` is called and may not
+        represent a valid point on the curve. You should not attempt to perform
+        any computations using the values from this class until you have either
+        validated it yourself or called ``public_key()`` successfully.
 
     .. versionadded:: 0.5
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -152,6 +152,10 @@ Elliptic Curve Signature Algorithms
 
 .. class:: EllipticCurvePublicNumbers(x, y, curve)
 
+    .. warning::
+        The point represented by this object is not validated in any way until
+        :meth:`EllipticCurvePublicNumbers.public_key` is called.
+
     .. versionadded:: 0.5
 
     The collection of integers that make up an EC public key.
@@ -175,12 +179,6 @@ Elliptic Curve Signature Algorithms
         The affine y component of the public point used for verifying.
 
     .. method:: public_key(backend)
-
-        .. note::
-            When calling this method the point is checked to to confirm that
-            it is on ``curve``. If the point is invalid then a ``ValueError``
-            will be raised. This can occur if the ``x`` and ``y`` points are
-            created from untrusted data.
 
         Convert a collection of numbers into a public key suitable for doing
         actual cryptographic operations.

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -176,12 +176,18 @@ Elliptic Curve Signature Algorithms
 
     .. method:: public_key(backend)
 
+        .. note::
+            The point represented by ``x`` and ``y`` in this object is checked
+            to confirm that it is on ``curve`` when calling this method. If the
+            point is not on the curve then a ``ValueError`` will be raised.
+
         Convert a collection of numbers into a public key suitable for doing
         actual cryptographic operations.
 
         :param backend: An instance of
             :class:`~cryptography.hazmat.backends.interfaces.EllipticCurveBackend`.
 
+        :raises ValueError: Raised if the point is invalid for the curve.
         :returns: A new instance of :class:`EllipticCurvePublicKey`.
 
     .. method:: encode_point()

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -177,9 +177,10 @@ Elliptic Curve Signature Algorithms
     .. method:: public_key(backend)
 
         .. note::
-            The point represented by ``x`` and ``y`` in this object is checked
-            to confirm that it is on ``curve`` when calling this method. If the
-            point is not on the curve then a ``ValueError`` will be raised.
+            When calling this method the point is checked to to confirm that
+            it is on ``curve``. If the point is invalid then a ``ValueError``
+            will be raised. This can occur if the ``x`` and ``y`` points are
+            created from untrusted data.
 
         Convert a collection of numbers into a public key suitable for doing
         actual cryptographic operations.


### PR DESCRIPTION
It is not guaranteed to be a valid point on the curve as that is not checked until you convert it to a PublicKey object.

fixes #4273 