### PR TITLE
Lock old issues+PRs automatically

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,14 @@
+name: Lock Issues
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-lock-inactive-days: 90
+          pr-lock-inactive-days: 90


### PR DESCRIPTION
@reaperhulk I think this might go back and lock all 90 gzillion closed issues... are we ok with that?

There's an option to make it not lock older things, but of course, lots of things with irrelevan comments _are_ older!