### PR TITLE
Lock aws-encryption-sdk and dynamodb-encryption-sdk downstream test dependencies

### DIFF
--- a/.travis/downstream.d/aws-encryption-sdk.sh
+++ b/.travis/downstream.d/aws-encryption-sdk.sh
@@ -4,7 +4,7 @@ case "${1}" in
     install)
         git clone --depth=1 https://github.com/awslabs/aws-encryption-sdk-python
         cd aws-encryption-sdk-python
-        pip install -r test/requirements.txt
+        pip install -r test/upstream-requirements-py27.txt
         pip install -e .
         ;;
     run)

--- a/.travis/downstream.d/aws-encryption-sdk.sh
+++ b/.travis/downstream.d/aws-encryption-sdk.sh
@@ -4,8 +4,8 @@ case "${1}" in
     install)
         git clone --depth=1 https://github.com/awslabs/aws-encryption-sdk-python
         cd aws-encryption-sdk-python
-        pip install -r test/upstream-requirements-py27.txt
         pip install -e .
+        pip install -r test/upstream-requirements-py27.txt
         ;;
     run)
         cd aws-encryption-sdk-python

--- a/.travis/downstream.d/dynamodb-encryption-sdk.sh
+++ b/.travis/downstream.d/dynamodb-encryption-sdk.sh
@@ -4,7 +4,7 @@ case "${1}" in
     install)
         git clone --depth=1 https://github.com/awslabs/aws-dynamodb-encryption-python
         cd aws-dynamodb-encryption-python
-        pip install -r test/requirements.txt
+        pip install -r test/upstream-requirements-py27.txt
         pip install -e .
         ;;
     run)

--- a/.travis/downstream.d/dynamodb-encryption-sdk.sh
+++ b/.travis/downstream.d/dynamodb-encryption-sdk.sh
@@ -4,8 +4,8 @@ case "${1}" in
     install)
         git clone --depth=1 https://github.com/awslabs/aws-dynamodb-encryption-python
         cd aws-dynamodb-encryption-python
-        pip install -r test/upstream-requirements-py27.txt
         pip install -e .
+        pip install -r test/upstream-requirements-py27.txt
         ;;
     run)
         cd aws-dynamodb-encryption-python

--- a/.travis/downstream.d/dynamodb-encryption-sdk.sh
+++ b/.travis/downstream.d/dynamodb-encryption-sdk.sh
@@ -9,7 +9,7 @@ case "${1}" in
         ;;
     run)
         cd aws-dynamodb-encryption-python
-        pytest -m "local and not slow and not veryslow and not nope"
+        pytest test/ -m "local and not slow and not veryslow and not nope"
         ;;
     *)
         exit 1


### PR DESCRIPTION
To avoid future cases of #4415, lock `aws-encryption-sdk` and `dynamodb-encryption-sdk` downstream tests to using the frozen dependency set that we prepare and test in each of those packages.