### PR TITLE
start trying to make our error handling a bit more generic

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -23,9 +23,6 @@ static const int ERR_LIB_PKCS12;
 static const int ERR_LIB_SSL;
 static const int ERR_LIB_X509;
 
-static const int ERR_R_MALLOC_FAILURE;
-static const int EVP_R_MEMORY_LIMIT_EXCEEDED;
-
 static const int ASN1_R_BOOLEAN_IS_WRONG_LENGTH;
 static const int ASN1_R_BUFFER_TOO_SMALL;
 static const int ASN1_R_CIPHER_HAS_NO_OBJECT_IDENTIFIER;
@@ -50,8 +47,6 @@ static const int ASN1_R_NO_CONTENT_TYPE;
 static const int ASN1_R_NO_MULTIPART_BODY_FAILURE;
 static const int ASN1_R_NO_MULTIPART_BOUNDARY;
 static const int ASN1_R_HEADER_TOO_LONG;
-
-static const int DH_R_INVALID_PUBKEY;
 
 static const int EVP_F_EVP_ENCRYPTFINAL_EX;
 
@@ -79,9 +74,6 @@ static const int EVP_R_UNSUPPORTED_SALT_TYPE;
 static const int EVP_R_UNSUPPORTED_PRIVATE_KEY_ALGORITHM;
 static const int EVP_R_WRONG_FINAL_BLOCK_LENGTH;
 static const int EVP_R_CAMELLIA_KEY_SETUP_FAILED;
-
-static const int EC_R_UNKNOWN_GROUP;
-static const int EC_R_NOT_A_NIST_PRIME;
 
 static const int PEM_R_BAD_BASE64_DECODE;
 static const int PEM_R_BAD_DECRYPT;

--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -11,7 +11,6 @@ INCLUDES = """
 TYPES = """
 static const int Cryptography_HAS_EC_CODES;
 static const int Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR;
-static const int Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED;
 
 static const int ERR_LIB_DH;
 static const int ERR_LIB_EVP;
@@ -165,12 +164,5 @@ static const long Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR = 1;
 #else
 static const long Cryptography_HAS_RSA_R_PKCS_DECODING_ERROR = 0;
 static const long RSA_R_PKCS_DECODING_ERROR = 0;
-#endif
-
-#ifdef EVP_R_MEMORY_LIMIT_EXCEEDED
-static const long Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED = 1;
-#else
-static const long EVP_R_MEMORY_LIMIT_EXCEEDED = 0;
-static const long Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED = 0;
 #endif
 """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2390,13 +2390,13 @@ class Backend(object):
             length,
         )
         if res != 1:
-            self._consume_errors()
+            errors = self._consume_errors_with_text()
             # memory required formula explained here:
             # https://blog.filippo.io/the-scrypt-parameters/
             min_memory = 128 * n * r // (1024 ** 2)
             raise MemoryError(
                 "Not enough memory to derive key. These parameters require"
-                " {} MB of memory.".format(min_memory)
+                " {} MB of memory.".format(min_memory), errors
             )
         return self._ffi.buffer(buf)[:]
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2396,7 +2396,8 @@ class Backend(object):
             min_memory = 128 * n * r // (1024 ** 2)
             raise MemoryError(
                 "Not enough memory to derive key. These parameters require"
-                " {} MB of memory.".format(min_memory), errors
+                " {} MB of memory.".format(min_memory),
+                errors,
             )
         return self._ffi.buffer(buf)[:]
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -435,6 +435,9 @@ class Backend(object):
     def _consume_errors(self):
         return binding._consume_errors(self._lib)
 
+    def _consume_errors_with_text(self):
+        return binding._consume_errors_with_text(self._lib)
+
     def _bn_to_int(self, bn):
         assert bn != self._ffi.NULL
 
@@ -1473,18 +1476,7 @@ class Backend(object):
         group = self._lib.EC_GROUP_new_by_curve_name(curve_nid)
 
         if group == self._ffi.NULL:
-            errors = self._consume_errors()
-            self.openssl_assert(
-                curve_nid == self._lib.NID_undef
-                or errors[0]._lib_reason_match(
-                    self._lib.ERR_LIB_EC, self._lib.EC_R_UNKNOWN_GROUP
-                )
-                or
-                # This occurs in FIPS mode for unsupported curves on RHEL
-                errors[0]._lib_reason_match(
-                    self._lib.ERR_LIB_EC, self._lib.EC_R_NOT_A_NIST_PRIME
-                )
-            )
+            self._consume_errors()
             return False
         else:
             self.openssl_assert(curve_nid != self._lib.NID_undef)
@@ -2398,19 +2390,7 @@ class Backend(object):
             length,
         )
         if res != 1:
-            errors = self._consume_errors()
-            if not self._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111:
-                # This error is only added to the stack in 1.1.1+
-                self.openssl_assert(
-                    errors[0]._lib_reason_match(
-                        self._lib.ERR_LIB_EVP, self._lib.ERR_R_MALLOC_FAILURE
-                    )
-                    or errors[0]._lib_reason_match(
-                        self._lib.ERR_LIB_EVP,
-                        self._lib.EVP_R_MEMORY_LIMIT_EXCEEDED,
-                    )
-                )
-
+            self._consume_errors()
             # memory required formula explained here:
             # https://blog.filippo.io/the-scrypt-parameters/
             min_memory = 128 * n * r // (1024 ** 2)

--- a/src/cryptography/hazmat/backends/openssl/dh.py
+++ b/src/cryptography/hazmat/backends/openssl/dh.py
@@ -142,7 +142,8 @@ class _DHPrivateKey(object):
             errors_with_text = self._backend._consume_errors_with_text()
             raise ValueError(
                 "Error computing shared key. Public key is likely invalid "
-                "for this exchange.", errors_with_text
+                "for this exchange.",
+                errors_with_text,
             )
         else:
             self._backend.openssl_assert(res >= 1)

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -270,12 +270,6 @@ def cryptography_has_raw_key():
     ]
 
 
-def cryptography_has_evp_r_memory_limit_exceeded():
-    return [
-        "EVP_R_MEMORY_LIMIT_EXCEEDED",
-    ]
-
-
 def cryptography_has_engine():
     return [
         "ENGINE_by_id",
@@ -356,9 +350,6 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_RAW_KEY": cryptography_has_raw_key,
     "Cryptography_HAS_EVP_DIGESTFINAL_XOF": (
         cryptography_has_evp_digestfinal_xof
-    ),
-    "Cryptography_HAS_EVP_R_MEMORY_LIMIT_EXCEEDED": (
-        cryptography_has_evp_r_memory_limit_exceeded
     ),
     "Cryptography_HAS_ENGINE": cryptography_has_engine,
     "Cryptography_HAS_VERIFIED_CHAIN": cryptography_has_verified_chain,


### PR DESCRIPTION
This adds a some helpers for "friendly" openssl error messages and removes error matching in three places.