### PR TITLE
issue-5041: do not add extra flags when compiler or platform does not support them

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import sys
-
 from distutils import dist
 from distutils.ccompiler import get_default_compiler
 from distutils.command.config import config
@@ -56,7 +55,8 @@ def _extra_compile_args(platform):
         d = dist.Distribution()
         cmd = config(d)
         cmd._check_compiler()
-        is_gcc = cmd.compiler.compiler[0].startswith("gcc")
+        is_gcc = "gcc" in cmd.compiler.compiler[0] or
+        "clang" in cmd.compiler.compiler[0]
     if is_gcc or not (platform in ["win32", "hp-ux11", "sunos5"] or
                       platform.startswith("aix")):
         return ["-Wconversion", "-Wno-error=sign-conversion"]

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -11,8 +11,8 @@ from _cffi_src.utils import (
     build_ffi_for_binding, compiler_type, extra_link_args
 )
 
-from distutils.ccompiler import get_default_compiler
 from distutils import dist
+from distutils.ccompiler import get_default_compiler
 from distutils.command.config import config
 
 

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -7,13 +7,13 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
-from _cffi_src.utils import (
-    build_ffi_for_binding, compiler_type, extra_link_args
-)
-
 from distutils import dist
 from distutils.ccompiler import get_default_compiler
 from distutils.command.config import config
+
+from _cffi_src.utils import (
+    build_ffi_for_binding, compiler_type, extra_link_args
+)
 
 
 def _get_openssl_libraries(platform):

--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -55,8 +55,8 @@ def _extra_compile_args(platform):
         d = dist.Distribution()
         cmd = config(d)
         cmd._check_compiler()
-        is_gcc = "gcc" in cmd.compiler.compiler[0] or
-        "clang" in cmd.compiler.compiler[0]
+        is_gcc = ("gcc" in cmd.compiler.compiler[0] or
+                  "clang" in cmd.compiler.compiler[0])
     if is_gcc or not (platform in ["win32", "hp-ux11", "sunos5"] or
                       platform.startswith("aix")):
         return ["-Wconversion", "-Wno-error=sign-conversion"]


### PR DESCRIPTION
Assuming that clang also supports these flags.

Please verify correct list of compilers that are known to support these flags.