### PR TITLE
ed448 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Changelog
   :func:`~cryptography.hazmat.primitives.asymmetric.ec.get_curve_for_oid`.
 * Add support for OpenSSL when compiled with the ``no-engine``
   (``OPENSSL_NO_ENGINE``) flag.
+* Added support for :doc:`/hazmat/primitives/asymmetric/ed448` when using
+  OpenSSL 1.1.1.
 
 .. _v2-5:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Changelog
 * **BACKWARDS INCOMPATIBLE**: Removed ``cryptography.x509.Certificate.serial``,
   which had been deprecated for nearly 3 years. Use
   :attr:`~cryptography.x509.Certificate.serial_number` instead.
+* Added support for :doc:`/hazmat/primitives/asymmetric/ed448` when using
+  OpenSSL 1.1.1.
 * Added support for :doc:`/hazmat/primitives/asymmetric/ed25519` when using
   OpenSSL 1.1.1.
 * Add support for easily mapping an object identifier to its elliptic curve
@@ -27,8 +29,6 @@ Changelog
   :func:`~cryptography.hazmat.primitives.asymmetric.ec.get_curve_for_oid`.
 * Add support for OpenSSL when compiled with the ``no-engine``
   (``OPENSSL_NO_ENGINE``) flag.
-* Added support for :doc:`/hazmat/primitives/asymmetric/ed448` when using
-  OpenSSL 1.1.1.
 
 .. _v2-5:
 

--- a/docs/hazmat/primitives/asymmetric/ed448.rst
+++ b/docs/hazmat/primitives/asymmetric/ed448.rst
@@ -1,0 +1,131 @@
+.. hazmat::
+
+Ed448 signing
+=============
+
+.. currentmodule:: cryptography.hazmat.primitives.asymmetric.ed448
+
+
+Ed448 is an elliptic curve signing algorithm using `EdDSA`_.
+
+
+Signing & Verification
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. doctest::
+
+    >>> from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey
+    >>> private_key = Ed448PrivateKey.generate()
+    >>> signature = private_key.sign(b"my authenticated message")
+    >>> public_key = private_key.public_key()
+    >>> # Raises InvalidSignature if verification fails
+    >>> public_key.verify(signature, b"my authenticated message")
+
+Key interfaces
+~~~~~~~~~~~~~~
+
+.. class:: Ed448PrivateKey
+
+    .. versionadded:: 2.6
+
+    .. classmethod:: generate()
+
+        Generate an Ed448 private key.
+
+        :returns: :class:`Ed448PrivateKey`
+
+    .. classmethod:: from_private_bytes(data)
+
+        :param data: 57 byte private key.
+        :type data: :term:`bytes-like`
+
+        :returns: :class:`Ed448PrivateKey`
+
+    .. method:: public_key()
+
+        :returns: :class:`Ed448PublicKey`
+
+    .. method:: sign(data)
+
+        :param bytes data: The data to sign.
+
+        :returns bytes: The 64 byte signature.
+
+    .. method:: private_bytes(encoding, format, encryption_algorithm)
+
+        Allows serialization of the key to bytes. Encoding (
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`,
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`, or
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`) and
+        format (
+        :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`
+        or
+        :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.Raw`
+        ) are chosen to define the exact serialization.
+
+        :param encoding: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+        :param format: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.PrivateFormat`
+            enum. If the ``encoding`` is
+            :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
+            then ``format`` must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.Raw`
+            , otherwise it must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`.
+
+        :param encryption_algorithm: An instance of an object conforming to the
+            :class:`~cryptography.hazmat.primitives.serialization.KeySerializationEncryption`
+            interface.
+
+        :return bytes: Serialized key.
+
+.. class:: Ed448PublicKey
+
+    .. versionadded:: 2.6
+
+    .. classmethod:: from_public_bytes(data)
+
+        :param bytes data: 57 byte public key.
+
+        :returns: :class:`Ed448PublicKey`
+
+    .. method:: public_bytes(encoding, format)
+
+        Allows serialization of the key to bytes. Encoding (
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`,
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`, or
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`) and
+        format (
+        :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`
+        or
+        :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.Raw`
+        ) are chosen to define the exact serialization.
+
+        :param encoding: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+        :param format: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.PublicFormat`
+            enum. If the ``encoding`` is
+            :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
+            then ``format`` must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.Raw`
+            , otherwise it must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`.
+
+        :returns bytes: The public key bytes.
+
+    .. method:: verify(signature, data)
+
+        :param bytes signature: The signature to verify.
+
+        :param bytes data: The data to verify.
+
+        :raises cryptography.exceptions.InvalidSignature: Raised when the
+            signature cannot be verified.
+
+
+
+.. _`EdDSA`: https://en.wikipedia.org/wiki/EdDSA

--- a/docs/hazmat/primitives/asymmetric/index.rst
+++ b/docs/hazmat/primitives/asymmetric/index.rst
@@ -25,6 +25,7 @@ private key is able to decrypt it.
 
     ed25519
     x25519
+    ed448
     x448
     ec
     rsa

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -37,11 +37,11 @@ from cryptography.hazmat.backends.openssl.dsa import (
 from cryptography.hazmat.backends.openssl.ec import (
     _EllipticCurvePrivateKey, _EllipticCurvePublicKey
 )
-from cryptography.hazmat.backends.openssl.ed448 import (
-    _ED448_KEY_SIZE, _Ed448PrivateKey, _Ed448PublicKey
-)
 from cryptography.hazmat.backends.openssl.ed25519 import (
     _ED25519_KEY_SIZE, _Ed25519PrivateKey, _Ed25519PublicKey
+)
+from cryptography.hazmat.backends.openssl.ed448 import (
+    _ED448_KEY_SIZE, _Ed448PrivateKey, _Ed448PublicKey
 )
 from cryptography.hazmat.backends.openssl.encode_asn1 import (
     _CRL_ENTRY_EXTENSION_ENCODE_HANDLERS,

--- a/src/cryptography/hazmat/backends/openssl/ed448.py
+++ b/src/cryptography/hazmat/backends/openssl/ed448.py
@@ -1,0 +1,154 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+from cryptography import exceptions, utils
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed448 import (
+    Ed448PrivateKey, Ed448PublicKey
+)
+
+_ED448_KEY_SIZE = 57
+_ED448_SIG_SIZE = 114
+
+
+@utils.register_interface(Ed448PublicKey)
+class _Ed448PublicKey(object):
+    def __init__(self, backend, evp_pkey):
+        self._backend = backend
+        self._evp_pkey = evp_pkey
+
+    def public_bytes(self, encoding, format):
+        if (
+            encoding is serialization.Encoding.Raw or
+            format is serialization.PublicFormat.Raw
+        ):
+            if (
+                encoding is not serialization.Encoding.Raw or
+                format is not serialization.PublicFormat.Raw
+            ):
+                raise ValueError(
+                    "When using Raw both encoding and format must be Raw"
+                )
+
+            return self._raw_public_bytes()
+
+        if (
+            encoding in serialization._PEM_DER and
+            format is not serialization.PublicFormat.SubjectPublicKeyInfo
+        ):
+            raise ValueError(
+                "format must be SubjectPublicKeyInfo when encoding is PEM or "
+                "DER"
+            )
+
+        return self._backend._public_key_bytes(
+            encoding, format, self, self._evp_pkey, None
+        )
+
+    def _raw_public_bytes(self):
+        buf = self._backend._ffi.new("unsigned char []", _ED448_KEY_SIZE)
+        buflen = self._backend._ffi.new("size_t *", _ED448_KEY_SIZE)
+        res = self._backend._lib.EVP_PKEY_get_raw_public_key(
+            self._evp_pkey, buf, buflen
+        )
+        self._backend.openssl_assert(res == 1)
+        self._backend.openssl_assert(buflen[0] == _ED448_KEY_SIZE)
+        return self._backend._ffi.buffer(buf, _ED448_KEY_SIZE)[:]
+
+    def verify(self, signature, data):
+        evp_md_ctx = self._backend._lib.Cryptography_EVP_MD_CTX_new()
+        self._backend.openssl_assert(evp_md_ctx != self._backend._ffi.NULL)
+        evp_md_ctx = self._backend._ffi.gc(
+            evp_md_ctx, self._backend._lib.Cryptography_EVP_MD_CTX_free
+        )
+        res = self._backend._lib.EVP_DigestVerifyInit(
+            evp_md_ctx, self._backend._ffi.NULL, self._backend._ffi.NULL,
+            self._backend._ffi.NULL, self._evp_pkey
+        )
+        self._backend.openssl_assert(res == 1)
+        res = self._backend._lib.EVP_DigestVerify(
+            evp_md_ctx, signature, len(signature), data, len(data)
+        )
+        if res != 1:
+            self._backend._consume_errors()
+            raise exceptions.InvalidSignature
+
+
+@utils.register_interface(Ed448PrivateKey)
+class _Ed448PrivateKey(object):
+    def __init__(self, backend, evp_pkey):
+        self._backend = backend
+        self._evp_pkey = evp_pkey
+
+    def public_key(self):
+        buf = self._backend._ffi.new("unsigned char []", _ED448_KEY_SIZE)
+        buflen = self._backend._ffi.new("size_t *", _ED448_KEY_SIZE)
+        res = self._backend._lib.EVP_PKEY_get_raw_public_key(
+            self._evp_pkey, buf, buflen
+        )
+        self._backend.openssl_assert(res == 1)
+        self._backend.openssl_assert(buflen[0] == _ED448_KEY_SIZE)
+        public_bytes = self._backend._ffi.buffer(buf)[:]
+        return self._backend.ed448_load_public_bytes(public_bytes)
+
+    def sign(self, data):
+        evp_md_ctx = self._backend._lib.Cryptography_EVP_MD_CTX_new()
+        self._backend.openssl_assert(evp_md_ctx != self._backend._ffi.NULL)
+        evp_md_ctx = self._backend._ffi.gc(
+            evp_md_ctx, self._backend._lib.Cryptography_EVP_MD_CTX_free
+        )
+        res = self._backend._lib.EVP_DigestSignInit(
+            evp_md_ctx, self._backend._ffi.NULL, self._backend._ffi.NULL,
+            self._backend._ffi.NULL, self._evp_pkey
+        )
+        self._backend.openssl_assert(res == 1)
+        buf = self._backend._ffi.new("unsigned char[]", _ED448_SIG_SIZE)
+        buflen = self._backend._ffi.new("size_t *", len(buf))
+        res = self._backend._lib.EVP_DigestSign(
+            evp_md_ctx, buf, buflen, data, len(data)
+        )
+        self._backend.openssl_assert(res == 1)
+        self._backend.openssl_assert(buflen[0] == _ED448_SIG_SIZE)
+        return self._backend._ffi.buffer(buf, buflen[0])[:]
+
+    def private_bytes(self, encoding, format, encryption_algorithm):
+        if (
+            encoding is serialization.Encoding.Raw or
+            format is serialization.PublicFormat.Raw
+        ):
+            if (
+                format is not serialization.PrivateFormat.Raw or
+                encoding is not serialization.Encoding.Raw or not
+                isinstance(encryption_algorithm, serialization.NoEncryption)
+            ):
+                raise ValueError(
+                    "When using Raw both encoding and format must be Raw "
+                    "and encryption_algorithm must be NoEncryption"
+                )
+
+            return self._raw_private_bytes()
+
+        if (
+            encoding in serialization._PEM_DER and
+            format is not serialization.PrivateFormat.PKCS8
+        ):
+            raise ValueError(
+                "format must be PKCS8 when encoding is PEM or DER"
+            )
+
+        return self._backend._private_key_bytes(
+            encoding, format, encryption_algorithm, self._evp_pkey, None
+        )
+
+    def _raw_private_bytes(self):
+        buf = self._backend._ffi.new("unsigned char []", _ED448_KEY_SIZE)
+        buflen = self._backend._ffi.new("size_t *", _ED448_KEY_SIZE)
+        res = self._backend._lib.EVP_PKEY_get_raw_private_key(
+            self._evp_pkey, buf, buflen
+        )
+        self._backend.openssl_assert(res == 1)
+        self._backend.openssl_assert(buflen[0] == _ED448_KEY_SIZE)
+        return self._backend._ffi.buffer(buf, _ED448_KEY_SIZE)[:]

--- a/src/cryptography/hazmat/primitives/asymmetric/ed448.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ed448.py
@@ -1,0 +1,79 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import abc
+
+import six
+
+from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Ed448PublicKey(object):
+    @classmethod
+    def from_public_bytes(cls, data):
+        from cryptography.hazmat.backends.openssl.backend import backend
+        if not backend.ed448_supported():
+            raise UnsupportedAlgorithm(
+                "ed448 is not supported by this version of OpenSSL.",
+                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
+            )
+
+        return backend.ed448_load_public_bytes(data)
+
+    @abc.abstractmethod
+    def public_bytes(self, encoding, format):
+        """
+        The serialized bytes of the public key.
+        """
+
+    @abc.abstractmethod
+    def verify(self, signature, data):
+        """
+        Verify the signature.
+        """
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Ed448PrivateKey(object):
+    @classmethod
+    def generate(cls):
+        from cryptography.hazmat.backends.openssl.backend import backend
+        if not backend.ed448_supported():
+            raise UnsupportedAlgorithm(
+                "ed448 is not supported by this version of OpenSSL.",
+                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
+            )
+        return backend.ed448_generate_key()
+
+    @classmethod
+    def from_private_bytes(cls, data):
+        from cryptography.hazmat.backends.openssl.backend import backend
+        if not backend.ed448_supported():
+            raise UnsupportedAlgorithm(
+                "ed448 is not supported by this version of OpenSSL.",
+                _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
+            )
+
+        return backend.ed448_load_private_bytes(data)
+
+    @abc.abstractmethod
+    def public_key(self):
+        """
+        The Ed448PublicKey derived from the private key.
+        """
+
+    @abc.abstractmethod
+    def sign(self, data):
+        """
+        Signs the data.
+        """
+
+    @abc.abstractmethod
+    def private_bytes(self, encoding, format, encryption_algorithm):
+        """
+        The serialized bytes of the private key.
+        """

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -1,0 +1,242 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import binascii
+import os
+
+import pytest
+
+from cryptography.exceptions import InvalidSignature, _Reasons
+from cryptography.hazmat.backends.interfaces import DHBackend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed448 import (
+    Ed448PrivateKey, Ed448PublicKey
+)
+
+from ...utils import (
+    load_nist_vectors, load_vectors_from_file, raises_unsupported_algorithm
+)
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: not backend.ed448_supported(),
+    skip_message="Requires OpenSSL without Ed448 support"
+)
+@pytest.mark.requires_backend_interface(interface=DHBackend)
+def test_ed448_unsupported(backend):
+    with raises_unsupported_algorithm(
+        _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
+    ):
+        Ed448PublicKey.from_public_bytes(b"0" * 57)
+
+    with raises_unsupported_algorithm(
+        _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
+    ):
+        Ed448PrivateKey.from_private_bytes(b"0" * 57)
+
+    with raises_unsupported_algorithm(
+        _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
+    ):
+        Ed448PrivateKey.generate()
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.ed448_supported(),
+    skip_message="Requires OpenSSL with Ed448 support"
+)
+@pytest.mark.requires_backend_interface(interface=DHBackend)
+class TestEd448Signing(object):
+    @pytest.mark.parametrize(
+        "vector",
+        load_vectors_from_file(
+            os.path.join("asymmetric", "Ed448", "rfc8032.txt"),
+            load_nist_vectors
+        )
+    )
+    def test_sign_input(self, vector, backend):
+        if vector.get("context") is not None:
+            pytest.skip("ed448 contexts are not currently supported")
+
+        sk = binascii.unhexlify(vector["secret"])
+        pk = binascii.unhexlify(vector["public"])
+        message = binascii.unhexlify(vector["message"])
+        signature = binascii.unhexlify(vector["signature"])
+        private_key = Ed448PrivateKey.from_private_bytes(sk)
+        computed_sig = private_key.sign(message)
+        assert computed_sig == signature
+        public_key = private_key.public_key()
+        assert public_key.public_bytes(
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
+        ) == pk
+        public_key.verify(signature, message)
+
+    def test_invalid_signature(self, backend):
+        key = Ed448PrivateKey.generate()
+        signature = key.sign(b"test data")
+        with pytest.raises(InvalidSignature):
+            key.public_key().verify(signature, b"wrong data")
+
+        with pytest.raises(InvalidSignature):
+            key.public_key().verify(b"0" * 64, b"test data")
+
+    def test_generate(self, backend):
+        key = Ed448PrivateKey.generate()
+        assert key
+        assert key.public_key()
+
+    @pytest.mark.parametrize(
+        "vector",
+        load_vectors_from_file(
+            os.path.join("asymmetric", "Ed448", "rfc8032.txt"),
+            load_nist_vectors
+        )
+    )
+    def test_pub_priv_bytes_raw(self, vector, backend):
+        sk = binascii.unhexlify(vector["secret"])
+        pk = binascii.unhexlify(vector["public"])
+        private_key = Ed448PrivateKey.from_private_bytes(sk)
+        assert private_key.private_bytes(
+            serialization.Encoding.Raw,
+            serialization.PrivateFormat.Raw,
+            serialization.NoEncryption()
+        ) == sk
+        assert private_key.public_key().public_bytes(
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
+        ) == pk
+        public_key = Ed448PublicKey.from_public_bytes(pk)
+        assert public_key.public_bytes(
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
+        ) == pk
+
+    @pytest.mark.parametrize(
+        ("encoding", "fmt", "encryption", "passwd", "load_func"),
+        [
+            (
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.BestAvailableEncryption(b"password"),
+                b"password",
+                serialization.load_pem_private_key
+            ),
+            (
+                serialization.Encoding.DER,
+                serialization.PrivateFormat.PKCS8,
+                serialization.BestAvailableEncryption(b"password"),
+                b"password",
+                serialization.load_der_private_key
+            ),
+            (
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+                None,
+                serialization.load_pem_private_key
+            ),
+            (
+                serialization.Encoding.DER,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+                None,
+                serialization.load_der_private_key
+            ),
+        ]
+    )
+    def test_round_trip_private_serialization(self, encoding, fmt, encryption,
+                                              passwd, load_func, backend):
+        key = Ed448PrivateKey.generate()
+        serialized = key.private_bytes(encoding, fmt, encryption)
+        loaded_key = load_func(serialized, passwd, backend)
+        assert isinstance(loaded_key, Ed448PrivateKey)
+
+    def test_invalid_type_public_bytes(self, backend):
+        with pytest.raises(TypeError):
+            Ed448PublicKey.from_public_bytes(object())
+
+    def test_invalid_type_private_bytes(self, backend):
+        with pytest.raises(TypeError):
+            Ed448PrivateKey.from_private_bytes(object())
+
+    def test_invalid_length_from_public_bytes(self, backend):
+        with pytest.raises(ValueError):
+            Ed448PublicKey.from_public_bytes(b"a" * 56)
+        with pytest.raises(ValueError):
+            Ed448PublicKey.from_public_bytes(b"a" * 58)
+
+    def test_invalid_length_from_private_bytes(self, backend):
+        with pytest.raises(ValueError):
+            Ed448PrivateKey.from_private_bytes(b"a" * 56)
+        with pytest.raises(ValueError):
+            Ed448PrivateKey.from_private_bytes(b"a" * 58)
+
+    def test_invalid_private_bytes(self, backend):
+        key = Ed448PrivateKey.generate()
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.Raw,
+                serialization.PrivateFormat.Raw,
+                None
+            )
+
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.Raw,
+                serialization.PrivateFormat.PKCS8,
+                None
+            )
+
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.Raw,
+                serialization.NoEncryption()
+            )
+
+    def test_invalid_public_bytes(self, backend):
+        key = Ed448PrivateKey.generate().public_key()
+        with pytest.raises(ValueError):
+            key.public_bytes(
+                serialization.Encoding.Raw,
+                serialization.PublicFormat.SubjectPublicKeyInfo
+            )
+
+        with pytest.raises(ValueError):
+            key.public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.PKCS1
+            )
+
+        with pytest.raises(ValueError):
+            key.public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.Raw
+            )
+
+    def test_buffer_protocol(self, backend):
+        private_bytes = os.urandom(57)
+        key = Ed448PrivateKey.from_private_bytes(bytearray(private_bytes))
+        assert key.private_bytes(
+            serialization.Encoding.Raw,
+            serialization.PrivateFormat.Raw,
+            serialization.NoEncryption()
+        ) == private_bytes
+
+    def test_malleability(self, backend):
+        # This is a signature where r > the group order. It should be
+        # rejected to prevent signature malleability issues. This test can
+        # be removed when wycheproof grows ed448 vectors
+        public_bytes = binascii.unhexlify(
+            "fedb02a658d74990244d9d10cf338e977565cbbda6b24c716829ed6ee1e4f28cf"
+            "2620c052db8d878f6243bffc22242816c1aaa67d2f3603600"
+        )
+        signature = binascii.unhexlify(
+            "0cc16ba24d69277f927c1554b0f08a2a711bbdd20b058ccc660d00ca13542a3ce"
+            "f9e5c44c54ab23a2eb14f947e167b990b080863e28b399380f30db6e54d5d1406"
+            "d23378ffde11b1fb81b2b438a3b8e8aa7f7f4e1befcc905023fab5a5465053844"
+            "f04cf0c1b51d84760f869588687f57500"
+        )
+        key = Ed448PublicKey.from_public_bytes(public_bytes)
+        with pytest.raises(InvalidSignature):
+            key.verify(signature, b"8")

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -1474,3 +1474,67 @@ class TestX25519Serialization(object):
         assert public_key.public_bytes(
             encoding, PublicFormat.SubjectPublicKeyInfo
         ) == data
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.ed448_supported(),
+    skip_message="Requires OpenSSL with Ed448 support"
+)
+class TestEd448Serialization(object):
+    def test_load_der_private_key(self, backend):
+        data = load_vectors_from_file(
+            os.path.join("asymmetric", "Ed448", "ed448-pkcs8-enc.der"),
+            lambda derfile: derfile.read(),
+            mode="rb"
+        )
+        unencrypted = load_vectors_from_file(
+            os.path.join("asymmetric", "Ed448", "ed448-pkcs8.der"),
+            lambda derfile: derfile.read(),
+            mode="rb"
+        )
+        key = load_der_private_key(data, b"password", backend)
+        assert key.private_bytes(
+            Encoding.DER, PrivateFormat.PKCS8, NoEncryption()
+        ) == unencrypted
+
+    def test_load_pem_private_key(self, backend):
+        data = load_vectors_from_file(
+            os.path.join("asymmetric", "Ed448", "ed448-pkcs8-enc.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb"
+        )
+        unencrypted = load_vectors_from_file(
+            os.path.join("asymmetric", "Ed448", "ed448-pkcs8.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb"
+        )
+        key = load_pem_private_key(data, b"password", backend)
+        assert key.private_bytes(
+            Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+        ) == unencrypted
+
+    @pytest.mark.parametrize(
+        ("key_path", "encoding", "loader"),
+        [
+            (
+                ["Ed448", "ed448-pub.pem"],
+                Encoding.PEM,
+                load_pem_public_key
+            ),
+            (
+                ["Ed448", "ed448-pub.der"],
+                Encoding.DER,
+                load_der_public_key
+            ),
+        ]
+    )
+    def test_load_public_key(self, key_path, encoding, loader, backend):
+        data = load_vectors_from_file(
+            os.path.join("asymmetric", *key_path),
+            lambda pemfile: pemfile.read(),
+            mode="rb"
+        )
+        public_key = loader(data, backend)
+        assert public_key.public_bytes(
+            encoding, PublicFormat.SubjectPublicKeyInfo
+        ) == data


### PR DESCRIPTION
refs #4197 

Blocked on OpenSSL 1.1.1b release.

- [x] Changelog entry
- [x] update versionadded
- [x] Wycheproof vectors if they exist (otherwise we'll add the vector I created to demonstrate the malleability bug to OpenSSL)
- [x] Rebase on top of ed448 vectors once they land