### PR TITLE
Added import for pkcs12

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/__init__.py
+++ b/src/cryptography/hazmat/primitives/serialization/__init__.py
@@ -14,6 +14,9 @@ from cryptography.hazmat.primitives.serialization.ssh import (
     load_ssh_public_key
 )
 
+from cryptography.hazmat.primitives.serialization.pkcs12 import (
+    load_key_and_certificates
+)
 
 _PEM_DER = (Encoding.PEM, Encoding.DER)
 


### PR DESCRIPTION
Since v2.5 it's possible to load a pkcs12 file. The necessary import was not set within the __init__-file.