### PR TITLE
Adds a more descriptive error msg for wrong wrapping

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -123,7 +123,7 @@ the following rules:
 
 * has a one-line header like this: ``-----BEGIN [FILE TYPE]-----``
   (where ``[FILE TYPE]`` is ``CERTIFICATE``, ``PUBLIC KEY``, ``PRIVATE KEY``,
-  et cetera)
+  etc.)
 
 * has a one-line footer like this: ``-----END [FILE TYPE]-----``
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -111,28 +111,22 @@ not yet possible you  can also install ``cryptography`` with
 dependency. This workaround will be available until the feature is fully
 removed.
 
-.. _`NaCl`: https://nacl.cr.yp.to/
-.. _`PyNaCl`: https://pynacl.readthedocs.io
-.. _`WSGIApplicationGroup`: https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIApplicationGroup.html
-.. _`issue`: https://github.com/pyca/cryptography/issues
-
-Why I can't import my PEM file?
+Why can't I import my PEM file?
 -------------------------------
 
-PEM is a file format to store keys, certificates and others cryptographic data
-into a file.  The format only uses ASCII characters to enhance compatibility,
-and the data is encoded as base64. It's defined by `RFC 7468`_. Alternatively,
-DER files stores data in binary format.
+PEM is a format (defined by several RFCs, but originally :rfc:`1421`) for
+encoding keys, certificates and others cryptographic data into a regular form.
+The data is encoded as base64 and wrapped with a header and footer.
 
-If you are having trouble to import PEM files, make sure your file fits
+If you are having trouble importing PEM files, make sure your file fits
 the following rules:
 
-- has a one-line header like this: ``-----BEGIN [FILE TYPE]-----``
-  (where ``[FILE TYPE]`` is certificate, public key, ...);
+* has a one-line header like this: ``-----BEGIN [FILE TYPE]-----``
+  (where ``[FILE TYPE]`` is certificate, public key, et cetera)
 
-- has a one-line footer like this: ``-----END [FILE TYPE]-----``;
+* has a one-line footer like this: ``-----END [FILE TYPE]-----``
 
-- all lines, except for the final one, must consist of exactly 64
+* all lines, except for the final one, must consist of exactly 64
   characters.
 
 For example, this is a PEM file for a RSA Public Key: ::
@@ -148,10 +142,7 @@ For example, this is a PEM file for a RSA Public Key: ::
    -----END PUBLIC KEY-----
 
 
-You can extract the info encoded in the file with OpenSSL command line:
-
-.. code-block:: console
-
-   $ openssl rsa -in keyfile.pem -pubin -text -noout
-
-.. _RFC 7468: https://tools.ietf.org/html/rfc7468
+.. _`NaCl`: https://nacl.cr.yp.to/
+.. _`PyNaCl`: https://pynacl.readthedocs.io
+.. _`WSGIApplicationGroup`: https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIApplicationGroup.html
+.. _`issue`: https://github.com/pyca/cryptography/issues

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -122,7 +122,8 @@ If you are having trouble importing PEM files, make sure your file fits
 the following rules:
 
 * has a one-line header like this: ``-----BEGIN [FILE TYPE]-----``
-  (where ``[FILE TYPE]`` is certificate, public key, et cetera)
+  (where ``[FILE TYPE]`` is ``CERTIFICATE``, ``PUBLIC KEY``, ``PRIVATE KEY``,
+  et cetera)
 
 * has a one-line footer like this: ``-----END [FILE TYPE]-----``
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -115,3 +115,43 @@ removed.
 .. _`PyNaCl`: https://pynacl.readthedocs.io
 .. _`WSGIApplicationGroup`: https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIApplicationGroup.html
 .. _`issue`: https://github.com/pyca/cryptography/issues
+
+Why I can't import my PEM file?
+-------------------------------
+
+PEM is a file format to store keys, certificates and others cryptographic data
+into a file.  The format only uses ASCII characters to enhance compatibility,
+and the data is encoded as base64. It's defined by `RFC 7468`_. Alternatively,
+DER files stores data in binary format.
+
+If you are having trouble to import PEM files, make sure your file fits
+the following rules:
+
+- has a one-line header like this: ``-----BEGIN [FILE TYPE]-----``
+  (where ``[FILE TYPE]`` is certificate, public key, ...);
+
+- has a one-line footer like this: ``-----END [FILE TYPE]-----``;
+
+- all lines, except for the final one, must consist of exactly 64
+  characters.
+
+For example, this is a PEM file for a RSA Public Key: ::
+
+   -----BEGIN PUBLIC KEY-----
+   MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7CsKFSzq20NLb2VQDXma
+   9DsDXtKADv0ziI5hT1KG6Bex5seE9pUoEcUxNv4uXo2jzAUgyRweRl/DLU8SoN8+
+   WWd6YWik4GZvNv7j0z28h9Q5jRySxy4dmElFtIRHGiKhqd1Z06z4AzrmKEzgxkOk
+   LJjY9cvwD+iXjpK2oJwNNyavvjb5YZq6V60RhpyNtKpMh2+zRLgIk9sROEPQeYfK
+   22zj2CnGBMg5Gm2uPOsGDltl/I/Fdh1aO3X4i1GXwCuPf1kSAg6lPJD0batftkSG
+   v0X0heUaV0j1HSNlBWamT4IR9+iJfKJHekOqvHQBcaCu7Ja4kXzx6GZ3M2j/Ja3A
+   2QIDAQAB
+   -----END PUBLIC KEY-----
+
+
+You can extract the info encoded in the file with OpenSSL command line:
+
+.. code-block:: console
+
+   $ openssl rsa -in keyfile.pem -pubin -text -noout
+
+.. _RFC 7468: https://tools.ietf.org/html/rfc7468

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -10,7 +10,6 @@ boolean
 Botan
 Brainpool
 Capitan
-cetera
 changelog
 Changelog
 ciphertext
@@ -42,7 +41,6 @@ Docstrings
 El
 Encodings
 endian
-et
 fallback
 Fernet
 fernet

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -10,6 +10,7 @@ boolean
 Botan
 Brainpool
 Capitan
+cetera
 changelog
 Changelog
 ciphertext
@@ -41,6 +42,7 @@ Docstrings
 El
 Encodings
 endian
+et
 fallback
 Fernet
 fernet

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1141,9 +1141,10 @@ class Backend(object):
         )
         if x509 == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load certificate. Check " \
-                "https://cryptography.io/en/latest/faq/#why-i-can-t-import-my-pem-file" \
-                " for more information.")
+            raise ValueError("Unable to load certificate. Check "
+                             "https://cryptography.io/en/latest/faq/"
+                             "#why-i-can-t-import-my-pem-file"
+                             " for more information.")
 
         x509 = self._ffi.gc(x509, self._lib.X509_free)
         return _Certificate(self, x509)
@@ -1165,9 +1166,10 @@ class Backend(object):
         )
         if x509_crl == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load CRL. Check " \
-                "https://cryptography.io/en/latest/faq/#why-i-can-t-import-my-pem-file" \
-                " for more information.")
+            raise ValueError("Unable to load CRL. Check "
+                             "https://cryptography.io/en/latest/faq/"
+                             "#why-i-can-t-import-my-pem-file"
+                             " for more information.")
 
         x509_crl = self._ffi.gc(x509_crl, self._lib.X509_CRL_free)
         return _CertificateRevocationList(self, x509_crl)
@@ -1189,9 +1191,10 @@ class Backend(object):
         )
         if x509_req == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load request. Check " \
-                "https://cryptography.io/en/latest/faq/#why-i-can-t-import-my-pem-file" \
-                " for more information.")
+            raise ValueError("Unable to load request. Check "
+                             "https://cryptography.io/en/latest/faq/"
+                             "#why-i-can-t-import-my-pem-file"
+                             " for more information.")
 
         x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)
         return _CertificateSigningRequest(self, x509_req)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1141,7 +1141,9 @@ class Backend(object):
         )
         if x509 == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load certificate")
+            raise ValueError("Unable to load certificate. Check " \
+                "https://cryptography.io/en/latest/faq/#why-i-can-t-import-my-pem-file" \
+                " for more information.")
 
         x509 = self._ffi.gc(x509, self._lib.X509_free)
         return _Certificate(self, x509)
@@ -1163,7 +1165,9 @@ class Backend(object):
         )
         if x509_crl == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load CRL")
+            raise ValueError("Unable to load CRL. Check " \
+                "https://cryptography.io/en/latest/faq/#why-i-can-t-import-my-pem-file" \
+                " for more information.")
 
         x509_crl = self._ffi.gc(x509_crl, self._lib.X509_CRL_free)
         return _CertificateRevocationList(self, x509_crl)
@@ -1185,7 +1189,9 @@ class Backend(object):
         )
         if x509_req == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load request")
+            raise ValueError("Unable to load request. Check " \
+                "https://cryptography.io/en/latest/faq/#why-i-can-t-import-my-pem-file" \
+                " for more information.")
 
         x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)
         return _CertificateSigningRequest(self, x509_req)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1141,10 +1141,10 @@ class Backend(object):
         )
         if x509 == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load certificate. Check "
-                             "https://cryptography.io/en/latest/faq/"
-                             "#why-i-can-t-import-my-pem-file"
-                             " for more information.")
+            raise ValueError(
+                "Unable to load certificate. See https://cryptography.io/en/la"
+                "test/faq/#why-can-t-i-import-my-pem-file for more details."
+            )
 
         x509 = self._ffi.gc(x509, self._lib.X509_free)
         return _Certificate(self, x509)
@@ -1166,10 +1166,10 @@ class Backend(object):
         )
         if x509_crl == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load CRL. Check "
-                             "https://cryptography.io/en/latest/faq/"
-                             "#why-i-can-t-import-my-pem-file"
-                             " for more information.")
+            raise ValueError(
+                "Unable to load CRL. See https://cryptography.io/en/la"
+                "test/faq/#why-can-t-i-import-my-pem-file for more details."
+            )
 
         x509_crl = self._ffi.gc(x509_crl, self._lib.X509_CRL_free)
         return _CertificateRevocationList(self, x509_crl)
@@ -1191,10 +1191,10 @@ class Backend(object):
         )
         if x509_req == self._ffi.NULL:
             self._consume_errors()
-            raise ValueError("Unable to load request. Check "
-                             "https://cryptography.io/en/latest/faq/"
-                             "#why-i-can-t-import-my-pem-file"
-                             " for more information.")
+            raise ValueError(
+                "Unable to load request. See https://cryptography.io/en/la"
+                "test/faq/#why-can-t-i-import-my-pem-file for more details."
+            )
 
         x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)
         return _CertificateSigningRequest(self, x509_req)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1135,34 +1135,6 @@ class Backend(object):
         self._handle_key_loading_error()
 
     def load_pem_x509_certificate(self, data):
-        # checks if the wrap is as expected, searching for '\n'
-        bad_wrapping = False
-
-        if len(data) == 778:
-            if chr(data[27]) != '\n':
-                bad_wrapping = True
-
-            elif not bad_wrapping:
-                for k in range(0, 11):
-                    if chr(data[92+65*k]) != '\n':
-                        bad_wrapping = True
-                        break
-
-            elif chr(data[751]) != '\n':
-                bad_wrapping = True
-
-            elif chr(data[777]) != '\n':
-                bad_wrapping = True
-
-        else:
-            bad_wrapping = True
-
-        if bad_wrapping:
-            self._consume_errors()
-            raise ValueError("Certificate with wrong wrapping. Make sure each "
-                            + "data line has 64 bytes.")
-
-
         mem_bio = self._bytes_to_bio(data)
         x509 = self._lib.PEM_read_bio_X509(
             mem_bio.bio, self._ffi.NULL, self._ffi.NULL, self._ffi.NULL


### PR DESCRIPTION
I made a proof of concept of a function that should fix #4498. I addressed my code to check specifically for a bad wrapped RSA 512 certificate, verifying positions to ensure that it has a `\n` there. I have some questions about my code:

- This function is OK like that or should it be more generic than this?
- Is my logic right? 
- Where should I place it? I think the code would be cleaner if it has a `pem_check_wrap()`  function.
- There are performance issue in this code? I could remove the `chr()` cast for example. I inserted it to make the logic more obvious. 

I also want to write a unit test in the future to match this  specific case. Thanks!