### PR TITLE
switch to twine check for verifying our readme renders on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -303,7 +303,7 @@ setup(
         "docstest": [
             "doc8",
             "pyenchant >= 1.6.11",
-            "readme_renderer >= 16.0",
+            "twine >= 1.12.0",
             "sphinxcontrib-spelling >= 4.0.1",
         ],
         "pep8test": [

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,8 @@ commands =
     sphinx-build -j4 -T -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -j4 -T -W -b spelling docs docs/_build/html
     doc8 --allow-long-titles README.rst CHANGELOG.rst docs/ --ignore-path docs/_build/
-    python setup.py check --restructuredtext --strict
+    python setup.py sdist
+    twine check dist/*
 
 [testenv:docs-linkcheck]
 extras =


### PR DESCRIPTION
I don't love needing to make an sdist, but that's what twine check requires.

fixes #4523