### PR TITLE
bind EVP_R_MEMORY_LIMIT_EXCEEDED and update a test

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -178,4 +178,5 @@ static const long Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED = 1;
 #else
 static const long EVP_R_MEMORY_LIMIT_EXCEEDED = 0;
 static const long Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED = 0;
+#endif
 """

--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -11,6 +11,7 @@ INCLUDES = """
 TYPES = """
 static const int Cryptography_HAS_EC_CODES;
 static const int Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR;
+static const int Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED;
 
 static const int ERR_LIB_DH;
 static const int ERR_LIB_EVP;
@@ -23,6 +24,7 @@ static const int ERR_LIB_SSL;
 static const int ERR_LIB_X509;
 
 static const int ERR_R_MALLOC_FAILURE;
+static const int EVP_R_MEMORY_LIMIT_EXCEEDED;
 
 static const int ASN1_R_BOOLEAN_IS_WRONG_LENGTH;
 static const int ASN1_R_BUFFER_TOO_SMALL;
@@ -170,4 +172,10 @@ static const long Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR = 1;
 static const long Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR = 0;
 static const long RSA_R_PKCS_DECODING_ERROR = 0;
 #endif
+
+#ifdef EVP_R_MEMORY_LIMIT_EXCEEDED
+static const long Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED = 1;
+#else
+static const long EVP_R_MEMORY_LIMIT_EXCEEDED = 0;
+static const long Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED = 0;
 """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2210,6 +2210,10 @@ class Backend(object):
                     errors[0]._lib_reason_match(
                         self._lib.ERR_LIB_EVP,
                         self._lib.ERR_R_MALLOC_FAILURE
+                    ) or
+                    errors[0]._lib_reason_match(
+                        self._lib.ERR_LIB_EVP,
+                        self._lib.EVP_R_MEMORY_LIMIT_EXCEEDED
                     )
                 )
 

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -335,6 +335,12 @@ def cryptography_has_raw_key():
     ]
 
 
+def cryptography_has_evp_r_memory_limit_exceeded():
+    return [
+        "EVP_R_MEMORY_LIMIT_EXCEEDED",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -402,5 +408,8 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_RAW_KEY": cryptography_has_raw_key,
     "Cryptography_HAS_EVP_DIGESTFINAL_XOF": (
         cryptography_has_evp_digestfinal_xof
+    ),
+    "Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED": (
+        cryptography_has_evp_r_memory_limit_exceeded
     ),
 }


### PR DESCRIPTION
This will allow OpenSSL 1.1.1 on 32-bit (including our Windows 32-bit builders) to fail as expected. Technically this isn't a malloc error, but rather failing because the allocation requested is larger than 32-bits, but raising a MemoryError still seems appropriate