### PR TITLE
Fix silly linter problem with CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,8 +21,8 @@ Changelog
   :attr:`~cryptography.x509.ocsp.OCSPResponse.single_extensions` in an OCSP
   response.
 * **BACKWARDS INCOMPATIBLE:** Reversed the order in which
-  :meth:`~cryptography.x509.Name.rfc4514_string` returns the RDNs as required by
-  :rfc:`4514`.
+  :meth:`~cryptography.x509.Name.rfc4514_string` returns the RDNs
+  as required by :rfc:`4514`.
 
 .. _v2-8:
 


### PR DESCRIPTION
This line triggers warning:

	CHANGELOG.rst:24: D001 Line too long

but only when an item is added after it.
Eg. "* Foo" is enough to trigger it.