### PR TITLE
support byteslike in hash updates

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/hashes.py
+++ b/src/cryptography/hazmat/backends/openssl/hashes.py
@@ -47,7 +47,10 @@ class _HashContext(object):
         return _HashContext(self._backend, self.algorithm, ctx=copied_ctx)
 
     def update(self, data):
-        res = self._backend._lib.EVP_DigestUpdate(self._ctx, data, len(data))
+        data_ptr = self._backend._ffi.from_buffer(data)
+        res = self._backend._lib.EVP_DigestUpdate(
+            self._ctx, data_ptr, len(data)
+        )
         self._backend.openssl_assert(res != 0)
 
     def finalize(self):

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -82,7 +82,7 @@ class Hash(object):
     def update(self, data):
         if self._ctx is None:
             raise AlreadyFinalized("Context was already finalized.")
-        utils._check_bytes("data", data)
+        utils._check_byteslike("data", data)
         self._ctx.update(data)
 
     def copy(self):

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import binascii
+
 import pytest
 
 from cryptography.exceptions import AlreadyFinalized, _Reasons
@@ -167,3 +169,13 @@ def test_invalid_backend():
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
         hashes.Hash(hashes.SHA1(), pretend_backend)
+
+
+@pytest.mark.requires_backend_interface(interface=HashBackend)
+def test_buffer_protocol_hash(backend):
+    data = binascii.unhexlify(b"b4190e")
+    h = hashes.Hash(hashes.SHA256(), backend)
+    h.update(bytearray(data))
+    assert h.finalize() == binascii.unhexlify(
+        b"dff2e73091f6c05e528896c4c831b9448653dc2ff043528f6769437bc7b975c2"
+    )


### PR DESCRIPTION
This is needed to handle keying material in some of the KDFs