### PR TITLE
Fix dynamodb-encryption-sdk downstream tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,6 @@ matrix:
           env: DOWNSTREAM=aws-encryption-sdk
         - python: 2.7
           env: DOWNSTREAM=dynamodb-encryption-sdk OPENSSL=1.1.0j BOTO_CONFIG=/dev/null
-          sudo: false
         - python: 2.7
           env: DOWNSTREAM=certbot OPENSSL=1.1.0j
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,8 +122,6 @@ matrix:
           env: DOWNSTREAM=aws-encryption-sdk
         - python: 2.7
           env: DOWNSTREAM=dynamodb-encryption-sdk OPENSSL=1.1.0j BOTO_CONFIG=/dev/null
-          # dynamodb-encryption-sdk tests fail on xenial for whatever reason
-          dist: trusty
           sudo: false
         - python: 2.7
           env: DOWNSTREAM=certbot OPENSSL=1.1.0j

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ matrix:
         - python: 2.7
           env: DOWNSTREAM=aws-encryption-sdk
         - python: 2.7
-          env: DOWNSTREAM=dynamodb-encryption-sdk OPENSSL=1.1.0j
+          env: DOWNSTREAM=dynamodb-encryption-sdk OPENSSL=1.1.0j BOTO_CONFIG=/dev/null
           # dynamodb-encryption-sdk tests fail on xenial for whatever reason
           dist: trusty
           sudo: false


### PR DESCRIPTION
Fix as discussed in #4626.

I also went ahead and normalized its build back to xenial, since it seems to be working just fine. I'm guessing that was modified trying to fix this issue?