### PR TITLE
raise ValueError on zero length GCM IV

### DIFF
--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -399,7 +399,8 @@ Modes
         this is ``16``, meaning tag truncation is not allowed. Allowing tag
         truncation is strongly discouraged for most applications.
 
-    :raises ValueError: This is raised if ``len(tag) < min_tag_length``.
+    :raises ValueError: This is raised if ``len(tag) < min_tag_length`` or the
+        ``initialization_vector`` is too short.
 
     :raises NotImplementedError: This is raised if the version of the OpenSSL
         backend used is 1.0.1 or earlier.

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -208,6 +208,8 @@ class GCM(object):
         # for it
         if not isinstance(initialization_vector, bytes):
             raise TypeError("initialization_vector must be bytes")
+        if len(initialization_vector) == 0:
+            raise ValueError("initialization_vector must be at least 1 byte")
         self._initialization_vector = initialization_vector
         if tag is not None:
             if not isinstance(tag, bytes):

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -191,6 +191,10 @@ class TestModeValidation(object):
                 backend,
             )
 
+    def test_gcm(self):
+        with pytest.raises(ValueError):
+            modes.GCM(b"")
+
 
 class TestModesRequireBytes(object):
     def test_cbc(self):


### PR DESCRIPTION
This prevents another InternalError that wycheproof's test vectors uncovered.