### PR TITLE
Updated BLAKE2s and BLAKE2b error messages from unsupportedalgorithm …

### DIFF
--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -151,6 +151,12 @@ class BLAKE2b(object):
     block_size = 128
 
     def __init__(self, digest_size):
+
+        if (
+            digest_size != 64
+        ):
+            raise ValueError("Digest size must be 64")
+
         if (
             digest_size > self._max_digest_size or
             digest_size < self._min_digest_size
@@ -172,6 +178,12 @@ class BLAKE2s(object):
     _min_digest_size = 1
 
     def __init__(self, digest_size):
+
+        if (
+            digest_size != 32
+        ):
+            raise ValueError("Digest size must be 32")
+
         if (
             digest_size > self._max_digest_size or
             digest_size < self._min_digest_size


### PR DESCRIPTION
…exception to an explicit error.

The error is now "ValueError: Digest size must be 32" (or 64 for BLAKE2b)
This was done to give a more contextual error message and should be in place until OpenSSL supports variable lengths.