### PR TITLE
Fix some backend feature checks in tests

### DIFF
--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -13,6 +13,7 @@ from cryptography.hazmat.backends.interfaces import CipherBackend
 from cryptography.hazmat.primitives.ciphers import algorithms, base, modes
 
 from .utils import _load_all_params, generate_aead_test, generate_encrypt_test
+from ...doubles import DummyMode
 from ...utils import load_nist_vectors
 
 
@@ -484,6 +485,8 @@ class TestAESModeGCM(object):
         modes.CFB(bytearray(b"\x00" * 16)),
         modes.CFB8(bytearray(b"\x00" * 16)),
         modes.XTS(bytearray(b"\x00" * 16)),
+        # Add a dummy mode for coverage of the cipher_supported check.
+        DummyMode(),
     ]
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -489,9 +489,10 @@ class TestAESModeGCM(object):
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
 def test_buffer_protocol_alternate_modes(mode, backend):
     data = bytearray(b"sixteen_byte_msg")
-    cipher = base.Cipher(
-        algorithms.AES(bytearray(os.urandom(32))), mode, backend
-    )
+    key = algorithms.AES(bytearray(os.urandom(32)))
+    if not backend.cipher_supported(key, mode):
+        pytest.skip("AES in {} mode not supported".format(mode.name))
+    cipher = base.Cipher(key, mode, backend)
     enc = cipher.encryptor()
     ct = enc.update(data) + enc.finalize()
     dec = cipher.decryptor()

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -1070,11 +1070,12 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             load_nist_vectors
         )
     )
-    def test_from_encoded_point_compressed(self, vector):
+    def test_from_encoded_point_compressed(self, vector, backend):
         curve = {
             b"SECP256R1": ec.SECP256R1(),
             b"SECP256K1": ec.SECP256K1(),
         }[vector["curve"]]
+        _skip_curve_unsupported(backend, curve)
         point = binascii.unhexlify(vector["point"])
         pn = ec.EllipticCurvePublicKey.from_encoded_point(curve, point)
         public_num = pn.public_numbers()
@@ -1155,6 +1156,7 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             b"SECP256R1": ec.SECP256R1(),
             b"SECP256K1": ec.SECP256K1(),
         }[vector["curve"]]
+        _skip_curve_unsupported(backend, curve)
         point = binascii.unhexlify(vector["point"])
         key = ec.EllipticCurvePublicKey.from_encoded_point(curve, point)
         key2 = ec.EllipticCurvePublicKey.from_encoded_point(

--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -10,7 +10,6 @@ import os
 import pytest
 
 from cryptography.exceptions import InvalidSignature, _Reasons
-from cryptography.hazmat.backends.interfaces import DHBackend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey, Ed25519PublicKey
@@ -47,7 +46,6 @@ def load_ed25519_vectors(vector_data):
     only_if=lambda backend: not backend.ed25519_supported(),
     skip_message="Requires OpenSSL without Ed25519 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 def test_ed25519_unsupported(backend):
     with raises_unsupported_algorithm(
         _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
@@ -69,7 +67,6 @@ def test_ed25519_unsupported(backend):
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 class TestEd25519Signing(object):
     @pytest.mark.parametrize(
         "vector",

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -10,7 +10,6 @@ import os
 import pytest
 
 from cryptography.exceptions import InvalidSignature, _Reasons
-from cryptography.hazmat.backends.interfaces import DHBackend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed448 import (
     Ed448PrivateKey, Ed448PublicKey
@@ -25,7 +24,6 @@ from ...utils import (
     only_if=lambda backend: not backend.ed448_supported(),
     skip_message="Requires OpenSSL without Ed448 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 def test_ed448_unsupported(backend):
     with raises_unsupported_algorithm(
         _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
@@ -47,7 +45,6 @@ def test_ed448_unsupported(backend):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 class TestEd448Signing(object):
     @pytest.mark.parametrize(
         "vector",

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -11,7 +11,6 @@ import pytest
 
 from cryptography import utils
 from cryptography.exceptions import _Reasons
-from cryptography.hazmat.backends.interfaces import DHBackend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x25519 import (
     X25519PrivateKey, X25519PublicKey
@@ -26,7 +25,6 @@ from ...utils import (
     only_if=lambda backend: not backend.x25519_supported(),
     skip_message="Requires OpenSSL without X25519 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 def test_x25519_unsupported(backend):
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
         X25519PublicKey.from_public_bytes(b"0" * 32)
@@ -42,7 +40,6 @@ def test_x25519_unsupported(backend):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 class TestX25519Exchange(object):
     @pytest.mark.parametrize(
         "vector",

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -10,7 +10,6 @@ import os
 import pytest
 
 from cryptography.exceptions import _Reasons
-from cryptography.hazmat.backends.interfaces import DHBackend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.x448 import (
     X448PrivateKey, X448PublicKey
@@ -25,7 +24,6 @@ from ...utils import (
     only_if=lambda backend: not backend.x448_supported(),
     skip_message="Requires OpenSSL without X448 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 def test_x448_unsupported(backend):
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
         X448PublicKey.from_public_bytes(b"0" * 56)
@@ -41,7 +39,6 @@ def test_x448_unsupported(backend):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 class TestX448Exchange(object):
     @pytest.mark.parametrize(
         "vector",

--- a/tests/wycheproof/test_eddsa.py
+++ b/tests/wycheproof/test_eddsa.py
@@ -9,7 +9,6 @@ import binascii
 import pytest
 
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends.interfaces import DHBackend
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PublicKey
 )
@@ -19,7 +18,6 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 @pytest.mark.wycheproof_tests(
     "eddsa_test.json",
 )

--- a/tests/wycheproof/test_x25519.py
+++ b/tests/wycheproof/test_x25519.py
@@ -8,7 +8,6 @@ import binascii
 
 import pytest
 
-from cryptography.hazmat.backends.interfaces import DHBackend
 from cryptography.hazmat.primitives.asymmetric.x25519 import (
     X25519PrivateKey, X25519PublicKey
 )
@@ -18,7 +17,6 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import (
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support"
 )
-@pytest.mark.requires_backend_interface(interface=DHBackend)
 @pytest.mark.wycheproof_tests("x25519_test.json")
 def test_x25519(backend, wycheproof):
     assert list(wycheproof.testgroup.items()) == [("curve", "curve25519")]


### PR DESCRIPTION
A bunch of tests have irrelevant `DHBackend` checks, and some EC and AES tests are missing checks for the curve and mode.