### PR TITLE
Test for expected CryptographyDeprecationWarnings

### DIFF
--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -378,7 +378,7 @@ class TestECDSAVectors(object):
 
         with raises_unsupported_algorithm(
             exceptions._Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
-        ):
+        ), pytest.warns(CryptographyDeprecationWarning):
             key.signer(DummySignatureAlgorithm())
 
         with raises_unsupported_algorithm(
@@ -388,7 +388,7 @@ class TestECDSAVectors(object):
 
         with raises_unsupported_algorithm(
             exceptions._Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
-        ):
+        ), pytest.warns(CryptographyDeprecationWarning):
             key.public_key().verifier(b"", DummySignatureAlgorithm())
 
         with raises_unsupported_algorithm(
@@ -546,9 +546,7 @@ class TestECDSAVectors(object):
         private_key = ec.generate_private_key(ec.SECP256R1(), backend)
         signature = private_key.sign(message, algorithm)
         public_key = private_key.public_key()
-        verifier = public_key.verifier(signature, algorithm)
-        verifier.update(message)
-        verifier.verify()
+        public_key.verify(signature, message, algorithm)
 
     def test_sign_prehashed(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
@@ -560,9 +558,7 @@ class TestECDSAVectors(object):
         private_key = ec.generate_private_key(ec.SECP256R1(), backend)
         signature = private_key.sign(data, algorithm)
         public_key = private_key.public_key()
-        verifier = public_key.verifier(signature, ec.ECDSA(hashes.SHA1()))
-        verifier.update(message)
-        verifier.verify()
+        public_key.verify(signature, message, ec.ECDSA(hashes.SHA1()))
 
     def test_sign_prehashed_digest_mismatch(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
@@ -580,9 +576,7 @@ class TestECDSAVectors(object):
         message = b"one little message"
         algorithm = ec.ECDSA(hashes.SHA1())
         private_key = ec.generate_private_key(ec.SECP256R1(), backend)
-        signer = private_key.signer(algorithm)
-        signer.update(message)
-        signature = signer.finalize()
+        signature = private_key.sign(message, algorithm)
         public_key = private_key.public_key()
         public_key.verify(signature, message, algorithm)
 
@@ -591,9 +585,7 @@ class TestECDSAVectors(object):
         message = b"one little message"
         algorithm = ec.ECDSA(hashes.SHA1())
         private_key = ec.generate_private_key(ec.SECP256R1(), backend)
-        signer = private_key.signer(algorithm)
-        signer.update(message)
-        signature = signer.finalize()
+        signature = private_key.sign(message, algorithm)
         h = hashes.Hash(hashes.SHA1(), backend)
         h.update(message)
         data = h.finalize()
@@ -618,14 +610,16 @@ class TestECDSAVectors(object):
     def test_prehashed_unsupported_in_signer_ctx(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
         private_key = ec.generate_private_key(ec.SECP256R1(), backend)
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError), \
+                pytest.warns(CryptographyDeprecationWarning):
             private_key.signer(ec.ECDSA(Prehashed(hashes.SHA1())))
 
     def test_prehashed_unsupported_in_verifier_ctx(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
         private_key = ec.generate_private_key(ec.SECP256R1(), backend)
         public_key = private_key.public_key()
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError), \
+                pytest.warns(CryptographyDeprecationWarning):
             public_key.verifier(
                 b"0" * 64,
                 ec.ECDSA(Prehashed(hashes.SHA1()))
@@ -1022,7 +1016,8 @@ class TestECDSAVerification(object):
         _skip_curve_unsupported(backend, ec.SECP256R1())
         key = ec.generate_private_key(ec.SECP256R1(), backend)
         public_key = key.public_key()
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError), \
+                pytest.warns(CryptographyDeprecationWarning):
             public_key.verifier(1234, ec.ECDSA(hashes.SHA256()))
 
 

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -541,7 +541,8 @@ class TestRSASignature(object):
     )
     def test_use_after_finalize(self, backend):
         private_key = RSA_KEY_512.private_key(backend)
-        signer = private_key.signer(padding.PKCS1v15(), hashes.SHA1())
+        with pytest.warns(CryptographyDeprecationWarning):
+            signer = private_key.signer(padding.PKCS1v15(), hashes.SHA1())
         signer.update(b"sign me")
         signer.finalize()
         with pytest.raises(AlreadyFinalized):
@@ -658,7 +659,8 @@ class TestRSASignature(object):
     )
     def test_prehashed_unsupported_in_signer_ctx(self, backend):
         private_key = RSA_KEY_512.private_key(backend)
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError), \
+                pytest.warns(CryptographyDeprecationWarning):
             private_key.signer(
                 padding.PKCS1v15(),
                 asym_utils.Prehashed(hashes.SHA1())
@@ -672,7 +674,8 @@ class TestRSASignature(object):
     )
     def test_prehashed_unsupported_in_verifier_ctx(self, backend):
         public_key = RSA_KEY_512.private_key(backend).public_key()
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError), \
+                pytest.warns(CryptographyDeprecationWarning):
             public_key.verifier(
                 b"0" * 64,
                 padding.PKCS1v15(),
@@ -702,14 +705,12 @@ class TestRSAVerification(object):
             e=public["public_exponent"],
             n=public["modulus"]
         ).public_key(backend)
-        with pytest.warns(CryptographyDeprecationWarning):
-            verifier = public_key.verifier(
-                binascii.unhexlify(example["signature"]),
-                padding.PKCS1v15(),
-                hashes.SHA1()
-            )
-        verifier.update(binascii.unhexlify(example["message"]))
-        verifier.verify()
+        public_key.verify(
+            binascii.unhexlify(example["signature"]),
+            binascii.unhexlify(example["message"]),
+            padding.PKCS1v15(),
+            hashes.SHA1()
+        )
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
@@ -932,11 +933,12 @@ class TestRSAVerification(object):
             b"sign me", padding.PKCS1v15(), hashes.SHA1()
         )
 
-        verifier = public_key.verifier(
-            signature,
-            padding.PKCS1v15(),
-            hashes.SHA1()
-        )
+        with pytest.warns(CryptographyDeprecationWarning):
+            verifier = public_key.verifier(
+                signature,
+                padding.PKCS1v15(),
+                hashes.SHA1()
+            )
         verifier.update(b"sign me")
         verifier.verify()
         with pytest.raises(AlreadyFinalized):
@@ -962,7 +964,8 @@ class TestRSAVerification(object):
         public_key = RSA_KEY_512.public_numbers.public_key(backend)
         signature = 1234
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError), \
+                pytest.warns(CryptographyDeprecationWarning):
             public_key.verifier(
                 signature,
                 padding.PKCS1v15(),


### PR DESCRIPTION
The remaining calls to `signer()` and `verifier()` are exercising the deprecated API intentionally. Let's test that the deprecation warnings are being raised as expected.

Closes #4311; see also #4314.