### PR TITLE
constrain RSA key generation more heavily

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,11 +16,10 @@ Changelog
   been removed (2.9.1+ is still supported).
 * **BACKWARDS INCOMPATIBLE:** Dropped support for macOS 10.9, macOS users must
   upgrade to 10.10 or newer.
-* **BACKWARDS INCOMPATIBLE:** Support for passing ``public_exponent`` values
-  less than 65537 (with the exception of 3) has been removed from RSA
-  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key`.
-  Small public exponents are vulnerable to a variety of potential attacks and
-  upcoming versions of OpenSSL also remove support for these unwise choices.
+* **BACKWARDS INCOMPATIBLE:** RSA
+  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key`
+  no longer accepts ``public_exponent`` values except 65537 and 3 (the latter
+  for legacy purposes).
 * Deprecated support for Python 2. At the time there is no time table for
   actually dropping support, however we strongly encourage all users to upgrade
   their Python, as Python 2 no longer receives support from the Python core

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Changelog
   been removed (2.9.1+ is still supported).
 * **BACKWARDS INCOMPATIBLE:** Dropped support for macOS 10.9, macOS users must
   upgrade to 10.10 or newer.
+* **BACKWARDS INCOMPATIBLE:** Support for passing ``public_exponent`` values
+  less than 65537 (with the exception of 3) has been removed from RSA
+  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key`.
+  Small public exponents are vulnerable to a variety of potential attacks and
+  upcoming versions of OpenSSL also remove support for these unwise choices.
 * Deprecated support for Python 2. At the time there is no time table for
   actually dropping support, however we strongly encourage all users to upgrade
   their Python, as Python 2 no longer receives support from the Python core

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -20,6 +20,8 @@ mathematical properties`_.
 
     .. versionchanged:: 3.0
 
+        Tightened restrictions on ``public_exponent``.
+
     Generates a new RSA private key using the provided ``backend``.
     ``key_size`` describes how many :term:`bits` long the key should be. Larger
     keys provide more security; currently ``1024`` and below are considered

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -18,6 +18,8 @@ mathematical properties`_.
 
     .. versionadded:: 0.5
 
+    .. versionchanged:: 3.0
+
     Generates a new RSA private key using the provided ``backend``.
     ``key_size`` describes how many :term:`bits` long the key should be. Larger
     keys provide more security; currently ``1024`` and below are considered
@@ -37,8 +39,8 @@ mathematical properties`_.
         ... )
 
     :param int public_exponent: The public exponent of the new key.
-        Usually one of the small Fermat primes 3, 5, 17, 257, 65537. If in
-        doubt you should `use 65537`_.
+        Either 65537 or 3 (for legacy purposes). Almost everyone should
+        `use 65537`_.
 
     :param int key_size: The length of the modulus in :term:`bits`. For keys
         generated in 2015 it is strongly recommended to be

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -120,8 +120,11 @@ def generate_private_key(public_exponent, key_size, backend):
 
 
 def _verify_rsa_parameters(public_exponent, key_size):
-    if public_exponent < 3:
-        raise ValueError("public_exponent must be >= 3.")
+    if public_exponent != 3 and public_exponent < 65537:
+        raise ValueError(
+            "public_exponent must be either 3 (for legacy compatibility) or "
+            ">= 65537. Almost everyone should choose 65537 here!"
+        )
 
     if public_exponent & 1 == 0:
         raise ValueError("public_exponent must be odd.")

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -120,14 +120,11 @@ def generate_private_key(public_exponent, key_size, backend):
 
 
 def _verify_rsa_parameters(public_exponent, key_size):
-    if public_exponent != 3 and public_exponent < 65537:
+    if public_exponent not in (3, 65537):
         raise ValueError(
             "public_exponent must be either 3 (for legacy compatibility) or "
-            ">= 65537. Almost everyone should choose 65537 here!"
+            "65537. Almost everyone should choose 65537 here!"
         )
-
-    if public_exponent & 1 == 0:
-        raise ValueError("public_exponent must be odd.")
 
     if key_size < 512:
         raise ValueError("key_size must be at least 512-bits.")

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -147,7 +147,7 @@ class TestRSA(object):
     @pytest.mark.parametrize(
         ("public_exponent", "key_size"),
         itertools.product(
-            (3, 5, 65537),
+            (3, 65537, 65539),
             (1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1536, 2048)
         )
     )
@@ -167,6 +167,11 @@ class TestRSA(object):
 
         with pytest.raises(ValueError):
             rsa.generate_private_key(public_exponent=4,
+                                     key_size=2048,
+                                     backend=backend)
+
+        with pytest.raises(ValueError):
+            rsa.generate_private_key(public_exponent=65538,
                                      key_size=2048,
                                      backend=backend)
 

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -147,7 +147,7 @@ class TestRSA(object):
     @pytest.mark.parametrize(
         ("public_exponent", "key_size"),
         itertools.product(
-            (3, 65537, 65539),
+            (3, 65537),
             (1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1536, 2048)
         )
     )
@@ -171,7 +171,7 @@ class TestRSA(object):
                                      backend=backend)
 
         with pytest.raises(ValueError):
-            rsa.generate_private_key(public_exponent=65538,
+            rsa.generate_private_key(public_exponent=65535,
                                      key_size=2048,
                                      backend=backend)
 


### PR DESCRIPTION
OpenSSL 3.0.0 is going to enforce this but we might as well get more proscriptive now.