### PR TITLE
Use A-label strings in tests

### DIFF
--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -3121,9 +3121,9 @@ class TestCertificateSigningRequestBuilder(object):
             ),
             x509.RFC822Name(u"test@example.com"),
             x509.RFC822Name(u"email"),
-            x509.RFC822Name(u"email@em\xe5\xefl.com"),
+            x509.RFC822Name(u"email@xn--eml-vla4c.com"),
             x509.UniformResourceIdentifier(
-                u"https://\u043f\u044b\u043a\u0430.cryptography"
+                u"https://xn--80ato2c.cryptography"
             ),
             x509.UniformResourceIdentifier(
                 u"gopher://cryptography:70/some/path"


### PR DESCRIPTION
We already have coverage of the U-label deprecation warnings in test_x509_ext.py; see [TestRFC822Name.test_idna](https://github.com/pyca/cryptography/blob/2.3/tests/x509/test_x509_ext.py#L1790-L1797) and [TestUniformResourceIdentifier.test_idna_no_port](https://github.com/pyca/cryptography/blob/2.3/tests/x509/test_x509_ext.py#L1829-L1835)