### PR TITLE
be clear that NoEncryption must be an instance in the exception

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/ed25519.py
+++ b/src/cryptography/hazmat/backends/openssl/ed25519.py
@@ -123,7 +123,7 @@ class _Ed25519PrivateKey(object):
             ):
                 raise ValueError(
                     "When using Raw both encoding and format must be Raw "
-                    "and encryption_algorithm must be NoEncryption"
+                    "and encryption_algorithm must be NoEncryption()"
                 )
 
             return self._raw_private_bytes()

--- a/src/cryptography/hazmat/backends/openssl/ed448.py
+++ b/src/cryptography/hazmat/backends/openssl/ed448.py
@@ -126,7 +126,7 @@ class _Ed448PrivateKey(object):
             ):
                 raise ValueError(
                     "When using Raw both encoding and format must be Raw "
-                    "and encryption_algorithm must be NoEncryption"
+                    "and encryption_algorithm must be NoEncryption()"
                 )
 
             return self._raw_private_bytes()

--- a/src/cryptography/hazmat/backends/openssl/x25519.py
+++ b/src/cryptography/hazmat/backends/openssl/x25519.py
@@ -115,7 +115,7 @@ class _X25519PrivateKey(object):
             ):
                 raise ValueError(
                     "When using Raw both encoding and format must be Raw "
-                    "and encryption_algorithm must be NoEncryption"
+                    "and encryption_algorithm must be NoEncryption()"
                 )
 
             return self._raw_private_bytes()

--- a/src/cryptography/hazmat/backends/openssl/x448.py
+++ b/src/cryptography/hazmat/backends/openssl/x448.py
@@ -95,7 +95,7 @@ class _X448PrivateKey(object):
             ):
                 raise ValueError(
                     "When using Raw both encoding and format must be Raw "
-                    "and encryption_algorithm must be NoEncryption"
+                    "and encryption_algorithm must be NoEncryption()"
                 )
 
             return self._raw_private_bytes()


### PR DESCRIPTION
We tell users to use NoEncryption in our [ed/x][25519/448] serialization APIs but don't make it clear that it needs to be an instance of the class and not the class itself. Simple enough to fix.

fixes #4983 