### PR TITLE
removing a bunch of builds we don't need

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,8 @@ matrix:
         - python: 3.8
           env: TOXENV=pep8
         # Setting 'python' is just to make travis's UI a bit prettier
-        - python: 2.7
-          env: TOXENV=py27
-        - python: 3.5
-          env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
-        - python: 3.7
-          env: TOXENV=py37
-        - python: 3.8
-          env: TOXENV=py38
         - python: 3.8
           env: TOXENV=py38-idna
         - python: pypy2.7-7.1.1
@@ -98,9 +90,9 @@ matrix:
         - python: 3.8
           services: docker
           env: TOXENV=py38 DOCKER=pyca/cryptography-runner-ubuntu-rolling
-        - python: 2.7
+        - python: 3.8
           services: docker
-          env: TOXENV=py27-randomorder DOCKER=pyca/cryptography-runner-ubuntu-rolling
+          env: TOXENV=py38-randomorder DOCKER=pyca/cryptography-runner-ubuntu-rolling
         - python: 3.7
           services: docker
           env: TOXENV=py37 DOCKER=pyca/cryptography-runner-fedora


### PR DESCRIPTION
I argue we do not need these builds. Rationale:

* For 2.7 builds we test 2.7 compatibility against 1.1.1-latest (which we support through our binary wheels) and we test distros that ship 2.7 as a primary python.
* For distros that ship a python > 2.7 (e.g. stretch) we can drop the 2.7 tests because we're already testing 2.7 in other configs that are substantially similar (2.7 in centos7 is against 1.0.2 as well)
* 2.7 in ubuntu rolling is pointless as it's deliberately difficult to get py2 on Ubuntu 20.04+ now and our 2.7 + 1.1.1-latest effectively test the same thing anyway. (We should also remove 2.7 from that container)
* We don't need the python 3.5 or 3.7 "base" travis builds because we're testing essentially the same thing with our stretch and buster docker containers.

Finally, I claim that reducing the number of builds will reduce the likelihood of ephemeral build failure, decrease cycle time when we're under load, and generally make me hate working on this project less. The extraordinarily limited additional advantage these builds provides is not worth the pain they cause.

This does not fix the single biggest travis issue at the moment (non-amd64 builds being ruinously slow), but I'll address that in a separate PR.