### PR TITLE
support encoding attributes via CertificateSigningRequestBuilder

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,8 @@ Changelog
   :class:`~cryptography.x509.SignedCertificateTimestamps` in OCSP responses.
 * Added support for parsing attributes in certificate signing requests via
   :meth:`~cryptography.x509.CertificateSigningRequest.get_attribute_for_oid`.
+* Added support for encoding attributes in certificate signing requests via
+  :meth:`~cryptography.x509.CertificateSigningRequestBuilder.add_attribute`.
 
 .. _v2-9-2:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1170,7 +1170,7 @@ X.509 CSR (Certificate Signing Request) Builder Object
         >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.asymmetric import rsa
-        >>> from cryptography.x509.oid import NameOID
+        >>> from cryptography.x509.oid import AttributeOID, NameOID
         >>> private_key = rsa.generate_private_key(
         ...     public_exponent=65537,
         ...     key_size=2048,
@@ -1182,6 +1182,9 @@ X.509 CSR (Certificate Signing Request) Builder Object
         ... ]))
         >>> builder = builder.add_extension(
         ...     x509.BasicConstraints(ca=False, path_length=None), critical=True,
+        ... )
+        >>> builder = builder.add_attribute(
+        ...     AttributeOID.CHALLENGE_PASSWORD, b"changeit"
         ... )
         >>> request = builder.sign(
         ...     private_key, hashes.SHA256(), default_backend()
@@ -1202,6 +1205,16 @@ X.509 CSR (Certificate Signing Request) Builder Object
             :class:`~cryptography.x509.ExtensionType` interface.
         :param critical: Set to `True` if the extension must be understood and
              handled by whoever reads the certificate.
+        :returns: A new
+            :class:`~cryptography.x509.CertificateSigningRequestBuilder`.
+
+    .. method:: add_attribute(oid, value)
+
+        .. versionadded:: 3.0
+
+        :param oid: An :class:`ObjectIdentifier` instance.
+        :param value: The value of the attribute.
+        :type value: bytes
         :returns: A new
             :class:`~cryptography.x509.CertificateSigningRequestBuilder`.
 

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -93,8 +93,8 @@ int X509_REQ_get_attr_by_OBJ(const X509_REQ *, const ASN1_OBJECT *, int);
 void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *, int, int, void *);
 ASN1_TYPE *X509_ATTRIBUTE_get0_type(X509_ATTRIBUTE *, int);
 int X509_ATTRIBUTE_count(const X509_ATTRIBUTE *);
-int X509_REQ_add1_attr_by_txt(X509_REQ *, const char *, int,
-                              const unsigned char *, int);
+int X509_REQ_add1_attr_by_OBJ(X509_REQ *, const ASN1_OBJECT *,
+                              int, const unsigned char *, int);
 
 int X509V3_EXT_print(BIO *, X509_EXTENSION *, unsigned long, int);
 ASN1_OCTET_STRING *X509_EXTENSION_get_data(X509_EXTENSION *);

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -812,7 +812,8 @@ class Backend(object):
         for attr_oid, attr_val in builder._attributes:
             obj = _txt2obj_gc(self, attr_oid.dotted_string)
             res = self._lib.X509_REQ_add1_attr_by_OBJ(
-                x509_req, obj, 12, attr_val, len(attr_val))
+                x509_req, obj, x509.name._ASN1Type.UTF8String.value,
+                attr_val, len(attr_val))
             self.openssl_assert(res == 1)
 
         # Sign the request using the requester's private key.

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -808,6 +808,13 @@ class Backend(object):
         res = self._lib.X509_REQ_add_extensions(x509_req, sk_extension)
         self.openssl_assert(res == 1)
 
+        # Add attributes (all bytes encoded as ASN1 UTF8_STRING)
+        for attr_oid, attr_val in builder._attributes:
+            obj = _txt2obj_gc(self, attr_oid.dotted_string)
+            res = self._lib.X509_REQ_add1_attr_by_OBJ(
+                x509_req, obj, 12, attr_val, len(attr_val))
+            self.openssl_assert(res == 1)
+
         # Sign the request using the requester's private key.
         res = self._lib.X509_REQ_sign(
             x509_req, private_key._evp_pkey, evp_md

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -16,8 +16,8 @@ from cryptography.hazmat.primitives.asymmetric import (
     dsa, ec, ed25519, ed448, rsa
 )
 from cryptography.x509.extensions import Extension, ExtensionType
-from cryptography.x509.oid import ObjectIdentifier
 from cryptography.x509.name import Name
+from cryptography.x509.oid import ObjectIdentifier
 
 
 _EARLIEST_UTC_TIME = datetime.datetime(1950, 1, 1)

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -16,6 +16,7 @@ from cryptography.hazmat.primitives.asymmetric import (
     dsa, ec, ed25519, ed448, rsa
 )
 from cryptography.x509.extensions import Extension, ExtensionType
+from cryptography.x509.oid import ObjectIdentifier
 from cryptography.x509.name import Name
 
 
@@ -402,12 +403,13 @@ class RevokedCertificate(object):
 
 
 class CertificateSigningRequestBuilder(object):
-    def __init__(self, subject_name=None, extensions=[]):
+    def __init__(self, subject_name=None, extensions=[], attributes=[]):
         """
         Creates an empty X.509 certificate request (v1).
         """
         self._subject_name = subject_name
         self._extensions = extensions
+        self._attributes = attributes
 
     def subject_name(self, name):
         """
@@ -417,7 +419,9 @@ class CertificateSigningRequestBuilder(object):
             raise TypeError('Expecting x509.Name object.')
         if self._subject_name is not None:
             raise ValueError('The subject name may only be set once.')
-        return CertificateSigningRequestBuilder(name, self._extensions)
+        return CertificateSigningRequestBuilder(
+            name, self._extensions, self._attributes
+        )
 
     def add_extension(self, extension, critical):
         """
@@ -430,7 +434,23 @@ class CertificateSigningRequestBuilder(object):
         _reject_duplicate_extension(extension, self._extensions)
 
         return CertificateSigningRequestBuilder(
-            self._subject_name, self._extensions + [extension]
+            self._subject_name, self._extensions + [extension],
+            self._attributes
+        )
+
+    def add_attribute(self, oid, value):
+        """
+        Adds an X.509 attribute with an OID and associated value.
+        """
+        if not isinstance(oid, ObjectIdentifier):
+            raise TypeError("oid must be an ObjectIdentifier")
+
+        if not isinstance(value, bytes):
+            raise TypeError("value must be bytes")
+
+        return CertificateSigningRequestBuilder(
+            self._subject_name, self._extensions,
+            self._attributes + [(oid, value)]
         )
 
     def sign(self, private_key, algorithm, backend):


### PR DESCRIPTION
I think this probably needs some discussion. This API makes assumptions about what ASN.1 type the provided values should be encoded as. We previously made similar assumptions with `NameAttribute` and eventually added the `_ASN1Type` to allow for alternate string type encodings since that wasn't good enough.

I see two major options here:
1) Assume that we can get away with the encoding as described and leave the API simple until such time as we're proven wrong. At that point we can make a new object and figure out how to handle the legacy getters (the `get_attribute_for_oid` method should return an object if we change this) and setters.
2) Shoulder the complexity now. In that case we need to decide if we're building a new class called `Attribute` or trying to reuse `NameAttribute` (which is an attribute with some limited validation we have discussed moving elsewhere in #3857 and in https://github.com/pyca/cryptography/pull/3862).