### PR TITLE
support x448 public/private serialization both raw and pkcs8

### DIFF
--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -538,14 +538,16 @@ Serialization Encodings
     :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKeyWithSerialization`
     ,
     :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKeyWithSerialization`
-    , :class:`~cryptography.hazmat.primitives.asymmetric.dh.DHPrivateKeyWithSerialization`
+    , :class:`~cryptography.hazmat.primitives.asymmetric.dh.DHPrivateKeyWithSerialization`,
+    :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithSerialization`,
     and
-    :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKeyWithSerialization`
+    :class:`~cryptography.hazmat.primitives.asymmetric.x448.X448PrivateKey`
     as well as ``public_bytes`` on
-    :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKeyWithSerialization`,
-    :class:`~cryptography.hazmat.primitives.asymmetric.dh.DHPublicKeyWithSerialization`
+    :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`,
+    :class:`~cryptography.hazmat.primitives.asymmetric.dh.DHPublicKey`,
+    :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey`,
     and
-    :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKeyWithSerialization`.
+    :class:`~cryptography.hazmat.primitives.asymmetric.x448.X448PublicKey`.
 
     .. attribute:: PEM
 
@@ -564,6 +566,13 @@ Serialization Encodings
         .. versionadded:: 1.4
 
         The format used by OpenSSH public keys. This is a text format.
+
+    .. attribute:: Raw
+
+        .. versionadded:: 2.5
+
+        A raw format used by doc:`/hazmat/primitives/asymmetric/x448`. It is a
+        binary format and is invalid for other key types.
 
 
 Serialization Encryption Types

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -473,6 +473,13 @@ Serialization Formats
             ...
             -----END PRIVATE KEY-----
 
+    .. attribute:: Raw
+
+        .. versionadded:: 2.5
+
+        A raw format used by :doc:`/hazmat/primitives/asymmetric/x448`. It is a
+        binary format and is invalid for other key types.
+
 .. class:: PublicFormat
 
     .. versionadded:: 0.8
@@ -515,6 +522,13 @@ Serialization Formats
 
         The public key format used by OpenSSH (e.g. as found in
         ``~/.ssh/id_rsa.pub`` or ``~/.ssh/authorized_keys``).
+
+    .. attribute:: Raw
+
+        .. versionadded:: 2.5
+
+        A raw format used by :doc:`/hazmat/primitives/asymmetric/x448`. It is a
+        binary format and is invalid for other key types.
 
 .. class:: ParameterFormat
 
@@ -571,7 +585,7 @@ Serialization Encodings
 
         .. versionadded:: 2.5
 
-        A raw format used by doc:`/hazmat/primitives/asymmetric/x448`. It is a
+        A raw format used by :doc:`/hazmat/primitives/asymmetric/x448`. It is a
         binary format and is invalid for other key types.
 
 

--- a/docs/hazmat/primitives/asymmetric/x448.rst
+++ b/docs/hazmat/primitives/asymmetric/x448.rst
@@ -77,7 +77,11 @@ Key interfaces
             >>> from cryptography.hazmat.primitives import serialization
             >>> from cryptography.hazmat.primitives.asymmetric import x448
             >>> private_key = x448.X448PrivateKey.generate()
-            >>> private_bytes = private_key.private_bytes(serialization.Encoding.Raw, serialization.PrivateFormat.Raw, serialization.NoEncryption())
+            >>> private_bytes = private_key.private_bytes(
+            ...     encoding=serialization.Encoding.Raw,
+            ...     format=serialization.PrivateFormat.Raw,
+            ...     encryption_algorithm=serialization.NoEncryption()
+            ... )
             >>> loaded_private_key = x448.X448PrivateKey.from_private_bytes(private_bytes)
 
     .. method:: public_key()
@@ -108,7 +112,7 @@ Key interfaces
 
         :param format: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.PrivateFormat`
-            enum or ``None``. If the ``encoding`` is
+            enum. If the ``encoding`` is
             :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
             then ``format`` must be
             :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.Raw`
@@ -137,7 +141,10 @@ Key interfaces
             >>> from cryptography.hazmat.primitives.asymmetric import x448
             >>> private_key = x448.X448PrivateKey.generate()
             >>> public_key = private_key.public_key()
-            >>> public_bytes = public_key.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+            >>> public_bytes = public_key.public_bytes(
+            ...     encoding=serialization.Encoding.Raw,
+            ...     format=serialization.PublicFormat.Raw
+            ... )
             >>> loaded_public_key = x448.X448PublicKey.from_public_bytes(public_bytes)
 
     .. method:: public_bytes(encoding, format)
@@ -157,7 +164,7 @@ Key interfaces
 
         :param format: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.PublicFormat`
-            enum or ``None``. If the ``encoding`` is
+            enum. If the ``encoding`` is
             :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
             then ``format`` must be
             :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.Raw`

--- a/docs/hazmat/primitives/asymmetric/x448.rst
+++ b/docs/hazmat/primitives/asymmetric/x448.rst
@@ -66,6 +66,20 @@ Key interfaces
 
         :returns: :class:`X448PrivateKey`
 
+    .. classmethod:: from_private_bytes(data)
+
+        :param bytes data: 56 byte private key.
+
+        :returns: :class:`X448PrivateKey`
+
+        .. doctest::
+
+            >>> from cryptography.hazmat.primitives import serialization
+            >>> from cryptography.hazmat.primitives.asymmetric import x448
+            >>> private_key = x448.X448PrivateKey.generate()
+            >>> private_bytes = private_key.private_bytes(serialization.Encoding.Raw, None, serialization.NoEncryption())
+            >>> loaded_private_key = x448.X448PrivateKey.from_private_bytes(private_bytes)
+
     .. method:: public_key()
 
         :returns: :class:`X448PublicKey`
@@ -76,6 +90,32 @@ Key interfaces
             peer.
 
         :returns bytes: A shared key.
+
+    .. method:: private_bytes(encoding, format, encryption_algorithm)
+
+        Allows serialization of the key to bytes. Encoding (
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`,
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`, or
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`) and
+        format (
+        :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`
+        or ``None``) are chosen to define the exact serialization.
+
+        :param encoding: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+        :param format: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.PrivateFormat`
+            enum or ``None``. If the ``encoding`` is
+            :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
+            then ``format`` must be ``None``, otherwise it must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`.
+
+        :param encryption_algorithm: An instance of an object conforming to the
+            :class:`~cryptography.hazmat.primitives.serialization.KeySerializationEncryption`
+            interface.
+
+        :return bytes: Serialized key.
 
 .. class:: X448PublicKey
 
@@ -89,15 +129,34 @@ Key interfaces
 
         .. doctest::
 
+            >>> from cryptography.hazmat.primitives import serialization
             >>> from cryptography.hazmat.primitives.asymmetric import x448
             >>> private_key = x448.X448PrivateKey.generate()
             >>> public_key = private_key.public_key()
-            >>> public_bytes = public_key.public_bytes()
+            >>> public_bytes = public_key.public_bytes(serialization.Encoding.Raw, None)
             >>> loaded_public_key = x448.X448PublicKey.from_public_bytes(public_bytes)
 
-    .. method:: public_bytes()
+    .. method:: public_bytes(encoding, format)
 
-        :returns bytes: The raw bytes of the public key.
+        Allows serialization of the key to bytes. Encoding (
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`,
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`, or
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`) and
+        format (
+        :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`
+        or ``None``) are chosen to define the exact serialization.
+
+        :param encoding: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+        :param format: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.PublicFormat`
+            enum or ``None``. If the ``encoding`` is
+            :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
+            then ``format`` must be ``None``, otherwise it must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`.
+
+        :returns bytes: The public key bytes.
 
 
 .. _`Diffie-Hellman key exchange`: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange

--- a/docs/hazmat/primitives/asymmetric/x448.rst
+++ b/docs/hazmat/primitives/asymmetric/x448.rst
@@ -77,7 +77,7 @@ Key interfaces
             >>> from cryptography.hazmat.primitives import serialization
             >>> from cryptography.hazmat.primitives.asymmetric import x448
             >>> private_key = x448.X448PrivateKey.generate()
-            >>> private_bytes = private_key.private_bytes(serialization.Encoding.Raw, None, serialization.NoEncryption())
+            >>> private_bytes = private_key.private_bytes(serialization.Encoding.Raw, serialization.PrivateFormat.Raw, serialization.NoEncryption())
             >>> loaded_private_key = x448.X448PrivateKey.from_private_bytes(private_bytes)
 
     .. method:: public_key()
@@ -99,7 +99,9 @@ Key interfaces
         :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`) and
         format (
         :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`
-        or ``None``) are chosen to define the exact serialization.
+        or
+        :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.Raw`
+        ) are chosen to define the exact serialization.
 
         :param encoding: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
@@ -108,7 +110,9 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.serialization.PrivateFormat`
             enum or ``None``. If the ``encoding`` is
             :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
-            then ``format`` must be ``None``, otherwise it must be
+            then ``format`` must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.Raw`
+            , otherwise it must be
             :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`.
 
         :param encryption_algorithm: An instance of an object conforming to the
@@ -133,7 +137,7 @@ Key interfaces
             >>> from cryptography.hazmat.primitives.asymmetric import x448
             >>> private_key = x448.X448PrivateKey.generate()
             >>> public_key = private_key.public_key()
-            >>> public_bytes = public_key.public_bytes(serialization.Encoding.Raw, None)
+            >>> public_bytes = public_key.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
             >>> loaded_public_key = x448.X448PublicKey.from_public_bytes(public_bytes)
 
     .. method:: public_bytes(encoding, format)
@@ -144,7 +148,9 @@ Key interfaces
         :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`) and
         format (
         :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`
-        or ``None``) are chosen to define the exact serialization.
+        or
+        :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.Raw`
+        ) are chosen to define the exact serialization.
 
         :param encoding: A value from the
             :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
@@ -153,7 +159,9 @@ Key interfaces
             :class:`~cryptography.hazmat.primitives.serialization.PublicFormat`
             enum or ``None``. If the ``encoding`` is
             :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
-            then ``format`` must be ``None``, otherwise it must be
+            then ``format`` must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.Raw`
+            , otherwise it must be
             :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`.
 
         :returns bytes: The public key bytes.

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -508,6 +508,9 @@ class Backend(object):
             self.openssl_assert(dh_cdata != self._ffi.NULL)
             dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
             return _DHPrivateKey(self, dh_cdata, evp_pkey)
+        elif key_type == getattr(self._lib, "EVP_PKEY_X448", None):
+            # EVP_PKEY_X448 is not present in OpenSSL < 1.1.1
+            return _X448PrivateKey(self, evp_pkey)
         else:
             raise UnsupportedAlgorithm("Unsupported key type.")
 
@@ -1737,7 +1740,7 @@ class Backend(object):
                 write_bio = self._lib.i2d_PKCS8PrivateKey_bio
                 key = evp_pkey
         else:
-            raise TypeError("encoding must be an item from the Encoding enum")
+            raise TypeError("encoding must be Encoding.PEM or Encoding.DER")
 
         bio = self._create_mem_bio_gc()
         res = write_bio(

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -542,6 +542,9 @@ class Backend(object):
             self.openssl_assert(dh_cdata != self._ffi.NULL)
             dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
             return _DHPublicKey(self, dh_cdata, evp_pkey)
+        elif key_type == getattr(self._lib, "EVP_PKEY_X448", None):
+            # EVP_PKEY_X448 is not present in OpenSSL < 1.1.1
+            return _X448PublicKey(self, evp_pkey)
         else:
             raise UnsupportedAlgorithm("Unsupported key type.")
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1684,6 +1684,16 @@ class Backend(object):
                 "format must be an item from the PrivateFormat enum"
             )
 
+        # Raw format and encoding are only valid for X25519, Ed25519, X448, and
+        # Ed448 keys. We capture those cases before this method is called so if
+        # we see those enum values here it means the caller has passed them to
+        # a key that doesn't support raw type
+        if format is serialization.PrivateFormat.Raw:
+            raise ValueError("raw format is invalid with this key or encoding")
+
+        if encoding is serialization.Encoding.Raw:
+            raise ValueError("raw encoding is invalid with this key or format")
+
         if not isinstance(encryption_algorithm,
                           serialization.KeySerializationEncryption):
             raise TypeError(
@@ -1775,6 +1785,16 @@ class Backend(object):
     def _public_key_bytes(self, encoding, format, key, evp_pkey, cdata):
         if not isinstance(encoding, serialization.Encoding):
             raise TypeError("encoding must be an item from the Encoding enum")
+
+        # Raw format and encoding are only valid for X25519, Ed25519, X448, and
+        # Ed448 keys. We capture those cases before this method is called so if
+        # we see those enum values here it means the caller has passed them to
+        # a key that doesn't support raw type
+        if format is serialization.PublicFormat.Raw:
+            raise ValueError("raw format is invalid with this key or encoding")
+
+        if encoding is serialization.Encoding.Raw:
+            raise ValueError("raw encoding is invalid with this key or format")
 
         if (
             format is serialization.PublicFormat.OpenSSH or

--- a/src/cryptography/hazmat/backends/openssl/x448.py
+++ b/src/cryptography/hazmat/backends/openssl/x448.py
@@ -24,9 +24,17 @@ class _X448PublicKey(object):
         self._evp_pkey = evp_pkey
 
     def public_bytes(self, encoding, format):
-        if encoding is serialization.Encoding.Raw:
-            if format is not None:
-                raise ValueError("When using Raw encoding format must be None")
+        if (
+            encoding is serialization.Encoding.Raw or
+            format is serialization.PublicFormat.Raw
+        ):
+            if (
+                encoding is not serialization.Encoding.Raw or
+                format is not serialization.PublicFormat.Raw
+            ):
+                raise ValueError(
+                    "When using Raw both encoding and format must be Raw"
+                )
 
             return self._raw_public_bytes()
 
@@ -79,14 +87,18 @@ class _X448PrivateKey(object):
         )
 
     def private_bytes(self, encoding, format, encryption_algorithm):
-        if encoding is serialization.Encoding.Raw:
+        if (
+            encoding is serialization.Encoding.Raw or
+            format is serialization.PublicFormat.Raw
+        ):
             if (
-                format is not None or not
+                format is not serialization.PrivateFormat.Raw or
+                encoding is not serialization.Encoding.Raw or not
                 isinstance(encryption_algorithm, serialization.NoEncryption)
             ):
                 raise ValueError(
-                    "When using Raw encoding format must be None and "
-                    "encryption_algorithm must be NoEncryption"
+                    "When using Raw both encoding and format must be Raw "
+                    "and encryption_algorithm must be NoEncryption"
                 )
 
             return self._raw_private_bytes()

--- a/src/cryptography/hazmat/primitives/asymmetric/x448.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x448.py
@@ -25,7 +25,7 @@ class X448PublicKey(object):
         return backend.x448_load_public_bytes(data)
 
     @abc.abstractmethod
-    def public_bytes(self):
+    def public_bytes(self, encoding, format):
         """
         The serialized bytes of the public key.
         """
@@ -44,7 +44,7 @@ class X448PrivateKey(object):
         return backend.x448_generate_key()
 
     @classmethod
-    def _from_private_bytes(cls, data):
+    def from_private_bytes(cls, data):
         from cryptography.hazmat.backends.openssl.backend import backend
         return backend.x448_load_private_bytes(data)
 
@@ -52,6 +52,12 @@ class X448PrivateKey(object):
     def public_key(self):
         """
         The serialized bytes of the public key.
+        """
+
+    @abc.abstractmethod
+    def private_bytes(self, encoding, format, encryption_algorithm):
+        """
+        The serialized bytes of the private key.
         """
 
     @abc.abstractmethod

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -46,12 +46,14 @@ class Encoding(Enum):
 class PrivateFormat(Enum):
     PKCS8 = "PKCS8"
     TraditionalOpenSSL = "TraditionalOpenSSL"
+    Raw = "Raw"
 
 
 class PublicFormat(Enum):
     SubjectPublicKeyInfo = "X.509 subjectPublicKeyInfo with PKCS#1"
     PKCS1 = "Raw PKCS#1"
     OpenSSH = "OpenSSH"
+    Raw = "Raw"
 
 
 class ParameterFormat(Enum):

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -40,6 +40,7 @@ class Encoding(Enum):
     PEM = "PEM"
     DER = "DER"
     OpenSSH = "OpenSSH"
+    Raw = "Raw"
 
 
 class PrivateFormat(Enum):

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -427,10 +427,17 @@ class TestDHPrivateKeySerialization(object):
     def test_private_bytes_rejects_raw(self, backend):
         parameters = dh.generate_parameters(2, 512, backend)
         key = parameters.generate_private_key()
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()
+            )
+
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.DER,
+                serialization.PrivateFormat.Raw,
                 serialization.NoEncryption()
             )
 
@@ -815,6 +822,23 @@ class TestDHParameterSerialization(object):
             assert parameter_numbers.q == int(vec["q"], 16)
         else:
             assert parameter_numbers.q is None
+
+    @pytest.mark.parametrize(
+        ("encoding", "fmt"),
+        [
+            (serialization.Encoding.Raw, serialization.PublicFormat.Raw),
+            (serialization.Encoding.PEM, serialization.PublicFormat.Raw),
+            (
+                serialization.Encoding.Raw,
+                serialization.PublicFormat.SubjectPublicKeyInfo
+            ),
+        ]
+    )
+    def test_public_bytes_rejects_raw(self, encoding, fmt, backend):
+        parameters = dh.generate_parameters(2, 512, backend)
+        key = parameters.generate_private_key().public_key()
+        with pytest.raises(ValueError):
+            key.public_bytes(encoding, fmt)
 
     def test_parameter_bytes_invalid_encoding(self, backend):
         parameters = dh.generate_parameters(2, 512, backend)

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -424,22 +424,19 @@ class TestDHPrivateKeySerialization(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
-    def test_private_bytes_rejects_raw(self, backend):
+    @pytest.mark.parametrize(
+        ("encoding", "fmt"),
+        [
+            (serialization.Encoding.Raw, serialization.PrivateFormat.PKCS8),
+            (serialization.Encoding.DER, serialization.PrivateFormat.Raw),
+            (serialization.Encoding.Raw, serialization.PrivateFormat.Raw),
+        ]
+    )
+    def test_private_bytes_rejects_raw(self, encoding, fmt, backend):
         parameters = dh.generate_parameters(2, 512, backend)
         key = parameters.generate_private_key()
         with pytest.raises(ValueError):
-            key.private_bytes(
-                serialization.Encoding.Raw,
-                serialization.PrivateFormat.PKCS8,
-                serialization.NoEncryption()
-            )
-
-        with pytest.raises(ValueError):
-            key.private_bytes(
-                serialization.Encoding.DER,
-                serialization.PrivateFormat.Raw,
-                serialization.NoEncryption()
-            )
+            key.private_bytes(encoding, fmt, serialization.NoEncryption())
 
     @pytest.mark.parametrize(
         ("key_path", "loader_func", "encoding", "is_dhx"),

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -424,6 +424,16 @@ class TestDHPrivateKeySerialization(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
+    def test_private_bytes_rejects_raw(self, backend):
+        parameters = dh.generate_parameters(2, 512, backend)
+        key = parameters.generate_private_key()
+        with pytest.raises(TypeError):
+            key.private_bytes(
+                serialization.Encoding.Raw,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()
+            )
+
     @pytest.mark.parametrize(
         ("key_path", "loader_func", "encoding", "is_dhx"),
         [

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -713,21 +713,18 @@ class TestDSASerialization(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
-    def test_private_bytes_rejects_raw(self, backend):
+    @pytest.mark.parametrize(
+        ("encoding", "fmt"),
+        [
+            (serialization.Encoding.Raw, serialization.PrivateFormat.PKCS8),
+            (serialization.Encoding.DER, serialization.PrivateFormat.Raw),
+            (serialization.Encoding.Raw, serialization.PrivateFormat.Raw),
+        ]
+    )
+    def test_private_bytes_rejects_raw(self, encoding, fmt, backend):
         key = DSA_KEY_1024.private_key(backend)
         with pytest.raises(ValueError):
-            key.private_bytes(
-                serialization.Encoding.Raw,
-                serialization.PrivateFormat.PKCS8,
-                serialization.NoEncryption()
-            )
-
-        with pytest.raises(ValueError):
-            key.private_bytes(
-                serialization.Encoding.PEM,
-                serialization.PrivateFormat.Raw,
-                serialization.NoEncryption()
-            )
+            key.private_bytes(encoding, fmt, serialization.NoEncryption())
 
     @pytest.mark.parametrize(
         ("fmt", "password"),

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -715,10 +715,17 @@ class TestDSASerialization(object):
 
     def test_private_bytes_rejects_raw(self, backend):
         key = DSA_KEY_1024.private_key(backend)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()
+            )
+
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.Raw,
                 serialization.NoEncryption()
             )
 
@@ -960,3 +967,19 @@ class TestDSAPEMPublicKeySerialization(object):
             key.public_bytes(
                 serialization.Encoding.PEM, serialization.PublicFormat.PKCS1
             )
+
+    @pytest.mark.parametrize(
+        ("encoding", "fmt"),
+        [
+            (serialization.Encoding.Raw, serialization.PublicFormat.Raw),
+            (serialization.Encoding.PEM, serialization.PublicFormat.Raw),
+            (
+                serialization.Encoding.Raw,
+                serialization.PublicFormat.SubjectPublicKeyInfo
+            ),
+        ]
+    )
+    def test_public_bytes_rejects_raw(self, encoding, fmt, backend):
+        key = DSA_KEY_2048.private_key(backend).public_key()
+        with pytest.raises(ValueError):
+            key.public_bytes(encoding, fmt)

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -713,6 +713,15 @@ class TestDSASerialization(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
+    def test_private_bytes_rejects_raw(self, backend):
+        key = DSA_KEY_1024.private_key(backend)
+        with pytest.raises(TypeError):
+            key.private_bytes(
+                serialization.Encoding.Raw,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()
+            )
+
     @pytest.mark.parametrize(
         ("fmt", "password"),
         [

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -705,6 +705,16 @@ class TestECSerialization(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
+    def test_private_bytes_rejects_raw(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+        key = ec.generate_private_key(ec.SECP256R1(), backend)
+        with pytest.raises(TypeError):
+            key.private_bytes(
+                serialization.Encoding.Raw,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()
+            )
+
     @pytest.mark.parametrize(
         ("fmt", "password"),
         [

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -705,22 +705,19 @@ class TestECSerialization(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
-    def test_private_bytes_rejects_raw(self, backend):
+    @pytest.mark.parametrize(
+        ("encoding", "fmt"),
+        [
+            (serialization.Encoding.Raw, serialization.PrivateFormat.PKCS8),
+            (serialization.Encoding.DER, serialization.PrivateFormat.Raw),
+            (serialization.Encoding.Raw, serialization.PrivateFormat.Raw),
+        ]
+    )
+    def test_private_bytes_rejects_raw(self, encoding, fmt, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
         key = ec.generate_private_key(ec.SECP256R1(), backend)
         with pytest.raises(ValueError):
-            key.private_bytes(
-                serialization.Encoding.Raw,
-                serialization.PrivateFormat.PKCS8,
-                serialization.NoEncryption()
-            )
-
-        with pytest.raises(ValueError):
-            key.private_bytes(
-                serialization.Encoding.DER,
-                serialization.PrivateFormat.Raw,
-                serialization.NoEncryption()
-            )
+            key.private_bytes(encoding, fmt, serialization.NoEncryption())
 
     @pytest.mark.parametrize(
         ("fmt", "password"),

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -708,10 +708,17 @@ class TestECSerialization(object):
     def test_private_bytes_rejects_raw(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
         key = ec.generate_private_key(ec.SECP256R1(), backend)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()
+            )
+
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.DER,
+                serialization.PrivateFormat.Raw,
                 serialization.NoEncryption()
             )
 
@@ -994,6 +1001,20 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
                 "notencoding",
                 serialization.PublicFormat.SubjectPublicKeyInfo
             )
+
+    @pytest.mark.parametrize(
+        ("encoding", "fmt"),
+        [
+            (serialization.Encoding.Raw, serialization.PublicFormat.Raw),
+            (serialization.Encoding.PEM, serialization.PublicFormat.Raw),
+            (serialization.Encoding.Raw, serialization.PublicFormat.PKCS1),
+        ]
+    )
+    def test_public_bytes_rejects_raw(self, encoding, fmt, backend):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+        key = ec.generate_private_key(ec.SECP256R1(), backend).public_key()
+        with pytest.raises(ValueError):
+            key.public_bytes(encoding, fmt)
 
     def test_public_bytes_invalid_format(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2061,21 +2061,18 @@ class TestRSAPrivateKeySerialization(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
-    def test_private_bytes_rejects_raw(self, backend):
+    @pytest.mark.parametrize(
+        ("encoding", "fmt"),
+        [
+            (serialization.Encoding.Raw, serialization.PrivateFormat.PKCS8),
+            (serialization.Encoding.DER, serialization.PrivateFormat.Raw),
+            (serialization.Encoding.Raw, serialization.PrivateFormat.Raw),
+        ]
+    )
+    def test_private_bytes_rejects_raw(self, encoding, fmt, backend):
         key = RSA_KEY_2048.private_key(backend)
         with pytest.raises(ValueError):
-            key.private_bytes(
-                serialization.Encoding.Raw,
-                serialization.PrivateFormat.PKCS8,
-                serialization.NoEncryption()
-            )
-
-        with pytest.raises(ValueError):
-            key.private_bytes(
-                serialization.Encoding.PEM,
-                serialization.PrivateFormat.Raw,
-                serialization.NoEncryption()
-            )
+            key.private_bytes(encoding, fmt, serialization.NoEncryption())
 
     @pytest.mark.parametrize(
         ("fmt", "password"),

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2063,10 +2063,17 @@ class TestRSAPrivateKeySerialization(object):
 
     def test_private_bytes_rejects_raw(self, backend):
         key = RSA_KEY_2048.private_key(backend)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()
+            )
+
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.Raw,
                 serialization.NoEncryption()
             )
 
@@ -2295,3 +2302,16 @@ class TestRSAPEMPublicKeySerialization(object):
         key = RSA_KEY_2048.private_key(backend).public_key()
         with pytest.raises(TypeError):
             key.public_bytes(serialization.Encoding.PEM, "invalidformat")
+
+    @pytest.mark.parametrize(
+        ("encoding", "fmt"),
+        [
+            (serialization.Encoding.Raw, serialization.PublicFormat.Raw),
+            (serialization.Encoding.PEM, serialization.PublicFormat.Raw),
+            (serialization.Encoding.Raw, serialization.PublicFormat.PKCS1),
+        ]
+    )
+    def test_public_bytes_rejects_raw(self, encoding, fmt, backend):
+        key = RSA_KEY_2048.private_key(backend).public_key()
+        with pytest.raises(ValueError):
+            key.public_bytes(encoding, fmt)

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2061,6 +2061,15 @@ class TestRSAPrivateKeySerialization(object):
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
+    def test_private_bytes_rejects_raw(self, backend):
+        key = RSA_KEY_2048.private_key(backend)
+        with pytest.raises(TypeError):
+            key.private_bytes(
+                serialization.Encoding.Raw,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption()
+            )
+
     @pytest.mark.parametrize(
         ("fmt", "password"),
         [

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -1254,7 +1254,7 @@ class TestX448Serialization(object):
         )
         key = load_der_private_key(data, b"password", backend)
         assert key.private_bytes(
-            Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+            Encoding.DER, PrivateFormat.PKCS8, NoEncryption()
         ) == unencrypted
 
     def test_load_pem_private_key(self, backend):

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -16,10 +16,10 @@ from cryptography.hazmat.backends.interfaces import (
     DERSerializationBackend, DSABackend, EllipticCurveBackend,
     PEMSerializationBackend, RSABackend
 )
-from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa, x448
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from cryptography.hazmat.primitives.serialization import (
     BestAvailableEncryption, Encoding, NoEncryption,
-    PublicFormat, PrivateFormat,
+    PrivateFormat, PublicFormat,
     load_der_parameters, load_der_private_key,
     load_der_public_key, load_pem_parameters, load_pem_private_key,
     load_pem_public_key, load_ssh_public_key

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -1246,7 +1246,6 @@ class TestX448Serialization(object):
             lambda derfile: derfile.read(),
             mode="rb"
         )
-        key = load_der_private_key(data, b"password", backend)
         unencrypted = load_vectors_from_file(
             os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
             lambda derfile: derfile.read(),

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -1240,13 +1240,13 @@ class TestKeySerializationEncryptionTypes(object):
     skip_message="Requires OpenSSL with X448 support"
 )
 class TestX448Serialization(object):
-    def test_load_der_private_key(self, key_path, password, backend):
+    def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "X448", "x448-pkcs8-enc.der"),
             lambda derfile: derfile.read(),
             mode="rb"
         )
-        key = load_der_private_key(data, password, backend)
+        key = load_der_private_key(data, b"password", backend)
         unencrypted = load_vectors_from_file(
             os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
             lambda derfile: derfile.read(),

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -107,14 +107,16 @@ class TestX448Exchange(object):
     def test_pub_priv_bytes_raw(self, private_bytes, public_bytes, backend):
         private_key = X448PrivateKey.from_private_bytes(private_bytes)
         assert private_key.private_bytes(
-            serialization.Encoding.Raw, None, serialization.NoEncryption()
+            serialization.Encoding.Raw,
+            serialization.PrivateFormat.Raw,
+            serialization.NoEncryption()
         ) == private_bytes
         assert private_key.public_key().public_bytes(
-            serialization.Encoding.Raw, None
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
         ) == public_bytes
         public_key = X448PublicKey.from_public_bytes(public_bytes)
         assert public_key.public_bytes(
-            serialization.Encoding.Raw, None
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
         ) == public_bytes
 
     @pytest.mark.parametrize(
@@ -176,7 +178,11 @@ class TestX448Exchange(object):
     def test_invalid_private_bytes(self, backend):
         key = X448PrivateKey.generate()
         with pytest.raises(ValueError):
-            key.private_bytes(serialization.Encoding.Raw, None, None)
+            key.private_bytes(
+                serialization.Encoding.Raw,
+                serialization.PrivateFormat.Raw,
+                None
+            )
 
         with pytest.raises(ValueError):
             key.private_bytes(
@@ -187,7 +193,9 @@ class TestX448Exchange(object):
 
         with pytest.raises(ValueError):
             key.private_bytes(
-                serialization.Encoding.PEM, None, serialization.NoEncryption()
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.Raw,
+                serialization.NoEncryption()
             )
 
     def test_invalid_public_bytes(self, backend):
@@ -202,4 +210,10 @@ class TestX448Exchange(object):
             key.public_bytes(
                 serialization.Encoding.PEM,
                 serialization.PublicFormat.PKCS1
+            )
+
+        with pytest.raises(ValueError):
+            key.public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.Raw
             )

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -172,3 +172,34 @@ class TestX448Exchange(object):
 
         with pytest.raises(ValueError):
             X448PublicKey.from_public_bytes(b"a" * 57)
+
+    def test_invalid_private_bytes(self, backend):
+        key = X448PrivateKey.generate()
+        with pytest.raises(ValueError):
+            key.private_bytes(serialization.Encoding.Raw, None, None)
+
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.Raw,
+                serialization.PrivateFormat.PKCS8,
+                None
+            )
+
+        with pytest.raises(ValueError):
+            key.private_bytes(
+                serialization.Encoding.PEM, None, serialization.NoEncryption()
+            )
+
+    def test_invalid_public_bytes(self, backend):
+        key = X448PrivateKey.generate().public_key()
+        with pytest.raises(ValueError):
+            key.public_bytes(
+                serialization.Encoding.Raw,
+                serialization.PublicFormat.SubjectPublicKeyInfo
+            )
+
+        with pytest.raises(ValueError):
+            key.public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.PKCS1
+            )

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -156,7 +156,8 @@ class TestX448Exchange(object):
                                               passwd, load_func, backend):
         key = X448PrivateKey.generate()
         serialized = key.private_bytes(encoding, fmt, encryption)
-        load_func(serialized, passwd, backend)
+        loaded_key = load_func(serialized, passwd, backend)
+        assert isinstance(loaded_key, X448PrivateKey)
 
     def test_generate(self, backend):
         key = X448PrivateKey.generate()


### PR DESCRIPTION
I'm putting this up so we can discuss the API and move forward on this.

This approach adds `Encoding.Raw` to the `serialization.Encoding` enum. This allows us to retain the method signatures we've used on every other asymmetric key type: `public_bytes(encoding, format)` and `private_bytes(encoding, format, encryption_algorithm)`. However, with this API `format` has no meaning with a raw encoding so `None` must be passed. Fortunately, the existing methods will already reject raw as a valid encoding (but tests need to be added to make sure we don't regress in the future)

I think this approach represents a reasonable compromise to extend our existing API without completely blowing up everything and introducing another multi-year deprecation (https://github.com/pyca/cryptography/issues/4497).

There are a few outstanding questions here though:

* Do we want `from_public_bytes` and `from_private_bytes` to be able to handle x448 pkcs8 or just raw?
* Do we want `load_{pem,der}_{public,private}_key` to understand x448 pkcs8? I think the answer here probably needs to be yes.

When we agree on the approach then this can be extended to x25519, ed25519, and ed448.

Outstanding work:
- [x] Add tests to confirm raw encodings are rejected for all other asym key types
- [x] Add tests to serialize keys to the PKCS8 forms and test roundtripping as well
- [x] Depending on what we choose to support from the questions above, complete that work and add testing around it.

refs #4386 