### PR TITLE
remove freebsd11 builder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,6 @@ def configs = [
         toxenvs: ['py27', 'py34', 'py35', 'py36', 'py37'],
     ],
     [
-        label: 'freebsd11',
-        toxenvs: ['py27'],
-    ],
-    [
         label: 'sierra',
         toxenvs: ['py27', 'py36'],
     ],

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,6 @@ Currently we test ``cryptography`` on Python 2.7, 3.4+, and
 PyPy 5.3+ on these operating systems.
 
 * x86-64 CentOS 7.x
-* x86-64 FreeBSD 11
 * macOS 10.12 Sierra, 10.11 El Capitan
 * x86-64 Ubuntu 14.04, 16.04, and rolling
 * x86-64 Debian Wheezy (7.x), Jessie (8.x), Stretch (9.x), and Sid (unstable)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,7 +26,6 @@ OpenSSL releases:
 * ``OpenSSL 1.0.1``
 * ``OpenSSL 1.0.1e-fips`` (``RHEL/CentOS 7``)
 * ``OpenSSL 1.0.1f``
-* ``OpenSSL 1.0.1j-freebsd``
 * ``OpenSSL 1.0.2-latest``
 * ``OpenSSL 1.1.0-latest``
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -277,8 +277,6 @@ class TestOpenSSLRandomEngine(object):
                 assert name == 'getentropy'
             else:
                 assert name == '/dev/urandom'
-        if 'bsd' in sys.platform:
-            assert name in ['getentropy', '/dev/urandom']
         if sys.platform == 'win32':
             assert name == 'CryptGenRandom'
 


### PR DESCRIPTION
it's out of date, we can't update it, and it is unreliable