### PR TITLE
Travis CI: test on a range of architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,19 @@ matrix:
           # Tests hangs when run under bionic
           dist: xenial
 
+        - python: 3.8
+          env: TOXENV=py38 OPENSSL=1.1.1g
+          arch: arm64
+        - python: 3.8
+          env: TOXENV=py38 OPENSSL=1.1.1g
+          arch: ppc64le
+        - python: 3.8
+          env: TOXENV=py38 LIBRESSL=3.2.0
+          arch: arm64
+        - python: 3.8
+          env: TOXENV=py38 LIBRESSL=3.2.0
+          arch: ppc64le
+
 install:
     - ./.travis/install.sh
 


### PR DESCRIPTION
Travis CI supports arm64, s390x and ppc64le ("Power") now. All of
those platforms have big distros shipping Python and cryptography, so
it would be nice to test on them.

I've picked a small subset of tests to build: just Python 3.8 and the
most recent version of OpenSSL and LibreSSL. I think that provides
decent coverage without bloating the test matrix too much. (We could
also test on pypy, for example, but I'm not sure that provides enough
value to be worth the extra runtime.)

s390x currently fails due to something to do with cffi. Directly
installing cffi first works, but it should be automatically pulled in
already. It's all a bit weird. Testing on arm64 and ppc64le is still
valuable though, so this can be investigated later.

I'm happy to talk about how this might interact with #5341 and the
best way forward for testing on a broader range of platforms.

I have access to some Power systems at work so if there are any
issues in future feel free to tag me in and I can have a look.