### PR TITLE
Add class methods for Poly1305 sign and verify operations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Added class methods
+  :meth:`Poly1305.generate_tag
+  <cryptography.hazmat.primitives.poly1305.Poly1305.generate_tag>`
+  and
+  :meth:`Poly1305.verify_tag
+  <cryptography.hazmat.primitives.poly1305.Poly1305.verify_tag>`
+  for Poly1305 sign and verify operations.
 * Deprecated support for OpenSSL 1.0.1. Support will be removed in
   ``cryptography`` 2.9.
 * We now ship ``manylinux2010`` wheels in addition to our ``manylinux1``

--- a/docs/hazmat/primitives/mac/poly1305.rst
+++ b/docs/hazmat/primitives/mac/poly1305.rst
@@ -85,3 +85,48 @@ messages allows an attacker to forge tags. Poly1305 is described in
 
         :return bytes: The message authentication code as bytes.
         :raises cryptography.exceptions.AlreadyFinalized:
+
+    .. classmethod:: generate_tag(key, data)
+
+        A single step alternative to do sign operations. Returns the message
+        authentication code as ``bytes`` for the given ``key`` and ``data``.
+
+        :param key: Secret key as ``bytes``.
+        :type key: :term:`bytes-like`
+        :param data: The bytes to hash and authenticate.
+        :type data: :term:`bytes-like`
+        :return bytes: The message authentication code as bytes.
+        :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised if
+            the version of OpenSSL ``cryptography`` is compiled against does not
+            support this algorithm.
+        :raises TypeError: This exception is raised if ``key`` or ``data`` are
+            not ``bytes``.
+
+        .. doctest::
+
+            >>> poly1305.Poly1305.generate_tag(key, b"message to authenticate")
+            b'T\xae\xff3\xbdW\xef\xd5r\x01\xe2n=\xb7\xd2h'
+
+    .. classmethod:: verify_tag(key, data, tag)
+
+        A single step alternative to do verify operations. Securely compares the
+        MAC to ``tag``, using the given ``key`` and ``data``.
+
+        :param key: Secret key as ``bytes``.
+        :type key: :term:`bytes-like`
+        :param data: The bytes to hash and authenticate.
+        :type data: :term:`bytes-like`
+        :param bytes tag: The bytes to compare against.
+        :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised if
+            the version of OpenSSL ``cryptography`` is compiled against does not
+            support this algorithm.
+        :raises TypeError: This exception is raised if ``key``, ``data`` or
+            ``tag`` are not ``bytes``.
+        :raises cryptography.exceptions.InvalidSignature: If tag does not match.
+
+        .. doctest::
+
+            >>> poly1305.Poly1305.verify_tag(key, b"message to authenticate", b"an incorrect tag")
+            Traceback (most recent call last):
+            ...
+            cryptography.exceptions.InvalidSignature: Value did not match computed tag.

--- a/src/cryptography/hazmat/primitives/poly1305.py
+++ b/src/cryptography/hazmat/primitives/poly1305.py
@@ -41,3 +41,15 @@ class Poly1305(object):
 
         ctx, self._ctx = self._ctx, None
         ctx.verify(tag)
+
+    @classmethod
+    def generate_tag(cls, key, data):
+        p = Poly1305(key)
+        p.update(data)
+        return p.finalize()
+
+    @classmethod
+    def verify_tag(cls, key, data, tag):
+        p = Poly1305(key)
+        p.update(data)
+        p.verify(tag)


### PR DESCRIPTION
Issue: https://github.com/pyca/cryptography/issues/4908

This PR adds two class methods to Poly1305 for single-step sign and verify operations. 

Two new methods are added:

```
Poly1305.sign(key, data)
```
And 
```
Poly1305.verify_tag(key, data, tag)
```

#### Screenshot
<img width="1039" alt="Screen Shot 2019-07-01 at 7 34 56 PM" src="https://user-images.githubusercontent.com/26511081/60563646-b5745c80-9d2a-11e9-81d2-cbbacb549b9e.png">

Let me know what you all think!
