### PR TITLE
PKCS12 basic storing support

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2455,11 +2455,8 @@ class Backend(object):
                     raise ValueError("Could not create PKCS12 structure")
 
         bio = self._create_mem_bio_gc()
-        if self._lib.i2d_PKCS12_bio(bio, p12):
-            return self._read_mem_bio(bio)
-        else:
-            self._consume_errors()
-            raise ValueError("Could not serialize PKCS12 data")
+        assert self._lib.i2d_PKCS12_bio(bio, p12)
+        return self._read_mem_bio(bio)
 
     def poly1305_supported(self):
         return self._lib.Cryptography_HAS_POLY1305 == 1

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2451,12 +2451,14 @@ class Backend(object):
                 if p12 != self._ffi.NULL:
                     p12 = self._ffi.gc(p12, self._lib.PKCS12_free)
                 else:
+                    self._consume_errors()
                     raise ValueError("Could not create PKCS12 structure")
 
         bio = self._create_mem_bio_gc()
         if self._lib.i2d_PKCS12_bio(bio, p12):
             return self._read_mem_bio(bio)
         else:
+            self._consume_errors()
             raise ValueError("Could not serialize PKCS12 data")
 
     def poly1305_supported(self):

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -162,6 +162,16 @@ class _Certificate(object):
         self._backend.openssl_assert(res == 1)
         return self._backend._read_mem_bio(bio)
 
+    @property
+    def alias(self):
+        len_ = self._backend._ffi.new("int *")
+        name_ptr = self._backend._lib.X509_alias_get0(self._x509, len_)
+        if len_[0]:
+            res = self._backend._ffi.buffer(name_ptr, len_[0])[:]
+        else:
+            res = None
+        return res
+
 
 @utils.register_interface(x509.RevokedCertificate)
 class _RevokedCertificate(object):

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -7,3 +7,11 @@ from __future__ import absolute_import, division, print_function
 
 def load_key_and_certificates(data, password, backend):
     return backend.load_key_and_certificates_from_pkcs12(data, password)
+
+
+def store_key_and_certificates(
+    key, cert, additional_certificates, password, backend, name=None,
+        nid_key=0, nid_cert=0, iter_=0, mac_iter=0, keytype=0):
+    return backend.store_key_and_certificates_in_pkcs12(
+        password, name, key, cert, additional_certificates, nid_key, nid_cert,
+        iter_, mac_iter, keytype)


### PR DESCRIPTION
backend: add `store_key_and_certificates_in_pkcs12` to wrap OpenSSL's
`PKCS12_create` and `i2d_PKCS12_bio`.
x509: add `@property alias` to wrap OpenSSL's `X509_alias_get0` to read
certificate's friendlyName.
pkcs12.py: add `store_key_and_certificates` with some default arguments.
test_pkcs12: add basic tests.