### PR TITLE
Add a way to pass current time to Fernet

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -55,6 +55,8 @@ has support for implementing key rotation via :class:`MultiFernet`.
 
     .. method:: encrypt_at_time(data, current_time)
 
+       .. versionadded:: 3.0
+
        Encrypts data passed using explicitly passed current time. See
        :meth:`encrypt` for the documentation of the ``data`` parameter, the
        return type and the exceptions raised.
@@ -101,6 +103,8 @@ has support for implementing key rotation via :class:`MultiFernet`.
                            ``bytes``.
 
     .. method:: decrypt_at_time(token, ttl, current_time)
+
+       .. versionadded:: 3.0
 
        Decrypts a token using explicitly passed current time. See
        :meth:`decrypt` for the documentation of the ``token`` and ``ttl``

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -56,7 +56,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
     .. method:: encrypt_at_time(data, current_time)
 
        Encrypts data passed using explicitly passed current time. See
-       :meth:`encrypt` for the documentaiton of the ``data`` parameter, the
+       :meth:`encrypt` for the documentation of the ``data`` parameter, the
        return type and the exceptions raised.
 
        The motivation behind this method is for the client code to be able to

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -100,7 +100,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
         :raises TypeError: This exception is raised if ``token`` is not
                            ``bytes``.
 
-    .. method:: dectypy_at_time(token, ttl, current_time)
+    .. method:: decrypt_at_time(token, ttl, current_time)
 
        Decrypts a token using explicitly passed current time. See
        :meth:`decrypt` for the documentation of the ``token`` and ``ttl``

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -35,15 +35,12 @@ has support for implementing key rotation via :class:`MultiFernet`.
         they'll also be able forge arbitrary messages that will be
         authenticated and decrypted.
 
-    .. method:: encrypt(data, current_time=None)
+    .. method:: encrypt(data)
 
         Encrypts data passed. The result of this encryption is known as a
         "Fernet token" and has strong privacy and authenticity guarantees.
 
         :param bytes data: The message you would like to encrypt.
-        :param int current_time: The current time to be used instead of
-                                 the value returned by time.time()
-                                 (can used in unit tests for example).
         :returns bytes: A secure message that cannot be read or altered
                         without the key. It is URL-safe base64-encoded. This is
                         referred to as a "Fernet token".
@@ -56,7 +53,27 @@ has support for implementing key rotation via :class:`MultiFernet`.
             generated in *plaintext*, the time a message was created will
             therefore be visible to a possible attacker.
 
-    .. method:: decrypt(token, ttl=None, current_time=None)
+    .. method:: encrypt_at_time(data, current_time)
+
+       Encrypts data passed using explicitly passed current time. See
+       :meth:`encrypt` for the documentaiton of the ``data`` parameter, the
+       return type and the exceptions raised.
+
+       The motivation behind this method is for the client code to be able to
+       test token expiration. Since this method can be used in an insecure
+       manner one should make sure the correct time (``int(time.time())``)
+       is passed as ``current_time`` outside testing.
+
+       :param int current_time: The current time.
+
+       .. note::
+
+            Similarly to :meth:`encrypt` the encrypted message contains the
+            timestamp in *plaintext*, in this case the timestamp is the value
+            of the ``current_time`` parameter.
+
+
+    .. method:: decrypt(token, ttl=None)
 
         Decrypts a Fernet token. If successfully decrypted you will receive the
         original plaintext as the result, otherwise an exception will be
@@ -71,9 +88,6 @@ has support for implementing key rotation via :class:`MultiFernet`.
                         created) an exception will be raised. If ``ttl`` is not
                         provided (or is ``None``), the age of the message is
                         not considered.
-        :param int current_time: The current time to be used instead of
-                                 the value returned by time.time()
-                                 (can used in unit tests for example).
         :returns bytes: The original plaintext.
         :raises cryptography.fernet.InvalidToken: If the ``token`` is in any
                                                   way invalid, this exception
@@ -85,6 +99,21 @@ has support for implementing key rotation via :class:`MultiFernet`.
                                                   signature.
         :raises TypeError: This exception is raised if ``token`` is not
                            ``bytes``.
+
+    .. method:: dectypy_at_time(token, ttl, current_time)
+
+       Decrypts a token using explicitly passed current time. See
+       :meth:`decrypt` for the documentation of the ``token`` and ``ttl``
+       parameters (``ttl`` is required here), the return type and the exceptions
+       raised.
+
+       The motivation behind this method is for the client code to be able to
+       test token expiration. Since this method can be used in an insecure
+       manner one should make sure the correct time (``int(time.time())``)
+       is passed as ``current_time`` outside testing.
+
+       :param int current_time: The current time.
+
 
     .. method:: extract_timestamp(token)
 
@@ -140,7 +169,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
     using that new key, and then retire the old fernet key(s) to which the
     employee had access.
 
-    .. method:: rotate(msg, current_time=None)
+    .. method:: rotate(msg)
 
         .. versionadded:: 2.2
 
@@ -168,9 +197,6 @@ has support for implementing key rotation via :class:`MultiFernet`.
            b'Secret message!'
 
         :param bytes msg: The token to re-encrypt.
-        :param int current_time: The current time to be used instead of
-                                 the value returned by time.time()
-                                 (can used in unit tests for example).
         :returns bytes: A secure message that cannot be read or altered without
            the key. This is URL-safe base64-encoded. This is referred to as a
            "Fernet token".

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -35,12 +35,15 @@ has support for implementing key rotation via :class:`MultiFernet`.
         they'll also be able forge arbitrary messages that will be
         authenticated and decrypted.
 
-    .. method:: encrypt(data)
+    .. method:: encrypt(data, current_time=None)
 
         Encrypts data passed. The result of this encryption is known as a
         "Fernet token" and has strong privacy and authenticity guarantees.
 
         :param bytes data: The message you would like to encrypt.
+        :param int current_time: The current time to be used instead of
+                                 the value returned by time.time()
+                                 (can used in unit tests for example).
         :returns bytes: A secure message that cannot be read or altered
                         without the key. It is URL-safe base64-encoded. This is
                         referred to as a "Fernet token".
@@ -53,7 +56,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
             generated in *plaintext*, the time a message was created will
             therefore be visible to a possible attacker.
 
-    .. method:: decrypt(token, ttl=None)
+    .. method:: decrypt(token, ttl=None, current_time=None)
 
         Decrypts a Fernet token. If successfully decrypted you will receive the
         original plaintext as the result, otherwise an exception will be
@@ -68,6 +71,9 @@ has support for implementing key rotation via :class:`MultiFernet`.
                         created) an exception will be raised. If ``ttl`` is not
                         provided (or is ``None``), the age of the message is
                         not considered.
+        :param int current_time: The current time to be used instead of
+                                 the value returned by time.time()
+                                 (can used in unit tests for example).
         :returns bytes: The original plaintext.
         :raises cryptography.fernet.InvalidToken: If the ``token`` is in any
                                                   way invalid, this exception
@@ -134,7 +140,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
     using that new key, and then retire the old fernet key(s) to which the
     employee had access.
 
-    .. method:: rotate(msg)
+    .. method:: rotate(msg, current_time=None)
 
         .. versionadded:: 2.2
 
@@ -162,6 +168,9 @@ has support for implementing key rotation via :class:`MultiFernet`.
            b'Secret message!'
 
         :param bytes msg: The token to re-encrypt.
+        :param int current_time: The current time to be used instead of
+                                 the value returned by time.time()
+                                 (can used in unit tests for example).
         :returns bytes: A secure message that cannot be read or altered without
            the key. This is URL-safe base64-encoded. This is referred to as a
            "Fernet token".

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -150,10 +150,10 @@ class MultiFernet(object):
         self._fernets = fernets
 
     def encrypt(self, msg):
-        return self._fernets[0].encrypt(msg)
+        return self.encrypt_at_time(msg, int(time.time()))
 
     def encrypt_at_time(self, msg, current_time):
-        return self._fernets[0].encrypt(msg, current_time)
+        return self._fernets[0].encrypt_at_time(msg, current_time)
 
     def rotate(self, msg):
         timestamp, data = Fernet._get_unverified_token_data(msg)

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -150,11 +150,11 @@ class MultiFernet(object):
     def encrypt(self, msg):
         return self._fernets[0].encrypt(msg)
 
-    def rotate(self, msg, current_time=None):
+    def rotate(self, msg):
         timestamp, data = Fernet._get_unverified_token_data(msg)
         for f in self._fernets:
             try:
-                p = f._decrypt_data(data, timestamp, None, current_time)
+                p = f._decrypt_data(data, timestamp, None, None)
                 break
             except InvalidToken:
                 pass

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -204,18 +204,14 @@ class TestMultiFernet(object):
         mf2 = MultiFernet([f2, f1])
 
         plaintext = b"abc"
-        mf1_ciphertext = mf1.encrypt(plaintext)
+        original_time = int(time.time()) - 5 * 60
+        mf1_ciphertext = mf1.encrypt_at_time(plaintext, original_time)
 
-        later = datetime.datetime.now() + datetime.timedelta(minutes=5)
-        later_time = time.mktime(later.timetuple())
-        monkeypatch.setattr(time, "time", lambda: later_time)
-
-        original_time, _ = Fernet._get_unverified_token_data(mf1_ciphertext)
         rotated_time, _ = Fernet._get_unverified_token_data(
             mf2.rotate(mf1_ciphertext)
         )
 
-        assert later_time != rotated_time
+        assert int(time.time()) != rotated_time
         assert original_time == rotated_time
 
     def test_rotate_decrypt_no_shared_keys(self, backend):

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -70,7 +70,7 @@ class TestFernet(object):
                     monkeypatch):
         f = Fernet(secret.encode("ascii"), backend=backend)
         current_time = calendar.timegm(iso8601.parse_date(now).utctimetuple())
-        payload = f.decrypt(
+        payload = f.decrypt_at_time(
             token.encode("ascii"), ttl=ttl_sec, current_time=current_time,
         )
         assert payload == src.encode("ascii")
@@ -83,7 +83,7 @@ class TestFernet(object):
         f = Fernet(secret.encode("ascii"), backend=backend)
         current_time = calendar.timegm(iso8601.parse_date(now).utctimetuple())
         with pytest.raises(InvalidToken):
-            f.decrypt(
+            f.decrypt_at_time(
                 token.encode("ascii"), ttl=ttl_sec, current_time=current_time,
             )
         monkeypatch.setattr(time, "time", lambda: current_time)
@@ -118,7 +118,8 @@ class TestFernet(object):
         token = f.encrypt(pt)
         ts = "1985-10-26T01:20:01-07:00"
         current_time = calendar.timegm(iso8601.parse_date(ts).utctimetuple())
-        assert f.decrypt(token, ttl=None, current_time=current_time) == pt
+        assert f.decrypt_at_time(
+            token, ttl=None, current_time=current_time) == pt
         monkeypatch.setattr(time, "time", lambda: current_time)
         assert f.decrypt(token, ttl=None) == pt
 
@@ -134,7 +135,7 @@ class TestFernet(object):
     def test_extract_timestamp(self, monkeypatch, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         current_time = 1526138327
-        token = f.encrypt(b'encrypt me', current_time)
+        token = f.encrypt_at_time(b'encrypt me', current_time)
         assert f.extract_timestamp(token) == current_time
         with pytest.raises(InvalidToken):
             f.extract_timestamp(b"nonsensetoken")

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -70,7 +70,9 @@ class TestFernet(object):
                     monkeypatch):
         f = Fernet(secret.encode("ascii"), backend=backend)
         current_time = calendar.timegm(iso8601.parse_date(now).utctimetuple())
-        payload = f.decrypt(token.encode("ascii"), ttl=ttl_sec, current_time=current_time)
+        payload = f.decrypt(
+            token.encode("ascii"), ttl=ttl_sec, current_time=current_time,
+        )
         assert payload == src.encode("ascii")
         monkeypatch.setattr(time, "time", lambda: current_time)
         payload = f.decrypt(token.encode("ascii"), ttl=ttl_sec)
@@ -81,7 +83,9 @@ class TestFernet(object):
         f = Fernet(secret.encode("ascii"), backend=backend)
         current_time = calendar.timegm(iso8601.parse_date(now).utctimetuple())
         with pytest.raises(InvalidToken):
-            f.decrypt(token.encode("ascii"), ttl=ttl_sec, current_time=current_time)
+            f.decrypt(
+                token.encode("ascii"), ttl=ttl_sec, current_time=current_time,
+            )
         monkeypatch.setattr(time, "time", lambda: current_time)
         with pytest.raises(InvalidToken):
             f.decrypt(token.encode("ascii"), ttl=ttl_sec)

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -70,6 +70,8 @@ class TestFernet(object):
                     monkeypatch):
         f = Fernet(secret.encode("ascii"), backend=backend)
         current_time = calendar.timegm(iso8601.parse_date(now).utctimetuple())
+        payload = f.decrypt(token.encode("ascii"), ttl=ttl_sec, current_time=current_time)
+        assert payload == src.encode("ascii")
         monkeypatch.setattr(time, "time", lambda: current_time)
         payload = f.decrypt(token.encode("ascii"), ttl=ttl_sec)
         assert payload == src.encode("ascii")
@@ -78,6 +80,8 @@ class TestFernet(object):
     def test_invalid(self, secret, token, now, ttl_sec, backend, monkeypatch):
         f = Fernet(secret.encode("ascii"), backend=backend)
         current_time = calendar.timegm(iso8601.parse_date(now).utctimetuple())
+        with pytest.raises(InvalidToken):
+            f.decrypt(token.encode("ascii"), ttl=ttl_sec, current_time=current_time)
         monkeypatch.setattr(time, "time", lambda: current_time)
         with pytest.raises(InvalidToken):
             f.decrypt(token.encode("ascii"), ttl=ttl_sec)
@@ -110,6 +114,7 @@ class TestFernet(object):
         token = f.encrypt(pt)
         ts = "1985-10-26T01:20:01-07:00"
         current_time = calendar.timegm(iso8601.parse_date(ts).utctimetuple())
+        assert f.decrypt(token, ttl=None, current_time=current_time) == pt
         monkeypatch.setattr(time, "time", lambda: current_time)
         assert f.decrypt(token, ttl=None) == pt
 

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function
 
 import base64
 import calendar
-import datetime
 import json
 import os
 import time

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -134,8 +134,7 @@ class TestFernet(object):
     def test_extract_timestamp(self, monkeypatch, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         current_time = 1526138327
-        monkeypatch.setattr(time, "time", lambda: current_time)
-        token = f.encrypt(b'encrypt me')
+        token = f.encrypt(b'encrypt me', current_time)
         assert f.extract_timestamp(token) == current_time
         with pytest.raises(InvalidToken):
             f.extract_timestamp(b"nonsensetoken")


### PR DESCRIPTION
The motivation behind this is to be able to unit test code using Fernet
easily without having to monkey patch global state.