### PR TITLE
Added an explicit content type for long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -250,6 +250,7 @@ setup(
 
     description=about["__summary__"],
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     license=about["__license__"],
     url=about["__uri__"],
 


### PR DESCRIPTION
It already defaults to x-rst, but this silences a warning