### PR TITLE
Raise MemoryError when backend.derive_scrypt can't malloc enough

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -22,6 +22,8 @@ static const int ERR_LIB_PKCS12;
 static const int ERR_LIB_SSL;
 static const int ERR_LIB_X509;
 
+static const int ERR_R_MALLOC_FAILURE;
+
 static const int ASN1_R_BOOLEAN_IS_WRONG_LENGTH;
 static const int ASN1_R_BUFFER_TOO_SMALL;
 static const int ASN1_R_CIPHER_HAS_NO_OBJECT_IDENTIFIER;

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2097,6 +2097,8 @@ class Backend(object):
                     )
                 )
 
+            # memory required formula explained here:
+            # https://blog.filippo.io/the-scrypt-parameters/
             min_memory = 128 * n * r // (1024**2)
             raise MemoryError(
                 "Not enough memory to derive key. These parameters require"

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2088,12 +2088,14 @@ class Backend(object):
         )
         if res != 1:
             errors = self._consume_errors()
-            self.openssl_assert(
-                errors[0]._lib_reason_match(
-                    self._lib.ERR_LIB_EVP,
-                    self._lib.ERR_R_MALLOC_FAILURE
+            if not self._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111:
+                # This error is only added to the stack in 1.1.1+
+                self.openssl_assert(
+                    errors[0]._lib_reason_match(
+                        self._lib.ERR_LIB_EVP,
+                        self._lib.ERR_R_MALLOC_FAILURE
+                    )
                 )
-            )
 
             min_memory = 128 * n * r // (1024**2)
             raise MemoryError(

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -80,6 +80,20 @@ class TestScrypt(object):
             Scrypt(salt, length, work_factor, block_size,
                    parallelization_factor, backend)
 
+    def test_scrypt_malloc_failure(self, backend):
+        password = b"NaCl"
+        work_factor = 1024
+        block_size = 589824
+        parallelization_factor = 16
+        length = 64
+        salt = b"NaCl"
+
+        scrypt = Scrypt(salt, length, work_factor, block_size,
+                        parallelization_factor, backend)
+
+        with pytest.raises(MemoryError):
+            scrypt.derive(password)
+
     def test_password_not_bytes(self, backend):
         password = 1
         work_factor = 1024

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -82,7 +82,7 @@ class TestScrypt(object):
 
     def test_scrypt_malloc_failure(self, backend):
         password = b"NaCl"
-        work_factor = 1024
+        work_factor = 1024 ** 3
         block_size = 589824
         parallelization_factor = 16
         length = 64


### PR DESCRIPTION
### What this does:
1. Catches when an OpenSSL error with a reason of `ERR_R_MALLOC_FAILURE` and raises a `MemoryError` with helpful info instead.
2. Adds a test for `test_scrypt_malloc_failure`.
3. Resolves #4591 