### PR TITLE
turn off hypothesis deadlines, enforced by default in 4.0

### DIFF
--- a/tests/hypothesis/test_fernet.py
+++ b/tests/hypothesis/test_fernet.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import binary
 from cryptography.fernet import Fernet
 
 
-@settings(suppress_health_check=[HealthCheck.too_slow])
+@settings(suppress_health_check=[HealthCheck.too_slow], deadline=None)
 @given(binary())
 def test_fernet(data):
     f = Fernet(Fernet.generate_key())

--- a/tests/hypothesis/test_padding.py
+++ b/tests/hypothesis/test_padding.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import binary, integers
 from cryptography.hazmat.primitives.padding import ANSIX923, PKCS7
 
 
-@settings(suppress_health_check=[HealthCheck.too_slow])
+@settings(suppress_health_check=[HealthCheck.too_slow], deadline=None)
 @given(integers(min_value=1, max_value=255), binary())
 def test_pkcs7(block_size, data):
     # Generate in [1, 31] so we can easily get block_size in bits by


### PR DESCRIPTION
we don't care about exceeding a deadline in CI because our infra has wild variability and this can just randomly happen.