### PR TITLE
Pin Certbot dependencies during testing

### DIFF
--- a/.travis/downstream.d/certbot.sh
+++ b/.travis/downstream.d/certbot.sh
@@ -5,8 +5,8 @@ case "${1}" in
         git clone --depth=1 https://github.com/certbot/certbot
         cd certbot
         git rev-parse HEAD
-        pip install -e ./acme[dev]
-        pip install -e ./certbot[dev]
+        tools/pip_install_editable.py ./acme[dev]
+        tools/pip_install_editable.py ./certbot[dev]
         ;;
     run)
         cd certbot


### PR DESCRIPTION
It appears the latest version of one of Certbot's dependencies is broken on Python 2.7. See https://github.com/bear/parsedatetime/issues/246. This PR fixes things by pinning Certbot's dependencies to known working versions.

A custom installation script is used because we have multiple requirements files you'd have to use to pin everything down and some of them contain hashes which causes `pip` to error when installing packages in editable mode. We could resolve these problems a different way here if you prefer, but the script we use upstream takes care of these problems.