### PR TITLE
Let Oid enforce positive decimal integers

### DIFF
--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -19,11 +19,16 @@ class ObjectIdentifier(object):
         # range 0..39.  All nodes must be integers.
         for node in nodes:
             try:
-                intnodes.append(int(node, 0))
+                node_value = int(node, 10)
             except ValueError:
                 raise ValueError(
                     "Malformed OID: %s (non-integer nodes)" % (
                         self._dotted_string))
+            if node_value < 0:
+                raise ValueError(
+                    "Malformed OID: %s (negative-integer nodes)" % (
+                        self._dotted_string))
+            intnodes.append(node_value)
 
         if len(nodes) < 2:
             raise ValueError(

--- a/tests/hazmat/test_oid.py
+++ b/tests/hazmat/test_oid.py
@@ -1,0 +1,39 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from cryptography.hazmat._oid import ObjectIdentifier
+
+
+def test_basic_oid():
+    assert ObjectIdentifier('1.2.3.4').dotted_string == '1.2.3.4'
+
+
+def test_oid_constraint():
+    # Too short
+    with pytest.raises(ValueError):
+        ObjectIdentifier('1')
+
+    # First node too big
+    with pytest.raises(ValueError):
+        ObjectIdentifier('3.2.1')
+
+    # Outside range
+    with pytest.raises(ValueError):
+        ObjectIdentifier('1.40')
+    with pytest.raises(ValueError):
+        ObjectIdentifier('0.42')
+
+    # non-decimal oid
+    with pytest.raises(ValueError):
+        ObjectIdentifier('1.2.foo.bar')
+    with pytest.raises(ValueError):
+        ObjectIdentifier('1.2.0xf00.0xba4')
+
+    # negative oid
+    with pytest.raises(ValueError):
+        ObjectIdentifier('1.2.-3.-4')


### PR DESCRIPTION
Failing that would lead to an OpenSSL error when calling OBJ_txt2obj at
serialization.

Adds basic tests for oids.

The code previously allowed any parsable int like 0b101, 0o42 or 0x23 as well as negative numbers and failed with a internal error upon serialization. 