### PR TITLE
fix osrandom/builtin switching methods for 1.1.0+

### DIFF
--- a/src/_cffi_src/openssl/rand.py
+++ b/src/_cffi_src/openssl/rand.py
@@ -9,10 +9,13 @@ INCLUDES = """
 """
 
 TYPES = """
+typedef ... RAND_METHOD;
+
 static const long Cryptography_HAS_EGD;
 """
 
 FUNCTIONS = """
+int RAND_set_rand_method(const RAND_METHOD *);
 void RAND_add(const void *, int, double);
 int RAND_status(void);
 int RAND_bytes(unsigned char *, int);
@@ -21,9 +24,6 @@ int RAND_bytes(unsigned char *, int);
    1 we'll just lie about the signature to preserve compatibility for
    pyOpenSSL (which calls this in its rand.py as of mid-2016) */
 void ERR_load_RAND_strings(void);
-
-/* RAND_cleanup became a macro in 1.1.0 */
-void RAND_cleanup(void);
 """
 
 CUSTOMIZATIONS = """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -170,6 +170,7 @@ class Backend(object):
                 self.openssl_assert(res == 1)
             # Reset the RNG to use the engine
             res = self._lib.RAND_set_rand_method(self._ffi.NULL)
+            self.openssl_assert(res == 1)
 
     def osrandom_engine_implementation(self):
         buf = self._ffi.new("char[]", 64)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -133,8 +133,9 @@ class Backend(object):
             e = self._lib.ENGINE_get_default_RAND()
             if e != self._ffi.NULL:
                 self._lib.ENGINE_unregister_RAND(e)
-                # Reset the RNG to use the new engine.
-                self._lib.RAND_cleanup()
+                # Reset the RNG to use the built-in.
+                res = self._lib.RAND_set_rand_method(self._ffi.NULL)
+                self.openssl_assert(res == 1)
                 # decrement the structural reference from get_default_RAND
                 res = self._lib.ENGINE_finish(e)
                 self.openssl_assert(res == 1)
@@ -167,8 +168,8 @@ class Backend(object):
                 # Set the engine as the default RAND provider.
                 res = self._lib.ENGINE_set_default_RAND(e)
                 self.openssl_assert(res == 1)
-            # Reset the RNG to use the new engine.
-            self._lib.RAND_cleanup()
+            # Reset the RNG to use the engine
+            res = self._lib.RAND_set_rand_method(self._ffi.NULL)
 
     def osrandom_engine_implementation(self):
         buf = self._ffi.new("char[]", 64)


### PR DESCRIPTION
In 1.1.0 RAND_cleanup became a no-op. This broke changing to the builtin random engine via activate_builtin_random(). Fixed by directly calling RAND_set_rand_method. This works on 1.0.x and 1.1.x

Testing this is very, very painful. I believe to test this we need to create, register, and activate a bad RNG that we can use to detect whether it has actually switched between engine and builtin. This will require adding quite a bit of C code since the RAND_METHOD and callbacks are all opaque to the Python layer. I've written most of this, but it feels very bad to be adding an engine like this (even if we only invoke its addition during tests). Opinions?