### PR TITLE
docs: full state or province name when generating a sample certificate

### DIFF
--- a/docs/x509/tutorial.rst
+++ b/docs/x509/tutorial.rst
@@ -63,7 +63,7 @@ a few details:
     >>> csr = x509.CertificateSigningRequestBuilder().subject_name(x509.Name([
     ...     # Provide various details about who we are.
     ...     x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
-    ...     x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"CA"),
+    ...     x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"California"),
     ...     x509.NameAttribute(NameOID.LOCALITY_NAME, u"San Francisco"),
     ...     x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"My Company"),
     ...     x509.NameAttribute(NameOID.COMMON_NAME, u"mysite.com"),
@@ -123,7 +123,7 @@ Then we generate the certificate itself:
     >>> # subject and issuer are always the same.
     >>> subject = issuer = x509.Name([
     ...     x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
-    ...     x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"CA"),
+    ...     x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"California"),
     ...     x509.NameAttribute(NameOID.LOCALITY_NAME, u"San Francisco"),
     ...     x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"My Company"),
     ...     x509.NameAttribute(NameOID.COMMON_NAME, u"mysite.com"),


### PR DESCRIPTION
Generally, it appears that a state or province name is not abbreviated, but is rather the full name.

6.3.5 of ITU-T X.520 (10/2016) provides a spelled out sample state. In other contexts, hints suggest the "full name" of a state or province.

Accordingly, replacement of CA with California in the sample code might be more consistent with general usage.