### PR TITLE
document one shot AEAD length restrictions

### DIFF
--- a/docs/hazmat/primitives/aead.rst
+++ b/docs/hazmat/primitives/aead.rst
@@ -61,8 +61,8 @@ also support providing integrity for associated data which is not encrypted.
             authenticated with the key, but does not need to be encrypted. Can
             be ``None``.
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
-        :raises OverflowError: If data passed is greater than 2\ :sup:`32`
-            bytes.
+        :raises OverflowError: If ``data`` or ``associated_data`` is greater
+            than 2\ :sup:`32` bytes.
 
     .. method:: decrypt(nonce, data, associated_data)
 
@@ -132,8 +132,8 @@ also support providing integrity for associated data which is not encrypted.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
-        :raises OverflowError: If data passed is greater than 2\ :sup:`32`
-            bytes.
+        :raises OverflowError: If ``data`` or ``associated_data`` is greater
+            than 2\ :sup:`32` bytes.
 
     .. method:: decrypt(nonce, data, associated_data)
 
@@ -219,8 +219,8 @@ also support providing integrity for associated data which is not encrypted.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
         :returns bytes: The ciphertext bytes with the tag appended.
-        :raises OverflowError: If data passed is greater than 2\ :sup:`32`
-            bytes.
+        :raises OverflowError: If ``data`` or ``associated_data`` is greater
+            than 2\ :sup:`32` bytes.
 
     .. method:: decrypt(nonce, data, associated_data)
 

--- a/docs/hazmat/primitives/aead.rst
+++ b/docs/hazmat/primitives/aead.rst
@@ -55,13 +55,12 @@ also support providing integrity for associated data which is not encrypted.
 
         :param bytes nonce: A 12 byte value. **NEVER REUSE A NONCE** with a
             key.
-        :param bytes data: The data to encrypt. Must be less than or equal to
-            2\ :sup:`32` bytes.
+        :param bytes data: The data to encrypt.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but does not need to be encrypted. Can
             be ``None``.
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
-        :raises OverflowError: If ``data`` or ``associated_data`` is greater
+        :raises OverflowError: If ``data`` or ``associated_data`` is larger
             than 2\ :sup:`32` bytes.
 
     .. method:: decrypt(nonce, data, associated_data)
@@ -127,12 +126,11 @@ also support providing integrity for associated data which is not encrypted.
         :param bytes nonce: NIST `recommends a 96-bit IV length`_ for best
             performance but it can be up to 2\ :sup:`64` - 1 :term:`bits`.
             **NEVER REUSE A NONCE** with a key.
-        :param bytes data: The data to encrypt. Must be less than or equal to
-            2\ :sup:`32` bytes.
+        :param bytes data: The data to encrypt.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
-        :raises OverflowError: If ``data`` or ``associated_data`` is greater
+        :raises OverflowError: If ``data`` or ``associated_data`` is larger
             than 2\ :sup:`32` bytes.
 
     .. method:: decrypt(nonce, data, associated_data)
@@ -214,12 +212,11 @@ also support providing integrity for associated data which is not encrypted.
             encrypting and must satisfy the condition:
             ``len(data) < 2 ** (8 * (15 - len(nonce)))``
             **NEVER REUSE A NONCE** with a key.
-        :param bytes data: The data to encrypt. Must be less than or equal to
-            2\ :sup:`32` bytes.
+        :param bytes data: The data to encrypt.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
         :returns bytes: The ciphertext bytes with the tag appended.
-        :raises OverflowError: If ``data`` or ``associated_data`` is greater
+        :raises OverflowError: If ``data`` or ``associated_data`` is larger
             than 2\ :sup:`32` bytes.
 
     .. method:: decrypt(nonce, data, associated_data)

--- a/docs/hazmat/primitives/aead.rst
+++ b/docs/hazmat/primitives/aead.rst
@@ -61,6 +61,8 @@ also support providing integrity for associated data which is not encrypted.
             authenticated with the key, but does not need to be encrypted. Can
             be ``None``.
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
+        :raises OverflowError: If data passed is greater than 2\ :sup:`32`
+            bytes.
 
     .. method:: decrypt(nonce, data, associated_data)
 
@@ -130,6 +132,8 @@ also support providing integrity for associated data which is not encrypted.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
+        :raises OverflowError: If data passed is greater than 2\ :sup:`32`
+            bytes.
 
     .. method:: decrypt(nonce, data, associated_data)
 
@@ -215,6 +219,8 @@ also support providing integrity for associated data which is not encrypted.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
         :returns bytes: The ciphertext bytes with the tag appended.
+        :raises OverflowError: If data passed is greater than 2\ :sup:`32`
+            bytes.
 
     .. method:: decrypt(nonce, data, associated_data)
 

--- a/docs/hazmat/primitives/aead.rst
+++ b/docs/hazmat/primitives/aead.rst
@@ -55,7 +55,8 @@ also support providing integrity for associated data which is not encrypted.
 
         :param bytes nonce: A 12 byte value. **NEVER REUSE A NONCE** with a
             key.
-        :param bytes data: The data to encrypt.
+        :param bytes data: The data to encrypt. Must be less than or equal to
+            2\ :sup:`32` bytes.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but does not need to be encrypted. Can
             be ``None``.
@@ -124,7 +125,8 @@ also support providing integrity for associated data which is not encrypted.
         :param bytes nonce: NIST `recommends a 96-bit IV length`_ for best
             performance but it can be up to 2\ :sup:`64` - 1 :term:`bits`.
             **NEVER REUSE A NONCE** with a key.
-        :param bytes data: The data to encrypt.
+        :param bytes data: The data to encrypt. Must be less than or equal to
+            2\ :sup:`32` bytes.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
@@ -208,7 +210,8 @@ also support providing integrity for associated data which is not encrypted.
             encrypting and must satisfy the condition:
             ``len(data) < 2 ** (8 * (15 - len(nonce)))``
             **NEVER REUSE A NONCE** with a key.
-        :param bytes data: The data to encrypt.
+        :param bytes data: The data to encrypt. Must be less than or equal to
+            2\ :sup:`32` bytes.
         :param bytes associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
         :returns bytes: The ciphertext bytes with the tag appended.

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -12,6 +12,8 @@ from cryptography.hazmat.backends.openssl.backend import backend
 
 
 class ChaCha20Poly1305(object):
+    _MAX_SIZE = 2 ** 32
+
     def __init__(self, key):
         if not backend.aead_cipher_supported(self):
             raise exceptions.UnsupportedAlgorithm(
@@ -32,6 +34,12 @@ class ChaCha20Poly1305(object):
     def encrypt(self, nonce, data, associated_data):
         if associated_data is None:
             associated_data = b""
+
+        if len(data) > self._MAX_SIZE or len(associated_data) > self._MAX_SIZE:
+            # This is OverflowError to match what cffi would raise
+            raise OverflowError(
+                "Data or associated data too long. Max 2**32 bytes"
+            )
 
         self._check_params(nonce, data, associated_data)
         return aead._encrypt(
@@ -56,6 +64,8 @@ class ChaCha20Poly1305(object):
 
 
 class AESCCM(object):
+    _MAX_SIZE = 2 ** 32
+
     def __init__(self, key, tag_length=16):
         utils._check_bytes("key", key)
         if len(key) not in (16, 24, 32):
@@ -90,6 +100,12 @@ class AESCCM(object):
         if associated_data is None:
             associated_data = b""
 
+        if len(data) > self._MAX_SIZE or len(associated_data) > self._MAX_SIZE:
+            # This is OverflowError to match what cffi would raise
+            raise OverflowError(
+                "Data or associated data too long. Max 2**32 bytes"
+            )
+
         self._check_params(nonce, data, associated_data)
         self._validate_lengths(nonce, len(data))
         return aead._encrypt(
@@ -121,6 +137,8 @@ class AESCCM(object):
 
 
 class AESGCM(object):
+    _MAX_SIZE = 2 ** 32
+
     def __init__(self, key):
         utils._check_bytes("key", key)
         if len(key) not in (16, 24, 32):
@@ -141,6 +159,12 @@ class AESGCM(object):
     def encrypt(self, nonce, data, associated_data):
         if associated_data is None:
             associated_data = b""
+
+        if len(data) > self._MAX_SIZE or len(associated_data) > self._MAX_SIZE:
+            # This is OverflowError to match what cffi would raise
+            raise OverflowError(
+                "Data or associated data too long. Max 2**32 bytes"
+            )
 
         self._check_params(nonce, data, associated_data)
         return aead._encrypt(

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -51,7 +51,7 @@ def test_chacha20poly1305_unsupported_on_older_openssl(backend):
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
 class TestChaCha20Poly1305(object):
-    def test_data_too_large(self, backend):
+    def test_data_too_large(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         nonce = b"0" * 12
@@ -184,7 +184,7 @@ def test_aesccm_unsupported_on_older_openssl(backend):
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
 class TestAESCCM(object):
-    def test_data_too_large(self, backend):
+    def test_data_too_large(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         nonce = b"0" * 12
@@ -336,7 +336,7 @@ def _load_gcm_vectors():
 
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
 class TestAESGCM(object):
-    def test_data_too_large(self, backend):
+    def test_data_too_large(self):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         nonce = b"0" * 12

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -22,6 +22,11 @@ from ...utils import (
 )
 
 
+class FakeData(object):
+    def __len__(self):
+        return 2 ** 32 + 1
+
+
 def _aead_supported(cls):
     try:
         cls(b"0" * 32)
@@ -46,6 +51,17 @@ def test_chacha20poly1305_unsupported_on_older_openssl(backend):
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
 class TestChaCha20Poly1305(object):
+    def test_data_too_large(self, backend):
+        key = ChaCha20Poly1305.generate_key()
+        chacha = ChaCha20Poly1305(key)
+        nonce = b"0" * 12
+
+        with pytest.raises(OverflowError):
+            chacha.encrypt(nonce, FakeData(), b"")
+
+        with pytest.raises(OverflowError):
+            chacha.encrypt(nonce, b"", FakeData())
+
     def test_generate_key(self):
         key = ChaCha20Poly1305.generate_key()
         assert len(key) == 32
@@ -168,6 +184,17 @@ def test_aesccm_unsupported_on_older_openssl(backend):
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
 class TestAESCCM(object):
+    def test_data_too_large(self, backend):
+        key = AESCCM.generate_key(128)
+        aesccm = AESCCM(key)
+        nonce = b"0" * 12
+
+        with pytest.raises(OverflowError):
+            aesccm.encrypt(nonce, FakeData(), b"")
+
+        with pytest.raises(OverflowError):
+            aesccm.encrypt(nonce, b"", FakeData())
+
     def test_default_tag_length(self, backend):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
@@ -309,6 +336,17 @@ def _load_gcm_vectors():
 
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
 class TestAESGCM(object):
+    def test_data_too_large(self, backend):
+        key = AESGCM.generate_key(128)
+        aesgcm = AESGCM(key)
+        nonce = b"0" * 12
+
+        with pytest.raises(OverflowError):
+            aesgcm.encrypt(nonce, FakeData(), b"")
+
+        with pytest.raises(OverflowError):
+            aesgcm.encrypt(nonce, b"", FakeData())
+
     @pytest.mark.parametrize("vector", _load_gcm_vectors())
     def test_vectors(self, vector):
         key = binascii.unhexlify(vector["key"])


### PR DESCRIPTION
These limitations are not enforced in the code outside of cffi raising an overflow if you pass > 32-bit int. Do we want to add tests for that?

fixes #4303 