### PR TITLE
Don't bother computing y coefficient in _modinv

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -184,12 +184,12 @@ def _modinv(e, m):
     """
     Modular Multiplicative Inverse. Returns x such that: (x*e) mod m == 1
     """
-    x1, y1, x2, y2 = 1, 0, 0, 1
+    x1, x2 = 1, 0
     a, b = e, m
     while b > 0:
         q, r = divmod(a, b)
-        xn, yn = x1 - q * x2, y1 - q * y2
-        a, b, x1, y1, x2, y2 = b, r, x2, y2, xn, yn
+        xn = x1 - q * x2
+        a, b, x1, x2 = b, r, x2, xn
     return x1 % m
 
 


### PR DESCRIPTION
The `_modinv` function uses the extended Euclidean algorithm to compute the modular inverse of a number. Both the `x` and `y` Bezout coefficients are computed, but only the `x` coefficient is needed. Here I've removed the unnecessary calculations for the unused `y` coefficient.