### PR TITLE
Avoid passing the wrong size to strncpy - simply use strcpy

### DIFF
--- a/src/_cffi_src/openssl/src/osrandom_engine.c
+++ b/src/_cffi_src/openssl/src/osrandom_engine.c
@@ -528,7 +528,7 @@ static int osrandom_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void)) 
             ENGINEerr(ENGINE_F_ENGINE_CTRL, ENGINE_R_INVALID_ARGUMENT);
             return 0;
         }
-        strncpy((char *)p, name, len);
+        strcpy((char *)p, name);
         return (int)len;
     default:
         ENGINEerr(ENGINE_F_ENGINE_CTRL, ENGINE_R_CTRL_COMMAND_NOT_IMPLEMENTED);


### PR DESCRIPTION
We have already validated that `p` is large enough to store `name`. In `strncpy` the `len` parameter should generally be the length of the target buffer, not the source buffer.