### PR TITLE
Don't initialize locks in OpenSSL 1.1.0+

### DIFF
--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -47,6 +47,7 @@ CUSTOMIZATIONS = """
    using CPython APIs by Armin Rigo of the PyPy project.
 */
 
+#if Cryptography_HAS_LOCKING_CALLBACKS
 #ifdef _WIN32
 typedef CRITICAL_SECTION Cryptography_mutex;
 static __inline void cryptography_mutex_init(Cryptography_mutex *mutex) {
@@ -78,7 +79,6 @@ static inline void cryptography_mutex_unlock(Cryptography_mutex *mutex) {
     ASSERT_STATUS(pthread_mutex_unlock(mutex));
 }
 #endif
-
 
 
 static unsigned int _ssl_locks_count = 0;
@@ -135,6 +135,9 @@ int Cryptography_setup_ssl_threads(void) {
     }
     return 1;
 }
+#else
+int (*Cryptography_setup_ssl_threads)(void) = NULL;
+#endif
 
 typedef struct {
     char *password;

--- a/src/_cffi_src/openssl/callbacks.py
+++ b/src/_cffi_src/openssl/callbacks.py
@@ -47,7 +47,7 @@ CUSTOMIZATIONS = """
    using CPython APIs by Armin Rigo of the PyPy project.
 */
 
-#if Cryptography_HAS_LOCKING_CALLBACKS
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
 #ifdef _WIN32
 typedef CRITICAL_SECTION Cryptography_mutex;
 static __inline void cryptography_mutex_init(Cryptography_mutex *mutex) {

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -143,6 +143,7 @@ def cryptography_has_locking_callbacks():
         "CRYPTO_READ",
         "CRYPTO_LOCK_SSL",
         "CRYPTO_lock",
+        "Cryptography_setup_ssl_threads",
     ]
 
 

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -140,7 +140,8 @@ class Binding(object):
             # the setup for this.
             __import__("_ssl")
 
-            if cls.lib.CRYPTO_get_locking_callback() != cls.ffi.NULL:
+            if (not cls.lib.Cryptography_HAS_LOCKING_CALLBACKS or
+                    cls.lib.CRYPTO_get_locking_callback() != cls.ffi.NULL):
                 return
 
             # If nothing else has setup a locking callback already, we set up

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -21,12 +21,15 @@ class TestOpenSSL(object):
 
     def test_crypto_lock_init(self):
         b = Binding()
-        if b.lib.CRYPTOGRAPHY_OPENSSL_110_OR_GREATER:
-            pytest.skip("Requires an older OpenSSL. Must be < 1.1.0")
 
         b.init_static_locks()
         lock_cb = b.lib.CRYPTO_get_locking_callback()
-        assert lock_cb != b.ffi.NULL
+        if b.lib.CRYPTOGRAPHY_OPENSSL_110_OR_GREATER:
+            assert lock_cb == b.ffi.NULL
+            assert b.lib.Cryptography_HAS_LOCKING_CALLBACKS == 0
+        else:
+            assert lock_cb != b.ffi.NULL
+            assert b.lib.Cryptography_HAS_LOCKING_CALLBACKS == 1
 
     def test_add_engine_more_than_once(self):
         b = Binding()


### PR DESCRIPTION
### What this does:
1. Checks if `Cryptography_HAS_LOCKING_CALLBACKS` is true before compiling `_ssl_thread_locking_functions` in `callbacks.py`.
2. Exposes `CRYPTOGRAPHY_OPENSSL_LESS_THAN_110` via types.
3. Checks if `Cryptography_HAS_LOCKING_CALLBACKS` is true when attempting to call `init_static_locks`; returns if it's `False`.
4. Adds better checks to `test_crypto_lock_init` for OpenSSL versions > 1.1.0 and < 1.1.0.
5. Closes #4315.