### PR TITLE
Allow cryptography to build with xlc on z/OS

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -40,7 +40,10 @@ def _get_openssl_libraries(platform):
         # -lpthread required due to usage of pthread an potential
         # existance of a static part containing e.g. pthread_atfork
         # (https://github.com/pyca/cryptography/issues/5084)
-        return ["ssl", "crypto", "pthread"]
+        if sys.platform == 'zos':
+            return ["ssl", "crypto"]
+        else:
+            return ["ssl", "crypto", "pthread"]
 
 
 def _extra_compile_args(platform):

--- a/src/_cffi_src/openssl/src/osrandom_engine.h
+++ b/src/_cffi_src/openssl/src/osrandom_engine.h
@@ -6,7 +6,9 @@
   #include <fcntl.h>
   #include <unistd.h>
    /* for defined(BSD) */
-  #include <sys/param.h>
+  #ifndef __MVS__
+    #include <sys/param.h>
+  #endif
 
   #ifdef BSD
     /* for SYS_getentropy */


### PR DESCRIPTION
This PR is to get cryptography building with xlc (c compiler), to be run on z/OS. There's a few minor changes that need to be done:

1) `src/_cffi_src/build_openssl.py` - When using xlc, you do not need to specify `-lpthread` to bring use pthreads, and it'll throw an error if you do. This change checks if we're running on z/OS, and removes it if so. 

2) `src/_cffi_src/openssl/src/osrandom_engine.h` - The included header doesn't exist on z/OS, so do not include it when compiling there.

3) `src/_cffi_src/openssl/callbacks.py` - When calling `pthread_mutex_init` more than once on the same mutex (after a `pthread_atfork`), z/OS throws an EBUSY error which is implementation defined (see [here](https://pubs.opengroup.org/onlinepubs/007908799/xsh/pthread_mutex_init.html)). On other platforms (I tried on x86-64 Ubuntu 18.04 with gcc 7.5.0 and clang 6.0.0), it doesn't seem to throw this error. This change is guarded to be z/OS specific to minimize impact to others - though it should be safe to apply it to all other platforms if that's wanted.