### PR TITLE
WIP: Add helper method to verify a certificate signature against an issuer

### DIFF
--- a/src/cryptography/x509/__init__.py
+++ b/src/cryptography/x509/__init__.py
@@ -38,7 +38,8 @@ from cryptography.x509.name import (
 from cryptography.x509.oid import (
     AuthorityInformationAccessOID, CRLEntryExtensionOID,
     CertificatePoliciesOID, ExtendedKeyUsageOID, ExtensionOID, NameOID,
-    ObjectIdentifier, SignatureAlgorithmOID, _SIG_OIDS_TO_HASH
+    ObjectIdentifier, SignatureAlgorithmOID, _SIG_OIDS_TO_HASH,
+    _SIG_OIDS_TO_KEY_CLASS, _SIG_OIDS_TO_PADDING
 )
 
 
@@ -175,6 +176,8 @@ __all__ = [
     "CertificateBuilder",
     "Version",
     "_SIG_OIDS_TO_HASH",
+    "_SIG_OIDS_TO_KEY_CLASS",
+    "_SIG_OIDS_TO_PADDING",
     "OID_CA_ISSUERS",
     "OID_OCSP",
     "_GENERAL_NAMES",

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa, ec, dsa
 
 
 class ExtensionOID(object):
@@ -114,6 +115,37 @@ _SIG_OIDS_TO_HASH = {
     SignatureAlgorithmOID.DSA_WITH_SHA1: hashes.SHA1(),
     SignatureAlgorithmOID.DSA_WITH_SHA224: hashes.SHA224(),
     SignatureAlgorithmOID.DSA_WITH_SHA256: hashes.SHA256()
+}
+
+
+_SIG_OIDS_TO_KEY_CLASS = {
+    SignatureAlgorithmOID.RSA_WITH_MD5: rsa.RSAPublicKey,
+    SignatureAlgorithmOID.RSA_WITH_SHA1: rsa.RSAPublicKey,
+    SignatureAlgorithmOID._RSA_WITH_SHA1: rsa.RSAPublicKey,
+    SignatureAlgorithmOID.RSA_WITH_SHA224: rsa.RSAPublicKey,
+    SignatureAlgorithmOID.RSA_WITH_SHA256: rsa.RSAPublicKey,
+    SignatureAlgorithmOID.RSA_WITH_SHA384: rsa.RSAPublicKey,
+    SignatureAlgorithmOID.RSA_WITH_SHA512: rsa.RSAPublicKey,
+    SignatureAlgorithmOID.RSASSA_PSS: rsa.RSAPublicKey,
+    SignatureAlgorithmOID.ECDSA_WITH_SHA1: ec.EllipticCurvePublicKey,
+    SignatureAlgorithmOID.ECDSA_WITH_SHA224: ec.EllipticCurvePublicKey,
+    SignatureAlgorithmOID.ECDSA_WITH_SHA256: ec.EllipticCurvePublicKey,
+    SignatureAlgorithmOID.ECDSA_WITH_SHA384: ec.EllipticCurvePublicKey,
+    SignatureAlgorithmOID.ECDSA_WITH_SHA512: ec.EllipticCurvePublicKey,
+    SignatureAlgorithmOID.DSA_WITH_SHA1: dsa.DSAPublicKey,
+    SignatureAlgorithmOID.DSA_WITH_SHA224: dsa.DSAPublicKey,
+    SignatureAlgorithmOID.DSA_WITH_SHA256: dsa.DSAPublicKey
+}
+
+
+_SIG_OIDS_TO_PADDING = {
+    SignatureAlgorithmOID.RSA_WITH_MD5: padding.PKCS1v15(),
+    SignatureAlgorithmOID.RSA_WITH_SHA1: padding.PKCS1v15(),
+    SignatureAlgorithmOID._RSA_WITH_SHA1: padding.PKCS1v15(),
+    SignatureAlgorithmOID.RSA_WITH_SHA224: padding.PKCS1v15(),
+    SignatureAlgorithmOID.RSA_WITH_SHA256: padding.PKCS1v15(),
+    SignatureAlgorithmOID.RSA_WITH_SHA384: padding.PKCS1v15(),
+    SignatureAlgorithmOID.RSA_WITH_SHA512: padding.PKCS1v15(),
 }
 
 


### PR DESCRIPTION
Just a proof of concept for now, how would you feel about adding this kind functionality to cryptography?

Doing the verification and handling different key types and padding is nontrivial, would be great if application authors didn't have to worry about this stuff.
