### PR TITLE
Add add_attribute to CSR Builder

### DIFF
--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -212,6 +212,9 @@ X509_EXTENSION *sk_X509_EXTENSION_delete(X509_EXTENSIONS *, int);
 void sk_X509_EXTENSION_free(X509_EXTENSIONS *);
 void sk_X509_EXTENSION_pop_free(X509_EXTENSIONS *, sk_X509_EXTENSION_freefunc);
 
+int X509_REQ_add1_attr_by_txt(X509_REQ *, const char *, int,
+                              const unsigned char *, int);
+
 int sk_X509_REVOKED_num(Cryptography_STACK_OF_X509_REVOKED *);
 X509_REVOKED *sk_X509_REVOKED_value(Cryptography_STACK_OF_X509_REVOKED *, int);
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -778,6 +778,17 @@ class Backend(object):
         res = self._lib.X509_REQ_add_extensions(x509_req, sk_extension)
         self.openssl_assert(res == 1)
 
+        # Add attributes.
+        for attribute in builder._attributes:
+            dotted_string = self._ffi.new(
+                "char[]", attribute.oid.dotted_string.encode('utf8'))
+            value = self._ffi.new("char[]", attribute.value.contents)
+            res = self._lib.X509_REQ_add1_attr_by_txt(
+                x509_req, dotted_string, attribute.value.tag,
+                value, len(value) - 1
+            )
+            self.openssl_assert(res == 1)
+
         # Sign the request using the requester's private key.
         res = self._lib.X509_REQ_sign(
             x509_req, private_key._evp_pkey, evp_md

--- a/src/cryptography/x509/__init__.py
+++ b/src/cryptography/x509/__init__.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 from cryptography.x509 import certificate_transparency
+from cryptography.x509.attributes import Attribute
 from cryptography.x509.base import (
     Certificate, CertificateBuilder, CertificateRevocationList,
     CertificateRevocationListBuilder,
@@ -129,6 +130,7 @@ __all__ = [
     "Name",
     "RelativeDistinguishedName",
     "ObjectIdentifier",
+    "Attribute",
     "ExtensionType",
     "Extensions",
     "Extension",

--- a/src/cryptography/x509/attributes.py
+++ b/src/cryptography/x509/attributes.py
@@ -1,0 +1,34 @@
+from cryptography import utils
+from cryptography.x509.oid import ObjectIdentifier
+
+
+class Attribute(object):
+    def __init__(self, oid, value):
+        if not isinstance(oid, ObjectIdentifier):
+            raise TypeError(
+                "oid argument must be an ObjectIdentifier instance."
+            )
+
+        self._oid = oid
+        self._value = value
+
+    oid = utils.read_only_property("_oid")
+    value = utils.read_only_property("_value")
+
+    def __repr__(self):
+        return ("<Attribute(oid={0.oid}, value={0.value})>").format(self)
+
+    def __eq__(self, other):
+        if not isinstance(other, Attribute):
+            return NotImplemented
+
+        return (
+            self.oid == other.oid and
+            self.value == other.value
+        )
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash((self.oid, self.value))


### PR DESCRIPTION
Add add_attribute method to CertificateSigningRequestBuilder so that
it's possible to add attributes to CSRs.

Example usage:
```python
    from asn1crypto import x509 as asn1x509
    from cryptography import x509

    builder = x509.CertificateSigningRequestBuilder()
    builder = builder.add_attribute(
        x509.ObjectIdentifier('1.2.840.113549.1.9.7'),
        asn1x509.PrintableString(challenge))

```

Still needs a test. Want to please ask if the API is OK?