### PR TITLE
restore apis needed for a _ssl module when using cryptograhpy v2.7

### DIFF
--- a/src/_cffi_src/openssl/asn1.py
+++ b/src/_cffi_src/openssl/asn1.py
@@ -33,6 +33,10 @@ typedef struct {
 } ASN1_TYPE;
 typedef ... ASN1_GENERALIZEDTIME;
 typedef ... ASN1_ENUMERATED;
+typedef ... ASN1_ITEM;
+typedef ... ASN1_VALUE;
+
+typedef ... ASN1_ITEM_EXP;
 typedef ... ASN1_NULL;
 
 static const int V_ASN1_GENERALIZEDTIME;
@@ -74,6 +78,8 @@ ASN1_ENUMERATED *ASN1_ENUMERATED_new(void);
 void ASN1_ENUMERATED_free(ASN1_ENUMERATED *);
 int ASN1_ENUMERATED_set(ASN1_ENUMERATED *, long);
 
+ASN1_VALUE *ASN1_item_d2i(ASN1_VALUE **, const unsigned char **, long,
+                          const ASN1_ITEM *);
 int ASN1_BIT_STRING_set_bit(ASN1_BIT_STRING *, int, int);
 /* These became const ASN1_* in 1.1.0 */
 int ASN1_STRING_type(ASN1_STRING *);
@@ -90,9 +96,12 @@ void ASN1_UTF8STRING_free(ASN1_UTF8STRING *);
 
 ASN1_BIT_STRING *ASN1_BIT_STRING_new(void);
 void ASN1_BIT_STRING_free(ASN1_BIT_STRING *);
+const ASN1_ITEM *ASN1_ITEM_ptr(ASN1_ITEM_EXP *);
+
 /* This is not a macro, but is const on some versions of OpenSSL */
 int ASN1_BIT_STRING_get_bit(ASN1_BIT_STRING *, int);
 
+int ASN1_TIME_print(BIO *, ASN1_TIME *);
 int ASN1_STRING_length(ASN1_STRING *);
 int ASN1_STRING_set_default_mask_asc(char *);
 

--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -27,15 +27,18 @@ int BIO_up_ref(BIO *);
 
 BIO *BIO_new(BIO_METHOD *);
 BIO_METHOD *BIO_s_mem(void);
+BIO_METHOD *BIO_s_file(void);
 BIO_METHOD *BIO_s_datagram(void);
 BIO *BIO_new_mem_buf(const void *, int);
 long BIO_set_mem_eof_return(BIO *, int);
 long BIO_get_mem_data(BIO *, char **);
+long BIO_read_filename(BIO *, char *);
 int BIO_should_read(BIO *);
 int BIO_should_write(BIO *);
 int BIO_should_io_special(BIO *);
 int BIO_should_retry(BIO *);
 int BIO_reset(BIO *);
+long BIO_set_nbio(BIO *, long);
 void BIO_set_retry_read(BIO *);
 void BIO_clear_retry_flags(BIO *);
 """

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -59,6 +59,7 @@ int EVP_DigestUpdate(EVP_MD_CTX *, const void *, size_t);
 int EVP_DigestFinal_ex(EVP_MD_CTX *, unsigned char *, unsigned int *);
 int EVP_DigestFinalXOF(EVP_MD_CTX *, unsigned char *, size_t);
 const EVP_MD *EVP_get_digestbyname(const char *);
+int EVP_MD_size(const EVP_MD *);
 
 EVP_PKEY *EVP_PKEY_new(void);
 void EVP_PKEY_free(EVP_PKEY *);

--- a/src/_cffi_src/openssl/nid.py
+++ b/src/_cffi_src/openssl/nid.py
@@ -23,8 +23,12 @@ static const int NID_ED25519;
 static const int NID_ED448;
 static const int NID_poly1305;
 
+static const int NID_info_access;
 static const int NID_subject_alt_name;
+static const int NID_crl_distribution_points;
 static const int NID_crl_reason;
+static const int NID_ad_OCSP;
+static const int NID_ad_ca_issuers;
 """
 
 FUNCTIONS = """

--- a/src/_cffi_src/openssl/pem.py
+++ b/src/_cffi_src/openssl/pem.py
@@ -44,6 +44,8 @@ X509_REQ *PEM_read_bio_X509_REQ(BIO *, X509_REQ **, pem_password_cb *, void *);
 
 X509_CRL *PEM_read_bio_X509_CRL(BIO *, X509_CRL **, pem_password_cb *, void *);
 
+X509 *PEM_read_bio_X509_AUX(BIO *, X509 **, pem_password_cb *, void *);
+
 int PEM_write_bio_X509_CRL(BIO *, X509_CRL *);
 
 PKCS7 *PEM_read_bio_PKCS7(BIO *, PKCS7 **, pem_password_cb *, void *);

--- a/src/_cffi_src/openssl/rand.py
+++ b/src/_cffi_src/openssl/rand.py
@@ -24,6 +24,9 @@ int RAND_bytes(unsigned char *, int);
    1 we'll just lie about the signature to preserve compatibility for
    pyOpenSSL (which calls this in its rand.py as of mid-2016) */
 void ERR_load_RAND_strings(void);
+
+/* RAND_cleanup became a macro in 1.1.0 */
+void RAND_cleanup(void);
 """
 
 CUSTOMIZATIONS = """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -621,9 +621,9 @@ static const long Cryptography_HAS_SSL2 = 0;
 
 #ifdef OPENSSL_NO_SSL3_METHOD
 static const long Cryptography_HAS_SSL3_METHOD = 0;
-SSL_METHOD* (*SSLv3_method)(void) = NULL;
-SSL_METHOD* (*SSLv3_client_method)(void) = NULL;
-SSL_METHOD* (*SSLv3_server_method)(void) = NULL;
+const SSL_METHOD* (*SSLv3_method)(void) = NULL;
+const SSL_METHOD* (*SSLv3_client_method)(void) = NULL;
+const SSL_METHOD* (*SSLv3_server_method)(void) = NULL;
 #else
 static const long Cryptography_HAS_SSL3_METHOD = 1;
 #endif

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -77,6 +77,8 @@ X509_EXTENSION *X509_EXTENSION_dup(X509_EXTENSION *);
 ASN1_OBJECT *X509_EXTENSION_get_object(X509_EXTENSION *);
 void X509_EXTENSION_free(X509_EXTENSION *);
 
+int i2d_X509(X509 *, unsigned char **);
+
 int X509_REQ_set_version(X509_REQ *, long);
 X509_REQ *X509_REQ_new(void);
 void X509_REQ_free(X509_REQ *);
@@ -163,6 +165,7 @@ int i2d_DSAPrivateKey_bio(BIO *, DSA *);
 /* These became const X509 in 1.1.0 */
 int X509_get_ext_count(X509 *);
 X509_EXTENSION *X509_get_ext(X509 *, int);
+int X509_get_ext_by_NID(X509 *, int, int);
 X509_NAME *X509_get_subject_name(X509 *);
 X509_NAME *X509_get_issuer_name(X509 *);
 

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -29,7 +29,6 @@ typedef struct {
     ...;
 } X509_ALGOR;
 
-typedef ... X509_ATTRIBUTE;
 typedef ... X509_EXTENSION;
 typedef ... X509_EXTENSIONS;
 typedef ... X509_REQ;
@@ -90,12 +89,6 @@ EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *);
 int X509_REQ_print_ex(BIO *, X509_REQ *, unsigned long, unsigned long);
 int X509_REQ_add_extensions(X509_REQ *, X509_EXTENSIONS *);
 X509_EXTENSIONS *X509_REQ_get_extensions(X509_REQ *);
-X509_ATTRIBUTE *X509_REQ_get_attr(const X509_REQ *, int);
-int X509_REQ_get_attr_by_OBJ(const X509_REQ *, const ASN1_OBJECT *, int);
-void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *, int, int, void *);
-ASN1_TYPE *X509_ATTRIBUTE_get0_type(X509_ATTRIBUTE *, int);
-int X509_REQ_add1_attr_by_txt(X509_REQ *, const char *, int,
-                              const unsigned char *, int);
 
 int X509V3_EXT_print(BIO *, X509_EXTENSION *, unsigned long, int);
 ASN1_OCTET_STRING *X509_EXTENSION_get_data(X509_EXTENSION *);
@@ -244,8 +237,6 @@ int X509_CRL_set_lastUpdate(X509_CRL *, ASN1_TIME *);
 int X509_CRL_set_nextUpdate(X509_CRL *, ASN1_TIME *);
 int X509_set_notBefore(X509 *, ASN1_TIME *);
 int X509_set_notAfter(X509 *, ASN1_TIME *);
-int X509_set1_notBefore(X509 *, ASN1_TIME *);
-int X509_set1_notAfter(X509 *, ASN1_TIME *);
 
 EC_KEY *d2i_EC_PUBKEY_bio(BIO *, EC_KEY **);
 int i2d_EC_PUBKEY_bio(BIO *, EC_KEY *);
@@ -365,7 +356,6 @@ const ASN1_INTEGER *X509_REVOKED_get0_serialNumber(const X509_REVOKED *x)
 {
     return x->serialNumber;
 }
-
 #define X509_set1_notBefore X509_set_notBefore
 #define X509_set1_notAfter X509_set_notAfter
 #define X509_getm_notAfter X509_get_notAfter

--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -41,6 +41,12 @@ typedef struct {
 
 typedef void * (*X509V3_EXT_D2I)(void *, const unsigned char **, long);
 
+typedef struct {
+    ASN1_ITEM_EXP *it;
+    X509V3_EXT_D2I d2i;
+    ...;
+} X509V3_EXT_METHOD;
+
 static const int GEN_OTHERNAME;
 static const int GEN_EMAIL;
 static const int GEN_X400;
@@ -240,6 +246,7 @@ void ACCESS_DESCRIPTION_free(ACCESS_DESCRIPTION *);
 X509_EXTENSION *X509V3_EXT_conf_nid(Cryptography_LHASH_OF_CONF_VALUE *,
                                     X509V3_CTX *, int, char *);
 
+const X509V3_EXT_METHOD *X509V3_EXT_get(X509_EXTENSION *);
 Cryptography_STACK_OF_DIST_POINT *sk_DIST_POINT_new_null(void);
 void sk_DIST_POINT_free(Cryptography_STACK_OF_DIST_POINT *);
 int sk_DIST_POINT_num(Cryptography_STACK_OF_DIST_POINT *);


### PR DESCRIPTION
PyPy uses cryptography to implement a pure-python _ssl stdlib module. After upgrading to v2.7 of cryptography, it turns out some API wrappers were removed that PyPy needed.

@alex suggested we collaborate to ensure future compatibility. I am not sure you want all the cruft of the python _ssl implementation in this repo. Perhaps it makes more sense to provide a new pyca/_ssl repo that would include the tests from the cpython stdlib test suite?