### PR TITLE
Fix compilation without deprecated OpenSSL 1.1 APIs

### DIFF
--- a/src/_cffi_src/openssl/asn1.py
+++ b/src/_cffi_src/openssl/asn1.py
@@ -41,7 +41,6 @@ FUNCTIONS = """
 void ASN1_OBJECT_free(ASN1_OBJECT *);
 
 /*  ASN1 STRING */
-unsigned char *ASN1_STRING_data(ASN1_STRING *);
 int ASN1_STRING_set(ASN1_STRING *, const void *, int);
 
 /*  ASN1 OCTET STRING */
@@ -103,4 +102,9 @@ ASN1_NULL *ASN1_NULL_new(void);
 """
 
 CUSTOMIZATIONS = """
+#if CRYPTOGRAPHY_OPENSSL_110_OR_GREATER
+const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x);
+#else
+unsigned char *ASN1_STRING_data(ASN1_STRING *);
+#endif
 """

--- a/src/_cffi_src/openssl/conf.py
+++ b/src/_cffi_src/openssl/conf.py
@@ -12,10 +12,12 @@ TYPES = """
 """
 
 FUNCTIONS = """
-void OPENSSL_config(const char *);
-/* This is a macro in 1.1.0 */
-void OPENSSL_no_config(void);
 """
 
 CUSTOMIZATIONS = """
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 || CRYPTOGRAPHY_IS_LIBRESSL
+void OPENSSL_config(const char *);
+/* This is a macro in 1.1.0 */
+void OPENSSL_no_config(void);
+#endif
 """

--- a/src/_cffi_src/openssl/crypto.py
+++ b/src/_cffi_src/openssl/crypto.py
@@ -36,14 +36,7 @@ static const int CRYPTO_LOCK_SSL;
 FUNCTIONS = """
 int CRYPTO_mem_ctrl(int);
 
-void CRYPTO_cleanup_all_ex_data(void);
 void OPENSSL_cleanup(void);
-
-/* as of 1.1.0 OpenSSL does its own locking *angelic chorus*. These functions
-   have become macros that are no ops */
-int CRYPTO_num_locks(void);
-void CRYPTO_set_locking_callback(void(*)(int, int, const char *, int));
-void (*CRYPTO_get_locking_callback(void))(int, int, const char *, int);
 
 /* SSLeay was removed in 1.1.0 */
 unsigned long SSLeay(void);
@@ -118,6 +111,8 @@ static const long Cryptography_HAS_OPENSSL_CLEANUP = 0;
 
 void (*OPENSSL_cleanup)(void) = NULL;
 
+void CRYPTO_cleanup_all_ex_data(void);
+
 /* This function has a significantly different signature pre-1.1.0. since it is
  * for testing only, we don't bother to expose it on older OpenSSLs.
  */
@@ -152,4 +147,12 @@ void *Cryptography_realloc_wrapper(void *ptr, size_t size, const char *path,
 void Cryptography_free_wrapper(void *ptr, const char *path, int line) {
     free(ptr);
 }
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+/* as of 1.1.0 OpenSSL does its own locking *angelic chorus*. These functions
+   have become macros that are no ops */
+int CRYPTO_num_locks(void);
+void CRYPTO_set_locking_callback(void(*)(int, int, const char *, int));
+void (*CRYPTO_get_locking_callback(void))(int, int, const char *, int);
+#endif
 """

--- a/src/_cffi_src/openssl/engine.py
+++ b/src/_cffi_src/openssl/engine.py
@@ -123,11 +123,13 @@ const ENGINE_CMD_DEFN *ENGINE_get_cmd_defns(const ENGINE *);
 EVP_PKEY *ENGINE_load_private_key(ENGINE *, const char *, UI_METHOD *, void *);
 EVP_PKEY *ENGINE_load_public_key(ENGINE *, const char *, UI_METHOD *, void *);
 void ENGINE_add_conf_module(void);
+"""
+
+CUSTOMIZATIONS = """
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
 /* these became macros in 1.1.0 */
 void ENGINE_load_openssl(void);
 void ENGINE_load_dynamic(void);
 void ENGINE_cleanup(void);
-"""
-
-CUSTOMIZATIONS = """
+#endif
 """

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -60,7 +60,6 @@ int EVP_CipherUpdate(EVP_CIPHER_CTX *, unsigned char *, int *,
                      const unsigned char *, int);
 int EVP_CipherFinal_ex(EVP_CIPHER_CTX *, unsigned char *, int *);
 int EVP_CIPHER_block_size(const EVP_CIPHER *);
-int EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *);
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void);
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *);
 int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *, int);
@@ -176,10 +175,6 @@ EVP_PKEY *EVP_PKCS82PKEY(PKCS8_PRIV_KEY_INFO *);
 /* EVP_PKEY * became const in 1.1.0 */
 int EVP_PKEY_bits(EVP_PKEY *);
 
-/* became a macro in 1.1.0 */
-void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *);
-
-void OpenSSL_add_all_algorithms(void);
 int EVP_PKEY_assign_RSA(EVP_PKEY *, RSA *);
 int EVP_PKEY_assign_DSA(EVP_PKEY *, DSA *);
 
@@ -316,5 +311,12 @@ static const long Cryptography_HAS_EVP_DIGESTFINAL_XOF = 1;
    conditional to remove it. */
 #ifndef EVP_PKEY_ED448
 #define EVP_PKEY_ED448 NID_ED448
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+/* became a macro in 1.1.0 */
+void EVP_CIPHER_CTX_init(EVP_CIPHER_CTX *);
+int EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *);
+void OpenSSL_add_all_algorithms(void);
 #endif
 """

--- a/src/_cffi_src/openssl/objects.py
+++ b/src/_cffi_src/openssl/objects.py
@@ -33,9 +33,11 @@ int OBJ_cmp(const ASN1_OBJECT *, const ASN1_OBJECT *);
 ASN1_OBJECT *OBJ_dup(const ASN1_OBJECT *);
 int OBJ_create(const char *, const char *, const char *);
 void OBJ_NAME_do_all(int, void (*) (const OBJ_NAME *, void *), void *);
-/* OBJ_cleanup became a macro in 1.1.0 */
-void OBJ_cleanup(void);
 """
 
 CUSTOMIZATIONS = """
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+/* OBJ_cleanup became a macro in 1.1.0 */
+void OBJ_cleanup(void);
+#endif
 """

--- a/src/_cffi_src/openssl/rand.py
+++ b/src/_cffi_src/openssl/rand.py
@@ -22,10 +22,13 @@ int RAND_bytes(unsigned char *, int);
    pyOpenSSL (which calls this in its rand.py as of mid-2016) */
 void ERR_load_RAND_strings(void);
 
-/* RAND_cleanup became a macro in 1.1.0 */
-void RAND_cleanup(void);
 """
 
 CUSTOMIZATIONS = """
 static const long Cryptography_HAS_EGD = 0;
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+/* RAND_cleanup became a macro in 1.1.0 */
+void RAND_cleanup(void);
+#endif
 """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -15,9 +15,12 @@ static const long Cryptography_HAS_SSL_ST;
 static const long Cryptography_HAS_TLS_ST;
 static const long Cryptography_HAS_SSL2;
 static const long Cryptography_HAS_SSL3_METHOD;
+static const long Cryptography_HAS_TLSv1;
 static const long Cryptography_HAS_TLSv1_1;
 static const long Cryptography_HAS_TLSv1_2;
 static const long Cryptography_HAS_TLSv1_3;
+static const long Cryptography_HAS_DTLSv1;
+static const long Cryptography_HAS_DTLSv1_2;
 static const long Cryptography_HAS_SECURE_RENEGOTIATION;
 static const long Cryptography_HAS_COMPRESSION;
 static const long Cryptography_HAS_TLSEXT_STATUS_REQ_CB;
@@ -28,6 +31,7 @@ static const long Cryptography_HAS_SSL_CTX_SET_CLIENT_CERT_ENGINE;
 static const long Cryptography_HAS_SSL_CTX_CLEAR_OPTIONS;
 static const long Cryptography_HAS_DTLS;
 static const long Cryptography_HAS_GENERIC_DTLS_METHOD;
+static const long Cryptography_HAS_GENERIC_TLS_METHOD;
 static const long Cryptography_HAS_SIGALGS;
 static const long Cryptography_HAS_PSK;
 static const long Cryptography_HAS_CIPHER_DETAILS;
@@ -307,9 +311,6 @@ Cryptography_STACK_OF_X509_NAME *SSL_load_client_CA_file(const char *);
 const char *SSL_get_servername(const SSL *, const int);
 /* Function signature changed to const char * in 1.1.0 */
 const char *SSL_CIPHER_get_version(const SSL_CIPHER *);
-/* These became macros in 1.1.0 */
-int SSL_library_init(void);
-void SSL_load_error_strings(void);
 
 /* these CRYPTO_EX_DATA functions became macros in 1.1.0 */
 int SSL_get_ex_new_index(long, void *, CRYPTO_EX_new *, CRYPTO_EX_dup *,
@@ -373,25 +374,6 @@ unsigned long SSL_CTX_add_extra_chain_cert(SSL_CTX *, X509 *);
  * TLSv1_1 and TLSv1_2 are recent additions.  Only sufficiently new versions of
  * OpenSSL support them.
  */
-const SSL_METHOD *TLSv1_1_method(void);
-const SSL_METHOD *TLSv1_1_server_method(void);
-const SSL_METHOD *TLSv1_1_client_method(void);
-
-const SSL_METHOD *TLSv1_2_method(void);
-const SSL_METHOD *TLSv1_2_server_method(void);
-const SSL_METHOD *TLSv1_2_client_method(void);
-
-const SSL_METHOD *SSLv3_method(void);
-const SSL_METHOD *SSLv3_server_method(void);
-const SSL_METHOD *SSLv3_client_method(void);
-
-const SSL_METHOD *TLSv1_method(void);
-const SSL_METHOD *TLSv1_server_method(void);
-const SSL_METHOD *TLSv1_client_method(void);
-
-const SSL_METHOD *DTLSv1_method(void);
-const SSL_METHOD *DTLSv1_server_method(void);
-const SSL_METHOD *DTLSv1_client_method(void);
 
 /* Added in 1.0.2 */
 const SSL_METHOD *DTLS_method(void);
@@ -627,6 +609,69 @@ SSL_METHOD* (*SSLv3_client_method)(void) = NULL;
 SSL_METHOD* (*SSLv3_server_method)(void) = NULL;
 #else
 static const long Cryptography_HAS_SSL3_METHOD = 1;
+const SSL_METHOD *SSLv3_method(void);
+const SSL_METHOD *SSLv3_server_method(void);
+const SSL_METHOD *SSLv3_client_method(void);
+#endif
+
+#ifdef OPENSSL_NO_TLS1_METHOD
+static const long Cryptography_HAS_TLSv1 = 0;
+SSL_METHOD* (*TLSv1_method)(void) = NULL;
+SSL_METHOD* (*TLSv1_client_method)(void) = NULL;
+SSL_METHOD* (*TLSv1_server_method)(void) = NULL;
+#else
+static const long Cryptography_HAS_TLSv1 = 1;
+const SSL_METHOD *TLSv1_method(void);
+const SSL_METHOD *TLSv1_server_method(void);
+const SSL_METHOD *TLSv1_client_method(void);
+#endif
+
+#ifdef OPENSSL_NO_TLS1_1_METHOD
+static const long Cryptography_HAS_TLSv1_1 = 0;
+SSL_METHOD* (*TLSv1_1_method)(void) = NULL;
+SSL_METHOD* (*TLSv1_1_client_method)(void) = NULL;
+SSL_METHOD* (*TLSv1_1_server_method)(void) = NULL;
+#else
+static const long Cryptography_HAS_TLSv1_1 = 1;
+const SSL_METHOD *TLSv1_1_method(void);
+const SSL_METHOD *TLSv1_1_server_method(void);
+const SSL_METHOD *TLSv1_1_client_method(void);
+#endif
+
+#ifdef OPENSSL_NO_TLS1_2_METHOD
+static const long Cryptography_HAS_TLSv1_2 = 0;
+SSL_METHOD* (*TLSv1_2_method)(void) = NULL;
+SSL_METHOD* (*TLSv1_2_client_method)(void) = NULL;
+SSL_METHOD* (*TLSv1_2_server_method)(void) = NULL;
+#else
+static const long Cryptography_HAS_TLSv1_2 = 1;
+const SSL_METHOD *TLSv1_2_method(void);
+const SSL_METHOD *TLSv1_2_server_method(void);
+const SSL_METHOD *TLSv1_2_client_method(void);
+#endif
+
+#ifdef OPENSSL_NO_DTLS1_METHOD
+static const long Cryptography_HAS_DTLSv1 = 0;
+SSL_METHOD* (*DTLSv1_method)(void) = NULL;
+SSL_METHOD* (*DTLSv1_client_method)(void) = NULL;
+SSL_METHOD* (*DTLSv1_server_method)(void) = NULL;
+#else
+static const long Cryptography_HAS_DTLSv1 = 1;
+const SSL_METHOD *DTLSv1_method(void);
+const SSL_METHOD *DTLSv1_server_method(void);
+const SSL_METHOD *DTLSv1_client_method(void);
+#endif
+
+#ifdef OPENSSL_NO_DTLS1_2_METHOD
+static const long Cryptography_HAS_DTLSv1_2 = 0;
+SSL_METHOD* (*DTLSv1_2_method)(void) = NULL;
+SSL_METHOD* (*DTLSv1_2_client_method)(void) = NULL;
+SSL_METHOD* (*DTLSv1_2_server_method)(void) = NULL;
+#else
+static const long Cryptography_HAS_DTLSv1_2 = 1;
+const SSL_METHOD *DTLSv1_2_method(void);
+const SSL_METHOD *DTLSv1_2_server_method(void);
+const SSL_METHOD *DTLSv1_2_client_method(void);
 #endif
 
 static const long Cryptography_HAS_TLSEXT_HOSTNAME = 1;
@@ -635,8 +680,6 @@ static const long Cryptography_HAS_STATUS_REQ_OCSP_RESP = 1;
 static const long Cryptography_HAS_TLSEXT_STATUS_REQ_TYPE = 1;
 static const long Cryptography_HAS_RELEASE_BUFFERS = 1;
 static const long Cryptography_HAS_OP_NO_COMPRESSION = 1;
-static const long Cryptography_HAS_TLSv1_1 = 1;
-static const long Cryptography_HAS_TLSv1_2 = 1;
 static const long Cryptography_HAS_SSL_OP_MSIE_SSLV2_RSA_PADDING = 1;
 static const long Cryptography_HAS_SSL_OP_NO_TICKET = 1;
 static const long Cryptography_HAS_SSL_SET_SSL_CTX = 1;
@@ -731,6 +774,18 @@ long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
 long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
 #else
 static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 1;
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+static const long Cryptography_HAS_GENERIC_TLS_METHOD = 0;
+const SSL_METHOD* (*TLS_method)(void) = NULL;
+const SSL_METHOD* (*TLS_client_method)(void) = NULL;
+const SSL_METHOD* (*TLS_server_method)(void) = NULL;
+#else
+static const long Cryptography_HAS_GENERIC_TLS_METHOD = 1;
+const SSL_METHOD *TLS_method(void);
+const SSL_METHOD *TLS_server_method(void);
+const SSL_METHOD *TLS_client_method(void);
 #endif
 
 static const long Cryptography_HAS_DTLS = 1;
@@ -848,5 +903,11 @@ int (*SSL_read_early_data)(SSL *, void *, size_t, size_t *) = NULL;
 int (*SSL_CTX_set_max_early_data)(SSL_CTX *, uint32_t) = NULL;
 #else
 static const long Cryptography_HAS_TLSv1_3 = 1;
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+/* These became macros in 1.1.0 */
+int SSL_library_init(void);
+void SSL_load_error_strings(void);
 #endif
 """

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -265,9 +265,6 @@ void X509_get0_signature(const ASN1_BIT_STRING **,
 
 long X509_get_version(X509 *);
 
-ASN1_TIME *X509_get_notBefore(X509 *);
-ASN1_TIME *X509_get_notAfter(X509 *);
-
 long X509_REQ_get_version(X509_REQ *);
 X509_NAME *X509_REQ_get_subject_name(X509_REQ *);
 
@@ -301,16 +298,8 @@ int i2d_DSAPublicKey(DSA *, unsigned char **);
 int i2d_DSAPrivateKey(DSA *, unsigned char **);
 
 long X509_CRL_get_version(X509_CRL *);
-ASN1_TIME *X509_CRL_get_lastUpdate(X509_CRL *);
-ASN1_TIME *X509_CRL_get_nextUpdate(X509_CRL *);
 X509_NAME *X509_CRL_get_issuer(X509_CRL *);
 Cryptography_STACK_OF_X509_REVOKED *X509_CRL_get_REVOKED(X509_CRL *);
-
-/* These aren't macros these arguments are all const X on openssl > 1.0.x */
-int X509_CRL_set_lastUpdate(X509_CRL *, ASN1_TIME *);
-int X509_CRL_set_nextUpdate(X509_CRL *, ASN1_TIME *);
-int X509_set_notBefore(X509 *, ASN1_TIME *);
-int X509_set_notAfter(X509 *, ASN1_TIME *);
 
 int i2d_EC_PUBKEY(EC_KEY *, unsigned char **);
 EC_KEY *d2i_EC_PUBKEY(EC_KEY **, const unsigned char **, long);
@@ -438,5 +427,22 @@ const ASN1_INTEGER *X509_REVOKED_get0_serialNumber(const X509_REVOKED *x)
     return x->serialNumber;
 }
 #endif
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_110_OR_GREATER
+const ASN1_TIME *X509_CRL_get0_lastUpdate(const X509_CRL *);
+const ASN1_TIME *X509_CRL_get0_nextUpdate(const X509_CRL *);
+int X509_set1_notBefore(X509 *, const ASN1_TIME *);
+int X509_set1_notAfter(X509 *, const ASN1_TIME *);
+#else
+ASN1_TIME *X509_get_notBefore(X509 *);
+ASN1_TIME *X509_get_notAfter(X509 *);
+int X509_set_notBefore(X509 *, ASN1_TIME *);
+int X509_set_notAfter(X509 *, ASN1_TIME *);
+ASN1_TIME *X509_CRL_get_lastUpdate(X509_CRL *);
+ASN1_TIME *X509_CRL_get_nextUpdate(X509_CRL *);
+/* These aren't macros these arguments are all const X on openssl > 1.0.x */
+int X509_CRL_set_lastUpdate(X509_CRL *, ASN1_TIME *);
+int X509_CRL_set_nextUpdate(X509_CRL *, ASN1_TIME *);
 #endif
 """

--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -106,7 +106,6 @@ static const int X509_V_ERR_IP_ADDRESS_MISMATCH;
 static const int X509_V_ERR_APPLICATION_VERIFICATION;
 
 /* Verification parameters */
-static const long X509_V_FLAG_CB_ISSUER_CHECK;
 static const long X509_V_FLAG_USE_CHECK_TIME;
 static const long X509_V_FLAG_CRL_CHECK;
 static const long X509_V_FLAG_CRL_CHECK_ALL;
@@ -157,16 +156,12 @@ void X509_STORE_CTX_cleanup(X509_STORE_CTX *);
 void X509_STORE_CTX_free(X509_STORE_CTX *);
 int X509_STORE_CTX_init(X509_STORE_CTX *, X509_STORE *, X509 *,
                         Cryptography_STACK_OF_X509 *);
-void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *,
-                                  Cryptography_STACK_OF_X509 *);
 void X509_STORE_CTX_set_cert(X509_STORE_CTX *, X509 *);
-void X509_STORE_CTX_set_chain(X509_STORE_CTX *,Cryptography_STACK_OF_X509 *);
 X509_VERIFY_PARAM *X509_STORE_CTX_get0_param(X509_STORE_CTX *);
 void X509_STORE_CTX_set0_param(X509_STORE_CTX *, X509_VERIFY_PARAM *);
 int X509_STORE_CTX_set_default(X509_STORE_CTX *, const char *);
 void X509_STORE_CTX_set_verify_cb(X509_STORE_CTX *,
                                   int (*)(int, X509_STORE_CTX *));
-Cryptography_STACK_OF_X509 *X509_STORE_CTX_get_chain(X509_STORE_CTX *);
 Cryptography_STACK_OF_X509 *X509_STORE_CTX_get1_chain(X509_STORE_CTX *);
 int X509_STORE_CTX_get_error(X509_STORE_CTX *);
 void X509_STORE_CTX_set_error(X509_STORE_CTX *, int);
@@ -335,6 +330,11 @@ typedef void *X509_STORE_CTX_get_issuer_fn;
 X509_STORE_CTX_get_issuer_fn (*X509_STORE_get_get_issuer)(X509_STORE *) = NULL;
 void (*X509_STORE_set_get_issuer)(X509_STORE *,
                                   X509_STORE_CTX_get_issuer_fn) = NULL;
+static const long X509_V_FLAG_CB_ISSUER_CHECK;
+void X509_STORE_CTX_set_chain(X509_STORE_CTX *,Cryptography_STACK_OF_X509 *);
+void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *,
+                                  Cryptography_STACK_OF_X509 *);
+Cryptography_STACK_OF_X509 *X509_STORE_CTX_get_chain(X509_STORE_CTX *);
 #else
 static const long Cryptography_HAS_X509_STORE_CTX_GET_ISSUER = 1;
 #endif

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -282,13 +282,13 @@ class _CertificateRevocationList(object):
 
     @property
     def next_update(self):
-        nu = self._backend._lib.X509_CRL_get_nextUpdate(self._x509_crl)
+        nu = self._backend._lib.X509_CRL_get0_nextUpdate(self._x509_crl)
         self._backend.openssl_assert(nu != self._backend._ffi.NULL)
         return _parse_asn1_time(self._backend, nu)
 
     @property
     def last_update(self):
-        lu = self._backend._lib.X509_CRL_get_lastUpdate(self._x509_crl)
+        lu = self._backend._lib.X509_CRL_get0_lastUpdate(self._x509_crl)
         self._backend.openssl_assert(lu != self._backend._ffi.NULL)
         return _parse_asn1_time(self._backend, lu)
 

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -126,13 +126,15 @@ class Binding(object):
             if not cls._lib_loaded:
                 cls.lib = build_conditional_library(lib, CONDITIONAL_NAMES)
                 cls._lib_loaded = True
-                # initialize the SSL library
-                cls.lib.SSL_library_init()
-                # adds all ciphers/digests for EVP
-                cls.lib.OpenSSL_add_all_algorithms()
-                # loads error strings for libcrypto and libssl functions
-                cls.lib.SSL_load_error_strings()
-                cls._register_osrandom_engine()
+                #initialization is deprecated in 1.1
+                if self._backend._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_110:
+                    # initialize the SSL library
+                    cls.lib.SSL_library_init()
+                    # adds all ciphers/digests for EVP
+                    cls.lib.OpenSSL_add_all_algorithms()
+                    # loads error strings for libcrypto and libssl functions
+                    cls.lib.SSL_load_error_strings()
+                    cls._register_osrandom_engine()
 
     @classmethod
     def init_static_locks(cls):


### PR DESCRIPTION
OpenWrt has a compile-time option to disable deprecated APIs to save some space for embedded devices.

I put the replacements in the #else path.

Untested with LibreSSL.