### PR TITLE
drop python 3.4 support

### DIFF
--- a/.azure-pipelines/wheel-builder.yml
+++ b/.azure-pipelines/wheel-builder.yml
@@ -12,7 +12,7 @@ jobs:
                   PYTHON_DOWNLOAD_URL: "https://www.python.org/ftp/python/2.7.16/python-2.7.16-macosx10.6.pkg"
                   PYTHON_BIN_PATH: /Library/Frameworks/Python.framework/Versions/2.7/bin/python
               Python3:
-                  python.version: '3.4'
+                  python.version: '3.5'
                   PYTHON_DOWNLOAD_URL: "https://www.python.org/ftp/python/3.7.3/python-3.7.3-macosx10.6.pkg"
                   PYTHON_BIN_PATH: /Library/Frameworks/Python.framework/Versions/3.7/bin/python3
       steps:
@@ -87,7 +87,7 @@ jobs:
                   PLATFORM: 'manylinux1_x86_64'
               Python3m-manylinux1:
                   containerImage: 'pyca/cryptography-manylinux1:x86_64'
-                  PYTHON_VERSION: 'cp34-cp34m'
+                  PYTHON_VERSION: 'cp35-cp35m'
                   PLATFORM: 'manylinux1_x86_64'
               Python27m-manylinux2010:
                   containerImage: 'pyca/cryptography-manylinux2010:x86_64'
@@ -99,7 +99,7 @@ jobs:
                   PLATFORM: 'manylinux2010_x86_64'
               Python3m-manylinux2010:
                   containerImage: 'pyca/cryptography-manylinux2010:x86_64'
-                  PYTHON_VERSION: 'cp34-cp34m'
+                  PYTHON_VERSION: 'cp35-cp35m'
                   PLATFORM: 'manylinux2010_x86_64'
       steps:
           - script: /opt/python/$PYTHON_VERSION/bin/python -m virtualenv .venv
@@ -162,16 +162,6 @@ jobs:
               Python27-x86-64:
                   containerImage: 'pyca/cryptography-runner-windows:py27-x86_64'
                   PYTHON_VERSION: '27'
-                  OPENSSL_DIR: 'OpenSSL-Win64-2010'
-                  WINDOWS_ARCH: 'x86_64'
-              Python34-x86:
-                  containerImage: 'pyca/cryptography-runner-windows:py34-x86'
-                  PYTHON_VERSION: '34'
-                  OPENSSL_DIR: 'OpenSSL-Win32-2010'
-                  WINDOWS_ARCH: 'x86'
-              Python34-x86-64:
-                  containerImage: 'pyca/cryptography-runner-windows:py34-x86_64'
-                  PYTHON_VERSION: '34'
                   OPENSSL_DIR: 'OpenSSL-Win64-2010'
                   WINDOWS_ARCH: 'x86_64'
               Python35-x86:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,11 @@ branches:
 
 matrix:
     include:
-        - python: 3.4
+        - python: 3.8
           env: TOXENV=pep8
         # Setting 'python' is just to make travis's UI a bit prettier
         - python: 2.7
           env: TOXENV=py27
-        - python: 3.4
-          env: TOXENV=py34
         - python: 3.5
           env: TOXENV=py35
         - python: 3.6
@@ -74,9 +72,6 @@ matrix:
         - python: 2.7
           services: docker
           env: TOXENV=py27 DOCKER=pyca/cryptography-runner-jessie
-        - python: 3.4
-          services: docker
-          env: TOXENV=py34 DOCKER=pyca/cryptography-runner-jessie
         - python: 2.7
           services: docker
           env: TOXENV=py27 DOCKER=pyca/cryptography-runner-stretch

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
-* **BACKWARDS INCOMPATIBLE:** Support for Python 3.4 has been dropped due to
+* **BACKWARDS INCOMPATIBLE:** Support for Python 3.4 has been removed due to
   low usage and maintenance burden.
 * **BACKWARDS INCOMPATIBLE:** Support for OpenSSL 1.0.1 has been removed.
   Users on older version of OpenSSL will need to upgrade.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,9 +8,11 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
-* Support for OpenSSL 1.0.1 has been removed. Users on older version of OpenSSL
-  will need to upgrade.
-* Support for LibreSSL 2.6.x has been removed.
+* **BACKWARDS INCOMPATIBLE:** Support for Python 3.4 has been dropped due to
+  low usage and maintenance burden.
+* **BACKWARDS INCOMPATIBLE:** Support for OpenSSL 1.0.1 has been removed.
+  Users on older version of OpenSSL will need to upgrade.
+* **BACKWARDS INCOMPATIBLE:** Support for LibreSSL 2.6.x has been removed.
 * Removed support for calling
   :meth:`~cryptography.hazmat.primitives.asymmetric.x25519.X25519PublicKey.public_bytes`
   with no arguments, as per our deprecation policy. You must now pass

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,18 +82,6 @@ jobs:
         OPENSSL_DIR: 'OpenSSL-Win64-2010'
         PYTHON_DIR: 'Python27'
         WINDOWS_ARCH: 'x86_64'
-      Python34-x86:
-        TOXENV: py34
-        containerImage: 'pyca/cryptography-runner-windows:py34-x86'
-        OPENSSL_DIR: 'OpenSSL-Win32-2010'
-        PYTHON_DIR: 'Python34'
-        WINDOWS_ARCH: 'x86'
-      Python34-x86-64:
-        TOXENV: py34
-        containerImage: 'pyca/cryptography-runner-windows:py34-x86_64'
-        OPENSSL_DIR: 'OpenSSL-Win64-2010'
-        PYTHON_DIR: 'Python34'
-        WINDOWS_ARCH: 'x86_64'
       Python35-x86:
         TOXENV: py35
         containerImage: 'pyca/cryptography-runner-windows:py35-x86'

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -81,7 +81,7 @@ each supported Python version and run the tests. For example:
     ...
      py27: commands succeeded
     ERROR:   pypy: InterpreterNotFound: pypy
-     py34: commands succeeded
+     py38: commands succeeded
      docs: commands succeeded
      pep8: commands succeeded
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -104,12 +104,12 @@ Since they are no longer receiving security patches from upstream,
 should upgrade to a newer version of OpenSSL (1.0.2 or later). This may require
 you to upgrade to a newer operating system.
 
-Why are there no wheels for Python 3.5+ on Linux or macOS?
+Why are there no wheels for Python 3.6+ on Linux or macOS?
 ----------------------------------------------------------
 
 Our Python3 wheels, for macOS and Linux, are ``abi3`` wheels. This means they
-support multiple versions of Python. The Python 3.4 ``abi3`` wheel can be used
-with any version of Python greater than or equal to 3.4. Recent versions of
+support multiple versions of Python. The Python 3.5 ``abi3`` wheel can be used
+with any version of Python greater than or equal to 3.5. Recent versions of
 ``pip`` will automatically install ``abi3`` wheels.
 
 ``ImportError``: ``idna`` is not installed

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ You can install ``cryptography`` with ``pip``:
 Supported platforms
 -------------------
 
-Currently we test ``cryptography`` on Python 2.7, 3.4+, and
+Currently we test ``cryptography`` on Python 2.7, 3.5+, and
 PyPy 5.4+ on these operating systems.
 
 * x86-64 CentOS 7.x
@@ -49,7 +49,7 @@ just run
 If you prefer to compile it yourself you'll need to have OpenSSL installed.
 You can compile OpenSSL yourself as well or use `a binary distribution`_.
 Be sure to download the proper version for your architecture and Python
-(VC2010 works for Python 2.7, 3.3, and 3.4 while VC2015 is required for 3.5 and above).
+(VC2010 works for Python 2.7 while VC2015 is required for 3.5 and above).
 Wherever you place your copy of OpenSSL you'll need to set the ``LIB`` and ``INCLUDE``
 environment variables to include the proper locations. For example:
 

--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -231,7 +230,7 @@ setup(
     packages=find_packages(where="src", exclude=["_cffi_src", "_cffi_src.*"]),
     include_package_data=True,
 
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
 
     install_requires=[
         "six >= 1.4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = py27,pypy,py34,py35,py36,py37,py38,docs,pep8,packaging
+envlist = py27,pypy,py35,py36,py37,py38,docs,pep8,packaging
 isolated_build = True
 
 [testenv]
@@ -18,7 +18,7 @@ setenv =
 commands =
     pip list
     # We use parallel mode and then combine here so that coverage.py will take
-    # the paths like .tox/py34/lib/python3.4/site-packages/cryptography/__init__.py
+    # the paths like .tox/py38/lib/python3.8/site-packages/cryptography/__init__.py
     # and collapse them into src/cryptography/__init__.py.
     coverage run --parallel-mode -m pytest --capture=no --strict {posargs}
     coverage combine


### PR DESCRIPTION
Our dependencies have started dropping support so it is becoming difficult to test. Additionally, Python 3.4 represents <2% of our downloads, so taking on a large maintenance burden to maintain support isn't a good use of limited time. Accordingly, we're dropping testing infrastructure and migrating our abi3 wheels to py35+.