### PR TITLE
use a random key for aes buffer protocol tests

### DIFF
--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -490,7 +490,7 @@ class TestAESModeGCM(object):
 def test_buffer_protocol_alternate_modes(mode, backend):
     data = bytearray(b"sixteen_byte_msg")
     cipher = base.Cipher(
-        algorithms.AES(bytearray(b"\x00" * 32)), mode, backend
+        algorithms.AES(bytearray(os.urandom(32))), mode, backend
     )
     enc = cipher.encryptor()
     ct = enc.update(data) + enc.finalize()


### PR DESCRIPTION
Using an all 0 key causes failures in OpenSSL master (and Fedora has cherry-picked the commit that causes it). The change requires that the key/tweak for XTS mode not be the same value, so let's just use a random key.

fixes #4885 