### PR TITLE
update pytest config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if platform.python_implementation() == "PyPy":
         )
 
 test_requirements = [
-    "pytest>=3.2.1,!=3.3.0",
+    "pytest>=3.6.0",
     "pretend",
     "iso8601",
     "pytz",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,8 @@ def pytest_generate_tests(metafunc):
         skip_if_wycheproof_none(wycheproof)
 
         testcases = []
-        for path in metafunc.function.wycheproof_tests.args:
+        marker = metafunc.definition.get_closest_marker("wycheproof_tests")
+        for path in marker.args:
             testcases.extend(load_wycheproof_tests(wycheproof, path))
         metafunc.parametrize("wycheproof", testcases)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def pytest_generate_tests(metafunc):
 def backend(request):
     required_interfaces = [
         mark.kwargs["interface"]
-        for mark in request.node.get_marker("requires_backend_interface")
+        for mark in request.node.iter_markers("requires_backend_interface")
     ]
     if not all(
         isinstance(openssl_backend, iface) for iface in required_interfaces

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,7 +32,8 @@ def test_check_backend_support_skip():
     supported = pretend.stub(
         kwargs={"only_if": lambda backend: False, "skip_message": "Nope"}
     )
-    item = pretend.stub(keywords={"supported": [supported]})
+    node = pretend.stub(iter_markers=lambda x: [supported])
+    item = pretend.stub(node=node)
     with pytest.raises(pytest.skip.Exception) as exc_info:
         check_backend_support(True, item)
     assert exc_info.value.args[0] == "Nope (True)"
@@ -42,7 +43,8 @@ def test_check_backend_support_no_skip():
     supported = pretend.stub(
         kwargs={"only_if": lambda backend: True, "skip_message": "Nope"}
     )
-    item = pretend.stub(keywords={"supported": [supported]})
+    node = pretend.stub(iter_markers=lambda x: [supported])
+    item = pretend.stub(node=node)
     assert check_backend_support(None, item) is None
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,7 +28,7 @@ KeyedHashVector = collections.namedtuple(
 
 
 def check_backend_support(backend, item):
-    supported = item.keywords.get("supported")
+    supported = item.node.iter_markers("supported")
     if supported:
         for mark in supported:
             if not mark.kwargs["only_if"](backend):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,13 +28,11 @@ KeyedHashVector = collections.namedtuple(
 
 
 def check_backend_support(backend, item):
-    supported = item.node.iter_markers("supported")
-    if supported:
-        for mark in supported:
-            if not mark.kwargs["only_if"](backend):
-                pytest.skip("{0} ({1})".format(
-                    mark.kwargs["skip_message"], backend
-                ))
+    for mark in item.node.iter_markers("supported"):
+        if not mark.kwargs["only_if"](backend):
+            pytest.skip("{0} ({1})".format(
+                mark.kwargs["skip_message"], backend
+            ))
 
 
 @contextmanager


### PR DESCRIPTION
pytest 3.8.0 was just released and officially deprecates some of the way we do pytest marks. They introduced a new way to do this in 3.6 so this PR switches to that mechanism and updates our minimum pytest requirement.

See https://docs.pytest.org/en/latest/mark.html#updating-code