### PR TITLE
add OCSP basic response extension parsing

### DIFF
--- a/docs/x509/ocsp.rst
+++ b/docs/x509/ocsp.rst
@@ -395,6 +395,11 @@ Interfaces
         :raises ValueError: If ``response_status`` is not
             :class:`~cryptography.x509.ocsp.OCSPResponseStatus.SUCCESSFUL`.
 
+    .. attribute:: extensions
+
+        :type: :class:`~cryptography.x509.Extensions`
+
+        The extensions encoded in the response.
 
 .. class:: OCSPResponseStatus
 

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -817,6 +817,10 @@ _OCSP_REQ_EXTENSION_HANDLERS = {
     OCSPExtensionOID.NONCE: _decode_nonce,
 }
 
+_OCSP_BASICRESP_EXTENSION_HANDLERS = {
+    OCSPExtensionOID.NONCE: _decode_nonce,
+}
+
 _CERTIFICATE_EXTENSION_PARSER_NO_SCT = _X509ExtensionParser(
     ext_count=lambda backend, x: backend._lib.X509_get_ext_count(x),
     get_ext=lambda backend, x, i: backend._lib.X509_get_ext(x, i),
@@ -851,4 +855,10 @@ _OCSP_REQ_EXT_PARSER = _X509ExtensionParser(
     ext_count=lambda backend, x: backend._lib.OCSP_REQUEST_get_ext_count(x),
     get_ext=lambda backend, x, i: backend._lib.OCSP_REQUEST_get_ext(x, i),
     handlers=_OCSP_REQ_EXTENSION_HANDLERS,
+)
+
+_OCSP_BASICRESP_EXT_PARSER = _X509ExtensionParser(
+    ext_count=lambda backend, x: backend._lib.OCSP_BASICRESP_get_ext_count(x),
+    get_ext=lambda backend, x, i: backend._lib.OCSP_BASICRESP_get_ext(x, i),
+    handlers=_OCSP_BASICRESP_EXTENSION_HANDLERS,
 )

--- a/src/cryptography/hazmat/backends/openssl/ocsp.py
+++ b/src/cryptography/hazmat/backends/openssl/ocsp.py
@@ -9,7 +9,8 @@ import functools
 from cryptography import utils, x509
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends.openssl.decode_asn1 import (
-    _CRL_ENTRY_REASON_CODE_TO_ENUM, _OCSP_REQ_EXT_PARSER, _asn1_integer_to_int,
+    _CRL_ENTRY_REASON_CODE_TO_ENUM, _OCSP_BASICRESP_EXT_PARSER,
+    _OCSP_REQ_EXT_PARSER, _asn1_integer_to_int,
     _asn1_string_to_bytes, _decode_x509_name, _obj2txt,
     _parse_asn1_generalized_time,
 )
@@ -299,6 +300,11 @@ class _OCSPResponse(object):
     @_requires_successful_response
     def serial_number(self):
         return _serial_number(self._backend, self._cert_id)
+
+    @utils.cached_property
+    @_requires_successful_response
+    def extensions(self):
+        return _OCSP_BASICRESP_EXT_PARSER.parse(self._backend, self._basic)
 
 
 @utils.register_interface(OCSPRequest)

--- a/src/cryptography/x509/ocsp.py
+++ b/src/cryptography/x509/ocsp.py
@@ -232,3 +232,9 @@ class OCSPResponse(object):
         """
         The serial number of the cert whose status is being checked
         """
+
+    @abc.abstractproperty
+    def extensions(self):
+        """
+        The list of response extensions. Not single response extensions.
+        """

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -207,6 +207,7 @@ class TestOCSPResponse(object):
         )
         assert isinstance(resp.hash_algorithm, hashes.SHA1)
         assert resp.serial_number == 271024907440004808294641238224534273948400
+        assert len(resp.extensions) == 0
 
     def test_load_unauthorized(self):
         resp = _load_data(
@@ -283,3 +284,15 @@ class TestOCSPResponse(object):
             ocsp.load_der_ocsp_response,
         )
         assert resp.revocation_reason is x509.ReasonFlags.superseded
+
+    def test_response_extensions(self):
+        resp = _load_data(
+            os.path.join("x509", "ocsp", "resp-revoked-reason.der"),
+            ocsp.load_der_ocsp_response,
+        )
+        assert len(resp.extensions) == 1
+        ext = resp.extensions[0]
+        assert ext.critical is False
+        assert ext.value == x509.OCSPNonce(
+            b'\x04\x105\x957\x9fa\x03\x83\x87\x89rW\x8f\xae\x99\xf7"'
+        )

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -247,6 +247,8 @@ class TestOCSPResponse(object):
             assert resp.hash_algorithm
         with pytest.raises(ValueError):
             assert resp.serial_number
+        with pytest.raises(ValueError):
+            assert resp.extensions
 
     def test_load_revoked(self):
         resp = _load_data(


### PR DESCRIPTION
Just nonce for now. This does not support SINGLERESP extension parsing.