### PR TITLE
fix epoch overflow 32bit

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function
 
 import base64
-import calendar
 import collections
 import contextlib
 import itertools

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -836,8 +836,8 @@ class Backend(object):
         return _Certificate(self, x509_cert)
 
     def _set_asn1_time(self, asn1_time, time):
-        timestamp = calendar.timegm(time.timetuple())
-        res = self._lib.ASN1_TIME_set(asn1_time, timestamp)
+        timestamp = time.strftime('%Y%m%d%H%M%SZ').encode('ascii')
+        res = self._lib.ASN1_TIME_set_string(asn1_time, timestamp)
         if res == self._ffi.NULL:
             errors = self._consume_errors()
             self.openssl_assert(


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Year_2038_problem

I've had a problem while generating certs with dates higher than 2038 while running it on a raspberry pi (32-bit architecture)

The openssl api has a function that takes the date as a string, so you don't have such problem when dealing with dates higher than 2038 
