### PR TITLE
add support for encoding compressed points

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,8 @@ Changelog
   additional serialization methods. Calling
   :meth:`~cryptography.hazmat.primitives.asymmetric.x25519.X25519PublicKey.public_bytes`
   with no arguments has been deprecated.
+* Added support for encoding compressed and uncompressed points via
+  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.public_bytes`.
 
 
 .. _v2-4-2:

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -668,12 +668,20 @@ Key Interfaces
 
     .. method:: public_bytes(encoding, format)
 
-        Allows serialization of the key to bytes. Encoding (
-        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM` or
+        Allows serialization of the key data to bytes. When encoding the public
+        key the encodings (
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`,
         :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`) and
         format (
         :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`)
-        are chosen to define the exact serialization.
+        are chosen to define the exact serialization. When encoding the point
+        the encoding
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.X962`
+        should be used with the formats (
+        :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.UncompressedPoint`
+        or
+        :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.CompressedPoint`
+        ).
 
         :param encoding: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
@@ -681,7 +689,7 @@ Key Interfaces
         :param format: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.PublicFormat` enum.
 
-        :return bytes: Serialized key.
+        :return bytes: Serialized data.
 
     .. method:: verify(signature, data, signature_algorithm)
 

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -536,6 +536,20 @@ Serialization Formats
         A raw format used by :doc:`/hazmat/primitives/asymmetric/x448`. It is a
         binary format and is invalid for other key types.
 
+    .. attribute:: CompressedPoint
+
+        .. versionadded:: 2.5
+
+        A compressed elliptic curve public key as defined in ANSI X9.62 section
+        4.3.6 (as well as `SEC 1 v2.0`_).
+
+    .. attribute:: UncompressedPoint
+
+        .. versionadded:: 2.5
+
+        An uncompressed elliptic curve public key as defined in ANSI X9.62
+        section 4.3.6 (as well as `SEC 1 v2.0`_).
+
 .. class:: ParameterFormat
 
     .. versionadded:: 2.0
@@ -594,6 +608,13 @@ Serialization Encodings
         A raw format used by :doc:`/hazmat/primitives/asymmetric/x448`. It is a
         binary format and is invalid for other key types.
 
+    .. attribute:: X962
+
+        .. versionadded:: 2.5
+
+        The format used by elliptic curve point encodings. This is a binary
+        format.
+
 
 Serialization Encryption Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -626,3 +647,4 @@ Serialization Encryption Types
 
 
 .. _`PKCS3`: https://www.emc.com/emc-plus/rsa-labs/standards-initiatives/pkcs-3-diffie-hellman-key-agreement-standar.htm
+.. _`SEC 1 v2.0`: http://www.secg.org/sec1-v2.pdf

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1690,6 +1690,10 @@ class Backend(object):
                 "format must be an item from the PrivateFormat enum"
             )
 
+        # X9.62 encoding is only valid for EC public keys
+        if encoding is serialization.Encoding.X962:
+            raise ValueError("X9.62 format is only valid for EC public keys")
+
         # Raw format and encoding are only valid for X25519, Ed25519, X448, and
         # Ed448 keys. We capture those cases before this method is called so if
         # we see those enum values here it means the caller has passed them to
@@ -1791,6 +1795,13 @@ class Backend(object):
     def _public_key_bytes(self, encoding, format, key, evp_pkey, cdata):
         if not isinstance(encoding, serialization.Encoding):
             raise TypeError("encoding must be an item from the Encoding enum")
+
+        # Compressed/UncompressedPoint are only valid for EC keys and those
+        # cases are handled by the ECPublicKey public_bytes method before this
+        # method is called
+        if format in (serialization.PublicFormat.UncompressedPoint,
+                      serialization.PublicFormat.CompressedPoint):
+            raise ValueError("Point formats are not valid for this key type")
 
         # Raw format and encoding are only valid for X25519, Ed25519, X448, and
         # Ed448 keys. We capture those cases before this method is called so if

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -276,9 +276,11 @@ class _EllipticCurvePublicKey(object):
         )
 
     def _encode_point(self, format):
-        conversion = self._backend._lib.POINT_CONVERSION_UNCOMPRESSED
         if format is serialization.PublicFormat.CompressedPoint:
             conversion = self._backend._lib.POINT_CONVERSION_COMPRESSED
+        else:
+            assert format is serialization.PublicFormat.UncompressedPoint
+            conversion = self._backend._lib.POINT_CONVERSION_UNCOMPRESSED
 
         group = self._backend._lib.EC_KEY_get0_group(self._ec_key)
         self._backend.openssl_assert(group != self._backend._ffi.NULL)

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -41,6 +41,7 @@ class Encoding(Enum):
     DER = "DER"
     OpenSSH = "OpenSSH"
     Raw = "Raw"
+    X962 = "ANSI X9.62"
 
 
 class PrivateFormat(Enum):
@@ -54,6 +55,8 @@ class PublicFormat(Enum):
     PKCS1 = "Raw PKCS#1"
     OpenSSH = "OpenSSH"
     Raw = "Raw"
+    CompressedPoint = "X9.62 Compressed Point"
+    UncompressedPoint = "X9.62 Uncompressed Point"
 
 
 class ParameterFormat(Enum):

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 import binascii
+import itertools
 import os
 
 import pytest
@@ -430,9 +431,10 @@ class TestDHPrivateKeySerialization(object):
             (serialization.Encoding.Raw, serialization.PrivateFormat.PKCS8),
             (serialization.Encoding.DER, serialization.PrivateFormat.Raw),
             (serialization.Encoding.Raw, serialization.PrivateFormat.Raw),
+            (serialization.Encoding.X962, serialization.PrivateFormat.PKCS8),
         ]
     )
-    def test_private_bytes_rejects_raw(self, encoding, fmt, backend):
+    def test_private_bytes_rejects_invalid(self, encoding, fmt, backend):
         parameters = dh.generate_parameters(2, 512, backend)
         key = parameters.generate_private_key()
         with pytest.raises(ValueError):
@@ -823,15 +825,26 @@ class TestDHParameterSerialization(object):
     @pytest.mark.parametrize(
         ("encoding", "fmt"),
         [
-            (serialization.Encoding.Raw, serialization.PublicFormat.Raw),
-            (serialization.Encoding.PEM, serialization.PublicFormat.Raw),
             (
                 serialization.Encoding.Raw,
                 serialization.PublicFormat.SubjectPublicKeyInfo
             ),
-        ]
+            (serialization.Encoding.Raw, serialization.PublicFormat.PKCS1),
+        ] + list(itertools.product(
+            [
+                serialization.Encoding.Raw,
+                serialization.Encoding.X962,
+                serialization.Encoding.PEM,
+                serialization.Encoding.DER
+            ],
+            [
+                serialization.PublicFormat.Raw,
+                serialization.PublicFormat.UncompressedPoint,
+                serialization.PublicFormat.CompressedPoint
+            ]
+        ))
     )
-    def test_public_bytes_rejects_raw(self, encoding, fmt, backend):
+    def test_public_bytes_rejects_invalid(self, encoding, fmt, backend):
         parameters = dh.generate_parameters(2, 512, backend)
         key = parameters.generate_private_key().public_key()
         with pytest.raises(ValueError):

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -719,9 +719,10 @@ class TestDSASerialization(object):
             (serialization.Encoding.Raw, serialization.PrivateFormat.PKCS8),
             (serialization.Encoding.DER, serialization.PrivateFormat.Raw),
             (serialization.Encoding.Raw, serialization.PrivateFormat.Raw),
+            (serialization.Encoding.X962, serialization.PrivateFormat.PKCS8),
         ]
     )
-    def test_private_bytes_rejects_raw(self, encoding, fmt, backend):
+    def test_private_bytes_rejects_invalid(self, encoding, fmt, backend):
         key = DSA_KEY_1024.private_key(backend)
         with pytest.raises(ValueError):
             key.private_bytes(encoding, fmt, serialization.NoEncryption())
@@ -968,15 +969,26 @@ class TestDSAPEMPublicKeySerialization(object):
     @pytest.mark.parametrize(
         ("encoding", "fmt"),
         [
-            (serialization.Encoding.Raw, serialization.PublicFormat.Raw),
-            (serialization.Encoding.PEM, serialization.PublicFormat.Raw),
             (
                 serialization.Encoding.Raw,
                 serialization.PublicFormat.SubjectPublicKeyInfo
             ),
-        ]
+            (serialization.Encoding.Raw, serialization.PublicFormat.PKCS1),
+        ] + list(itertools.product(
+            [
+                serialization.Encoding.Raw,
+                serialization.Encoding.X962,
+                serialization.Encoding.PEM,
+                serialization.Encoding.DER
+            ],
+            [
+                serialization.PublicFormat.Raw,
+                serialization.PublicFormat.UncompressedPoint,
+                serialization.PublicFormat.CompressedPoint
+            ]
+        ))
     )
-    def test_public_bytes_rejects_raw(self, encoding, fmt, backend):
+    def test_public_bytes_rejects_invalid(self, encoding, fmt, backend):
         key = DSA_KEY_2048.private_key(backend).public_key()
         with pytest.raises(ValueError):
             key.public_bytes(encoding, fmt)

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2067,9 +2067,10 @@ class TestRSAPrivateKeySerialization(object):
             (serialization.Encoding.Raw, serialization.PrivateFormat.PKCS8),
             (serialization.Encoding.DER, serialization.PrivateFormat.Raw),
             (serialization.Encoding.Raw, serialization.PrivateFormat.Raw),
+            (serialization.Encoding.X962, serialization.PrivateFormat.PKCS8),
         ]
     )
-    def test_private_bytes_rejects_raw(self, encoding, fmt, backend):
+    def test_private_bytes_rejects_invalid(self, encoding, fmt, backend):
         key = RSA_KEY_2048.private_key(backend)
         with pytest.raises(ValueError):
             key.private_bytes(encoding, fmt, serialization.NoEncryption())
@@ -2303,12 +2304,26 @@ class TestRSAPEMPublicKeySerialization(object):
     @pytest.mark.parametrize(
         ("encoding", "fmt"),
         [
-            (serialization.Encoding.Raw, serialization.PublicFormat.Raw),
-            (serialization.Encoding.PEM, serialization.PublicFormat.Raw),
+            (
+                serialization.Encoding.Raw,
+                serialization.PublicFormat.SubjectPublicKeyInfo
+            ),
             (serialization.Encoding.Raw, serialization.PublicFormat.PKCS1),
-        ]
+        ] + list(itertools.product(
+            [
+                serialization.Encoding.Raw,
+                serialization.Encoding.X962,
+                serialization.Encoding.PEM,
+                serialization.Encoding.DER
+            ],
+            [
+                serialization.PublicFormat.Raw,
+                serialization.PublicFormat.UncompressedPoint,
+                serialization.PublicFormat.CompressedPoint
+            ]
+        ))
     )
-    def test_public_bytes_rejects_raw(self, encoding, fmt, backend):
+    def test_public_bytes_rejects_invalid(self, encoding, fmt, backend):
         key = RSA_KEY_2048.private_key(backend).public_key()
         with pytest.raises(ValueError):
             key.public_bytes(encoding, fmt)


### PR DESCRIPTION
- [x] Tests for passing X962 encoding and UncompressedPoint/CompressedPoint format to non-EC keys.