### PR TITLE
Add support for more AES key sizes

### DIFF
--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -33,18 +33,24 @@ class Fernet(object):
             backend = default_backend()
 
         key = base64.urlsafe_b64decode(key)
-        if len(key) != 32:
-            raise ValueError(
-                "Fernet key must be 32 url-safe base64-encoded bytes."
-            )
+        Fernet._verify_key_size(len(key))
 
         self._signing_key = key[:16]
         self._encryption_key = key[16:]
         self._backend = backend
 
     @classmethod
-    def generate_key(cls):
-        return base64.urlsafe_b64encode(os.urandom(32))
+    def _verify_key_size(cls, key_size):
+        if key_size not in frozenset([32, 40, 48]):
+            raise ValueError(
+                "Fernet key must be 32, 40, or 48 url-safe base64-encoded"
+                " bytes."
+            )
+
+    @classmethod
+    def generate_key(cls, key_size=32):
+        Fernet._verify_key_size(key_size)
+        return base64.urlsafe_b64encode(os.urandom(key_size))
 
     def encrypt(self, data):
         current_time = int(time.time())

--- a/vectors/cryptography_vectors/fernet/generate.json
+++ b/vectors/cryptography_vectors/fernet/generate.json
@@ -5,5 +5,19 @@
     "iv": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
     "src": "hello",
     "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "token": "gAAAAAAdwJ6wAAECAwQFBgcICQoLDA0OD708dSY6kSnIHy1C8Dw8C75oHMgQKG-KG75oxTc2AXIpEPY-6eWC53cJr3tM0C9BYw==",
+    "now": "1985-10-26T01:20:00-07:00",
+    "iv": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    "src": "hello",
+    "secret": "yTdieR_DiL9X42yTliifqshHUbFry2gcAwkbSQpz1gyUj_jA0do4yg=="
+  },
+  {
+    "token": "gAAAAAAdwJ6wAAECAwQFBgcICQoLDA0OD9Rw-JVKSI7TRcuEZsfZFfW9ao_jANDkkDgx2U4Laq7EigdsIl7q_30TpR8Wqtyojg==",
+    "now": "1985-10-26T01:20:00-07:00",
+    "iv": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    "src": "hello",
+    "secret": "ZugEV1uXHXDPRn_lTPbCPjrVosNlGovOWIrSl4KOE5D0T9bg961i1qhWKB1ceodl"
   }
 ]

--- a/vectors/cryptography_vectors/fernet/verify.json
+++ b/vectors/cryptography_vectors/fernet/verify.json
@@ -5,5 +5,19 @@
     "ttl_sec": 60,
     "src": "hello",
     "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "token": "gAAAAAAdwJ6xAAECAwQFBgcICQoLDA0OD708dSY6kSnIHy1C8Dw8C76jNd_teIQw0CgtjS0BRc2uyerIZyJ9acJKWEN1EHtVSw==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "src": "hello",
+    "secret": "yTdieR_DiL9X42yTliifqshHUbFry2gcAwkbSQpz1gyUj_jA0do4yg=="
+  },
+  {
+    "token": "gAAAAAAdwJ6xAAECAwQFBgcICQoLDA0OD9Rw-JVKSI7TRcuEZsfZFfX-yc1sU1tL7JXw_g-n9eTsrOMpw5XB52wP7sE7ki47rQ==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "src": "hello",
+    "secret": "ZugEV1uXHXDPRn_lTPbCPjrVosNlGovOWIrSl4KOE5D0T9bg961i1qhWKB1ceodl"
   }
 ]


### PR DESCRIPTION
Add support for all the supported AES key sizes under the current Fernet setup (128, 192 and 256 bits).