### PR TITLE
rfc4514_string: use oid._name before dotted_string

### DIFF
--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -120,9 +120,12 @@ class NameAttribute(object):
         Format as RFC4514 Distinguished Name string.
 
         Use short attribute name if available, otherwise fall back to OID
-        dotted string.
+        name, and finally to dotted string.
         """
-        key = _NAMEOID_TO_NAME.get(self.oid, self.oid.dotted_string)
+        key = _NAMEOID_TO_NAME.get(self.oid, (
+            self.oid._name if self.oid._name != "Unknown OID"
+            else self.oid.dotted_string
+        ))
         return '%s=%s' % (key, _escape_dn_value(self.value))
 
     def __eq__(self, other):

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -22,7 +22,6 @@ from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends.interfaces import (
     DSABackend, EllipticCurveBackend, RSABackend, X509Backend
 )
-from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, padding, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import (
@@ -3940,9 +3939,11 @@ class TestNameAttribute(object):
         assert na.rfc4514_string() == 'emailAddress=somebody@example.com'
 
         # Unknown OID
-        na = x509.NameAttribute(ObjectIdentifier('0.9.2342.19200300.100.1.5'),
-                                'Ambrosia')
-        assert na.rfc4514_sring() == r'0.9.2342.19200300.100.1.5=Ambrosia'
+        na = x509.NameAttribute(
+            x509.ObjectIdentifier('0.9.2342.19200300.100.1.5'),
+            u'Ambrosia'
+        )
+        assert na.rfc4514_string() == r'0.9.2342.19200300.100.1.5=Ambrosia'
 
 
 class TestRelativeDistinguishedName(object):

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -22,6 +22,7 @@ from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends.interfaces import (
     DSABackend, EllipticCurveBackend, RSABackend, X509Backend
 )
+from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, padding, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import (
@@ -3934,10 +3935,14 @@ class TestNameAttribute(object):
         na = x509.NameAttribute(NameOID.USER_ID, u'# escape+,;\0this ')
         assert na.rfc4514_string() == r'UID=\# escape\+\,\;\00this\ '
 
-        # Nonstandard attribute OID
+        # Nonshort-name attribute OID
         na = x509.NameAttribute(NameOID.EMAIL_ADDRESS, u'somebody@example.com')
-        assert (na.rfc4514_string() ==
-                '1.2.840.113549.1.9.1=somebody@example.com')
+        assert na.rfc4514_string() == 'emailAddress=somebody@example.com'
+
+        # Unknown OID
+        na = x509.NameAttribute(ObjectIdentifier('0.9.2342.19200300.100.1.5'),
+                                'Ambrosia')
+        assert na.rfc4514_sring() == r'0.9.2342.19200300.100.1.5=Ambrosia'
 
 
 class TestRelativeDistinguishedName(object):


### PR DESCRIPTION
The oid._name propery is compliant with the LDAP registry:

```
FROM RFC4514:

   If the AttributeType is defined to have a short name (descriptor)
   [RFC4512] and that short name is known to be registered [REGISTRY]
   [RFC4520] as identifying the AttributeType, that short name, a
   <descr>, is used.
```

[REGISTRY]: https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml

So I believe it is compliant to use the oid._name values whenever they
are not equal to "Unknown OID".

This improves readability for many of the common attributes which do not appear in the short table.