### PR TITLE
Add the rest of the curve OIDs, make oid a part of the EC interface

### DIFF
--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -529,6 +529,12 @@ Key Interfaces
         Size (in :term:`bits`) of a secret scalar for the curve (as generated
         by :func:`generate_private_key`).
 
+    .. attribute:: oid
+
+        :type: :class:`~cryptography.x509.ObjectIdentifier`
+
+        Returns the object identifier assigned to the curve.
+
 
 .. class:: EllipticCurveSignatureAlgorithm
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -38,6 +38,12 @@ class EllipticCurveOID(object):
 @six.add_metaclass(abc.ABCMeta)
 class EllipticCurve(object):
     @abc.abstractproperty
+    def oid(self):
+        """
+        The ObjectIdentifier associated with the curve.
+        """
+
+    @abc.abstractproperty
     def name(self):
         """
         The name of the curve. e.g. secp256r1.
@@ -174,114 +180,133 @@ EllipticCurvePublicKeyWithSerialization = EllipticCurvePublicKey
 
 @utils.register_interface(EllipticCurve)
 class SECT571R1(object):
+    oid = EllipticCurveOID.SECT571R1
     name = "sect571r1"
     key_size = 570
 
 
 @utils.register_interface(EllipticCurve)
 class SECT409R1(object):
+    oid = EllipticCurveOID.SECT409R1
     name = "sect409r1"
     key_size = 409
 
 
 @utils.register_interface(EllipticCurve)
 class SECT283R1(object):
+    oid = EllipticCurveOID.SECT283R1
     name = "sect283r1"
     key_size = 283
 
 
 @utils.register_interface(EllipticCurve)
 class SECT233R1(object):
+    oid = EllipticCurveOID.SECT233R1
     name = "sect233r1"
     key_size = 233
 
 
 @utils.register_interface(EllipticCurve)
 class SECT163R2(object):
+    oid = EllipticCurveOID.SECT163R2
     name = "sect163r2"
     key_size = 163
 
 
 @utils.register_interface(EllipticCurve)
 class SECT571K1(object):
+    oid = EllipticCurveOID.SECT571K1
     name = "sect571k1"
     key_size = 571
 
 
 @utils.register_interface(EllipticCurve)
 class SECT409K1(object):
+    oid = EllipticCurveOID.SECT409K1
     name = "sect409k1"
     key_size = 409
 
 
 @utils.register_interface(EllipticCurve)
 class SECT283K1(object):
+    oid = EllipticCurveOID.SECT283K1
     name = "sect283k1"
     key_size = 283
 
 
 @utils.register_interface(EllipticCurve)
 class SECT233K1(object):
+    oid = EllipticCurveOID.SECT233K1
     name = "sect233k1"
     key_size = 233
 
 
 @utils.register_interface(EllipticCurve)
 class SECT163K1(object):
+    oid = EllipticCurveOID.SECT163K1
     name = "sect163k1"
     key_size = 163
 
 
 @utils.register_interface(EllipticCurve)
 class SECP521R1(object):
+    oid = EllipticCurveOID.SECP521R1
     name = "secp521r1"
     key_size = 521
 
 
 @utils.register_interface(EllipticCurve)
 class SECP384R1(object):
+    oid = EllipticCurveOID.SECP384R1
     name = "secp384r1"
     key_size = 384
 
 
 @utils.register_interface(EllipticCurve)
 class SECP256R1(object):
+    oid = EllipticCurveOID.SECP256R1
     name = "secp256r1"
     key_size = 256
 
 
 @utils.register_interface(EllipticCurve)
 class SECP256K1(object):
+    oid = EllipticCurveOID.SECP256K1
     name = "secp256k1"
     key_size = 256
 
 
 @utils.register_interface(EllipticCurve)
 class SECP224R1(object):
+    oid = EllipticCurveOID.SECP224R1
     name = "secp224r1"
     key_size = 224
 
 
 @utils.register_interface(EllipticCurve)
 class SECP192R1(object):
+    oid = EllipticCurveOID.SECP192R1
     name = "secp192r1"
     key_size = 192
 
 
 @utils.register_interface(EllipticCurve)
 class BrainpoolP256R1(object):
+    oid = EllipticCurveOID.BRAINPOOLP256R1
     name = "brainpoolP256r1"
     key_size = 256
 
 
 @utils.register_interface(EllipticCurve)
 class BrainpoolP384R1(object):
+    oid = EllipticCurveOID.BRAINPOOLP384R1
     name = "brainpoolP384r1"
     key_size = 384
 
 
 @utils.register_interface(EllipticCurve)
 class BrainpoolP512R1(object):
+    oid = EllipticCurveOID.BRAINPOOLP512R1
     name = "brainpoolP512r1"
     key_size = 512
 

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -73,6 +73,7 @@ def _skip_exchange_algorithm_unsupported(backend, algorithm, curve):
 
 @utils.register_interface(ec.EllipticCurve)
 class DummyCurve(object):
+    oid = "doesntmatter"
     name = "dummy-curve"
     key_size = 1
 


### PR DESCRIPTION
fixes #3345 

We're obviously talking about deprecating the binary curves (#4440), but we let ourselves get gridlocked too easily. This is a thing that makes sense to add, and if we need to add some more OIDs to make it happen immediately then fine. (I have some other thoughts on the SECT curves in the other issue as well)