### PR TITLE
[FIX] RFC4514 compliance

### DIFF
--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -218,7 +218,7 @@ class Name(object):
         elements are separated by '+'. The latter is almost never used in
         real world certificates.
         """
-        return ', '.join(attr.rfc4514_string() for attr in self._attributes)
+        return ','.join(attr.rfc4514_string() for attr in self._attributes)
 
     def get_attributes_for_oid(self, oid):
         return [i for i in self if i.oid == oid]


### PR DESCRIPTION
That space doesn't seem to be covered by the RFC.
See: https://www.ietf.org/rfc/rfc4514.txt
Specifically, the example: UID=jsmith,DC=example,DC=net