### PR TITLE
shrink bindings more

### DIFF
--- a/src/_cffi_src/openssl/aes.py
+++ b/src/_cffi_src/openssl/aes.py
@@ -13,9 +13,6 @@ typedef ... AES_KEY;
 """
 
 FUNCTIONS = """
-int AES_set_encrypt_key(const unsigned char *, const int, AES_KEY *);
-int AES_set_decrypt_key(const unsigned char *, const int, AES_KEY *);
-
 int AES_wrap_key(AES_KEY *, const unsigned char *, unsigned char *,
                  const unsigned char *, unsigned int);
 int AES_unwrap_key(AES_KEY *, const unsigned char *, unsigned char *,

--- a/src/_cffi_src/openssl/asn1.py
+++ b/src/_cffi_src/openssl/asn1.py
@@ -62,7 +62,6 @@ int ASN1_INTEGER_set(ASN1_INTEGER *, long);
 /*  ASN1 TIME */
 ASN1_TIME *ASN1_TIME_new(void);
 void ASN1_TIME_free(ASN1_TIME *);
-ASN1_TIME *ASN1_TIME_set(ASN1_TIME *, time_t);
 int ASN1_TIME_set_string(ASN1_TIME *, const char *);
 
 /*  ASN1 GENERALIZEDTIME */

--- a/src/_cffi_src/openssl/ecdsa.py
+++ b/src/_cffi_src/openssl/ecdsa.py
@@ -9,8 +9,6 @@ INCLUDES = """
 """
 
 TYPES = """
-static const int Cryptography_HAS_ECDSA;
-
 typedef ... ECDSA_SIG;
 
 typedef ... CRYPTO_EX_new;
@@ -19,12 +17,6 @@ typedef ... CRYPTO_EX_free;
 """
 
 FUNCTIONS = """
-ECDSA_SIG *ECDSA_SIG_new();
-void ECDSA_SIG_free(ECDSA_SIG *);
-int i2d_ECDSA_SIG(const ECDSA_SIG *, unsigned char **);
-ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **s, const unsigned char **, long);
-ECDSA_SIG *ECDSA_do_sign(const unsigned char *, int, EC_KEY *);
-int ECDSA_do_verify(const unsigned char *, int, const ECDSA_SIG *, EC_KEY *);
 int ECDSA_sign(int, const unsigned char *, int, unsigned char *,
                unsigned int *, EC_KEY *);
 int ECDSA_verify(int, const unsigned char *, int, const unsigned char *, int,
@@ -34,5 +26,4 @@ int ECDSA_size(const EC_KEY *);
 """
 
 CUSTOMIZATIONS = """
-static const long Cryptography_HAS_ECDSA = 1;
 """

--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -36,7 +36,6 @@ const char *ERR_func_error_string(unsigned long);
 const char *ERR_reason_error_string(unsigned long);
 unsigned long ERR_get_error(void);
 unsigned long ERR_peek_error(void);
-unsigned long ERR_peek_last_error(void);
 void ERR_clear_error(void);
 void ERR_put_error(int, int, int, const char *, int);
 

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -90,8 +90,6 @@ int EVP_DigestVerifyInit(EVP_MD_CTX *, EVP_PKEY_CTX **, const EVP_MD *,
                          ENGINE *, EVP_PKEY *);
 
 
-int PKCS5_PBKDF2_HMAC_SHA1(const char *, int, const unsigned char *, int, int,
-                           int, unsigned char *);
 
 EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *, ENGINE *);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int, ENGINE *);
@@ -147,9 +145,6 @@ EC_KEY *EVP_PKEY_get1_EC_KEY(EVP_PKEY *);
 int EVP_PKEY_set1_EC_KEY(EVP_PKEY *, EC_KEY *);
 
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *, int, int, void *);
-
-int PKCS5_PBKDF2_HMAC(const char *, int, const unsigned char *, int, int,
-                      const EVP_MD *, int, unsigned char *);
 
 int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *, const EVP_MD *);
 

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -146,6 +146,9 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *, EC_KEY *);
 
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *, int, int, void *);
 
+int PKCS5_PBKDF2_HMAC(const char *, int, const unsigned char *, int, int,
+                      const EVP_MD *, int, unsigned char *);
+
 int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *, const EVP_MD *);
 
 int EVP_PBE_scrypt(const char *, size_t, const unsigned char *, size_t,

--- a/src/_cffi_src/openssl/objects.py
+++ b/src/_cffi_src/openssl/objects.py
@@ -20,21 +20,13 @@ static const long OBJ_NAME_TYPE_MD_METH;
 """
 
 FUNCTIONS = """
-ASN1_OBJECT *OBJ_nid2obj(int);
 const char *OBJ_nid2ln(int);
 const char *OBJ_nid2sn(int);
 int OBJ_obj2nid(const ASN1_OBJECT *);
-int OBJ_ln2nid(const char *);
 int OBJ_sn2nid(const char *);
 int OBJ_txt2nid(const char *);
 ASN1_OBJECT *OBJ_txt2obj(const char *, int);
 int OBJ_obj2txt(char *, int, const ASN1_OBJECT *, int);
-int OBJ_cmp(const ASN1_OBJECT *, const ASN1_OBJECT *);
-ASN1_OBJECT *OBJ_dup(const ASN1_OBJECT *);
-int OBJ_create(const char *, const char *, const char *);
-void OBJ_NAME_do_all(int, void (*) (const OBJ_NAME *, void *), void *);
-/* OBJ_cleanup became a macro in 1.1.0 */
-void OBJ_cleanup(void);
 """
 
 CUSTOMIZATIONS = """

--- a/src/_cffi_src/openssl/pem.py
+++ b/src/_cffi_src/openssl/pem.py
@@ -24,13 +24,9 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *, EVP_PKEY **, pem_password_cb *,
 
 int PEM_write_bio_PKCS8PrivateKey(BIO *, EVP_PKEY *, const EVP_CIPHER *,
                                   char *, int, pem_password_cb *, void *);
-int PEM_write_bio_PKCS8PrivateKey_nid(BIO *, EVP_PKEY *, int, char *, int,
-                                      pem_password_cb *, void *);
 
 int i2d_PKCS8PrivateKey_bio(BIO *, EVP_PKEY *, const EVP_CIPHER *,
                             char *, int, pem_password_cb *, void *);
-int i2d_PKCS8PrivateKey_nid_bio(BIO *, EVP_PKEY *, int,
-                                char *, int, pem_password_cb *, void *);
 
 int i2d_PKCS7_bio(BIO *, PKCS7 *);
 PKCS7 *d2i_PKCS7_bio(BIO *, PKCS7 **);

--- a/src/_cffi_src/openssl/pkcs7.py
+++ b/src/_cffi_src/openssl/pkcs7.py
@@ -56,12 +56,10 @@ static const int PKCS7_TEXT;
 FUNCTIONS = """
 void PKCS7_free(PKCS7 *);
 
-int PKCS7_type_is_encrypted(PKCS7 *);
 int PKCS7_type_is_signed(PKCS7 *);
 int PKCS7_type_is_enveloped(PKCS7 *);
 int PKCS7_type_is_signedAndEnveloped(PKCS7 *);
 int PKCS7_type_is_data(PKCS7 *);
-int PKCS7_type_is_digest(PKCS7 *);
 """
 
 CUSTOMIZATIONS = ""

--- a/src/_cffi_src/openssl/rsa.py
+++ b/src/_cffi_src/openssl/rsa.py
@@ -25,19 +25,10 @@ static const int Cryptography_HAS_RSA_OAEP_LABEL;
 FUNCTIONS = """
 RSA *RSA_new(void);
 void RSA_free(RSA *);
-int RSA_size(const RSA *);
 int RSA_generate_key_ex(RSA *, int, BIGNUM *, BN_GENCB *);
 int RSA_check_key(const RSA *);
 RSA *RSAPublicKey_dup(RSA *);
 int RSA_blinding_on(RSA *, BN_CTX *);
-int RSA_public_encrypt(int, const unsigned char *, unsigned char *,
-                       RSA *, int);
-int RSA_private_encrypt(int, const unsigned char *, unsigned char *,
-                        RSA *, int);
-int RSA_public_decrypt(int, const unsigned char *, unsigned char *,
-                       RSA *, int);
-int RSA_private_decrypt(int, const unsigned char *, unsigned char *,
-                        RSA *, int);
 int RSA_print(BIO *, const RSA *, int);
 
 /* added in 1.1.0 when the RSA struct was opaqued */

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -311,6 +311,9 @@ unsigned long SSL_set_mode(SSL *, unsigned long);
 unsigned long SSL_clear_mode(SSL *, unsigned long);
 unsigned long SSL_get_mode(SSL *);
 
+unsigned long SSL_set_options(SSL *, unsigned long);
+unsigned long SSL_get_options(SSL *);
+
 int SSL_want_read(const SSL *);
 int SSL_want_write(const SSL *);
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -19,7 +19,6 @@ static const long Cryptography_HAS_TLSv1_1;
 static const long Cryptography_HAS_TLSv1_2;
 static const long Cryptography_HAS_TLSv1_3;
 static const long Cryptography_HAS_SECURE_RENEGOTIATION;
-static const long Cryptography_HAS_COMPRESSION;
 static const long Cryptography_HAS_TLSEXT_STATUS_REQ_CB;
 static const long Cryptography_HAS_STATUS_REQ_OCSP_RESP;
 static const long Cryptography_HAS_TLSEXT_STATUS_REQ_TYPE;
@@ -151,7 +150,6 @@ static const long TLSEXT_STATUSTYPE_ocsp;
 
 typedef ... SSL_CIPHER;
 typedef ... Cryptography_STACK_OF_SSL_CIPHER;
-typedef ... COMP_METHOD;
 
 typedef struct {
     const char *name;
@@ -164,20 +162,10 @@ FUNCTIONS = """
 const char *SSL_state_string_long(const SSL *);
 SSL_SESSION *SSL_get1_session(SSL *);
 int SSL_set_session(SSL *, SSL_SESSION *);
-int SSL_get_verify_mode(const SSL *);
-void SSL_set_verify(SSL *, int, int (*)(int, X509_STORE_CTX *));
-void SSL_set_verify_depth(SSL *, int);
-int SSL_get_verify_depth(const SSL *);
-int (*SSL_get_verify_callback(const SSL *))(int, X509_STORE_CTX *);
-void SSL_set_info_callback(SSL *ssl, void (*)(const SSL *, int, int));
-void (*SSL_get_info_callback(const SSL *))(const SSL *, int, int);
 SSL *SSL_new(SSL_CTX *);
 void SSL_free(SSL *);
 int SSL_set_fd(SSL *, int);
-SSL_CTX *SSL_get_SSL_CTX(const SSL *);
 SSL_CTX *SSL_set_SSL_CTX(SSL *, SSL_CTX *);
-BIO *SSL_get_rbio(const SSL *);
-BIO *SSL_get_wbio(const SSL *);
 void SSL_set_bio(SSL *, BIO *, BIO *);
 void SSL_set_connect_state(SSL *);
 void SSL_set_accept_state(SSL *);
@@ -195,14 +183,6 @@ int SSL_get_ex_data_X509_STORE_CTX_idx(void);
 X509_VERIFY_PARAM *SSL_get0_param(SSL *);
 X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *);
 
-int SSL_use_certificate(SSL *, X509 *);
-int SSL_use_certificate_ASN1(SSL *, const unsigned char *, int);
-int SSL_use_certificate_file(SSL *, const char *, int);
-int SSL_use_PrivateKey(SSL *, EVP_PKEY *);
-int SSL_use_PrivateKey_ASN1(int, SSL *, const unsigned char *, long);
-int SSL_use_PrivateKey_file(SSL *, const char *, int);
-int SSL_check_private_key(const SSL *);
-
 int SSL_get_sigalgs(SSL *, int, int *, int *, int *, unsigned char *,
                     unsigned char *);
 
@@ -217,7 +197,6 @@ int SSL_shutdown(SSL *);
 int SSL_renegotiate(SSL *);
 int SSL_renegotiate_pending(SSL *);
 const char *SSL_get_cipher_list(const SSL *, int);
-Cryptography_STACK_OF_SSL_CIPHER *SSL_get_ciphers(const SSL *);
 
 /*  context */
 void SSL_CTX_free(SSL_CTX *);
@@ -225,7 +204,6 @@ long SSL_CTX_set_timeout(SSL_CTX *, long);
 int SSL_CTX_set_default_verify_paths(SSL_CTX *);
 void SSL_CTX_set_verify(SSL_CTX *, int, int (*)(int, X509_STORE_CTX *));
 void SSL_CTX_set_verify_depth(SSL_CTX *, int);
-int (*SSL_CTX_get_verify_callback(const SSL_CTX *))(int, X509_STORE_CTX *);
 int SSL_CTX_get_verify_mode(const SSL_CTX *);
 int SSL_CTX_get_verify_depth(const SSL_CTX *);
 int SSL_CTX_set_cipher_list(SSL_CTX *, const char *);
@@ -233,11 +211,9 @@ int SSL_CTX_load_verify_locations(SSL_CTX *, const char *, const char *);
 void SSL_CTX_set_default_passwd_cb(SSL_CTX *, pem_password_cb *);
 void SSL_CTX_set_default_passwd_cb_userdata(SSL_CTX *, void *);
 int SSL_CTX_use_certificate(SSL_CTX *, X509 *);
-int SSL_CTX_use_certificate_ASN1(SSL_CTX *, int, const unsigned char *);
 int SSL_CTX_use_certificate_file(SSL_CTX *, const char *, int);
 int SSL_CTX_use_certificate_chain_file(SSL_CTX *, const char *);
 int SSL_CTX_use_PrivateKey(SSL_CTX *, EVP_PKEY *);
-int SSL_CTX_use_PrivateKey_ASN1(int, SSL_CTX *, const unsigned char *, long);
 int SSL_CTX_use_PrivateKey_file(SSL_CTX *, const char *, int);
 int SSL_CTX_check_private_key(const SSL_CTX *);
 void SSL_CTX_set_cert_verify_callback(SSL_CTX *,
@@ -331,21 +307,9 @@ long SSL_SESSION_get_timeout(const SSL_SESSION *);
 int SSL_SESSION_has_ticket(const SSL_SESSION *);
 long SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *);
 
-/* not macros, but will be conditionally bound so can't live in functions */
-const COMP_METHOD *SSL_get_current_compression(SSL *);
-const COMP_METHOD *SSL_get_current_expansion(SSL *);
-const char *SSL_COMP_get_name(const COMP_METHOD *);
-
 unsigned long SSL_set_mode(SSL *, unsigned long);
 unsigned long SSL_clear_mode(SSL *, unsigned long);
 unsigned long SSL_get_mode(SSL *);
-
-unsigned long SSL_set_options(SSL *, unsigned long);
-unsigned long SSL_get_options(SSL *);
-
-void SSL_set_app_data(SSL *, char *);
-char * SSL_get_app_data(SSL *);
-void SSL_set_read_ahead(SSL *, int);
 
 int SSL_want_read(const SSL *);
 int SSL_want_write(const SSL *);
@@ -643,16 +607,6 @@ void (*SSL_set_cert_cb)(SSL *, int (*)(SSL *, void *), void *) = NULL;
 static const long Cryptography_HAS_SET_CERT_CB = 0;
 #else
 static const long Cryptography_HAS_SET_CERT_CB = 1;
-#endif
-
-/* In OpenSSL 1.0.2i+ the handling of COMP_METHOD when OPENSSL_NO_COMP was
-   changed and we no longer need to typedef void */
-#if (defined(OPENSSL_NO_COMP) && CRYPTOGRAPHY_OPENSSL_LESS_THAN_102I) || \
-    CRYPTOGRAPHY_IS_LIBRESSL
-static const long Cryptography_HAS_COMPRESSION = 0;
-typedef void COMP_METHOD;
-#else
-static const long Cryptography_HAS_COMPRESSION = 1;
 #endif
 
 static const long Cryptography_HAS_SSL_CTX_CLEAR_OPTIONS = 1;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -33,14 +33,6 @@ def cryptography_has_ssl3_method():
     ]
 
 
-def cryptography_has_compression():
-    return [
-        "SSL_get_current_compression",
-        "SSL_get_current_expansion",
-        "SSL_COMP_get_name",
-    ]
-
-
 def cryptography_has_102_verification():
     return [
         "X509_V_ERR_SUITE_B_INVALID_VERSION",
@@ -305,7 +297,6 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_RSA_OAEP_MD": cryptography_has_rsa_oaep_md,
     "Cryptography_HAS_RSA_OAEP_LABEL": cryptography_has_rsa_oaep_label,
     "Cryptography_HAS_SSL3_METHOD": cryptography_has_ssl3_method,
-    "Cryptography_HAS_COMPRESSION": cryptography_has_compression,
     "Cryptography_HAS_102_VERIFICATION": cryptography_has_102_verification,
     "Cryptography_HAS_110_VERIFICATION_PARAMS": (
         cryptography_has_110_verification_params


### PR DESCRIPTION
This attempts to remove many of the bindings we do not use in cryptography or pyopenssl. Newer bindings (added by external consumers or for upcoming pyopenssl PRs) were generally not touched. However, supporting consumers we're unaware of with these huge bindings is becoming an untenable burden. If you see this PR in the future and are one of the people affected: we cannot support you if we don't know you exist!