### PR TITLE
Fixed #4380 -- do not assume TLSv1 is available in OpenSSL

### DIFF
--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -115,7 +115,7 @@ class TestOpenSSL(object):
         assert len(errors) == 10
 
     def test_ssl_ciphers_registered(self):
-        meth = backend._lib.TLSv1_method()
+        meth = backend._lib.SSLv23_method()
         ctx = backend._lib.SSL_CTX_new(meth)
         assert ctx != backend._ffi.NULL
         backend._lib.SSL_CTX_free(ctx)

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -37,7 +37,8 @@ class TestOpenSSL(object):
         # Test that we're properly handling 32-bit unsigned on all platforms.
         b = Binding()
         assert b.lib.SSL_OP_ALL > 0
-        ctx = b.lib.SSL_CTX_new(b.lib.TLSv1_method())
+        ctx = b.lib.SSL_CTX_new(b.lib.SSLv23_method())
+        assert ctx != b.ffi.NULL
         ctx = b.ffi.gc(ctx, b.lib.SSL_CTX_free)
         current_options = b.lib.SSL_CTX_get_options(ctx)
         resp = b.lib.SSL_CTX_set_options(ctx, b.lib.SSL_OP_ALL)
@@ -49,7 +50,8 @@ class TestOpenSSL(object):
         # Test that we're properly handling 32-bit unsigned on all platforms.
         b = Binding()
         assert b.lib.SSL_OP_ALL > 0
-        ctx = b.lib.SSL_CTX_new(b.lib.TLSv1_method())
+        ctx = b.lib.SSL_CTX_new(b.lib.SSLv23_method())
+        assert ctx != b.ffi.NULL
         ctx = b.ffi.gc(ctx, b.lib.SSL_CTX_free)
         ssl = b.lib.SSL_new(ctx)
         ssl = b.ffi.gc(ssl, b.lib.SSL_free)


### PR DESCRIPTION
Hallelujah! It's starting to become the case that some OpenSSLs are disabling it.


@tiran Can you please verify this fixes the tests?