### PR TITLE
more error simplification

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -91,8 +91,6 @@ static const int PEM_R_UNSUPPORTED_ENCRYPTION;
 
 static const int PKCS12_R_PKCS12_CIPHERFINAL_ERROR;
 
-static const int RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY;
-
 static const int SSL_TLSEXT_ERR_OK;
 static const int SSL_TLSEXT_ERR_ALERT_WARNING;
 static const int SSL_TLSEXT_ERR_ALERT_FATAL;
@@ -128,7 +126,6 @@ static const int SSL_AD_BAD_CERTIFICATE_HASH_VALUE;
 static const int SSL_AD_UNKNOWN_PSK_IDENTITY;
 
 static const int X509_R_CERT_ALREADY_IN_HASH_TABLE;
-static const int X509_R_KEY_VALUES_MISMATCH;
 """
 
 FUNCTIONS = """

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -4085,10 +4085,8 @@ class TestCertificateSigningRequestBuilder(object):
             x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, u"US")])
         )
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError):
             builder.sign(private_key, hashes.SHA512(), backend)
-
-        assert str(exc.value) == "Digest too big for RSA key"
 
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)


### PR DESCRIPTION
X509 signing for RSA keys that are too small: Let's just say signing failed and attach the more specific problem as the error stack. A bit uglier, but far more generic and stable to OpenSSL/LibreSSL/BoringSSL

Also be a bit more generic for OCSP signing.