### PR TITLE
suppress healthcheck too slow error

### DIFF
--- a/tests/hypothesis/test_fernet.py
+++ b/tests/hypothesis/test_fernet.py
@@ -2,17 +2,13 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
-from hypothesis import given, settings, unlimited
+from hypothesis import HealthCheck, given, settings
 from hypothesis.strategies import binary
 
 from cryptography.fernet import Fernet
 
 
-# Unlimited timeout will become the default in the future. When it does
-# we should remove this. See:
-# https://hypothesis.readthedocs.io/en/latest/settings.html
-# #hypothesis.settings.timeout
-@settings(deadline=None, timeout=unlimited)
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(binary())
 def test_fernet(data):
     f = Fernet(Fernet.generate_key())


### PR DESCRIPTION
Rather than try to change a variety of other settings, let's just suppress this healthcheck, which doesn't matter for our CI.