### PR TITLE
Change the exception we raise in keywrap unwrapping on invalid length

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Changelog
 * The :class:`~cryptography.x509.RelativeDistinguishedName` class now
   preserves the order of attributes. Duplicate attributes now raise an error
   instead of silently discarding duplicates.
+* :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap` and
+  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap_with_padding`
+  now raise :class:`~cryptography.hazmat.primitives.keywrap.InvalidUnwrap` if
+  the wrapped key is an invalid length, instead of ``ValueError``.
 
 .. _v2-2-2:
 

--- a/src/cryptography/hazmat/primitives/keywrap.py
+++ b/src/cryptography/hazmat/primitives/keywrap.py
@@ -89,7 +89,7 @@ def aes_key_wrap_with_padding(wrapping_key, key_to_wrap, backend):
 
 def aes_key_unwrap_with_padding(wrapping_key, wrapped_key, backend):
     if len(wrapped_key) < 16:
-        raise ValueError("Must be at least 16 bytes")
+        raise InvalidUnwrap("Must be at least 16 bytes")
 
     if len(wrapping_key) not in [16, 24, 32]:
         raise ValueError("The wrapping key must be a valid AES key length")
@@ -132,10 +132,10 @@ def aes_key_unwrap_with_padding(wrapping_key, wrapped_key, backend):
 
 def aes_key_unwrap(wrapping_key, wrapped_key, backend):
     if len(wrapped_key) < 24:
-        raise ValueError("Must be at least 24 bytes")
+        raise InvalidUnwrap("Must be at least 24 bytes")
 
     if len(wrapped_key) % 8 != 0:
-        raise ValueError("The wrapped key must be a multiple of 8 bytes")
+        raise InvalidUnwrap("The wrapped key must be a multiple of 8 bytes")
 
     if len(wrapping_key) not in [16, 24, 32]:
         raise ValueError("The wrapping key must be a valid AES key length")

--- a/tests/hazmat/primitives/test_keywrap.py
+++ b/tests/hazmat/primitives/test_keywrap.py
@@ -108,11 +108,11 @@ class TestAESKeyWrap(object):
 
     def test_unwrap_invalid_wrapped_key_length(self, backend):
         # Keys to unwrap must be at least 24 bytes
-        with pytest.raises(ValueError):
+        with pytest.raises(keywrap.InvalidUnwrap):
             keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 16, backend)
 
         # Keys to unwrap must be a multiple of 8 bytes
-        with pytest.raises(ValueError):
+        with pytest.raises(keywrap.InvalidUnwrap):
             keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 27, backend)
 
 
@@ -189,7 +189,9 @@ class TestAESKeyWrapWithPadding(object):
 
     def test_unwrap_invalid_wrapped_key_length(self, backend):
         # Keys to unwrap must be at least 16 bytes
-        with pytest.raises(ValueError, match='Must be at least 16 bytes'):
+        with pytest.raises(
+            keywrap.InvalidUnwrap, match='Must be at least 16 bytes'
+        ):
             keywrap.aes_key_unwrap_with_padding(
                 b"sixteen_byte_key", b"\x00" * 15, backend
             )


### PR DESCRIPTION
I believe this can reasonably be considered backwards compatible since other invalid inputs already lead to InvalidUnwrap, and clients shouldn't be distinguishing between these two conditions, and ValueError wasn't documented anyways.