### PR TITLE
add new branch for unsupported openssh serialization

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1892,8 +1892,7 @@ class Backend(object):
                 ssh._ssh_write_string(b"ssh-ed25519") +
                 ssh._ssh_write_string(raw_bytes)
             )
-        else:
-            assert isinstance(key, ec.EllipticCurvePublicKey)
+        elif isinstance(key, ec.EllipticCurvePublicKey):
             public_numbers = key.public_numbers()
             try:
                 curve_name = {
@@ -1915,6 +1914,10 @@ class Backend(object):
                 ssh._ssh_write_string(b"ecdsa-sha2-" + curve_name) +
                 ssh._ssh_write_string(curve_name) +
                 ssh._ssh_write_string(point)
+            )
+        else:
+            raise ValueError(
+                "OpenSSH encoding is not supported for this key type"
             )
 
     def _parameter_bytes(self, encoding, format, cdata):

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -16,7 +16,9 @@ from cryptography.hazmat.backends.interfaces import (
     DERSerializationBackend, DSABackend, EllipticCurveBackend,
     PEMSerializationBackend, RSABackend
 )
-from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed25519, rsa
+from cryptography.hazmat.primitives.asymmetric import (
+    dsa, ec, ed25519, ed448, rsa
+)
 from cryptography.hazmat.primitives.serialization import (
     BestAvailableEncryption, Encoding, NoEncryption,
     PrivateFormat, PublicFormat,
@@ -1585,3 +1587,10 @@ class TestEd448Serialization(object):
         assert public_key.public_bytes(
             encoding, PublicFormat.SubjectPublicKeyInfo
         ) == data
+
+    def test_openssh_serialization_unsupported(self, backend):
+        key = ed448.Ed448PrivateKey.generate().public_key()
+        with pytest.raises(ValueError):
+            key.public_bytes(
+                Encoding.OpenSSH, PublicFormat.OpenSSH
+            )


### PR DESCRIPTION
we don't support ed448 openssh keys so we'll use that to test this branch. if we ever do support ed448 keys we can always just call this private method directly to keep coverage.