### PR TITLE
Explicitly state that X25519 uses little endian byteorder (#4981)

### DIFF
--- a/docs/hazmat/primitives/asymmetric/x25519.rst
+++ b/docs/hazmat/primitives/asymmetric/x25519.rst
@@ -56,6 +56,8 @@ present.
 Key interfaces
 ~~~~~~~~~~~~~~
 
+.. note:: This module uses *little endian* as its byte-level encoding, as per :rfc:`7748`.
+
 .. class:: X25519PrivateKey
 
     .. versionadded:: 2.0

--- a/docs/hazmat/primitives/asymmetric/x448.rst
+++ b/docs/hazmat/primitives/asymmetric/x448.rst
@@ -56,6 +56,8 @@ present.
 Key interfaces
 ~~~~~~~~~~~~~~
 
+.. note:: This module uses *little endian* as its byte-level encoding, as per :rfc:`7748`.
+
 .. class:: X448PrivateKey
 
     .. versionadded:: 2.5


### PR DESCRIPTION
#4981