### PR TITLE
Add PEP 517 to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
-# Must be kept in sync with `setup_requirements` in `setup.py`
 requires = [
-    "setuptools>=18.5",
+    # The minimum setuptools version is specific to the PEP 517 backend,
+    # and may be stricter than the version required in `setup.py`
+    "setuptools>=40.6.0",
     "wheel",
+    # Must be kept in sync with the `setup_requirements` in `setup.py`
     "cffi>=1.8,!=1.11.3; python_implementation != 'PyPy'",
 ]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This puts a new minimum on the PEP 518 requirement for `setuptools` because older versions of setuptools' PEP 517 backend will fail to include `setup.py` in an sdist.

I will note that the presence of `pyproject.toml` alone is enough to trigger PEP 517 in the latest version of `pip`, using the default backend, so regardless of whether or not `build-backend` is added to `pyproject.toml`, the bounds on `setuptools` need to be bumped (in `pyproject.toml` only).