### PR TITLE
Add SSL_get0_verified_chain to cffi lib

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -31,6 +31,7 @@ static const long Cryptography_HAS_GENERIC_DTLS_METHOD;
 static const long Cryptography_HAS_SIGALGS;
 static const long Cryptography_HAS_PSK;
 static const long Cryptography_HAS_CIPHER_DETAILS;
+static const long Cryptography_HAS_VERIFIED_CHAIN;
 
 /* Internally invented symbol to tell us if SNI is supported */
 static const long Cryptography_HAS_TLSEXT_HOSTNAME;
@@ -208,9 +209,7 @@ int SSL_get_sigalgs(SSL *, int, int *, int *, int *, unsigned char *,
                     unsigned char *);
 
 Cryptography_STACK_OF_X509 *SSL_get_peer_cert_chain(const SSL *);
-#if CRYPTOGRAPHY_OPENSSL_110_OR_GREATER
 Cryptography_STACK_OF_X509 *SSL_get0_verified_chain(const SSL *);
-#endif
 Cryptography_STACK_OF_X509_NAME *SSL_get_client_CA_list(const SSL *);
 
 int SSL_get_error(const SSL *, int);
@@ -560,6 +559,13 @@ CUSTOMIZATIONS = """
 const SSL_METHOD *SSL_CTX_get_ssl_method(SSL_CTX *ctx) {
     return ctx->method;
 }
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+static const long Cryptography_HAS_VERIFIED_CHAIN = 0;
+Cryptography_STACK_OF_X509 *(*SSL_get0_verified_chain)(const SSL *) = NULL;
+#else
+static const long Cryptography_HAS_VERIFIED_CHAIN = 1;
 #endif
 
 /* Added in 1.1.0 in the great opaquing, but we need to define it for older

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -208,6 +208,9 @@ int SSL_get_sigalgs(SSL *, int, int *, int *, int *, unsigned char *,
                     unsigned char *);
 
 Cryptography_STACK_OF_X509 *SSL_get_peer_cert_chain(const SSL *);
+#if CRYPTOGRAPHY_OPENSSL_110_OR_GREATER
+Cryptography_STACK_OF_X509 *SSL_get0_verified_chain(const SSL *);
+#endif
 Cryptography_STACK_OF_X509_NAME *SSL_get_client_CA_list(const SSL *);
 
 int SSL_get_error(const SSL *, int);

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -358,6 +358,12 @@ def cryptography_has_engine():
     ]
 
 
+def cryptography_has_verified_chain():
+    return [
+        "SSL_get0_verified_chain",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -431,4 +437,5 @@ CONDITIONAL_NAMES = {
         cryptography_has_evp_r_memory_limit_exceeded
     ),
     "Cryptography_HAS_ENGINE": cryptography_has_engine,
+    "Cryptography_HAS_VERIFIED_CHAIN": cryptography_has_verified_chain,
 }


### PR DESCRIPTION
OpenSSL 1.1.0 supports SSL_get0_verified_chain. This gives the full chain from the peer cert including your trusted CA cert.