### PR TITLE
block_size isn't part of our interface and future hashes won't have it

### DIFF
--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -53,7 +53,6 @@ class TestSHA1(object):
     test_SHA1 = generate_base_hash_test(
         hashes.SHA1(),
         digest_size=20,
-        block_size=64,
     )
 
 
@@ -66,7 +65,6 @@ class TestSHA224(object):
     test_SHA224 = generate_base_hash_test(
         hashes.SHA224(),
         digest_size=28,
-        block_size=64,
     )
 
 
@@ -79,7 +77,6 @@ class TestSHA256(object):
     test_SHA256 = generate_base_hash_test(
         hashes.SHA256(),
         digest_size=32,
-        block_size=64,
     )
 
 
@@ -92,7 +89,6 @@ class TestSHA384(object):
     test_SHA384 = generate_base_hash_test(
         hashes.SHA384(),
         digest_size=48,
-        block_size=128,
     )
 
 
@@ -105,7 +101,6 @@ class TestSHA512(object):
     test_SHA512 = generate_base_hash_test(
         hashes.SHA512(),
         digest_size=64,
-        block_size=128,
     )
 
 
@@ -118,7 +113,6 @@ class TestMD5(object):
     test_MD5 = generate_base_hash_test(
         hashes.MD5(),
         digest_size=16,
-        block_size=64,
     )
 
 
@@ -132,7 +126,6 @@ class TestBLAKE2b(object):
     test_BLAKE2b = generate_base_hash_test(
         hashes.BLAKE2b(digest_size=64),
         digest_size=64,
-        block_size=128,
     )
 
     def test_invalid_digest_size(self, backend):
@@ -156,7 +149,6 @@ class TestBLAKE2s(object):
     test_BLAKE2s = generate_base_hash_test(
         hashes.BLAKE2s(digest_size=32),
         digest_size=32,
-        block_size=64,
     )
 
     def test_invalid_digest_size(self, backend):

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -168,16 +168,15 @@ def hash_test(backend, algorithm, params):
     assert m.finalize() == binascii.unhexlify(expected_md)
 
 
-def generate_base_hash_test(algorithm, digest_size, block_size):
+def generate_base_hash_test(algorithm, digest_size):
     def test_base_hash(self, backend):
-        base_hash_test(backend, algorithm, digest_size, block_size)
+        base_hash_test(backend, algorithm, digest_size)
     return test_base_hash
 
 
-def base_hash_test(backend, algorithm, digest_size, block_size):
+def base_hash_test(backend, algorithm, digest_size):
     m = hashes.Hash(algorithm, backend=backend)
     assert m.algorithm.digest_size == digest_size
-    assert m.algorithm.block_size == block_size
     m_copy = m.copy()
     assert m != m_copy
     assert m._ctx != m_copy._ctx


### PR DESCRIPTION
As of https://github.com/pyca/cryptography/pull/4249 `block_size` isn't an official part of the interface and future hashes we add won't have it so let's remove it from the base hash tests.