### PR TITLE
x448 and x25519 should enforce key lengths in backend

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2083,6 +2083,9 @@ class Backend(object):
     def x25519_load_public_bytes(self, data):
         # When we drop support for CRYPTOGRAPHY_OPENSSL_LESS_THAN_111 we can
         # switch this to EVP_PKEY_new_raw_public_key
+        if len(data) != 32:
+            raise ValueError("An X25519 public key is 32 bytes long")
+
         evp_pkey = self._create_evp_pkey_gc()
         res = self._lib.EVP_PKEY_set_type(evp_pkey, self._lib.NID_X25519)
         backend.openssl_assert(res == 1)
@@ -2108,6 +2111,9 @@ class Backend(object):
         # Of course there's a bit more complexity. In reality OCTET STRING
         # contains an OCTET STRING of length 32! So the last two bytes here
         # are \x04\x20, which is an OCTET STRING of length 32.
+        if len(data) != 32:
+            raise ValueError("An X25519 private key is 32 bytes long")
+
         pkcs8_prefix = b'0.\x02\x01\x000\x05\x06\x03+en\x04"\x04 '
         bio = self._bytes_to_bio(pkcs8_prefix + data)
         evp_pkey = backend._lib.d2i_PrivateKey_bio(bio.bio, self._ffi.NULL)
@@ -2139,6 +2145,9 @@ class Backend(object):
         return self._lib.CRYPTOGRAPHY_OPENSSL_110_OR_GREATER
 
     def x448_load_public_bytes(self, data):
+        if len(data) != 56:
+            raise ValueError("An X448 public key is 56 bytes long")
+
         evp_pkey = self._lib.EVP_PKEY_new_raw_public_key(
             self._lib.NID_X448, self._ffi.NULL, data, len(data)
         )
@@ -2147,6 +2156,9 @@ class Backend(object):
         return _X448PublicKey(self, evp_pkey)
 
     def x448_load_private_bytes(self, data):
+        if len(data) != 56:
+            raise ValueError("An X448 private key is 56 bytes long")
+
         data_ptr = self._ffi.from_buffer(data)
         evp_pkey = self._lib.EVP_PKEY_new_raw_private_key(
             self._lib.NID_X448, self._ffi.NULL, data_ptr, len(data)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2139,9 +2139,6 @@ class Backend(object):
         return self._lib.CRYPTOGRAPHY_OPENSSL_110_OR_GREATER
 
     def x448_load_public_bytes(self, data):
-        if len(data) != 56:
-            raise ValueError("An X448 public key is 56 bytes long")
-
         evp_pkey = self._lib.EVP_PKEY_new_raw_public_key(
             self._lib.NID_X448, self._ffi.NULL, data, len(data)
         )

--- a/src/cryptography/hazmat/primitives/asymmetric/x25519.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x25519.py
@@ -22,9 +22,6 @@ class X25519PublicKey(object):
                 _Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
             )
 
-        if len(data) != 32:
-            raise ValueError("An X25519 public key is 32 bytes long")
-
         return backend.x25519_load_public_bytes(data)
 
     @abc.abstractmethod
@@ -54,9 +51,6 @@ class X25519PrivateKey(object):
                 "X25519 is not supported by this version of OpenSSL.",
                 _Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
             )
-
-        if len(data) != 32:
-            raise ValueError("An X25519 private key is 32 bytes long")
 
         return backend.x25519_load_private_bytes(data)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/x25519.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x25519.py
@@ -49,6 +49,15 @@ class X25519PrivateKey(object):
     @classmethod
     def from_private_bytes(cls, data):
         from cryptography.hazmat.backends.openssl.backend import backend
+        if not backend.x25519_supported():
+            raise UnsupportedAlgorithm(
+                "X25519 is not supported by this version of OpenSSL.",
+                _Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
+            )
+
+        if len(data) != 32:
+            raise ValueError("An X25519 private key is 32 bytes long")
+
         return backend.x25519_load_private_bytes(data)
 
     @abc.abstractmethod

--- a/src/cryptography/hazmat/primitives/asymmetric/x448.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x448.py
@@ -22,9 +22,6 @@ class X448PublicKey(object):
                 _Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
             )
 
-        if len(data) != 56:
-            raise ValueError("An X448 public key is 56 bytes long")
-
         return backend.x448_load_public_bytes(data)
 
     @abc.abstractmethod
@@ -54,9 +51,6 @@ class X448PrivateKey(object):
                 "X448 is not supported by this version of OpenSSL.",
                 _Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
             )
-
-        if len(data) != 56:
-            raise ValueError("An X448 private key is 56 bytes long")
 
         return backend.x448_load_private_bytes(data)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/x448.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x448.py
@@ -22,6 +22,9 @@ class X448PublicKey(object):
                 _Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
             )
 
+        if len(data) != 56:
+            raise ValueError("An X448 public key is 56 bytes long")
+
         return backend.x448_load_public_bytes(data)
 
     @abc.abstractmethod
@@ -46,6 +49,15 @@ class X448PrivateKey(object):
     @classmethod
     def from_private_bytes(cls, data):
         from cryptography.hazmat.backends.openssl.backend import backend
+        if not backend.x448_supported():
+            raise UnsupportedAlgorithm(
+                "X448 is not supported by this version of OpenSSL.",
+                _Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
+            )
+
+        if len(data) != 56:
+            raise ValueError("An X448 private key is 56 bytes long")
+
         return backend.x448_load_private_bytes(data)
 
     @abc.abstractmethod

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -32,6 +32,9 @@ def test_x25519_unsupported(backend):
         X25519PublicKey.from_public_bytes(b"0" * 32)
 
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
+        X25519PublicKey.from_private_bytes(b"0" * 32)
+
+    with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
         X25519PrivateKey.generate()
 
 
@@ -165,6 +168,13 @@ class TestX25519Exchange(object):
 
         with pytest.raises(ValueError):
             X25519PublicKey.from_public_bytes(b"a" * 33)
+
+    def test_invalid_length_from_private_bytes(self, backend):
+        with pytest.raises(ValueError):
+            X25519PrivateKey.from_private_bytes(b"a" * 31)
+
+        with pytest.raises(ValueError):
+            X25519PrivateKey.from_private_bytes(b"a" * 33)
 
     def test_invalid_private_bytes(self, backend):
         key = X25519PrivateKey.generate()

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -32,7 +32,7 @@ def test_x25519_unsupported(backend):
         X25519PublicKey.from_public_bytes(b"0" * 32)
 
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
-        X25519PublicKey.from_private_bytes(b"0" * 32)
+        X25519PrivateKey.from_private_bytes(b"0" * 32)
 
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
         X25519PrivateKey.generate()

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -28,7 +28,10 @@ from ...utils import (
 @pytest.mark.requires_backend_interface(interface=DHBackend)
 def test_x448_unsupported(backend):
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
-        X448PublicKey.from_public_bytes(b"0" * 32)
+        X448PublicKey.from_public_bytes(b"0" * 56)
+
+    with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
+        X448PrivateKey.from_private_bytes(b"0" * 56)
 
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
         X448PrivateKey.generate()
@@ -175,6 +178,13 @@ class TestX448Exchange(object):
 
         with pytest.raises(ValueError):
             X448PublicKey.from_public_bytes(b"a" * 57)
+
+    def test_invalid_length_from_private_bytes(self, backend):
+        with pytest.raises(ValueError):
+            X448PrivateKey.from_private_bytes(b"a" * 55)
+
+        with pytest.raises(ValueError):
+            X448PrivateKey.from_private_bytes(b"a" * 57)
 
     def test_invalid_private_bytes(self, backend):
         key = X448PrivateKey.generate()


### PR DESCRIPTION
they should also check if the algorithm is supported like the public bytes class methods do