### PR TITLE
Add deprecation warning handling advice note

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,26 @@ Changelog
   actually dropping support, however we strongly encourage all users to upgrade
   their Python, as Python 2 no longer receives support from the Python core
   team.
+
+  .. hint::
+
+     The deprecation warning emitted on import does not inherit
+     :py:exc:`DeprecationWarning` but subclasses :py:exc:`UserWarning`
+     instead.
+
+     If your pytest setup follows the best practices of failing on
+     emitted warnings (``filterwarnings = error``), you may ignore it
+     by adding the following line in the end of the list::
+
+       ignore:Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.:UserWarning:cryptography
+
+     **Note:** Using :py:exc:`~cryptography.utils.CryptographyDeprecationWarning`
+     is not possible here because specifying it triggers
+     ``import cryptography`` internally that emits the warning before
+     the ignore rule even kicks in.
+
+     Ref: https://github.com/pytest-dev/pytest/issues/7524
+
 * Added support for ``OpenSSH`` serialization format for
   ``ec``, ``ed25519``, ``rsa`` and ``dsa`` private keys:
   :func:`~cryptography.hazmat.primitives.serialization.load_ssh_private_key`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,24 +38,8 @@ Changelog
   their Python, as Python 2 no longer receives support from the Python core
   team.
 
-  .. hint::
-
-     The deprecation warning emitted on import does not inherit
-     :py:exc:`DeprecationWarning` but subclasses :py:exc:`UserWarning`
-     instead.
-
-     If your pytest setup follows the best practices of failing on
-     emitted warnings (``filterwarnings = error``), you may ignore it
-     by adding the following line in the end of the list::
-
-       ignore:Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.:UserWarning:cryptography
-
-     **Note:** Using :py:exc:`~cryptography.utils.CryptographyDeprecationWarning`
-     is not possible here because specifying it triggers
-     ``import cryptography`` internally that emits the warning before
-     the ignore rule even kicks in.
-
-     Ref: https://github.com/pytest-dev/pytest/issues/7524
+  If you have trouble suppressing this warning, please, check out :ref:`an FAQ
+  entry about addressing this issue <faq-howto-handle-deprecation-warning>`.
 
 * Added support for ``OpenSSH`` serialization format for
   ``ec``, ``ed25519``, ``rsa`` and ``dsa`` private keys:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,6 +1,33 @@
 Frequently asked questions
 ==========================
 
+.. _faq-howto-handle-deprecation-warning:
+
+I cannot suppress the deprecation warning that ``cryptography`` emits on import
+-------------------------------------------------------------------------------
+
+.. hint::
+
+   The deprecation warning emitted on import does not inherit
+   :py:exc:`DeprecationWarning` but inherits :py:exc:`UserWarning`
+   instead.
+
+If your pytest setup follows the best practices of failing on
+emitted warnings (``filterwarnings = error``), you may ignore it
+by adding the following line at the end of the list::
+
+   ignore:Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.:UserWarning:cryptography
+
+**Note:** Using ``cryptography.utils.CryptographyDeprecationWarning``
+is not possible here because specifying it triggers
+``import cryptography`` internally that emits the warning before
+the ignore rule even kicks in.
+
+Ref: https://github.com/pytest-dev/pytest/issues/7524
+
+The same applies when you use :py:func:`~warnings.filterwarnings` in
+your code or invoke CPython with :std:option:`-W` command line option.
+
 ``cryptography`` failed to install!
 -----------------------------------
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -19,6 +19,7 @@ codebook
 committer
 committers
 conda
+CPython
 Cryptanalysis
 crypto
 cryptographic
@@ -88,6 +89,7 @@ preprocessors
 presentational
 pseudorandom
 pyOpenSSL
+pytest
 relicensed
 responder
 runtime


### PR DESCRIPTION
This tip is being added to help the library maintainers keep
testing cryptography where supporting multiple Python runtime
is still necessary.

Resolves https://github.com/pyca/cryptography/issues/5335