### PR TITLE
remove every error we don't use in cryptography or pyopenssl

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -9,6 +9,7 @@ INCLUDES = """
 """
 
 TYPES = """
+static const int EVP_F_EVP_ENCRYPTFINAL_EX;
 static const int EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH;
 static const int EVP_R_BAD_DECRYPT;
 static const int EVP_R_UNSUPPORTED_PRIVATE_KEY_ALGORITHM;

--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -22,6 +22,10 @@ static const int ERR_LIB_PEM;
 static const int ERR_LIB_ASN1;
 static const int ERR_LIB_PKCS12;
 
+static const int SSL_TLSEXT_ERR_OK;
+static const int SSL_TLSEXT_ERR_ALERT_FATAL;
+static const int SSL_TLSEXT_ERR_NOACK;
+
 static const int X509_R_CERT_ALREADY_IN_HASH_TABLE;
 """
 

--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -9,121 +9,17 @@ INCLUDES = """
 """
 
 TYPES = """
-static const int Cryptography_HAS_EC_CODES;
+static const int EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH;
+static const int EVP_R_BAD_DECRYPT;
+static const int EVP_R_UNSUPPORTED_PRIVATE_KEY_ALGORITHM;
+static const int PKCS12_R_PKCS12_CIPHERFINAL_ERROR;
+static const int PEM_R_UNSUPPORTED_ENCRYPTION;
+static const int EVP_R_UNKNOWN_PBE_ALGORITHM;
 
-static const int ERR_LIB_DH;
 static const int ERR_LIB_EVP;
-static const int ERR_LIB_EC;
 static const int ERR_LIB_PEM;
 static const int ERR_LIB_ASN1;
-static const int ERR_LIB_RSA;
 static const int ERR_LIB_PKCS12;
-static const int ERR_LIB_SSL;
-static const int ERR_LIB_X509;
-
-static const int ASN1_R_BOOLEAN_IS_WRONG_LENGTH;
-static const int ASN1_R_BUFFER_TOO_SMALL;
-static const int ASN1_R_CIPHER_HAS_NO_OBJECT_IDENTIFIER;
-static const int ASN1_R_DATA_IS_WRONG;
-static const int ASN1_R_DECODE_ERROR;
-static const int ASN1_R_DEPTH_EXCEEDED;
-static const int ASN1_R_ENCODE_ERROR;
-static const int ASN1_R_ERROR_GETTING_TIME;
-static const int ASN1_R_ERROR_LOADING_SECTION;
-static const int ASN1_R_MSTRING_WRONG_TAG;
-static const int ASN1_R_NESTED_ASN1_STRING;
-static const int ASN1_R_NO_MATCHING_CHOICE_TYPE;
-static const int ASN1_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM;
-static const int ASN1_R_UNKNOWN_OBJECT_TYPE;
-static const int ASN1_R_UNKNOWN_PUBLIC_KEY_TYPE;
-static const int ASN1_R_UNKNOWN_TAG;
-static const int ASN1_R_UNSUPPORTED_ANY_DEFINED_BY_TYPE;
-static const int ASN1_R_UNSUPPORTED_PUBLIC_KEY_TYPE;
-static const int ASN1_R_UNSUPPORTED_TYPE;
-static const int ASN1_R_WRONG_TAG;
-static const int ASN1_R_NO_CONTENT_TYPE;
-static const int ASN1_R_NO_MULTIPART_BODY_FAILURE;
-static const int ASN1_R_NO_MULTIPART_BOUNDARY;
-static const int ASN1_R_HEADER_TOO_LONG;
-
-static const int EVP_F_EVP_ENCRYPTFINAL_EX;
-
-static const int EVP_R_AES_KEY_SETUP_FAILED;
-static const int EVP_R_BAD_DECRYPT;
-static const int EVP_R_CIPHER_PARAMETER_ERROR;
-static const int EVP_R_CTRL_NOT_IMPLEMENTED;
-static const int EVP_R_CTRL_OPERATION_NOT_IMPLEMENTED;
-static const int EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH;
-static const int EVP_R_DECODE_ERROR;
-static const int EVP_R_DIFFERENT_KEY_TYPES;
-static const int EVP_R_INITIALIZATION_ERROR;
-static const int EVP_R_INPUT_NOT_INITIALIZED;
-static const int EVP_R_INVALID_KEY_LENGTH;
-static const int EVP_R_KEYGEN_FAILURE;
-static const int EVP_R_MISSING_PARAMETERS;
-static const int EVP_R_NO_CIPHER_SET;
-static const int EVP_R_NO_DIGEST_SET;
-static const int EVP_R_PUBLIC_KEY_NOT_RSA;
-static const int EVP_R_UNKNOWN_PBE_ALGORITHM;
-static const int EVP_R_UNSUPPORTED_CIPHER;
-static const int EVP_R_UNSUPPORTED_KEY_DERIVATION_FUNCTION;
-static const int EVP_R_UNSUPPORTED_KEYLENGTH;
-static const int EVP_R_UNSUPPORTED_SALT_TYPE;
-static const int EVP_R_UNSUPPORTED_PRIVATE_KEY_ALGORITHM;
-static const int EVP_R_WRONG_FINAL_BLOCK_LENGTH;
-static const int EVP_R_CAMELLIA_KEY_SETUP_FAILED;
-
-static const int PEM_R_BAD_BASE64_DECODE;
-static const int PEM_R_BAD_DECRYPT;
-static const int PEM_R_BAD_END_LINE;
-static const int PEM_R_BAD_IV_CHARS;
-static const int PEM_R_BAD_PASSWORD_READ;
-static const int PEM_R_ERROR_CONVERTING_PRIVATE_KEY;
-static const int PEM_R_NO_START_LINE;
-static const int PEM_R_NOT_DEK_INFO;
-static const int PEM_R_NOT_ENCRYPTED;
-static const int PEM_R_NOT_PROC_TYPE;
-static const int PEM_R_PROBLEMS_GETTING_PASSWORD;
-static const int PEM_R_READ_KEY;
-static const int PEM_R_SHORT_HEADER;
-static const int PEM_R_UNSUPPORTED_CIPHER;
-static const int PEM_R_UNSUPPORTED_ENCRYPTION;
-
-static const int PKCS12_R_PKCS12_CIPHERFINAL_ERROR;
-
-static const int SSL_TLSEXT_ERR_OK;
-static const int SSL_TLSEXT_ERR_ALERT_WARNING;
-static const int SSL_TLSEXT_ERR_ALERT_FATAL;
-static const int SSL_TLSEXT_ERR_NOACK;
-
-static const int SSL_AD_CLOSE_NOTIFY;
-static const int SSL_AD_UNEXPECTED_MESSAGE;
-static const int SSL_AD_BAD_RECORD_MAC;
-static const int SSL_AD_RECORD_OVERFLOW;
-static const int SSL_AD_DECOMPRESSION_FAILURE;
-static const int SSL_AD_HANDSHAKE_FAILURE;
-static const int SSL_AD_BAD_CERTIFICATE;
-static const int SSL_AD_UNSUPPORTED_CERTIFICATE;
-static const int SSL_AD_CERTIFICATE_REVOKED;
-static const int SSL_AD_CERTIFICATE_EXPIRED;
-static const int SSL_AD_CERTIFICATE_UNKNOWN;
-static const int SSL_AD_ILLEGAL_PARAMETER;
-static const int SSL_AD_UNKNOWN_CA;
-static const int SSL_AD_ACCESS_DENIED;
-static const int SSL_AD_DECODE_ERROR;
-static const int SSL_AD_DECRYPT_ERROR;
-static const int SSL_AD_PROTOCOL_VERSION;
-static const int SSL_AD_INSUFFICIENT_SECURITY;
-static const int SSL_AD_INTERNAL_ERROR;
-static const int SSL_AD_USER_CANCELLED;
-static const int SSL_AD_NO_RENEGOTIATION;
-
-static const int SSL_AD_UNSUPPORTED_EXTENSION;
-static const int SSL_AD_CERTIFICATE_UNOBTAINABLE;
-static const int SSL_AD_UNRECOGNIZED_NAME;
-static const int SSL_AD_BAD_CERTIFICATE_STATUS_RESPONSE;
-static const int SSL_AD_BAD_CERTIFICATE_HASH_VALUE;
-static const int SSL_AD_UNKNOWN_PSK_IDENTITY;
 
 static const int X509_R_CERT_ALREADY_IN_HASH_TABLE;
 """
@@ -146,6 +42,4 @@ int ERR_GET_REASON(unsigned long);
 """
 
 CUSTOMIZATIONS = """
-static const long Cryptography_HAS_EC_CODES = 1;
-
 """


### PR DESCRIPTION
sorry external consumers, carrying things we don't use and don't have downstream tests for has become too much of a burden.