### PR TITLE
Serialization x25519

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,10 @@ Changelog
   :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers.from_encoded_point`.
 * Added :attr:`~cryptography.x509.ocsp.OCSPResponse.signature_hash_algorithm`
   to ``OCSPResponse``.
+* Updated :doc:`/hazmat/primitives/asymmetric/x25519` support to allow
+  additional serialization methods. Zero argument calling of
+  :meth:`~cryptography.hazmat.primitives.asymmetric.x25519.X25519PublicKey.public_bytes`
+  has been deprecated.
 
 
 .. _v2-4-2:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,9 +38,9 @@ Changelog
 * Added :attr:`~cryptography.x509.ocsp.OCSPResponse.signature_hash_algorithm`
   to ``OCSPResponse``.
 * Updated :doc:`/hazmat/primitives/asymmetric/x25519` support to allow
-  additional serialization methods. Zero argument calling of
+  additional serialization methods. Calling
   :meth:`~cryptography.hazmat.primitives.asymmetric.x25519.X25519PublicKey.public_bytes`
-  has been deprecated.
+  with no arguments has been deprecated.
 
 
 .. _v2-4-2:

--- a/docs/hazmat/primitives/asymmetric/x25519.rst
+++ b/docs/hazmat/primitives/asymmetric/x25519.rst
@@ -66,6 +66,26 @@ Key interfaces
 
         :returns: :class:`X25519PrivateKey`
 
+    .. classmethod:: from_private_bytes(data)
+
+        .. versionadded:: 2.5
+
+        :param bytes data: 32 byte private key.
+
+        :returns: :class:`X25519PrivateKey`
+
+        .. doctest::
+
+            >>> from cryptography.hazmat.primitives import serialization
+            >>> from cryptography.hazmat.primitives.asymmetric import x25519
+            >>> private_key = x25519.X25519PrivateKey.generate()
+            >>> private_bytes = private_key.private_bytes(
+            ...     encoding=serialization.Encoding.Raw,
+            ...     format=serialization.PrivateFormat.Raw,
+            ...     encryption_algorithm=serialization.NoEncryption()
+            ... )
+            >>> loaded_private_key = x25519.X25519PrivateKey.from_private_bytes(private_bytes)
+
     .. method:: public_key()
 
         :returns: :class:`X25519PublicKey`
@@ -76,6 +96,38 @@ Key interfaces
             peer.
 
         :returns bytes: A shared key.
+
+    .. method:: private_bytes(encoding, format, encryption_algorithm)
+
+        .. versionadded:: 2.5
+
+        Allows serialization of the key to bytes. Encoding (
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`,
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`, or
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`) and
+        format (
+        :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`
+        or
+        :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.Raw`
+        ) are chosen to define the exact serialization.
+
+        :param encoding: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+        :param format: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.PrivateFormat`
+            enum. If the ``encoding`` is
+            :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
+            then ``format`` must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.Raw`
+            , otherwise it must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8`.
+
+        :param encryption_algorithm: An instance of an object conforming to the
+            :class:`~cryptography.hazmat.primitives.serialization.KeySerializationEncryption`
+            interface.
+
+        :return bytes: Serialized key.
 
 .. class:: X25519PublicKey
 
@@ -92,12 +144,37 @@ Key interfaces
             >>> from cryptography.hazmat.primitives.asymmetric import x25519
             >>> private_key = x25519.X25519PrivateKey.generate()
             >>> public_key = private_key.public_key()
-            >>> public_bytes = public_key.public_bytes()
+            >>> public_bytes = public_key.public_bytes(
+            ...     encoding=serialization.Encoding.Raw,
+            ...     format=serialization.PublicFormat.Raw
+            ... )
             >>> loaded_public_key = x25519.X25519PublicKey.from_public_bytes(public_bytes)
 
-    .. method:: public_bytes()
+    .. method:: public_bytes(encoding, format)
 
-        :returns bytes: The raw bytes of the public key.
+        Allows serialization of the key to bytes. Encoding (
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`,
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`, or
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`) and
+        format (
+        :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`
+        or
+        :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.Raw`
+        ) are chosen to define the exact serialization.
+
+        :param encoding: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.Encoding` enum.
+
+        :param format: A value from the
+            :class:`~cryptography.hazmat.primitives.serialization.PublicFormat`
+            enum. If the ``encoding`` is
+            :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`
+            then ``format`` must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.Raw`
+            , otherwise it must be
+            :attr:`~cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo`.
+
+        :returns bytes: The public key bytes.
 
 
 .. _`Diffie-Hellman key exchange`: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange

--- a/docs/hazmat/primitives/asymmetric/x25519.rst
+++ b/docs/hazmat/primitives/asymmetric/x25519.rst
@@ -70,6 +70,9 @@ Key interfaces
 
         .. versionadded:: 2.5
 
+        A class method for loading an X25519 key encoded as
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.Raw`.
+
         :param bytes data: 32 byte private key.
 
         :returns: :class:`X25519PrivateKey`

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -511,6 +511,9 @@ class Backend(object):
         elif key_type == getattr(self._lib, "EVP_PKEY_X448", None):
             # EVP_PKEY_X448 is not present in OpenSSL < 1.1.1
             return _X448PrivateKey(self, evp_pkey)
+        elif key_type == getattr(self._lib, "EVP_PKEY_X25519", None):
+            # EVP_PKEY_X25519 is not present in OpenSSL < 1.1.0
+            return _X25519PrivateKey(self, evp_pkey)
         else:
             raise UnsupportedAlgorithm("Unsupported key type.")
 
@@ -545,6 +548,9 @@ class Backend(object):
         elif key_type == getattr(self._lib, "EVP_PKEY_X448", None):
             # EVP_PKEY_X448 is not present in OpenSSL < 1.1.1
             return _X448PublicKey(self, evp_pkey)
+        elif key_type == getattr(self._lib, "EVP_PKEY_X25519", None):
+            # EVP_PKEY_X25519 is not present in OpenSSL < 1.1.0
+            return _X25519PublicKey(self, evp_pkey)
         else:
             raise UnsupportedAlgorithm("Unsupported key type.")
 

--- a/src/cryptography/hazmat/backends/openssl/x25519.py
+++ b/src/cryptography/hazmat/backends/openssl/x25519.py
@@ -4,10 +4,19 @@
 
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 from cryptography import utils
 from cryptography.hazmat.backends.openssl.utils import _evp_pkey_derive
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x25519 import (
     X25519PrivateKey, X25519PublicKey
+)
+
+
+_X25519_KEY_SIZE = 32
+_PEM_DER = (
+    serialization.Encoding.PEM, serialization.Encoding.DER
 )
 
 
@@ -17,7 +26,47 @@ class _X25519PublicKey(object):
         self._backend = backend
         self._evp_pkey = evp_pkey
 
-    def public_bytes(self):
+    def public_bytes(self, encoding=None, format=None):
+        if encoding is None or format is None:
+            if encoding is not None or format is not None:
+                raise ValueError("Both encoding and format are required")
+            else:
+                warnings.warn(
+                    "public_bytes now requires encoding and format arguments. "
+                    "Support for calling without arguments will be removed in "
+                    "cryptography 2.7",
+                    utils.DeprecatedIn25,
+                )
+                encoding = serialization.Encoding.Raw
+                format = serialization.PublicFormat.Raw
+        if (
+            encoding is serialization.Encoding.Raw or
+            format is serialization.PublicFormat.Raw
+        ):
+            if (
+                encoding is not serialization.Encoding.Raw or
+                format is not serialization.PublicFormat.Raw
+            ):
+                raise ValueError(
+                    "When using Raw both encoding and format must be Raw"
+                )
+
+            return self._raw_public_bytes()
+
+        if (
+            encoding in _PEM_DER and
+            format is not serialization.PublicFormat.SubjectPublicKeyInfo
+        ):
+            raise ValueError(
+                "format must be SubjectPublicKeyInfo when encoding is PEM or "
+                "DER"
+            )
+
+        return self._backend._public_key_bytes(
+            encoding, format, self, self._evp_pkey, None
+        )
+
+    def _raw_public_bytes(self):
         ucharpp = self._backend._ffi.new("unsigned char **")
         res = self._backend._lib.EVP_PKEY_get1_tls_encodedpoint(
             self._evp_pkey, ucharpp
@@ -56,3 +105,47 @@ class _X25519PrivateKey(object):
         return _evp_pkey_derive(
             self._backend, self._evp_pkey, peer_public_key
         )
+
+    def private_bytes(self, encoding, format, encryption_algorithm):
+        if (
+            encoding is serialization.Encoding.Raw or
+            format is serialization.PublicFormat.Raw
+        ):
+            if (
+                format is not serialization.PrivateFormat.Raw or
+                encoding is not serialization.Encoding.Raw or not
+                isinstance(encryption_algorithm, serialization.NoEncryption)
+            ):
+                raise ValueError(
+                    "When using Raw both encoding and format must be Raw "
+                    "and encryption_algorithm must be NoEncryption"
+                )
+
+            return self._raw_private_bytes()
+
+        if (
+            encoding in _PEM_DER and
+            format is not serialization.PrivateFormat.PKCS8
+        ):
+            raise ValueError(
+                "format must be PKCS8 when encoding is PEM or DER"
+            )
+
+        return self._backend._private_key_bytes(
+            encoding, format, encryption_algorithm, self._evp_pkey, None
+        )
+
+    def _raw_private_bytes(self):
+        # When we drop support for CRYPTOGRAPHY_OPENSSL_LESS_THAN_111 we can
+        # switch this to EVP_PKEY_new_raw_private_key
+        # The trick we use here is serializing to a PKCS8 key and just
+        # using the last 32 bytes, which is the key itself.
+        bio = self._backend._create_mem_bio_gc()
+        res = self._backend._lib.i2d_PKCS8PrivateKey_bio(
+            bio, self._evp_pkey,
+            self._backend._ffi.NULL, self._backend._ffi.NULL,
+            0, self._backend._ffi.NULL, self._backend._ffi.NULL
+        )
+        self._backend.openssl_assert(res == 1)
+        pkcs8 = self._backend._read_mem_bio(bio)
+        return pkcs8[-_X25519_KEY_SIZE:len(pkcs8)]

--- a/src/cryptography/hazmat/backends/openssl/x25519.py
+++ b/src/cryptography/hazmat/backends/openssl/x25519.py
@@ -148,4 +148,4 @@ class _X25519PrivateKey(object):
         )
         self._backend.openssl_assert(res == 1)
         pkcs8 = self._backend._read_mem_bio(bio)
-        return pkcs8[-_X25519_KEY_SIZE:len(pkcs8)]
+        return pkcs8[-_X25519_KEY_SIZE:]

--- a/src/cryptography/hazmat/backends/openssl/x25519.py
+++ b/src/cryptography/hazmat/backends/openssl/x25519.py
@@ -15,9 +15,6 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import (
 
 
 _X25519_KEY_SIZE = 32
-_PEM_DER = (
-    serialization.Encoding.PEM, serialization.Encoding.DER
-)
 
 
 @utils.register_interface(X25519PublicKey)
@@ -54,7 +51,7 @@ class _X25519PublicKey(object):
             return self._raw_public_bytes()
 
         if (
-            encoding in _PEM_DER and
+            encoding in serialization._PEM_DER and
             format is not serialization.PublicFormat.SubjectPublicKeyInfo
         ):
             raise ValueError(
@@ -124,7 +121,7 @@ class _X25519PrivateKey(object):
             return self._raw_private_bytes()
 
         if (
-            encoding in _PEM_DER and
+            encoding in serialization._PEM_DER and
             format is not serialization.PrivateFormat.PKCS8
         ):
             raise ValueError(
@@ -148,4 +145,5 @@ class _X25519PrivateKey(object):
         )
         self._backend.openssl_assert(res == 1)
         pkcs8 = self._backend._read_mem_bio(bio)
+        self._backend.openssl_assert(len(pkcs8) == 48)
         return pkcs8[-_X25519_KEY_SIZE:]

--- a/src/cryptography/hazmat/backends/openssl/x448.py
+++ b/src/cryptography/hazmat/backends/openssl/x448.py
@@ -12,9 +12,6 @@ from cryptography.hazmat.primitives.asymmetric.x448 import (
 )
 
 _X448_KEY_SIZE = 56
-_PEM_DER = (
-    serialization.Encoding.PEM, serialization.Encoding.DER
-)
 
 
 @utils.register_interface(X448PublicKey)
@@ -39,7 +36,7 @@ class _X448PublicKey(object):
             return self._raw_public_bytes()
 
         if (
-            encoding in _PEM_DER and
+            encoding in serialization._PEM_DER and
             format is not serialization.PublicFormat.SubjectPublicKeyInfo
         ):
             raise ValueError(
@@ -104,7 +101,7 @@ class _X448PrivateKey(object):
             return self._raw_private_bytes()
 
         if (
-            encoding in _PEM_DER and
+            encoding in serialization._PEM_DER and
             format is not serialization.PrivateFormat.PKCS8
         ):
             raise ValueError(

--- a/src/cryptography/hazmat/primitives/asymmetric/x25519.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x25519.py
@@ -28,7 +28,7 @@ class X25519PublicKey(object):
         return backend.x25519_load_public_bytes(data)
 
     @abc.abstractmethod
-    def public_bytes(self):
+    def public_bytes(self, encoding=None, format=None):
         """
         The serialized bytes of the public key.
         """
@@ -47,7 +47,7 @@ class X25519PrivateKey(object):
         return backend.x25519_generate_key()
 
     @classmethod
-    def _from_private_bytes(cls, data):
+    def from_private_bytes(cls, data):
         from cryptography.hazmat.backends.openssl.backend import backend
         return backend.x25519_load_private_bytes(data)
 
@@ -55,6 +55,12 @@ class X25519PrivateKey(object):
     def public_key(self):
         """
         The serialized bytes of the public key.
+        """
+
+    @abc.abstractmethod
+    def private_bytes(self, encoding, format, encryption_algorithm):
+        """
+        The serialized bytes of the private key.
         """
 
     @abc.abstractmethod

--- a/src/cryptography/hazmat/primitives/serialization/__init__.py
+++ b/src/cryptography/hazmat/primitives/serialization/__init__.py
@@ -14,6 +14,9 @@ from cryptography.hazmat.primitives.serialization.ssh import (
     load_ssh_public_key
 )
 
+
+_PEM_DER = (Encoding.PEM, Encoding.DER)
+
 __all__ = [
     "load_der_parameters", "load_der_private_key", "load_der_public_key",
     "load_pem_parameters", "load_pem_private_key", "load_pem_public_key",

--- a/tests/wycheproof/test_x25519.py
+++ b/tests/wycheproof/test_x25519.py
@@ -23,7 +23,7 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import (
 def test_x25519(backend, wycheproof):
     assert list(wycheproof.testgroup.items()) == [("curve", "curve25519")]
 
-    private_key = X25519PrivateKey._from_private_bytes(
+    private_key = X25519PrivateKey.from_private_bytes(
         binascii.unhexlify(wycheproof.testcase["private"])
     )
     public_key = X25519PublicKey.from_public_bytes(


### PR DESCRIPTION
supports raw and pkcs8 encoding on private_bytes and raw and subjectpublickeyinfo on public_bytes.

deprecates zero argument call to public_bytes.