### PR TITLE
Add initial OpenDev ARM64 testing

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -1,0 +1,33 @@
+- job:
+    name: pyca-cryptography-base
+    abstract: true
+    description: Run pyca/cryptography unit testing
+    run: .zuul.playbooks/playbooks/main.yaml
+
+- job:
+    name: pyca-cryptography-ubuntu-focal-py38-arm64
+    parent: pyca-cryptography-base
+    nodeset: ubuntu-focal-arm64
+    vars:
+      tox_envlist: py38
+
+- job:
+    name: pyca-cryptography-ubuntu-bionic-py36-arm64
+    parent: pyca-cryptography-base
+    nodeset: ubuntu-bionic-arm64
+    vars:
+      tox_envlist: py36
+
+- job:
+    name: pyca-cryptography-ubuntu-xenial-py27-arm64
+    parent: pyca-cryptography-base
+    nodeset: ubuntu-xenial-arm64
+    vars:
+      tox_envlist: py27
+
+- job:
+    name: pyca-cryptography-centos-8-py36-arm64
+    parent: pyca-cryptography-base
+    nodeset: centos-8-arm64
+    vars:
+      tox_envlist: py36

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,0 +1,7 @@
+- project:
+    check:
+      jobs:
+        - pyca-cryptography-ubuntu-focal-py38-arm64
+        - pyca-cryptography-ubuntu-bionic-py36-arm64
+        - pyca-cryptography-ubuntu-xenial-py27-arm64
+        - pyca-cryptography-centos-8-py36-arm64

--- a/.zuul.playbooks/playbooks/main.yaml
+++ b/.zuul.playbooks/playbooks/main.yaml
@@ -1,0 +1,32 @@
+- hosts: all
+  tasks:
+
+    - name: Install tox
+      include_role:
+        name: ensure-tox
+
+    - name: Install required packages
+      package:
+        name:
+          - build-essential
+          - libssl-dev
+          - libffi-dev
+          - python3-dev
+      become: yes
+      when: ansible_distribution in ['Debian', 'Ubuntu']
+
+    - name: Install required packages
+      package:
+        name:
+          - redhat-rpm-config
+          - gcc
+          - libffi-devel
+          - openssl-devel
+          - python3-devel
+      become: yes
+      when: ansible_distribution == 'CentOS'
+
+    - name: Run tox
+      include_role:
+        name: tox
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,6 @@ recursive-exclude .travis *
 recursive-exclude .github *
 
 exclude release.py .coveragerc codecov.yml dev-requirements.txt rtd-requirements.txt tox.ini
+
+recursive-exclude .zuul.d *
+recursive-exclude .zuul.playbooks *


### PR DESCRIPTION
This is the initial configuration for Zuul to run pyca/cryptography
tox jobs on a range of ARM64 nodes provided by OpenDev.  The
underlying ARM64 resources are donated for use by the OpenDev project
by Linaro.

This is under discussion at https://github.com/pyca/cryptography/issues/5339

If the OpenDev Zuul app (https://github.com/apps/opendev-zuul) is
added to this repository, it should be able to speculatively test and
run these jobs (however, some configuration will be required on the
OpenDev side before this will happen).

This is currently a very simple run of tox on the code.  For basic job
documentation see https://zuul-ci.org/docs/zuul/reference/jobs.html.

These jobs inherit from the opendev base job defined in
https://opendev.org/opendev/base-jobs.  This handles the node setup,
initial clone of pull requests, etc. and then after the job runs the
log collection, upload and publishing steps.  This in turn uses a lot
of reusable components from https://zuul-ci.org/docs/zuul-jobs/