### PR TITLE
add docker builders, migrate travis to focal by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,8 @@ matrix:
 
         - python: 2.7
           env: DOWNSTREAM=pyopenssl
+          # Tests fail on OpenSSLs that enforce reasonable key length minimums
+          dist: bionic
         - python: 3.7
           env: DOWNSTREAM=twisted OPENSSL=1.1.1g
         - python: 2.7
@@ -134,6 +136,8 @@ matrix:
           env: DOWNSTREAM=certbot-josepy
         - python: 2.7
           env: DOWNSTREAM=urllib3
+          # Tests hang when run under bionic/focal
+          dist: xenial
 
 install:
     - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
           env: TOXENV=py38 DOCKER=pyca/cryptography-runner-sid
         - python: 3.6
           services: docker
-          env: TOXENV=py38 DOCKER=pyca/cryptography-runner-ubuntu-bionic
+          env: TOXENV=py36 DOCKER=pyca/cryptography-runner-ubuntu-bionic
         - python: 3.8
           services: docker
           env: TOXENV=py38 DOCKER=pyca/cryptography-runner-ubuntu-focal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: true
-dist: bionic
+dist: focal
 
 language: python
 
@@ -27,7 +27,6 @@ matrix:
           # https://docs.travis-ci.com/user/languages/python/#python-versions
         - python: pypy2.7-7.3.1
           env: TOXENV=pypy-nocoverage
-          dist: xenial
         - python: pypy3.6-7.3.1
           env: TOXENV=pypy3-nocoverage
         - python: 3.8
@@ -82,6 +81,12 @@ matrix:
         - python: 3.8
           services: docker
           env: TOXENV=py38 DOCKER=pyca/cryptography-runner-sid
+        - python: 3.6
+          services: docker
+          env: TOXENV=py38 DOCKER=pyca/cryptography-runner-ubuntu-bionic
+        - python: 3.8
+          services: docker
+          env: TOXENV=py38 DOCKER=pyca/cryptography-runner-ubuntu-focal
         - python: 2.7
           services: docker
           env: TOXENV=py27 DOCKER=pyca/cryptography-runner-ubuntu-rolling
@@ -129,8 +134,6 @@ matrix:
           env: DOWNSTREAM=certbot-josepy
         - python: 2.7
           env: DOWNSTREAM=urllib3
-          # Tests hangs when run under bionic
-          dist: xenial
 
 install:
     - ./.travis/install.sh

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,7 +16,7 @@ PyPy 7.1+, and PyPy3 7.0 on these operating systems.
 * x86-64 CentOS 7.x, 8.x
 * x86-64 Fedora (latest)
 * macOS 10.15 Catalina
-* x86-64 Ubuntu 16.04 and rolling
+* x86-64 Ubuntu 18.04, 20.04, and rolling
 * x86-64 Debian Stretch (9.x), Buster (10.x), Bullseye (11.x), and Sid
   (unstable)
 * x86-64 Alpine (latest)


### PR DESCRIPTION
This is 50% experiment since we've had some issues with some builders having trouble with newer distros. Let's see what happens now.