### PR TITLE
Make it easy to have custom extension handlers

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -119,6 +119,11 @@ class Backend(object):
     OpenSSL API binding interfaces.
     """
     name = "openssl"
+    crl_entry_extension_encode_handlers = _CRL_ENTRY_EXTENSION_ENCODE_HANDLERS
+    crl_extension_encode_handlers = _CRL_EXTENSION_ENCODE_HANDLERS
+    extension_encode_handlers = _EXTENSION_ENCODE_HANDLERS
+    ocsp_basicresp_extension_encode_handlers = _OCSP_BASICRESP_EXTENSION_ENCODE_HANDLERS
+    ocsp_request_extension_encode_handlers = _OCSP_REQUEST_EXTENSION_ENCODE_HANDLERS
 
     def __init__(self):
         self._binding = binding.Binding()
@@ -792,7 +797,7 @@ class Backend(object):
         # sk_extensions and will be freed along with it.
         self._create_x509_extensions(
             extensions=builder._extensions,
-            handlers=_EXTENSION_ENCODE_HANDLERS,
+            handlers=self.extension_encode_handlers,
             x509_obj=sk_extension,
             add_func=self._lib.sk_X509_EXTENSION_insert,
             gc=False
@@ -878,7 +883,7 @@ class Backend(object):
         # Add extensions.
         self._create_x509_extensions(
             extensions=builder._extensions,
-            handlers=_EXTENSION_ENCODE_HANDLERS,
+            handlers=self.extension_encode_handlers,
             x509_obj=x509_cert,
             add_func=self._lib.X509_add_ext,
             gc=True
@@ -978,7 +983,7 @@ class Backend(object):
         # Add extensions.
         self._create_x509_extensions(
             extensions=builder._extensions,
-            handlers=_CRL_EXTENSION_ENCODE_HANDLERS,
+            handlers=self.crl_extension_encode_handlers,
             x509_obj=x509_crl,
             add_func=self._lib.X509_CRL_add_ext,
             gc=True
@@ -1083,7 +1088,7 @@ class Backend(object):
         # add CRL entry extensions
         self._create_x509_extensions(
             extensions=builder._extensions,
-            handlers=_CRL_ENTRY_EXTENSION_ENCODE_HANDLERS,
+            handlers=self.crl_entry_extension_encode_handlers,
             x509_obj=x509_revoked,
             add_func=self._lib.X509_REVOKED_add_ext,
             gc=True
@@ -1553,7 +1558,7 @@ class Backend(object):
         self.openssl_assert(onereq != self._ffi.NULL)
         self._create_x509_extensions(
             extensions=builder._extensions,
-            handlers=_OCSP_REQUEST_EXTENSION_ENCODE_HANDLERS,
+            handlers=self.ocsp_request_extension_encode_handlers,
             x509_obj=ocsp_req,
             add_func=self._lib.OCSP_REQUEST_add_ext,
             gc=True,
@@ -1618,7 +1623,7 @@ class Backend(object):
 
         self._create_x509_extensions(
             extensions=builder._extensions,
-            handlers=_OCSP_BASICRESP_EXTENSION_ENCODE_HANDLERS,
+            handlers=self.ocsp_basicresp_extension_encode_handlers,
             x509_obj=basic,
             add_func=self._lib.OCSP_BASICRESP_add_ext,
             gc=True,


### PR DESCRIPTION
I want to have custom extension handler to read and write values for custom OID.
With the current implementation it's a bit hard to do: extension handlers are registered in the `encode_asn1.py` in a constant. So I thought it would be great to have the possibility to subclass a `Backend` class and override handler in the subclass. 
I am not very familiar with the source code of `cryptography` so the solution proposed maybe not the best one. It also introduces two more hash lookups. 
Please tell if the solution does not fit somehow.