### PR TITLE
AES-CCM data length validation error message fix.

### DIFF
--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -126,7 +126,7 @@ class AESCCM(object):
         # https://tools.ietf.org/html/rfc3610#section-2.1
         l_val = 15 - len(nonce)
         if 2 ** (8 * l_val) < data_len:
-            raise ValueError("Nonce too long for data")
+            raise ValueError("Data too long for nonce")
 
     def _check_params(self, nonce, data, associated_data):
         utils._check_byteslike("nonce", nonce)


### PR DESCRIPTION
Fixed error message in AES-CCM data length validation to reflect the true reason of error more accurately.

AES-CCM encrypted input data is limited by the length of provided nonce. Error message should indicate that the provided data input is too long for the nonce of given length.