### PR TITLE
Make codecov upload errors in GHA pass silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Upload coverage
         run: |
           curl -o codecov.sh -f https://codecov.io/bash
-          bash codecov.sh -n "Python ${{ matrix.PYTHON.VERSION }} on macOS" -Z
+          bash codecov.sh -n "Python ${{ matrix.PYTHON.VERSION }} on macOS"
 
   windows:
     runs-on: windows-latest
@@ -96,4 +96,4 @@ jobs:
       - name: Upload coverage
         run: |
           curl -o codecov.sh -f https://codecov.io/bash
-          bash codecov.sh -n "Python ${{ matrix.PYTHON.VERSION }} on ${{ matrix.WINDOWS.WINDOWS }}" -Z
+          bash codecov.sh -n "Python ${{ matrix.PYTHON.VERSION }} on ${{ matrix.WINDOWS.WINDOWS }}"


### PR DESCRIPTION
The spurious failure rate on codecov uploads is high enough that this is a cure worse than the disease