### PR TITLE
Pass test_invalid_version_cert if the certificate is rejected.

### DIFF
--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -1000,11 +1000,18 @@ class TestRSACertificate(object):
         assert cert.version is x509.Version.v3
 
     def test_invalid_version_cert(self, backend):
-        cert = _load_cert(
-            os.path.join("x509", "custom", "invalid_version.pem"),
-            x509.load_pem_x509_certificate,
-            backend
-        )
+        try:
+            cert = _load_cert(
+                os.path.join("x509", "custom", "invalid_version.pem"),
+                x509.load_pem_x509_certificate,
+                backend
+            )
+        except ValueError:
+            # OpenSSL 1.1.1 accepts certificates with an invalid version, but
+            # future versions or other libraries may reject this. _load_cert
+            # will then fail to parse. Consider that a passing result.
+            return
+
         with pytest.raises(x509.InvalidVersion) as exc:
             cert.version
 


### PR DESCRIPTION
OpenSSL currently accepts certificates with invalid versions, leaving
the `cert.version` getter to reject unknown ones. Stricter X.509
implementations may reject them at parse time. Tolerate this in the
tests.