### PR TITLE
raise valueerror for null x25519 derived keys

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/x25519.py
+++ b/src/cryptography/hazmat/backends/openssl/x25519.py
@@ -71,5 +71,9 @@ class _X25519PrivateKey(object):
         self._backend.openssl_assert(keylen[0] > 0)
         buf = self._backend._ffi.new("unsigned char[]", keylen[0])
         res = self._backend._lib.EVP_PKEY_derive(ctx, buf, keylen)
-        self._backend.openssl_assert(res == 1)
+        if res != 1:
+            raise ValueError(
+                "Null shared key derived from public/private pair."
+            )
+
         return self._backend._ffi.buffer(buf, keylen[0])[:]

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -76,6 +76,23 @@ class TestX25519Exchange(object):
 
         assert computed_shared_key == shared_key
 
+    def test_null_shared_key_raises_error(self, backend):
+        """
+        The vector used here is taken from wycheproof's x25519 test vectors
+        """
+        public = binascii.unhexlify(
+            "5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157"
+        )
+        private = binascii.unhexlify(
+            "78f1e8edf14481b389448dac8f59c70b038e7cf92ef2c7eff57a72466e115296"
+        )
+        private_key = X25519PrivateKey._from_private_bytes(
+            private
+        )
+        public_key = X25519PublicKey.from_public_bytes(public)
+        with pytest.raises(ValueError):
+            private_key.exchange(public_key)
+
     # These vectors are also from RFC 7748
     # https://tools.ietf.org/html/rfc7748#section-6.1
     @pytest.mark.parametrize(


### PR DESCRIPTION
OpenSSL errors when it hits this edge case and a null shared key is bad anyway so let's raise an error.

We can bikeshed on language now. Also, do we want to document this exception? `:raises ValueError: If derived key is null`?

refs #4310 