### PR TITLE
Hotfix: use enum34 != 1.1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -236,7 +236,7 @@ setup(
         "six >= 1.4.1",
     ] + setup_requirements,
     extras_require={
-        ":python_version < '3'": ["enum34", "ipaddress"],
+        ":python_version < '3'": ["enum34!=1.1.8", "ipaddress"],
 
         "test": [
             "pytest>=3.6.0,!=3.9.0,!=3.9.1,!=3.9.2",


### PR DESCRIPTION
Cryptography is currently broken on Python 2 because of enum34 1.1.8. See
https://bitbucket.org/stoneleaf/enum34/issues/27/enum34-118-broken