### PR TITLE
remove NPN bindings -- you should be using ALPN!

### DIFF
--- a/.travis/downstream.d/twisted.sh
+++ b/.travis/downstream.d/twisted.sh
@@ -9,7 +9,7 @@ case "${1}" in
         ;;
     run)
         cd twisted
-        python -m twisted.trial twisted.protocols.test.test_tls.TLSMemoryBIOTests.test_disorderlyShutdown
+        python -m twisted.trial src/twisted
         ;;
     *)
         exit 1

--- a/.travis/downstream.d/twisted.sh
+++ b/.travis/downstream.d/twisted.sh
@@ -9,7 +9,7 @@ case "${1}" in
         ;;
     run)
         cd twisted
-        python -m twisted.trial src/twisted
+        python -m twisted.trial twisted.protocols.test.test_tls.TLSMemoryBIOTests.test_disorderlyShutdown
         ;;
     *)
         exit 1

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -440,25 +440,9 @@ SRTP_PROTECTION_PROFILE *SSL_get_selected_srtp_profile(SSL *);
 
 long SSL_session_reused(SSL *);
 
-void SSL_CTX_set_next_protos_advertised_cb(SSL_CTX *,
-                                           int (*)(SSL *,
-                                                   const unsigned char **,
-                                                   unsigned int *,
-                                                   void *),
-                                           void *);
-void SSL_CTX_set_next_proto_select_cb(SSL_CTX *,
-                                      int (*)(SSL *,
-                                              unsigned char **,
-                                              unsigned char *,
-                                              const unsigned char *,
-                                              unsigned int,
-                                              void *),
-                                      void *);
 int SSL_select_next_proto(unsigned char **, unsigned char *,
                           const unsigned char *, unsigned int,
                           const unsigned char *, unsigned int);
-void SSL_get0_next_proto_negotiated(const SSL *,
-                                    const unsigned char **, unsigned *);
 
 int sk_SSL_CIPHER_num(Cryptography_STACK_OF_SSL_CIPHER *);
 const SSL_CIPHER *sk_SSL_CIPHER_value(Cryptography_STACK_OF_SSL_CIPHER *, int);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -649,7 +649,7 @@ static const long Cryptography_HAS_TLSv1_2 = 1;
 static const long Cryptography_HAS_SSL_OP_MSIE_SSLV2_RSA_PADDING = 1;
 static const long Cryptography_HAS_SSL_OP_NO_TICKET = 1;
 static const long Cryptography_HAS_SSL_SET_SSL_CTX = 1;
-static const long Cryptography_HAS_NEXTPROTONEG = 1;
+static const long Cryptography_HAS_NEXTPROTONEG = 0;
 static const long Cryptography_HAS_ALPN = 1;
 
 #if CRYPTOGRAPHY_IS_LIBRESSL

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -139,8 +139,6 @@ static const long SSL3_RANDOM_SIZE;
 static const long TLS_ST_BEFORE;
 static const long TLS_ST_OK;
 
-static const long OPENSSL_NPN_NEGOTIATED;
-
 typedef ... SSL_METHOD;
 typedef ... SSL_CTX;
 


### PR DESCRIPTION
pyOpenSSL consumed these, but we've marked it as deprecated and it already handles the case where the bindings are not available.