### PR TITLE
fix a memory leak when calling X25519PrivateKey.public_key()

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/x25519.py
+++ b/src/cryptography/hazmat/backends/openssl/x25519.py
@@ -42,6 +42,10 @@ class _X25519PrivateKey(object):
         evp_pkey = self._backend._lib.d2i_PUBKEY_bio(
             bio, self._backend._ffi.NULL
         )
+        self._backend.openssl_assert(evp_pkey != self._backend._ffi.NULL)
+        evp_pkey = self._backend._ffi.gc(
+            evp_pkey, self._backend._lib.EVP_PKEY_free
+        )
         return _X25519PublicKey(self._backend, evp_pkey)
 
     def exchange(self, peer_public_key):

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -225,3 +225,11 @@ class TestOpenSSLMemoryLeaks(object):
             from cryptography.hazmat.primitives.asymmetric import ec
             ec.derive_private_key(1, ec.SECP256R1(), backend)
         """))
+
+    def test_x25519_pubkey_from_private_key(self):
+        assert_no_memory_leaks(textwrap.dedent("""
+        def func():
+            from cryptography.hazmat.primitives.asymmetric import x25519
+            private_key = x25519.X25519PrivateKey.generate()
+            private_key.public_key()
+        """))


### PR DESCRIPTION
Noticed this while working on #4310 