### PR TITLE
allow multi-valued RDNs

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/encode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/encode_asn1.py
@@ -114,7 +114,7 @@ def _encode_sk_name_entry(backend, attributes):
     for attribute in attributes:
         name_entry = _encode_name_entry(backend, attribute)
         res = backend._lib.sk_X509_NAME_ENTRY_push(stack, name_entry)
-        backend.openssl_assert(res == 1)
+        backend.openssl_assert(res >= 1)
     return stack
 
 

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -2598,6 +2598,23 @@ class TestCertificateBuilder(object):
                     crl_issuer=None,
                 )
             ]),
+            x509.FreshestCRL([
+                x509.DistributionPoint(
+                    full_name=None,
+                    relative_name=x509.RelativeDistinguishedName([
+                        x509.NameAttribute(
+                            NameOID.COMMON_NAME,
+                            u"indirect CRL for indirectCRL CA3"
+                        ),
+                        x509.NameAttribute(
+                            NameOID.COUNTRY_NAME,
+                            u"US"
+                        ),
+                    ]),
+                    reasons=None,
+                    crl_issuer=None,
+                )
+            ]),
         ]
     )
     def test_ext(self, add_ext, backend):


### PR DESCRIPTION
RDNs can have multiple values. This allows them in FreshestCRL and upcoming IssuingDistributionPoint encoding support.