### PR TITLE
move ObjectIdentifier to break an upcoming import cycle

### DIFF
--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -1,0 +1,67 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+from cryptography import utils
+
+
+class ObjectIdentifier(object):
+    def __init__(self, dotted_string):
+        self._dotted_string = dotted_string
+
+        nodes = self._dotted_string.split(".")
+        intnodes = []
+
+        # There must be at least 2 nodes, the first node must be 0..2, and
+        # if less than 2, the second node cannot have a value outside the
+        # range 0..39.  All nodes must be integers.
+        for node in nodes:
+            try:
+                intnodes.append(int(node, 0))
+            except ValueError:
+                raise ValueError(
+                    "Malformed OID: %s (non-integer nodes)" % (
+                        self._dotted_string))
+
+        if len(nodes) < 2:
+            raise ValueError(
+                "Malformed OID: %s (insufficient number of nodes)" % (
+                    self._dotted_string))
+
+        if intnodes[0] > 2:
+            raise ValueError(
+                "Malformed OID: %s (first node outside valid range)" % (
+                    self._dotted_string))
+
+        if intnodes[0] < 2 and intnodes[1] >= 40:
+            raise ValueError(
+                "Malformed OID: %s (second node outside valid range)" % (
+                    self._dotted_string))
+
+    def __eq__(self, other):
+        if not isinstance(other, ObjectIdentifier):
+            return NotImplemented
+
+        return self.dotted_string == other.dotted_string
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __repr__(self):
+        return "<ObjectIdentifier(oid={0}, name={1})>".format(
+            self.dotted_string,
+            self._name
+        )
+
+    def __hash__(self):
+        return hash(self.dotted_string)
+
+    @property
+    def _name(self):
+        # Lazy import to avoid an import cycle
+        from cryptography.x509.oid import _OID_NAMES
+        return _OID_NAMES.get(self, "Unknown OID")
+
+    dotted_string = utils.read_only_property("_dotted_string")

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -4,66 +4,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-from cryptography import utils
+from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat.primitives import hashes
-
-
-class ObjectIdentifier(object):
-    def __init__(self, dotted_string):
-        self._dotted_string = dotted_string
-
-        nodes = self._dotted_string.split(".")
-        intnodes = []
-
-        # There must be at least 2 nodes, the first node must be 0..2, and
-        # if less than 2, the second node cannot have a value outside the
-        # range 0..39.  All nodes must be integers.
-        for node in nodes:
-            try:
-                intnodes.append(int(node, 0))
-            except ValueError:
-                raise ValueError(
-                    "Malformed OID: %s (non-integer nodes)" % (
-                        self._dotted_string))
-
-        if len(nodes) < 2:
-            raise ValueError(
-                "Malformed OID: %s (insufficient number of nodes)" % (
-                    self._dotted_string))
-
-        if intnodes[0] > 2:
-            raise ValueError(
-                "Malformed OID: %s (first node outside valid range)" % (
-                    self._dotted_string))
-
-        if intnodes[0] < 2 and intnodes[1] >= 40:
-            raise ValueError(
-                "Malformed OID: %s (second node outside valid range)" % (
-                    self._dotted_string))
-
-    def __eq__(self, other):
-        if not isinstance(other, ObjectIdentifier):
-            return NotImplemented
-
-        return self.dotted_string == other.dotted_string
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __repr__(self):
-        return "<ObjectIdentifier(oid={0}, name={1})>".format(
-            self.dotted_string,
-            self._name
-        )
-
-    def __hash__(self):
-        return hash(self.dotted_string)
-
-    @property
-    def _name(self):
-        return _OID_NAMES.get(self, "Unknown OID")
-
-    dotted_string = utils.read_only_property("_dotted_string")
 
 
 class ExtensionOID(object):


### PR DESCRIPTION
refs #4435 

Move ObjectIdentifier to a private import (which we can move around and change to a better location whenever we think of one).