### PR TITLE
Compressed point support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,11 @@ Changelog
   ``cryptography`` from a wheel.
 * Added initial :doc:`OCSP </x509/ocsp>` support.
 * Added support for :class:`~cryptography.x509.PrecertPoison`.
+* Deprecated
+  :meth:`cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers.from_encoded_point`
+  in favor of
+  :meth:`cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`,
+  which checks that the resulting point is on the curve, and supports compressed points
 
 .. _v2-3-1:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,9 +28,7 @@ Changelog
   :class:`~cryptography.x509.RelativeDistinguishedName` and
   :class:`~cryptography.x509.NameAttribute` to format the name or component as
   a RFC 4514 Distinguished Name string.
-* Deprecated
-  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers.from_encoded_point`
-  in favor of
+* Added
   :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`,
   which immediately checks if the point is on the curve and supports compressed
   points.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,12 @@ Changelog
   :class:`~cryptography.x509.RelativeDistinguishedName` and
   :class:`~cryptography.x509.NameAttribute` to format the name or component as
   a RFC 4514 Distinguished Name string.
+* Deprecated
+  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers.from_encoded_point`
+  in favor of
+  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`,
+  which immediately checks if the point is on the curve and supports compressed
+  points.
 
 .. _v2-4-2:
 
@@ -56,11 +62,6 @@ Changelog
   ``cryptography`` from a wheel.
 * Added initial :doc:`OCSP </x509/ocsp>` support.
 * Added support for :class:`~cryptography.x509.PrecertPoison`.
-* Deprecated
-  :meth:`cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers.from_encoded_point`
-  in favor of
-  :meth:`cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`,
-  which checks that the resulting point is on the curve, and supports compressed points
 
 .. _v2-3-1:
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -223,7 +223,7 @@ Elliptic Curve Signature Algorithms
 
         :returns: An :class:`EllipticCurvePublicNumbers` instance.
 
-        :raises ValueError: Raised when an invalid point is supplied.
+        :raises ValueError: Raised on invalid point type or data length.
 
         :raises TypeError: Raised when curve is not an
             :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`.
@@ -725,7 +725,7 @@ Key Interfaces
 
         :returns: An :class:`EllipticCurvePublicKey` instance.
 
-        :raises ValueError: Raised on invalid point type or data length.
+        :raises ValueError: Raised when an invalid point is supplied.
 
         :raises TypeError: Raised when curve is not an
             :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`.

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -704,6 +704,26 @@ Key Interfaces
         Size (in :term:`bits`) of a secret scalar for the curve (as generated
         by :func:`generate_private_key`).
 
+    .. classmethod:: from_encoded_point(curve, data, backend)
+
+        .. versionadded:: 2.4
+
+        Decodes a byte string as described in `SEC 1 v2.0`_ section 2.3.3 and
+        returns an :class:`EllipticCurvePublicKey`.
+
+        :param curve: An
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`
+            instance.
+
+        :param bytes data: The serialized point byte string.
+
+        :returns: An :class:`EllipticCurvePublicKey` instance.
+
+        :raises ValueError: Raised on invalid point type or data length.
+
+        :raises TypeError: Raised when curve is not an
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`.
+
 
 .. class:: EllipticCurvePublicKeyWithSerialization
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -206,11 +206,6 @@ Elliptic Curve Signature Algorithms
 
         .. versionadded:: 1.1
 
-        .. note::
-
-            This has been deprecated in favor of
-            :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`
-
         Decodes a byte string as described in `SEC 1 v2.0`_ section 2.3.3 and
         returns an :class:`EllipticCurvePublicNumbers`. This method only
         supports uncompressed points.

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -206,6 +206,11 @@ Elliptic Curve Signature Algorithms
 
         .. versionadded:: 1.1
 
+        .. note::
+
+            This has been deprecated in favor of
+            :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`
+
         Decodes a byte string as described in `SEC 1 v2.0`_ section 2.3.3 and
         returns an :class:`EllipticCurvePublicNumbers`. This method only
         supports uncompressed points.
@@ -218,7 +223,7 @@ Elliptic Curve Signature Algorithms
 
         :returns: An :class:`EllipticCurvePublicNumbers` instance.
 
-        :raises ValueError: Raised on invalid point type or data length.
+        :raises ValueError: Raised when an invalid point is supplied.
 
         :raises TypeError: Raised when curve is not an
             :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`.
@@ -706,10 +711,11 @@ Key Interfaces
 
     .. classmethod:: from_encoded_point(curve, data, backend)
 
-        .. versionadded:: 2.4
+        .. versionadded:: 2.5
 
         Decodes a byte string as described in `SEC 1 v2.0`_ section 2.3.3 and
-        returns an :class:`EllipticCurvePublicKey`.
+        returns an :class:`EllipticCurvePublicKey`. This class method supports
+        compressed points.
 
         :param curve: An
             :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve`

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -704,7 +704,7 @@ Key Interfaces
         Size (in :term:`bits`) of a secret scalar for the curve (as generated
         by :func:`generate_private_key`).
 
-    .. classmethod:: from_encoded_point(curve, data, backend)
+    .. classmethod:: from_encoded_point(curve, data)
 
         .. versionadded:: 2.5
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1398,7 +1398,6 @@ class Backend(object):
                 self._consume_errors()
                 raise ValueError("Invalid public bytes for the given curve")
 
-        curve_nid = self._elliptic_curve_to_nid(curve)
         ec_cdata = self._lib.EC_KEY_new_by_curve_name(curve_nid)
         self.openssl_assert(ec_cdata != self._ffi.NULL)
         ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1383,6 +1383,43 @@ class Backend(object):
 
         return _EllipticCurvePublicKey(self, ec_cdata, evp_pkey)
 
+    def uncompress_elliptic_curve_bytes(self, curve, point_bytes):
+        with self._tmp_bn_ctx() as bn_ctx:
+            curve_nid = self._elliptic_curve_to_nid(curve)
+
+            group = self._lib.EC_GROUP_new_by_curve_name(curve_nid)
+            self.openssl_assert(group != self._ffi.NULL)
+
+            group = self._ffi.gc(group, self._lib.EC_GROUP_free)
+
+            point = self._lib.EC_POINT_new(group)
+            self.openssl_assert(point != self._ffi.NULL)
+            point = self._ffi.gc(point, self._lib.EC_POINT_free)
+
+            res = self._lib.EC_POINT_oct2point(group, point, point_bytes,
+                                               len(point_bytes), bn_ctx)
+            self.openssl_assert(res == 1)
+
+            length = self._lib.EC_POINT_point2oct(
+                group,
+                point,
+                self._lib.POINT_CONVERSION_UNCOMPRESSED,
+                self._ffi.NULL,
+                0,
+                bn_ctx)
+            self.openssl_assert(length > 0)
+
+            buf = self._ffi.new("unsigned char[]", length)
+            self._lib.EC_POINT_point2oct(
+                group,
+                point,
+                self._lib.POINT_CONVERSION_UNCOMPRESSED,
+                buf,
+                length,
+                bn_ctx)
+
+            return self._ffi.buffer(buf)[:]
+
     def derive_elliptic_curve_private_key(self, private_value, curve):
         ec_cdata = self._ec_key_new_by_curve(curve)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -157,7 +157,7 @@ class EllipticCurvePublicKey(object):
         if not isinstance(curve, EllipticCurve):
             raise TypeError("curve must be an EllipticCurve instance")
 
-        if data[0:1] not in (b"\x02", b"\x03", b"\x04"):
+        if six.indexbytes(data, 0) not in [0x02, 0x03, 0x04]:
             raise ValueError("Unsupported elliptic curve point type")
 
         from cryptography.hazmat.backends.openssl.backend import backend

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -9,9 +9,7 @@ import abc
 import six
 
 from cryptography import utils
-from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat._oid import ObjectIdentifier
-from cryptography.hazmat.backends.interfaces import EllipticCurveBackend
 
 
 class EllipticCurveOID(object):
@@ -154,20 +152,15 @@ class EllipticCurvePublicKey(object):
         """
 
     @classmethod
-    def from_encoded_point(cls, curve, data, backend):
+    def from_encoded_point(cls, curve, data):
         utils._check_bytes("data", data)
         if not isinstance(curve, EllipticCurve):
             raise TypeError("curve must be an EllipticCurve instance")
 
-        if not isinstance(backend, EllipticCurveBackend):
-            raise UnsupportedAlgorithm(
-                "Backend object does not implement EllipticCurveBackend.",
-                _Reasons.BACKEND_MISSING_INTERFACE
-            )
-
         if data[0:1] not in (b"\x02", b"\x03", b"\x04"):
             raise ValueError("Unsupported elliptic curve point type")
 
+        from cryptography.hazmat.backends.openssl.backend import backend
         return backend.load_elliptic_curve_public_bytes(curve, data)
 
 

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -99,7 +99,7 @@ def _load_ssh_ecdsa_public_key(expected_key_type, decoded_data, backend):
             "Compressed elliptic curve points are not supported"
         )
 
-    return ec.EllipticCurvePublicKey.from_encoded_point(curve, data, backend)
+    return ec.EllipticCurvePublicKey.from_encoded_point(curve, data)
 
 
 def _ssh_read_next_string(data):

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -99,8 +99,7 @@ def _load_ssh_ecdsa_public_key(expected_key_type, decoded_data, backend):
             "Compressed elliptic curve points are not supported"
         )
 
-    numbers = ec.EllipticCurvePublicNumbers.from_encoded_point(curve, data)
-    return numbers.public_key(backend)
+    return ec.EllipticCurvePublicKey.from_encoded_point(curve, data, backend)
 
 
 def _ssh_read_next_string(data):

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -23,6 +23,7 @@ class CryptographyDeprecationWarning(UserWarning):
 PersistentlyDeprecated = CryptographyDeprecationWarning
 DeprecatedIn21 = CryptographyDeprecationWarning
 DeprecatedIn23 = CryptographyDeprecationWarning
+DeprecatedIn24 = CryptographyDeprecationWarning
 
 
 def _check_bytes(name, value):

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -23,7 +23,7 @@ class CryptographyDeprecationWarning(UserWarning):
 PersistentlyDeprecated = CryptographyDeprecationWarning
 DeprecatedIn21 = CryptographyDeprecationWarning
 DeprecatedIn23 = CryptographyDeprecationWarning
-DeprecatedIn24 = CryptographyDeprecationWarning
+DeprecatedIn25 = CryptographyDeprecationWarning
 
 
 def _check_bytes(name, value):

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -23,7 +23,6 @@ class CryptographyDeprecationWarning(UserWarning):
 PersistentlyDeprecated = CryptographyDeprecationWarning
 DeprecatedIn21 = CryptographyDeprecationWarning
 DeprecatedIn23 = CryptographyDeprecationWarning
-DeprecatedIn25 = CryptographyDeprecationWarning
 
 
 def _check_bytes(name, value):

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -221,17 +221,6 @@ def test_encode_point():
     )
 
 
-@pytest.mark.parametrize("dat", _compressed_points)
-def test_encode_compressed_point(dat):
-    # secp256r1 point
-    compressed = binascii.unhexlify(dat["in"])
-    x = int(dat["x"], 16)
-    y = int(dat["y"], 16)
-    pn = ec.EllipticCurvePublicNumbers(x, y, ec.SECP256R1())
-    data = pn.encode_point(compressed=True)
-    assert data == compressed
-
-
 def test_from_encoded_point():
     # secp256r1 point
     data = binascii.unhexlify(
@@ -267,7 +256,7 @@ def test_from_encoded_point_invalid_length():
 def test_from_encoded_point_unsupported_without_backend():
     # set to point type 2.
     unsupported_type = binascii.unhexlify(
-        "02233ea3b0027127084cd2cd336a13aeef69c598d8af61369a36454a17c6c22aec"
+        "02233ea3b0027127084cd2cd336a13aeef69c598d8af61369a36454a17c6c22a"
     )
     with pytest.raises(ValueError):
         with pytest.warns(CryptographyDeprecationWarning):
@@ -1069,8 +1058,9 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
         pn = ec.EllipticCurvePublicKey.from_encoded_point(
             dat["curve"](), compressed_point, backend
         )
-        assert pn.public_numbers().x == int(dat["x"], 16), dat
-        assert pn.public_numbers().y == int(dat["y"], 16), dat
+        public_num = pn.public_numbers()
+        assert public_num.x == int(dat["x"], 16), dat
+        assert public_num.y == int(dat["y"], 16), dat
 
     def test_from_encoded_point_notoncurve(self, backend):
         uncompressed_point = binascii.unhexlify(
@@ -1130,7 +1120,6 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             )
 
     def test_from_encoded_point_unsupported_encoding(self, backend):
-        # set to point type 2.
         unsupported_type = binascii.unhexlify(
             "057399336a9edf2197c2f8eb3d39aed9c34a66e45d918a07dc7684c42c9b37ac6"
             "8"

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -227,10 +227,9 @@ def test_from_encoded_point():
         "04233ea3b0027127084cd2cd336a13aeef69c598d8af61369a36454a17c6c22ae"
         "c3ea2c10a84153862be4ec82940f0543f9ba866af9751a6ee79d38460b35f442e"
     )
-    with pytest.warns(CryptographyDeprecationWarning):
-        pn = ec.EllipticCurvePublicNumbers.from_encoded_point(
-            ec.SECP256R1(), data
-        )
+    pn = ec.EllipticCurvePublicNumbers.from_encoded_point(
+        ec.SECP256R1(), data
+    )
     assert pn.x == int(
         '233ea3b0027127084cd2cd336a13aeef69c598d8af61369a36454a17c6c22aec',
         16
@@ -247,30 +246,27 @@ def test_from_encoded_point_invalid_length():
         "c3ea2c10a84153862be4ec82940f0543f9ba866af9751a6ee79d38460"
     )
     with pytest.raises(ValueError):
-        with pytest.warns(CryptographyDeprecationWarning):
-            ec.EllipticCurvePublicNumbers.from_encoded_point(
-                ec.SECP384R1(), bad_data
-            )
+        ec.EllipticCurvePublicNumbers.from_encoded_point(
+            ec.SECP384R1(), bad_data
+        )
 
 
-def test_from_encoded_point_unsupported_without_backend():
+def test_from_encoded_point_unsupported_point_no_backend():
     # set to point type 2.
     unsupported_type = binascii.unhexlify(
         "02233ea3b0027127084cd2cd336a13aeef69c598d8af61369a36454a17c6c22a"
     )
     with pytest.raises(ValueError):
-        with pytest.warns(CryptographyDeprecationWarning):
-            ec.EllipticCurvePublicNumbers.from_encoded_point(
-                ec.SECP256R1(), unsupported_type
-            )
+        ec.EllipticCurvePublicNumbers.from_encoded_point(
+            ec.SECP256R1(), unsupported_type
+        )
 
 
 def test_from_encoded_point_not_a_curve():
     with pytest.raises(TypeError):
-        with pytest.warns(CryptographyDeprecationWarning):
-            ec.EllipticCurvePublicNumbers.from_encoded_point(
-                "notacurve", b"\x04data"
-            )
+        ec.EllipticCurvePublicNumbers.from_encoded_point(
+            "notacurve", b"\x04data"
+        )
 
 
 def test_ec_public_numbers_repr():
@@ -1108,7 +1104,9 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             "686699ececc4f5f0d756d3c450708a0694eb0a07a68b805070b40b058d27271f"
             "6d"
         )
-        with pytest.raises(ValueError):
+        with raises_unsupported_algorithm(
+            exceptions._Reasons.BACKEND_MISSING_INTERFACE
+        ):
             ec.EllipticCurvePublicKey.from_encoded_point(
                 ec.SECP384R1(), bad_data, None
             )

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -1049,16 +1049,16 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             )
 
     @pytest.mark.parametrize("dat", _compressed_points)
-    def test_from_encoded_point_compressed(self, backend, dat):
+    def test_from_encoded_point_compressed(self, dat):
         compressed_point = binascii.unhexlify(dat["in"])
         pn = ec.EllipticCurvePublicKey.from_encoded_point(
-            dat["curve"](), compressed_point, backend
+            dat["curve"](), compressed_point
         )
         public_num = pn.public_numbers()
         assert public_num.x == int(dat["x"], 16), dat
         assert public_num.y == int(dat["y"], 16), dat
 
-    def test_from_encoded_point_notoncurve(self, backend):
+    def test_from_encoded_point_notoncurve(self):
         uncompressed_point = binascii.unhexlify(
             "047399336a9edf2197c2f8eb3d39aed9c34a66e45d918a07dc7684c42c9b37ac"
             "686699ececc4f5f0d756d3c450708a0694eb0a07a68b805070b40b058d27271f"
@@ -1066,17 +1066,17 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
         )
         with pytest.raises(ValueError):
             ec.EllipticCurvePublicKey.from_encoded_point(
-                ec.SECP256R1(), uncompressed_point, backend
+                ec.SECP256R1(), uncompressed_point
             )
 
-    def test_from_encoded_point_uncompressed(self, backend):
+    def test_from_encoded_point_uncompressed(self):
         uncompressed_point = binascii.unhexlify(
             "047399336a9edf2197c2f8eb3d39aed9c34a66e45d918a07dc7684c42c9b37ac"
             "686699ececc4f5f0d756d3c450708a0694eb0a07a68b805070b40b058d27271f"
             "6d"
         )
         pn = ec.EllipticCurvePublicKey.from_encoded_point(
-            ec.SECP256R1(), uncompressed_point, backend
+            ec.SECP256R1(), uncompressed_point
         )
         assert pn.public_numbers().x == int(
             '7399336a9edf2197c2f8eb3d39aed9c34a66e45d918a07dc7684c42c9b37ac68',
@@ -1087,7 +1087,7 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             16
         )
 
-    def test_from_encoded_point_invalid_length(self, backend):
+    def test_from_encoded_point_invalid_length(self):
         bad_data = binascii.unhexlify(
             "047399336a9edf2197c2f8eb3d39aed9c34a66e45d918a07dc7684c42c9b37ac"
             "686699ececc4f5f0d756d3c450708a0694eb0a07a68b805070b40b058d27271f"
@@ -1095,36 +1095,23 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
         )
         with pytest.raises(ValueError):
             ec.EllipticCurvePublicKey.from_encoded_point(
-                ec.SECP384R1(), bad_data, backend
+                ec.SECP384R1(), bad_data
             )
 
-    def test_from_encoded_point_need_backend(self, backend):
-        bad_data = binascii.unhexlify(
-            "047399336a9edf2197c2f8eb3d39aed9c34a66e45d918a07dc7684c42c9b37ac"
-            "686699ececc4f5f0d756d3c450708a0694eb0a07a68b805070b40b058d27271f"
-            "6d"
-        )
-        with raises_unsupported_algorithm(
-            exceptions._Reasons.BACKEND_MISSING_INTERFACE
-        ):
-            ec.EllipticCurvePublicKey.from_encoded_point(
-                ec.SECP384R1(), bad_data, None
-            )
-
-    def test_from_encoded_point_not_a_curve(self, backend):
+    def test_from_encoded_point_not_a_curve(self):
         with pytest.raises(TypeError):
             ec.EllipticCurvePublicKey.from_encoded_point(
-                "notacurve", b"\x04data", backend
+                "notacurve", b"\x04data"
             )
 
-    def test_from_encoded_point_unsupported_encoding(self, backend):
+    def test_from_encoded_point_unsupported_encoding(self):
         unsupported_type = binascii.unhexlify(
             "057399336a9edf2197c2f8eb3d39aed9c34a66e45d918a07dc7684c42c9b37ac6"
             "8"
         )
         with pytest.raises(ValueError):
             ec.EllipticCurvePublicKey.from_encoded_point(
-                ec.SECP256R1(), unsupported_type, backend
+                ec.SECP256R1(), unsupported_type
             )
 
 


### PR DESCRIPTION
A refactor of #4419 to use a new backend method. Removes compressed point support in `encode_point`, which will be re-added in a subsequent PR. Huge thanks to @earonesty for much of this work.