### PR TITLE
handle empty byte string in from_encoded_point

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -155,6 +155,9 @@ class EllipticCurvePublicKey(object):
     @classmethod
     def from_encoded_point(cls, curve, data):
         utils._check_bytes("data", data)
+        if len(data) == 0:
+            raise ValueError("data must not be an empty byte string")
+
         if not isinstance(curve, EllipticCurve):
             raise TypeError("curve must be an EllipticCurve instance")
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -155,11 +155,12 @@ class EllipticCurvePublicKey(object):
     @classmethod
     def from_encoded_point(cls, curve, data):
         utils._check_bytes("data", data)
-        if len(data) == 0:
-            raise ValueError("data must not be an empty byte string")
 
         if not isinstance(curve, EllipticCurve):
             raise TypeError("curve must be an EllipticCurve instance")
+
+        if len(data) == 0:
+            raise ValueError("data must not be an empty byte string")
 
         if six.indexbytes(data, 0) not in [0x02, 0x03, 0x04]:
             raise ValueError("Unsupported elliptic curve point type")

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -1071,6 +1071,12 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
                 ec.SECP384R1(), bad_data
             )
 
+    def test_from_encoded_point_empty_byte_string(self):
+        with pytest.raises(ValueError):
+            ec.EllipticCurvePublicKey.from_encoded_point(
+                ec.SECP384R1(), b""
+            )
+
     def test_from_encoded_point_not_a_curve(self):
         with pytest.raises(TypeError):
             ec.EllipticCurvePublicKey.from_encoded_point(


### PR DESCRIPTION
Previously raised an index out of range error since we try to check the first byte to learn the encoding type.