### PR TITLE
use OpenSSL 1.1.1's internal RNG + atfork handlers where possible

### DIFF
--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -12,6 +12,7 @@ TYPES = """
 static const long Cryptography_HAS_LOCKING_CALLBACKS;
 static const long Cryptography_HAS_MEM_FUNCTIONS;
 static const long Cryptography_HAS_OPENSSL_CLEANUP;
+static const long Cryptography_HAS_OPENSSL_INIT_CRYPTO;
 
 static const int SSLEAY_VERSION;
 static const int SSLEAY_CFLAGS;
@@ -31,6 +32,10 @@ static const int CRYPTO_LOCK;
 static const int CRYPTO_UNLOCK;
 static const int CRYPTO_READ;
 static const int CRYPTO_LOCK_SSL;
+
+static const int OPENSSL_INIT_ATFORK;
+
+typedef ... OPENSSL_INIT_SETTINGS;
 """
 
 FUNCTIONS = """
@@ -58,6 +63,8 @@ void OPENSSL_free(void *);
 
 /* This was removed in 1.1.0 */
 void CRYPTO_lock(int, int, const char *, int);
+
+int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *);
 
 /* Signature changed significantly in 1.1.0, only expose there for sanity */
 int Cryptography_CRYPTO_set_mem_functions(
@@ -93,6 +100,21 @@ CUSTOMIZATIONS = """
 # define OPENSSL_BUILT_ON        SSLEAY_BUILT_ON
 # define OPENSSL_PLATFORM        SSLEAY_PLATFORM
 # define OPENSSL_DIR             SSLEAY_DIR
+#endif
+#ifndef OPENSSL_INIT_ATFORK
+#define OPENSSL_INIT_ATFORK 0x00020000L
+#endif
+#if CRYPTOGRAPHY_IS_LIBRESSL
+typedef void OPENSSL_INIT_SETTINGS;
+#endif
+#if (!CRYPTOGRAPHY_IS_LIBRESSL && CRYPTOGRAPHY_OPENSSL_LESS_THAN_110) || \
+    (CRYPTOGRAPHY_IS_LIBRESSL && !CRYPTOGRAPHY_LIBRESSL_27_OR_GREATER)
+static const long Cryptography_HAS_OPENSSL_INIT_CRYPTO = 0;
+typedef void OPENSSL_INIT_SETTINGS;
+int (*OPENSSL_init_crypto)(uint64_t opts,
+                           const OPENSSL_INIT_SETTINGS *) = NULL;
+#else
+static const long Cryptography_HAS_OPENSSL_INIT_CRYPTO = 1;
 #endif
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
 static const long Cryptography_HAS_LOCKING_CALLBACKS = 1;

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -111,7 +111,9 @@ class Backend(object):
 
         self._cipher_registry = {}
         self._register_default_ciphers()
-        self.activate_osrandom_engine()
+        if self._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111:
+            # Only activate the osrandom engine by default with OpenSSL < 1.1.1
+            self.activate_osrandom_engine()
         self._dh_types = [self._lib.EVP_PKEY_DH]
         if self._lib.Cryptography_HAS_EVP_PKEY_DHX:
             self._dh_types.append(self._lib.EVP_PKEY_DHX)

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -301,6 +301,12 @@ def cryptography_has_openssl_cleanup():
     ]
 
 
+def cryptography_has_openssl_init_crypto():
+    return [
+        "OPENSSL_init_crypto",
+    ]
+
+
 def cryptography_has_cipher_details():
     return [
         "SSL_CIPHER_is_aead",
@@ -397,6 +403,9 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_PSK": cryptography_has_psk,
     "Cryptography_HAS_CUSTOM_EXT": cryptography_has_custom_ext,
     "Cryptography_HAS_OPENSSL_CLEANUP": cryptography_has_openssl_cleanup,
+    "Cryptography_HAS_OPENSSL_INIT_CRYPTO": (
+        cryptography_has_openssl_init_crypto
+    ),
     "Cryptography_HAS_CIPHER_DETAILS": cryptography_has_cipher_details,
     "Cryptography_HAS_TLSv1_3": cryptography_has_tlsv13,
     "Cryptography_HAS_RAW_KEY": cryptography_has_raw_key,

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -114,8 +114,20 @@ class Binding(object):
         # reliably clear the error queue. Once we clear it here we will
         # error on any subsequent unexpected item in the stack.
         cls.lib.ERR_clear_error()
+        if not cls.lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111:
+            # In OpenSSL 1.1.1 and above the internal RNG can be made forksafe
+            # by calling OPENSSL_INIT_ATFORK to register the proper fork
+            # handlers. In this case we init that and do not activate our
+            # own engine, although we do add it still.
+            result = cls.lib.OPENSSL_init_crypto(
+                cls.lib.OPENSSL_INIT_ATFORK, cls.ffi.NULL
+            )
+            _openssl_assert(cls.lib, result == 1)
+
         cls._osrandom_engine_id = cls.lib.Cryptography_osrandom_engine_id
-        cls._osrandom_engine_name = cls.lib.Cryptography_osrandom_engine_name
+        cls._osrandom_engine_name = (
+            cls.lib.Cryptography_osrandom_engine_name
+        )
         result = cls.lib.Cryptography_add_osrandom_engine()
         _openssl_assert(cls.lib, result in (1, 2))
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -170,6 +170,10 @@ class TestOpenSSL(object):
         assert backend._bn_to_int(bn) == 0
 
 
+@pytest.mark.skipif(
+    not backend._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111,
+    reason="Requires OpenSSL < 1.1.1",
+)
 class TestOpenSSLRandomEngine(object):
     def setup(self):
         # The default RAND engine is global and shared between
@@ -292,6 +296,15 @@ class TestOpenSSLRandomEngine(object):
         assert name == backend._binding._osrandom_engine_name
         res = backend._lib.ENGINE_free(e)
         assert res == 1
+
+
+@pytest.mark.skipif(
+    backend._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111,
+    reason="Requires OpenSSL >= 1.1.1",
+)
+def test_default_random_is_not_osrandom():
+    e = backend._lib.ENGINE_get_default_RAND()
+    assert e == backend._ffi.NULL
 
 
 class TestOpenSSLRSA(object):


### PR DESCRIPTION
Well, I made this, but I'm not actually convinced we should merge it. This doesn't really gain us much until 1.1.1 is the lowest version we support (timeline on that: at least 5 years, probably more like 8-10?).