### PR TITLE
test: allow skip of hypothesis tests

### DIFF
--- a/tests/hypothesis/__init__.py
+++ b/tests/hypothesis/__init__.py
@@ -3,3 +3,6 @@
 # for complete details.
 
 from __future__ import absolute_import, division, print_function
+
+import pytest
+hypothesis = pytest.importorskip("hypothesis")


### PR DESCRIPTION
The module hypothesis may not be available, so we conditionally
skip two tests that need it.

Signed-off-by: Joe Slater <joe.slater@windriver.com>