### PR TITLE
Add missing exceptions to documentation in key derivation function primitives

### DIFF
--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -302,7 +302,7 @@ Different KDFs are suitable for different tasks such as:
                                                           :meth:`derive` or
                                                           :meth:`verify` is
                                                           called more than
-                                                          once.                           
+                                                          once.
 
         Derives a new key from the input key material by performing both the
         extract and expand operations.
@@ -397,7 +397,7 @@ Different KDFs are suitable for different tasks such as:
                                                           :meth:`verify` is
                                                           called more than
                                                           once.
-        
+
         Derives a new key from the input key material.
 
     .. method:: verify(key_material, expected_key)
@@ -495,7 +495,7 @@ Different KDFs are suitable for different tasks such as:
                                                           :meth:`verify` is
                                                           called more than
                                                           once.
-                                                          
+
         Derives a new key from the input key material.
 
     .. method:: verify(key_material, expected_key)
@@ -593,7 +593,7 @@ Different KDFs are suitable for different tasks such as:
                                                           :meth:`verify` is
                                                           called more than
                                                           once.
-        
+
         Derives a new key from the input key material.
 
     .. method:: verify(key_material, expected_key)

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -205,6 +205,11 @@ Different KDFs are suitable for different tasks such as:
         :return bytes: The derived key.
         :raises TypeError: This exception is raised if ``key_material`` is not
                            ``bytes``.
+        :raises cryptography.exceptions.AlreadyFinalized: This is raised when
+                                                          :meth:`derive` or
+                                                          :meth:`verify` is
+                                                          called more than
+                                                          once.
 
         Derives a new key from the input key material by performing both the
         extract and expand operations.

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -298,6 +298,11 @@ Different KDFs are suitable for different tasks such as:
 
         :raises TypeError: This exception is raised if ``key_material`` is not
                            ``bytes``.
+        :raises cryptography.exceptions.AlreadyFinalized: This is raised when
+                                                          :meth:`derive` or
+                                                          :meth:`verify` is
+                                                          called more than
+                                                          once.                           
 
         Derives a new key from the input key material by performing both the
         extract and expand operations.
@@ -387,7 +392,12 @@ Different KDFs are suitable for different tasks such as:
         :return bytes: The derived key.
         :raises TypeError: This exception is raised if ``key_material`` is
                             not ``bytes``.
-
+        :raises cryptography.exceptions.AlreadyFinalized: This is raised when
+                                                          :meth:`derive` or
+                                                          :meth:`verify` is
+                                                          called more than
+                                                          once.
+        
         Derives a new key from the input key material.
 
     .. method:: verify(key_material, expected_key)
@@ -480,7 +490,12 @@ Different KDFs are suitable for different tasks such as:
         :return bytes: The derived key.
         :raises TypeError: This exception is raised if ``key_material`` is not
                            ``bytes``.
-
+        :raises cryptography.exceptions.AlreadyFinalized: This is raised when
+                                                          :meth:`derive` or
+                                                          :meth:`verify` is
+                                                          called more than
+                                                          once.
+                                                          
         Derives a new key from the input key material.
 
     .. method:: verify(key_material, expected_key)
@@ -573,7 +588,12 @@ Different KDFs are suitable for different tasks such as:
         :return bytes: The derived key.
         :raises TypeError: This exception is raised if ``key_material`` is
                             not ``bytes``.
-
+        :raises cryptography.exceptions.AlreadyFinalized: This is raised when
+                                                          :meth:`derive` or
+                                                          :meth:`verify` is
+                                                          called more than
+                                                          once.
+        
         Derives a new key from the input key material.
 
     .. method:: verify(key_material, expected_key)
@@ -700,6 +720,11 @@ Different KDFs are suitable for different tasks such as:
         :return bytes: The derived key.
         :raises TypeError: This exception is raised if ``key_material`` is
                             not ``bytes``.
+        :raises cryptography.exceptions.AlreadyFinalized: This is raised when
+                                                          :meth:`derive` or
+                                                          :meth:`verify` is
+                                                          called more than
+                                                          once.
 
         Derives a new key from the input key material.
 


### PR DESCRIPTION
Added missing exception to documentation for derive function of cryptography.hazmat.primitives.kdf.hkdf.HKDF