### PR TITLE
reuse the libressl branch for OpenSSL built with OPENSSL_NO_PSK

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -756,7 +756,7 @@ const long (*SSL_CTX_set1_sigalgs_list)(SSL_CTX *, const char *) = NULL;
 static const long Cryptography_HAS_SIGALGS = 1;
 #endif
 
-#if CRYPTOGRAPHY_IS_LIBRESSL
+#if CRYPTOGRAPHY_IS_LIBRESSL || defined(OPENSSL_NO_PSK)
 static const long Cryptography_HAS_PSK = 0;
 int (*SSL_CTX_use_psk_identity_hint)(SSL_CTX *, const char *) = NULL;
 void (*SSL_CTX_set_psk_server_callback)(SSL_CTX *,


### PR DESCRIPTION
Fixes #4588 

Since we already test this branch via Libre I'm comfortable not adding another builder.