### PR TITLE
Silence unguarded availability warnings for `getentropy` when targeting macOS 10.12

### DIFF
--- a/src/_cffi_src/openssl/src/osrandom_engine.c
+++ b/src/_cffi_src/openssl/src/osrandom_engine.c
@@ -251,7 +251,13 @@ static int osrandom_init(ENGINE *e) {
 #if !defined(__APPLE__)
     getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_WORKS;
 #else
+
+    // clang will complain that use of `getentropy` is not guarded, but the
+    // symbol is already weakly imported
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
     if (&getentropy != NULL) {
+#pragma clang diagnostic pop
         getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_WORKS;
     } else {
         getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_FALLBACK;
@@ -277,7 +283,10 @@ static int osrandom_rand_bytes(unsigned char *buffer, int size) {
         while (size > 0) {
             /* OpenBSD and macOS restrict maximum buffer size to 256. */
             len = size > 256 ? 256 : size;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
             res = getentropy(buffer, (size_t)len);
+#pragma clang diagnostic pop
             if (res < 0) {
                 ERR_Cryptography_OSRandom_error(
                     CRYPTOGRAPHY_OSRANDOM_F_RAND_BYTES,

--- a/src/_cffi_src/openssl/src/osrandom_engine.c
+++ b/src/_cffi_src/openssl/src/osrandom_engine.c
@@ -251,13 +251,7 @@ static int osrandom_init(ENGINE *e) {
 #if !defined(__APPLE__)
     getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_WORKS;
 #else
-
-    // clang will complain that use of `getentropy` is not guarded, but the
-    // symbol is already weakly imported
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-    if (&getentropy != NULL) {
-#pragma clang diagnostic pop
+    if (__builtin_available(macOS 10.12, *)) {
         getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_WORKS;
     } else {
         getentropy_works = CRYPTOGRAPHY_OSRANDOM_GETENTROPY_FALLBACK;
@@ -283,6 +277,7 @@ static int osrandom_rand_bytes(unsigned char *buffer, int size) {
         while (size > 0) {
             /* OpenBSD and macOS restrict maximum buffer size to 256. */
             len = size > 256 ? 256 : size;
+/* on mac, availability is already checked using `__builtin_available` above */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
             res = getentropy(buffer, (size_t)len);


### PR DESCRIPTION
Apple recommends the use of `__builtin_available` to runtime-check whether a function is available.  This patch silences the `unguarded-availability` warning emitted by `clang` as a result of not using `__builtin_available`. Cryptography currently uses `weak_import` and checks whether the symbol is `NULL`, which achieves the same result.

Fixes #5020.