### PR TITLE
fix encoding BMPString in x509 name entries

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/encode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/encode_asn1.py
@@ -14,6 +14,7 @@ from cryptography.hazmat.backends.openssl.decode_asn1 import (
     _CRL_ENTRY_REASON_ENUM_TO_CODE, _DISTPOINT_TYPE_FULLNAME,
     _DISTPOINT_TYPE_RELATIVENAME
 )
+from cryptography.x509.name import _ASN1Type
 from cryptography.x509.oid import CRLEntryExtensionOID, ExtensionOID
 
 
@@ -116,11 +117,15 @@ def _encode_sk_name_entry(backend, attributes):
 
 
 def _encode_name_entry(backend, attribute):
-    value = attribute.value.encode('utf8')
+    if attribute._type is _ASN1Type.BMPString:
+        value = attribute.value.encode('utf_16_be')
+    else:
+        value = attribute.value.encode('utf8')
+
     obj = _txt2obj_gc(backend, attribute.oid.dotted_string)
 
     name_entry = backend._lib.X509_NAME_ENTRY_create_by_OBJ(
-        backend._ffi.NULL, obj, attribute._type.value, value, -1
+        backend._ffi.NULL, obj, attribute._type.value, value, len(value)
     )
     return name_entry
 

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -4089,6 +4089,24 @@ class TestName(object):
             b"b060355040a0c0450794341"
         )
 
+    @pytest.mark.requires_backend_interface(interface=X509Backend)
+    def test_bmpstring_bytes(self, backend):
+        # For this test we need an odd length string. BMPString is UCS-2
+        # encoded so it will always be even length and OpenSSL will error if
+        # you pass an odd length string without encoding it properly first.
+        name = x509.Name([
+            x509.NameAttribute(
+                NameOID.COMMON_NAME,
+                u'cryptography.io',
+                _ASN1Type.BMPString
+            ),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, u'PyCA'),
+        ])
+        assert name.public_bytes(backend) == binascii.unhexlify(
+            b"30383127302506035504031e1e00630072007900700074006f00670072006100"
+            b"7000680079002e0069006f310d300b060355040a0c0450794341"
+        )
+
 
 def test_random_serial_number(monkeypatch):
     sample_data = os.urandom(20)


### PR DESCRIPTION
Previously we encoded them as UTF-8, but as best I can tell in reality a BMPString is fixed-width basic multilingual plane big endian encoding. This is basically UCS-2 (aka original Unicode). However, Python doesn't support UCS-2 encoding via `encode` so we need to use `utf_16_be`. This means you can encode surrogate code points that are invalid in the context of what a BMPString is supposed to be, but in reality I strongly suspect the sane encoding ship has sailed and dozens if not hundreds of implementations both do this and expect other systems to handle their nonsense.

To be clear, this is not strictly correct because a correct encoder would error on any attempt to encode a character not in the BMP. If someone wants to write some code to verify that fact then we'd be More Correct™, but potentially less compatible. To see what horrifying things OpenSSL is forced to do when converting bmpstring to utf8 check out: https://github.com/openssl/openssl/blob/master/crypto/asn1/a_mbstr.c

fixes #4175 cc @tdsmith 