### PR TITLE
Reversed the order of RDNs in x509.Name.rfc4514_string()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Changelog
 * Added support for parsing
   :attr:`~cryptography.x509.ocsp.OCSPResponse.single_extensions` in an OCSP
   response.
+* **BACKWARDS INCOMPATIBLE:** Reversed the order in which
+  :meth:`~cryptography.x509.Name.rfc4514_string` returns the RDNs as required by
+  RFC4514.
 
 .. _v2-8:
 

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -216,9 +216,11 @@ class Name(object):
         An X.509 name is a two-level structure: a list of sets of attributes.
         Each list element is separated by ',' and within each list element, set
         elements are separated by '+'. The latter is almost never used in
-        real world certificates.
+        real world certificates. According to RFC4514 section 2.1 the
+        RDNSequence must be reversed when converting to string representation.
         """
-        return ','.join(attr.rfc4514_string() for attr in self._attributes)
+        return ','.join(
+            attr.rfc4514_string() for attr in reversed(self._attributes))
 
     def get_attributes_for_oid(self, oid):
         return [i for i in self if i.oid == oid]
@@ -253,7 +255,9 @@ class Name(object):
         return sum(len(rdn) for rdn in self._attributes)
 
     def __repr__(self):
+        rdns = ','.join(attr.rfc4514_string() for attr in self._attributes)
+
         if six.PY2:
-            return "<Name({})>".format(self.rfc4514_string().encode('utf8'))
+            return "<Name({})>".format(rdns.encode('utf8'))
         else:
-            return "<Name({})>".format(self.rfc4514_string())
+            return "<Name({})>".format(rdns)

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -4556,14 +4556,14 @@ class TestName(object):
     def test_rfc4514_string(self):
         n = x509.Name([
             x509.RelativeDistinguishedName([
-                x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, u'Sales'),
-                x509.NameAttribute(NameOID.COMMON_NAME, u'J.  Smith'),
+                x509.NameAttribute(NameOID.DOMAIN_COMPONENT, u'net'),
             ]),
             x509.RelativeDistinguishedName([
                 x509.NameAttribute(NameOID.DOMAIN_COMPONENT, u'example'),
             ]),
             x509.RelativeDistinguishedName([
-                x509.NameAttribute(NameOID.DOMAIN_COMPONENT, u'net'),
+                x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, u'Sales'),
+                x509.NameAttribute(NameOID.COMMON_NAME, u'J.  Smith'),
             ]),
         ])
         assert (n.rfc4514_string() ==


### PR DESCRIPTION
When converting a RDNSequence to a string representation according to RFC 4514, one shall reverse the order of the RDNs. The RFC states this in section 2.1:

> Otherwise, the output consists of the string encodings of each
> RelativeDistinguishedName in the RDNSequence (according to Section
> 2.2), starting with the last element of the sequence and moving
> backwards toward the first.

I.e. if one creates a CSR using OpenSSL like `openssl req -new -newkey rsa:1024 -keyout test.key -nodes -out test.csr -subj "/C=TZ/O=serengeti/CN=elephant"` and reads this CSR using cryptography, `csr.subject.rfc4514_string()` should return `C=TZ,O=serengeti,CN=elephant`. This makes it consistent with, for example, `openssl req -noout -text -in test.csr -nameopt rfc2253` or what Apache2's mod_ssl returnes in client authentication meta-data. Note that RFC 2253 was the predecessor of RFC 4514, which did not change the conversion order for string representations of RDNSequences.

I've also updated the test for `x509.Name.rfc4514_string`. To not have to change more tests, and for backwards compatibility, I've kept the `x509.Name.__repr__` method's output the same though this required changing them (they used `rfc4514_string`). However I also think it is intuitive for `__repr__` to return something more close to the RDNSequence, since that is the way the name is stored in a binary representation. But I'm happy to update the PR if you think keeping `rfc4514_string` in `__repr__` would be better.

This PR should fix #5119.