### PR TITLE
it's called FIPS_mode_set, not FIPS_set_mode

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -269,7 +269,7 @@ def cryptography_has_evp_pkey_get_set_tls_encodedpoint():
 
 def cryptography_has_fips():
     return [
-        "FIPS_set_mode",
+        "FIPS_mode_set",
         "FIPS_mode",
     ]
 


### PR DESCRIPTION
We should remove the proper null func pointer if FIPS functions aren't present.