### PR TITLE
fix indexing on X509 request attribute value

### DIFF
--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -92,6 +92,7 @@ X509_ATTRIBUTE *X509_REQ_get_attr(const X509_REQ *, int);
 int X509_REQ_get_attr_by_OBJ(const X509_REQ *, const ASN1_OBJECT *, int);
 void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *, int, int, void *);
 ASN1_TYPE *X509_ATTRIBUTE_get0_type(X509_ATTRIBUTE *, int);
+int X509_ATTRIBUTE_count(const X509_ATTRIBUTE *);
 int X509_REQ_add1_attr_by_txt(X509_REQ *, const char *, int,
                               const unsigned char *, int);
 

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -498,7 +498,11 @@ class _CertificateSigningRequest(object):
 
         attr = self._backend._lib.X509_REQ_get_attr(self._x509_req, pos)
         self._backend.openssl_assert(attr != self._backend._ffi.NULL)
-        asn1_type = self._backend._lib.X509_ATTRIBUTE_get0_type(attr, pos)
+        # We don't support multiple valued attributes for now.
+        self._backend.openssl_assert(
+            self._backend._lib.X509_ATTRIBUTE_count(attr) == 1
+        )
+        asn1_type = self._backend._lib.X509_ATTRIBUTE_get0_type(attr, 0)
         self._backend.openssl_assert(asn1_type != self._backend._ffi.NULL)
         # We need this to ensure that our C type cast is safe.
         # Also this should always be a sane string type, but we'll see if
@@ -513,7 +517,7 @@ class _CertificateSigningRequest(object):
             ))
 
         data = self._backend._lib.X509_ATTRIBUTE_get0_data(
-            attr, pos, asn1_type.type, self._backend._ffi.NULL
+            attr, 0, asn1_type.type, self._backend._ffi.NULL
         )
         self._backend.openssl_assert(data != self._backend._ffi.NULL)
         # This cast is safe iff we assert on the type above to ensure


### PR DESCRIPTION
Previously this improperly used the position of the X509_ATTRIBUTE as the position of the type/value we wanted from the attribute. Now we assert that the supported attributes are single-valued, which is all we're planning to support at this time, and get the 0 index.