### PR TITLE
Add more SSL_CIPHER_* functions, necessary to implement ctx.get_ciphers() in PyPy

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -286,11 +286,11 @@ void SSL_SESSION_free(SSL_SESSION *);
 const char *SSL_CIPHER_get_name(const SSL_CIPHER *);
 int SSL_CIPHER_get_bits(const SSL_CIPHER *, int *);
 const char *SSL_CIPHER_get_id(const SSL_CIPHER *);
-int SSL_CIPHER_is_aead(const SSL_CIPHER *c);
-int SSL_CIPHER_get_cipher_nid(const SSL_CIPHER *c);
-int SSL_CIPHER_get_digest_nid(const SSL_CIPHER *c);
-int SSL_CIPHER_get_kx_nid(const SSL_CIPHER *c);
-int SSL_CIPHER_get_auth_nid(const SSL_CIPHER *c);
+int SSL_CIPHER_is_aead(const SSL_CIPHER *);
+int SSL_CIPHER_get_cipher_nid(const SSL_CIPHER *);
+int SSL_CIPHER_get_digest_nid(const SSL_CIPHER *);
+int SSL_CIPHER_get_kx_nid(const SSL_CIPHER *);
+int SSL_CIPHER_get_auth_nid(const SSL_CIPHER *);
 
 size_t SSL_get_finished(const SSL *, void *, size_t);
 size_t SSL_get_peer_finished(const SSL *, void *, size_t);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -285,7 +285,7 @@ void SSL_SESSION_free(SSL_SESSION *);
 /* Information about actually used cipher */
 const char *SSL_CIPHER_get_name(const SSL_CIPHER *);
 int SSL_CIPHER_get_bits(const SSL_CIPHER *, int *);
-const char *SSL_CIPHER_get_id(const SSL_CIPHER *);
+uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *);
 int SSL_CIPHER_is_aead(const SSL_CIPHER *);
 int SSL_CIPHER_get_cipher_nid(const SSL_CIPHER *);
 int SSL_CIPHER_get_digest_nid(const SSL_CIPHER *);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -284,6 +284,12 @@ void SSL_SESSION_free(SSL_SESSION *);
 /* Information about actually used cipher */
 const char *SSL_CIPHER_get_name(const SSL_CIPHER *);
 int SSL_CIPHER_get_bits(const SSL_CIPHER *, int *);
+const char *SSL_CIPHER_get_id(const SSL_CIPHER *);
+int SSL_CIPHER_is_aead(const SSL_CIPHER *c);
+int SSL_CIPHER_get_cipher_nid(const SSL_CIPHER *c);
+int SSL_CIPHER_get_digest_nid(const SSL_CIPHER *c);
+int SSL_CIPHER_get_kx_nid(const SSL_CIPHER *c);
+int SSL_CIPHER_get_auth_nid(const SSL_CIPHER *c);
 
 size_t SSL_get_finished(const SSL *, void *, size_t);
 size_t SSL_get_peer_finished(const SSL *, void *, size_t);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -798,7 +798,7 @@ int (*SSL_CTX_add_server_custom_ext)(SSL_CTX *, unsigned int,
 int (*SSL_extension_supported)(unsigned int) = NULL;
 #endif
 
-#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 || CRYPTOGRAPHY_IS_LIBRESSL
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 && !CRYPTOGRAPHY_LIBRESSL_27_OR_GREATER
 int (*SSL_CIPHER_is_aead)(const SSL_CIPHER *) = NULL;
 int (*SSL_CIPHER_get_cipher_nid)(const SSL_CIPHER *) = NULL;
 int (*SSL_CIPHER_get_digest_nid)(const SSL_CIPHER *) = NULL;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -29,6 +29,7 @@ static const long Cryptography_HAS_DTLS;
 static const long Cryptography_HAS_GENERIC_DTLS_METHOD;
 static const long Cryptography_HAS_SIGALGS;
 static const long Cryptography_HAS_PSK;
+static const long Cryptography_HAS_CIPHER_DETAILS;
 
 /* Internally invented symbol to tell us if SNI is supported */
 static const long Cryptography_HAS_TLSEXT_HOSTNAME;
@@ -796,4 +797,16 @@ int (*SSL_CTX_add_server_custom_ext)(SSL_CTX *, unsigned int,
 
 int (*SSL_extension_supported)(unsigned int) = NULL;
 #endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 || CRYPTOGRAPHY_IS_LIBRESSL
+int (*SSL_CIPHER_is_aead)(const SSL_CIPHER *) = NULL;
+int (*SSL_CIPHER_get_cipher_nid)(const SSL_CIPHER *) = NULL;
+int (*SSL_CIPHER_get_digest_nid)(const SSL_CIPHER *) = NULL;
+int (*SSL_CIPHER_get_kx_nid)(const SSL_CIPHER *) = NULL;
+int (*SSL_CIPHER_get_auth_nid)(const SSL_CIPHER *) = NULL;
+static const long Cryptography_HAS_CIPHER_DETAILS = 0;
+#else
+static const long Cryptography_HAS_CIPHER_DETAILS = 1;
+#endif
+
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -246,6 +246,16 @@ def cryptography_has_openssl_cleanup():
     ]
 
 
+def cryptography_has_cipher_details():
+    return [
+        "SSL_CIPHER_is_aead",
+        "SSL_CIPHER_get_cipher_nid",
+        "SSL_CIPHER_get_digest_nid",
+        "SSL_CIPHER_get_kx_nid",
+        "SSL_CIPHER_get_auth_nid",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -299,4 +309,5 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_PSK": cryptography_has_psk,
     "Cryptography_HAS_CUSTOM_EXT": cryptography_has_custom_ext,
     "Cryptography_HAS_OPENSSL_CLEANUP": cryptography_has_openssl_cleanup,
+    "Cryptography_HAS_CIPHER_DETAILS": cryptography_has_cipher_details,
 }


### PR DESCRIPTION
SSLContext.get_ciphers() was added by Python 3.6.1.