### PR TITLE
Attempt to run tests against BoringSSL in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           - {VERSION: "3.9", TOXENV: "py39", OPENSSL: {TYPE: "libressl", VERSION: "3.4.1"}}
           - {VERSION: "3.10", TOXENV: "py310"}
           # Latest commit on the main-with-bazel branch, as of October 11, 2021
-          - {VERSION: "3.10", TOXENV: "backend-import", OPENSSL: {TYPE: "boringssl", VERSION: "1285d5305ad69ceb519de76cd74e743aed1efd89"}}
+          - {VERSION: "3.10", TOXENV: "py310", OPENSSL: {TYPE: "boringssl", VERSION: "1285d5305ad69ceb519de76cd74e743aed1efd89"}}
         RUST:
           - stable
     name: "${{ matrix.PYTHON.TOXENV }} ${{ matrix.PYTHON.OPENSSL.TYPE }} ${{ matrix.PYTHON.OPENSSL.VERSION }} ${{ matrix.PYTHON.TOXARGS }} ${{ matrix.PYTHON.OPENSSL.CONFIG_FLAGS }}"

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1825,7 +1825,10 @@ class Backend(BackendInterface):
     def x448_supported(self):
         if self._fips_enabled:
             return False
-        return not self._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+        return (
+            not self._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+            and not self._lib.CRYPTOGRAPHY_IS_BORINGSSL
+        )
 
     def ed25519_supported(self):
         if self._fips_enabled:
@@ -1867,7 +1870,10 @@ class Backend(BackendInterface):
     def ed448_supported(self):
         if self._fips_enabled:
             return False
-        return not self._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111B
+        return (
+            not self._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111B
+            and not self._lib.CRYPTOGRAPHY_IS_BORINGSSL
+        )
 
     def ed448_load_public_bytes(self, data):
         utils._check_bytes("data", data)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2043,7 +2043,10 @@ class Backend(BackendInterface):
             # In OpenSSL < 3.0.0 PKCS12 parsing reverses the order of the
             # certificates.
             indices: typing.Iterable[int]
-            if self._lib.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER:
+            if (
+                self._lib.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER
+                or self._lib.CRYPTOGRAPHY_IS_BORINGSSL
+            ):
                 indices = range(num)
             else:
                 indices = reversed(range(num))

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -91,6 +91,12 @@ class AESCCM(object):
 
         self._tag_length = tag_length
 
+        if not backend.aead_cipher_supported(self):
+            raise exceptions.UnsupportedAlgorithm(
+                "AESCCM is not supported by this version of OpenSSL",
+                exceptions._Reasons.UNSUPPORTED_CIPHER,
+            )
+
     @classmethod
     def generate_key(cls, bit_length: int) -> bytes:
         if not isinstance(bit_length, int):

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -67,9 +67,11 @@ class TestOpenSSL(object):
         if it starts with OpenSSL or LibreSSL as that appears
         to be true for every OpenSSL-alike.
         """
-        assert backend.openssl_version_text().startswith(
-            "OpenSSL"
-        ) or backend.openssl_version_text().startswith("LibreSSL")
+        assert (
+            backend.openssl_version_text().startswith("OpenSSL")
+            or backend.openssl_version_text().startswith("LibreSSL")
+            or backend.openssl_version_text().startswith("BoringSSL")
+        )
 
     def test_openssl_version_number(self):
         assert backend.openssl_version_number() > 0

--- a/tox.ini
+++ b/tox.ini
@@ -23,11 +23,6 @@ commands =
     pip list
     pytest -n auto --capture=no --strict-markers --durations=10 {posargs} tests/
 
-[testenv:backend-import]
-basepython = python3
-commands:
-    coverage run -m cryptography.hazmat.backends.openssl.backend
-
 [testenv:docs]
 extras =
     docs


### PR DESCRIPTION
- [x] `BIO_new_dgram`
- [x] `BIO_s_datagram`
- [x] `BN_FLG_CONSTTIME`
- [x] `BN_prime_checks_for_size`
- [x] `BN_set_flags`
- [x] `CRYPTO_set_mem_functions`
- [x] `DTLSv1_listen`
- [x] `ERR_LIB_PKCS12`
- [x] `EVP_F_EVP_ENCRYPTFINAL_EX`
- [x] `EVP_PKEY_set1_DH`
- [x] `EVP_R_BAD_DECRYPT`
- [x] `EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH`
- [x] `EVP_R_UNSUPPORTED_PRIVATE_KEY_ALGORITHM`
- [x] `EVP_R_XTS_DUPLICATED_KEYS`
- [x] `PEM_write_bio_PKCS7_stream`
- [x] `PKCS12_R_PKCS12_CIPHERFINAL_ERROR`
- [x] `PKCS7_final`
- [x] `PKCS7_get0_signers`
- [x] `PKCS7_sign_add_signer`
- [x] `PKCS7_verify`
- [x] `SMIME_read_PKCS7`
- [x] `SMIME_write_PKCS7`
- [x] `SSL_CTX_add_client_custom_ext`
- [x] `SSL_CTX_add_server_custom_ext`
- [x] `SSL_CTX_set_cookie_generate_cb`
- [x] `SSL_CTX_set_cookie_verify_cb`
- [x] `SSL_extension_supported`
- [x] `SSL_get0_verified_chain`
- [x] `SSL_get_sigalgs`
- [x] `SSL_OP_COOKIE_EXCHANGE`
- [x] `X509_V_FLAG_NO_CHECK_TIME`
