### PR TITLE
support unstructured name x509 attributes

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -2874,6 +2874,12 @@ instances. The following common OIDs are available as constants.
 
         Corresponds to the dotted string ``"2.5.4.17"``.
 
+    .. attribute:: UNSTRUCTURED_NAME
+
+        .. versionadded:: 3.0
+
+        Corresponds to the dotted string ``"1.2.840.113549.1.9.2"``.
+
 
 .. class:: SignatureAlgorithmOID
 
@@ -3234,6 +3240,10 @@ instances. The following common OIDs are available as constants.
     .. attribute:: CHALLENGE_PASSWORD
 
         Corresponds to the dotted string ``"1.2.840.113549.1.9.7"``.
+
+    .. attribute:: UNSTRUCTURED_NAME
+
+        Corresponds to the dotted string ``"1.2.840.113549.1.9.2"``.
 
 Helper Functions
 ~~~~~~~~~~~~~~~~

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -82,6 +82,7 @@ class NameOID(object):
     INN = ObjectIdentifier("1.2.643.3.131.1.1")
     OGRN = ObjectIdentifier("1.2.643.100.1")
     SNILS = ObjectIdentifier("1.2.643.100.3")
+    UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2")
 
 
 class SignatureAlgorithmOID(object):
@@ -164,6 +165,7 @@ class CertificatePoliciesOID(object):
 
 class AttributeOID(object):
     CHALLENGE_PASSWORD = ObjectIdentifier("1.2.840.113549.1.9.7")
+    UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2")
 
 
 _OID_NAMES = {
@@ -196,6 +198,7 @@ _OID_NAMES = {
     NameOID.INN: "INN",
     NameOID.OGRN: "OGRN",
     NameOID.SNILS: "SNILS",
+    NameOID.UNSTRUCTURED_NAME: "unstructuredName",
 
     SignatureAlgorithmOID.RSA_WITH_MD5: "md5WithRSAEncryption",
     SignatureAlgorithmOID.RSA_WITH_SHA1: "sha1WithRSAEncryption",

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -1232,7 +1232,7 @@ class TestRSACertificateRequest(object):
         assert isinstance(extensions, x509.Extensions)
         assert list(extensions) == []
 
-    def test_get_attribute_for_oid(self, backend):
+    def test_get_attribute_for_oid_challenge(self, backend):
         request = _load_cert(
             os.path.join(
                 "x509", "requests", "challenge.pem"
@@ -1241,6 +1241,19 @@ class TestRSACertificateRequest(object):
         assert request.get_attribute_for_oid(
             x509.oid.AttributeOID.CHALLENGE_PASSWORD
         ) == b"challenge me!"
+
+    def test_get_attribute_for_oid_multiple(self, backend):
+        request = _load_cert(
+            os.path.join(
+                "x509", "requests", "challenge-unstructured.pem"
+            ), x509.load_pem_x509_csr, backend
+        )
+        assert request.get_attribute_for_oid(
+            x509.oid.AttributeOID.CHALLENGE_PASSWORD
+        ) == b"beauty"
+        assert request.get_attribute_for_oid(
+            x509.oid.AttributeOID.UNSTRUCTURED_NAME
+        ) == b"an unstructured field"
 
     def test_invalid_attribute_for_oid(self, backend):
         """


### PR DESCRIPTION
This PR also verifies the fix in #5312 with a multi-attribute X509 CSR.