### PR TITLE
reorganize downstream tests to avoid dependency squashing

### DIFF
--- a/.travis/downstream.d/_HOW_TO_ADD_DOWNSTREAM_TESTS_
+++ b/.travis/downstream.d/_HOW_TO_ADD_DOWNSTREAM_TESTS_
@@ -1,0 +1,8 @@
+In order to add downstream tests to be run in CI, first add a test handler for
+the downstream consumer that you want to test. This should be a file in this
+".travis/downstream.d/" directory and follow the form defined in the
+"downstream-template.sh" template file. The new test handler file should be
+named in the format of {downstream name}.sh where {downstream name} is the
+name that you wish to use to identify the consumer. Next, add an entry to
+the test matrix in ".travis.yml" that sets the DOWNSTREAM environment
+variable to the downstream name that you selected.

--- a/.travis/downstream.d/aws-encryption-sdk.sh
+++ b/.travis/downstream.d/aws-encryption-sdk.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/awslabs/aws-encryption-sdk-python
+        cd aws-encryption-sdk-python
+        pip install -r test/requirements.txt
+        pip install -e .
+        ;;
+    run)
+        cd aws-encryption-sdk-python
+        pytest -m local test/
+        ;;
+    *)
+        exit
+        ;;
+esac

--- a/.travis/downstream.d/certbot-josepy.sh
+++ b/.travis/downstream.d/certbot-josepy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/certbot/josepy
+        cd josepy
+        pip install -e ".[tests]"
+        ;;
+    run)
+        cd josepy
+        pytest src
+        ;;
+    *)
+        exit
+        ;;
+esac

--- a/.travis/downstream.d/certbot.sh
+++ b/.travis/downstream.d/certbot.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/certbot/certbot
+        cd certbot
+        pip install pytest pytest-mock mock
+        pip install -e acme
+        pip install -e .
+        ;;
+    run)
+        cd certbot
+        pytest certbot/tests
+        pytest acme
+        ;;
+    *)
+        exit
+        ;;
+esac

--- a/.travis/downstream.d/downstream-template.sh
+++ b/.travis/downstream.d/downstream-template.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        # Download source and install requirements
+        ;;
+    run)
+        # Run tests
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/.travis/downstream.d/dynamodb-encryption-sdk.sh
+++ b/.travis/downstream.d/dynamodb-encryption-sdk.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/awslabs/aws-dynamodb-encryption-python
+        cd aws-dynamodb-encryption-python
+        pip install -r test/requirements.txt
+        pip install -e .
+        ;;
+    run)
+        cd aws-dynamodb-encryption-python
+        pytest -m "local and not slow and not veryslow and not nope"
+        ;;
+    *)
+        exit
+        ;;
+esac

--- a/.travis/downstream.d/paramiko.sh
+++ b/.travis/downstream.d/paramiko.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/paramiko/paramiko
+        cd paramiko
+        pip install -e .
+        pip install -r dev-requirements.txt
+        ;;
+    run)
+        cd paramiko
+        inv test
+        ;;
+    *)
+        exit
+        ;;
+esac

--- a/.travis/downstream.d/pyopenssl.sh
+++ b/.travis/downstream.d/pyopenssl.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/pyca/pyopenssl
+        cd pyopenssl
+        pip install -e ".[test]"
+        ;;
+    run)
+        cd pyopenssl
+        pytest tests
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/.travis/downstream.d/twisted.sh
+++ b/.travis/downstream.d/twisted.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/twisted/twisted
+        cd twisted
+        pip install -e .[tls,conch,http2]
+        ;;
+    run)
+        cd twisted
+        python -m twisted.trial src/twisted
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/.travis/downstream.d/urllib3.sh
+++ b/.travis/downstream.d/urllib3.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+case "${1}" in
+    install)
+        git clone --depth 1 https://github.com/shazow/urllib3
+        cd urllib3
+        pip install -r ./dev-requirements.txt
+        pip install -e ".[socks]"
+        ;;
+    run)
+        cd urllib3
+        pytest test
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -26,65 +26,11 @@ source ~/.venv/bin/activate
 if [ -n "${TOXENV}" ]; then
     tox -- --wycheproof-root=$HOME/wycheproof
 else
+    downstream_script = "${0}/downstream.d/${DOWNSTREAM}.sh"
+    if [ ! -x $downstream_script ]; then
+        exit 1
+    fi
+    $(downstream_script) install
     pip install .
-    case "${DOWNSTREAM}" in
-        pyopenssl)
-            git clone --depth=1 https://github.com/pyca/pyopenssl
-            cd pyopenssl
-            pip install -e ".[test]"
-            pytest tests
-            ;;
-        twisted)
-            git clone --depth=1 https://github.com/twisted/twisted
-            cd twisted
-            pip install -e .[tls,conch,http2]
-            python -m twisted.trial src/twisted
-            ;;
-        paramiko)
-            git clone --depth=1 https://github.com/paramiko/paramiko
-            cd paramiko
-            pip install -e .
-            pip install -r dev-requirements.txt
-            inv test
-            ;;
-        aws-encryption-sdk)
-            git clone --depth=1 https://github.com/awslabs/aws-encryption-sdk-python
-            cd aws-encryption-sdk-python
-            pip install -r test/requirements.txt
-            pip install -e .
-            pytest -m local test/
-            ;;
-        dynamodb-encryption-sdk)
-            git clone --depth=1 https://github.com/awslabs/aws-dynamodb-encryption-python
-            cd aws-dynamodb-encryption-python
-            pip install -r test/requirements.txt
-            pip install -e .
-            pytest -m "local and not slow and not veryslow and not nope"
-            ;;
-        certbot)
-            git clone --depth=1 https://github.com/certbot/certbot
-            cd certbot
-            pip install pytest pytest-mock mock
-            pip install -e acme
-            pip install -e .
-            pytest certbot/tests
-            pytest acme
-            ;;
-        certbot-josepy)
-            git clone --depth=1 https://github.com/certbot/josepy
-            cd josepy
-            pip install -e ".[tests]"
-            pytest src
-            ;;
-        urllib3)
-            git clone --depth 1 https://github.com/shazow/urllib3
-            cd urllib3
-            pip install -r ./dev-requirements.txt
-            pip install -e ".[socks]"
-            pytest test
-            ;;
-        *)
-            exit 1
-            ;;
-    esac
+    $(downstream_script) run
 fi

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -26,11 +26,11 @@ source ~/.venv/bin/activate
 if [ -n "${TOXENV}" ]; then
     tox -- --wycheproof-root=$HOME/wycheproof
 else
-    downstream_script = "${0}/downstream.d/${DOWNSTREAM}.sh"
+    downstream_script="${TRAVIS_BUILD_DIR}/.travis/downstream.d/${DOWNSTREAM}.sh"
     if [ ! -x $downstream_script ]; then
         exit 1
     fi
-    $(downstream_script) install
+    $downstream_script install
     pip install .
-    $(downstream_script) run
+    $downstream_script run
 fi


### PR DESCRIPTION
Related issue: #4415

## Background/Problem

When a downstream test is performed, if the downstream repository defines loose requirements (generally the most common pattern) when it installs requirements, we create the opportunity for a scenario where these downstream tests are testing the downstream consumer against dependencies that the consumer has not necessarily themselves tested against. This can cause issues if a change in those dependencies breaks the downstream consumer in ways that are unrelated to changes in `pyca/cryptography`.

Given that the intention of these downstream tests is to verify that changes made in `pyca/cryptography` are not going to break that consumer, this complicates matters because they are not actually testing just that. The simple solution to this is for the downstream consumers to provide a frozen requirements file that describes "this is a known good set of dependencies, use those to run your tests". However, this causes problems with the way that the downstream consumer test setup was being done because a frozen requirements file applied *after* installing the `pyca/cryptography` dev build would by definition remove the same dev build that we are wanting to test against.

## Solution

What this change does is separate the downstream consumer install and test steps into two separate stages so that we can install the `pyca/cryptography` dev build *after* installing the consumer's dependencies.

## Other potential issues

This does leave open the possible issue of `pyca/cryptography` removing a dependency and that dependency sticking around and masking failures that might otherwise be caused, but given current `pip` tooling this is a much simpler solution than trying to extract a `pyca/cryptography` dependency tree from a set of frozen dependencies.