### PR TITLE
don't sort the serial numbers in a parsed CRL

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -239,10 +239,16 @@ class _CertificateRevocationList(object):
         return h.finalize()
 
     def get_revoked_certificate_by_serial_number(self, serial_number):
+        # X509_CRL_get0_by_serial sorts in place, which breaks a variety of
+        # things we don't want to break (like iteration and the signature).
+        # Let's dupe it and sort that instead.
+        dup = self._backend._lib.X509_CRL_dup(self._x509_crl)
+        self._backend.openssl_assert(dup != self._backend._ffi.NULL)
+        dup = self._backend._ffi.gc(dup, self._backend._lib.X509_CRL_free)
         revoked = self._backend._ffi.new("X509_REVOKED **")
         asn1_int = _encode_asn1_int_gc(self._backend, serial_number)
         res = self._backend._lib.X509_CRL_get0_by_serial(
-            self._x509_crl, revoked, asn1_int
+            dup, revoked, asn1_int
         )
         if res == 0:
             return None
@@ -251,7 +257,7 @@ class _CertificateRevocationList(object):
                 revoked[0] != self._backend._ffi.NULL
             )
             return _RevokedCertificate(
-                self._backend, self._x509_crl, revoked[0]
+                self._backend, dup, revoked[0]
             )
 
     @property


### PR DESCRIPTION
OpenSSL sorts them in place and this breaks the signature and more.

fixes #4456 