### PR TITLE
Add pthread linking on non-win32

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -37,7 +37,10 @@ def _get_openssl_libraries(platform):
         # specified on the linker command-line is significant;
         # libssl must come before libcrypto
         # (https://marc.info/?l=openssl-users&m=135361825921871)
-        return ["ssl", "crypto"]
+        # -lpthread required due to usage of pthread an potential
+        # existance of a static part containing e.g. pthread_atfork
+        # (https://github.com/pyca/cryptography/issues/5084)
+        return ["ssl", "crypto", "pthread"]
 
 
 def _extra_compile_args(platform):


### PR DESCRIPTION
Required to link in static part of pthread, e.g. pthread_atfork
Fixes https://github.com/pyca/cryptography/issues/5084