### PR TITLE
add SSL_get_verify_result

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -214,6 +214,7 @@ Cryptography_STACK_OF_X509 *SSL_get0_verified_chain(const SSL *);
 Cryptography_STACK_OF_X509_NAME *SSL_get_client_CA_list(const SSL *);
 
 int SSL_get_error(const SSL *, int);
+long SSL_get_verify_result(const SSL *ssl);
 int SSL_do_handshake(SSL *);
 int SSL_shutdown(SSL *);
 int SSL_renegotiate(SSL *);


### PR DESCRIPTION
This PR exposes `SSL_get_verify_result`, which can provide more useful certificate verification error messages. 

Meta comment: I hope the trickle of super small PRs isn't too bad - sorry about that. I'm rewriting our TLS implementation for @mitmproxy, just figuring a few things out on the way. Thanks for the super-fast merges so far! 🍰 