### PR TITLE
OpenSSL: Expose SSL_CTX_clear_mode/SSL_clear_mode

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -338,6 +338,7 @@ const COMP_METHOD *SSL_get_current_expansion(SSL *);
 const char *SSL_COMP_get_name(const COMP_METHOD *);
 
 unsigned long SSL_set_mode(SSL *, unsigned long);
+unsigned long SSL_clear_mode(SSL *, unsigned long);
 unsigned long SSL_get_mode(SSL *);
 
 unsigned long SSL_set_options(SSL *, unsigned long);
@@ -359,6 +360,7 @@ unsigned long SSL_CTX_set_options(SSL_CTX *, unsigned long);
 unsigned long SSL_CTX_clear_options(SSL_CTX *, unsigned long);
 unsigned long SSL_CTX_get_options(SSL_CTX *);
 unsigned long SSL_CTX_set_mode(SSL_CTX *, unsigned long);
+unsigned long SSL_CTX_clear_mode(SSL_CTX *, unsigned long);
 unsigned long SSL_CTX_get_mode(SSL_CTX *);
 unsigned long SSL_CTX_set_session_cache_mode(SSL_CTX *, unsigned long);
 unsigned long SSL_CTX_get_session_cache_mode(SSL_CTX *);


### PR DESCRIPTION
This PR adds `SSL_CTX_clear_mode` and `SSL_clear_mode` bindings, which were introduced in OpenSSL 1.1.1: https://www.openssl.org/docs/man1.1.1/man3/SSL_clear_mode.html

We have an ugly combination of `select()`, blocking I/O and `SSL_read()` in our old TCP proxying code for @mitmproxy, so we need a way to turn off  `SSL_MODE_AUTO_RETRY` and hide our atrocities until our sans-io proxying is ready.