### PR TITLE
don't limit hypothesis's time to generate valid test permutations

### DIFF
--- a/tests/hypothesis/test_fernet.py
+++ b/tests/hypothesis/test_fernet.py
@@ -10,8 +10,8 @@ from cryptography.fernet import Fernet
 
 # Unlimited timeout will become the default in the future. When it does
 # we should remove this. See:
-# https://hypothesis.readthedocs.io/en/latest/settings.html?highlight=
-# timeout#hypothesis.settings.timeout
+# https://hypothesis.readthedocs.io/en/latest/settings.html
+# #hypothesis.settings.timeout
 @settings(deadline=None, timeout=unlimited)
 @given(binary())
 def test_fernet(data):

--- a/tests/hypothesis/test_fernet.py
+++ b/tests/hypothesis/test_fernet.py
@@ -2,12 +2,13 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
-from hypothesis import given
+from hypothesis import given, settings, unlimited
 from hypothesis.strategies import binary
 
 from cryptography.fernet import Fernet
 
 
+@settings(deadline=None, timeout=unlimited)
 @given(binary())
 def test_fernet(data):
     f = Fernet(Fernet.generate_key())

--- a/tests/hypothesis/test_fernet.py
+++ b/tests/hypothesis/test_fernet.py
@@ -8,6 +8,10 @@ from hypothesis.strategies import binary
 from cryptography.fernet import Fernet
 
 
+# Unlimited timeout will become the default in the future. When it does
+# we should remove this. See:
+# https://hypothesis.readthedocs.io/en/latest/settings.html?highlight=
+# timeout#hypothesis.settings.timeout
 @settings(deadline=None, timeout=unlimited)
 @given(binary())
 def test_fernet(data):


### PR DESCRIPTION
It's important that CI find a new way to be flaky every single day.