### PR TITLE
Expose SSL_CTX_(get|set)_keylog_callback

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -32,6 +32,7 @@ static const long Cryptography_HAS_SIGALGS;
 static const long Cryptography_HAS_PSK;
 static const long Cryptography_HAS_CIPHER_DETAILS;
 static const long Cryptography_HAS_VERIFIED_CHAIN;
+static const long Cryptography_HAS_KEYLOG;
 
 /* Internally invented symbol to tell us if SNI is supported */
 static const long Cryptography_HAS_TLSEXT_HOSTNAME;
@@ -285,6 +286,10 @@ void SSL_CTX_set_client_CA_list(SSL_CTX *, Cryptography_STACK_OF_X509_NAME *);
 
 void SSL_CTX_set_info_callback(SSL_CTX *, void (*)(const SSL *, int, int));
 void (*SSL_CTX_get_info_callback(SSL_CTX *))(const SSL *, int, int);
+
+void SSL_CTX_set_keylog_callback(SSL_CTX *,
+                                 void (*)(const SSL *, const char *));
+void (*SSL_CTX_get_keylog_callback(SSL_CTX *))(const SSL *, const char *);
 
 long SSL_CTX_set1_sigalgs_list(SSL_CTX *, const char *);
 
@@ -570,6 +575,19 @@ static const long Cryptography_HAS_VERIFIED_CHAIN = 0;
 Cryptography_STACK_OF_X509 *(*SSL_get0_verified_chain)(const SSL *) = NULL;
 #else
 static const long Cryptography_HAS_VERIFIED_CHAIN = 1;
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+static const long Cryptography_HAS_KEYLOG = 0;
+void (*SSL_CTX_set_keylog_callback)(SSL_CTX *,
+                                    void (*) (const SSL *, const char *)
+                                    ) = NULL;
+void (*(*SSL_CTX_get_keylog_callback)(SSL_CTX *))(
+                                                  const SSL *,
+                                                  const char *
+                                                  ) = NULL;
+#else
+static const long Cryptography_HAS_KEYLOG = 1;
 #endif
 
 /* Added in 1.1.0 in the great opaquing, but we need to define it for older

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -329,6 +329,13 @@ def cryptography_has_tlsv13():
     ]
 
 
+def cryptography_has_keylog():
+    return [
+        "SSL_CTX_set_keylog_callback",
+        "SSL_CTX_get_keylog_callback",
+    ]
+
+
 def cryptography_has_raw_key():
     return [
         "EVP_PKEY_new_raw_private_key",
@@ -430,6 +437,7 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_OPENSSL_CLEANUP": cryptography_has_openssl_cleanup,
     "Cryptography_HAS_CIPHER_DETAILS": cryptography_has_cipher_details,
     "Cryptography_HAS_TLSv1_3": cryptography_has_tlsv13,
+    "Cryptography_HAS_KEYLOG": cryptography_has_keylog,
     "Cryptography_HAS_RAW_KEY": cryptography_has_raw_key,
     "Cryptography_HAS_EVP_DIGESTFINAL_XOF": (
         cryptography_has_evp_digestfinal_xof


### PR DESCRIPTION
Thanks for the new cryptography release! 😃🍰 

We're currently upgrading @mitmproxy and it looks like our SSLKEYLOGFILE implementation breaks somewhere between OpenSSL 1.1.1d and 1.1.1f. This is something we can implement ugly workarounds for at the moment, but the long-term fix is to just use SSL_CTX_set_keylog_callback (thanks for building that, @Lukasa!). There will be a [follow-up PR](https://github.com/mhils/pyopenssl/tree/keylog) for pyOpenSSL once this one has landed.