### PR TITLE
Improve deprecation warning to specify the release

### DIFF
--- a/src/cryptography/hazmat/primitives/constant_time.py
+++ b/src/cryptography/hazmat/primitives/constant_time.py
@@ -21,8 +21,8 @@ if hasattr(hmac, "compare_digest"):
 else:
     warnings.warn(
         "Support for your Python version is deprecated. The next version of "
-        "cryptography will remove support. Please upgrade to a 2.7.x "
-        "release that supports hmac.compare_digest as soon as possible.",
+        "cryptography will remove support. Please upgrade to a release "
+        "(2.7.7+) that supports hmac.compare_digest as soon as possible.",
         utils.PersistentlyDeprecated2018,
     )
 


### PR DESCRIPTION
https://github.com/certbot/certbot/issues/6827#issuecomment-470981623

The warning yielded by this message was very confusing in the context of certbot-auto. It seemed to indicate I should upgrade to python 2.7, but as I was already using python 2.7 (via redhat scl), I, and others misunderstood what it was trying to say.