### PR TITLE
Remove unnecessary use of six.binary_type

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -43,7 +43,7 @@ def _key_identifier_from_public_key(public_key):
             serialization.PublicFormat.SubjectPublicKeyInfo
         )
 
-        data = six.binary_type(PublicKeyInfo.load(serialized)['public_key'])
+        data = bytes(PublicKeyInfo.load(serialized)['public_key'])
 
     return hashlib.sha1(data).digest()
 


### PR DESCRIPTION
All supported Pythons have type bytes. On Python 2, it is an alias of
str, same as six.binary_type. Makes the code slightly more forward
compatible and removes some indirection.