### PR TITLE
Make backend optional part 1 of n

### DIFF
--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -36,7 +36,7 @@ PBKDF2
 
 .. currentmodule:: cryptography.hazmat.primitives.kdf.pbkdf2
 
-.. class:: PBKDF2HMAC(algorithm, length, salt, iterations, backend)
+.. class:: PBKDF2HMAC(algorithm, length, salt, iterations, backend=None)
 
     .. versionadded:: 0.2
 
@@ -89,7 +89,7 @@ PBKDF2
         takes. Higher numbers help mitigate brute force attacks against derived
         keys. A `more detailed description`_ can be consulted for additional
         information.
-    :param backend: An instance of
+    :param backend: An optional instance of
         :class:`~cryptography.hazmat.backends.interfaces.PBKDF2HMACBackend`.
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised if the
@@ -143,7 +143,7 @@ Scrypt
 
 .. currentmodule:: cryptography.hazmat.primitives.kdf.scrypt
 
-.. class:: Scrypt(salt, length, n, r, p, backend)
+.. class:: Scrypt(salt, length, n, r, p, backend=None)
 
     .. versionadded:: 1.6
 
@@ -189,7 +189,7 @@ Scrypt
         power of 2.
     :param int r: Block size parameter.
     :param int p: Parallelization parameter.
-    :param backend: An instance of
+    :param backend: An optional instance of
         :class:`~cryptography.hazmat.backends.interfaces.ScryptBackend`.
 
     The computational and memory cost of Scrypt can be adjusted by manipulating
@@ -259,7 +259,7 @@ ConcatKDF
 
 .. currentmodule:: cryptography.hazmat.primitives.kdf.concatkdf
 
-.. class:: ConcatKDFHash(algorithm, length, otherinfo, backend)
+.. class:: ConcatKDFHash(algorithm, length, otherinfo, backend=None)
 
     .. versionadded:: 1.0
 
@@ -303,7 +303,7 @@ ConcatKDF
     :param bytes otherinfo: Application specific context information.
         If ``None`` is explicitly passed an empty byte string will be used.
 
-    :param backend: An instance of
+    :param backend: An optional instance of
         :class:`~cryptography.hazmat.backends.interfaces.HashBackend`.
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised
@@ -349,7 +349,7 @@ ConcatKDF
         raises an exception if they do not match.
 
 
-.. class:: ConcatKDFHMAC(algorithm, length, salt, otherinfo, backend)
+.. class:: ConcatKDFHMAC(algorithm, length, salt, otherinfo, backend=None)
 
     .. versionadded:: 1.0
 
@@ -402,7 +402,7 @@ ConcatKDF
     :param bytes otherinfo: Application specific context information.
         If ``None`` is explicitly passed an empty byte string will be used.
 
-    :param backend: An instance of
+    :param backend: An optional instance of
         :class:`~cryptography.hazmat.backends.interfaces.HMACBackend`.
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised if the
@@ -452,7 +452,7 @@ HKDF
 
 .. currentmodule:: cryptography.hazmat.primitives.kdf.hkdf
 
-.. class:: HKDF(algorithm, length, salt, info, backend)
+.. class:: HKDF(algorithm, length, salt, info, backend=None)
 
     .. versionadded:: 0.2
 
@@ -508,7 +508,7 @@ HKDF
     :param bytes info: Application specific context information.  If ``None``
         is explicitly passed an empty byte string will be used.
 
-    :param backend: An instance of
+    :param backend: An optional instance of
         :class:`~cryptography.hazmat.backends.interfaces.HMACBackend`.
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised if the
@@ -555,7 +555,7 @@ HKDF
         raises an exception if they do not match.
 
 
-.. class:: HKDFExpand(algorithm, length, info, backend)
+.. class:: HKDFExpand(algorithm, length, info, backend=None)
 
     .. versionadded:: 0.5
 
@@ -603,7 +603,7 @@ HKDF
     :param bytes info: Application specific context information.  If ``None``
         is explicitly passed an empty byte string will be used.
 
-    :param backend: An instance of
+    :param backend: An optional instance of
         :class:`~cryptography.hazmat.backends.interfaces.HMACBackend`.
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised if the
@@ -656,7 +656,7 @@ KBKDF
 .. currentmodule:: cryptography.hazmat.primitives.kdf.kbkdf
 
 .. class:: KBKDFHMAC(algorithm, mode, length, rlen, llen, location,\
-           label, context, fixed, backend)
+           label, context, fixed, backend=None)
 
     .. versionadded:: 1.4
 
@@ -734,9 +734,8 @@ KBKDF
         may supply your own fixed data. If ``fixed`` is specified, ``label``
         and ``context`` is ignored.
 
-    :param backend: A cryptography backend
-        :class:`~cryptography.hazmat.backends.interfaces.HMACBackend`
-        instance.
+    :param backend: An optional instance of
+        :class:`~cryptography.hazmat.backends.interfaces.HMACBackend`.
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised
         if the provided ``backend`` does not implement
@@ -813,7 +812,7 @@ X963KDF
 
 .. currentmodule:: cryptography.hazmat.primitives.kdf.x963kdf
 
-.. class:: X963KDF(algorithm, length, otherinfo, backend)
+.. class:: X963KDF(algorithm, length, otherinfo, backend=None)
 
     .. versionadded:: 1.1
 
@@ -863,9 +862,8 @@ X963KDF
     :param bytes sharedinfo: Application specific context information.
         If ``None`` is explicitly passed an empty byte string will be used.
 
-    :param backend: A cryptography backend
-        :class:`~cryptography.hazmat.backends.interfaces.HashBackend`
-        instance.
+    :param backend: An optional instance of
+        :class:`~cryptography.hazmat.backends.interfaces.HashBackend`.
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised
         if the provided ``backend`` does not implement

--- a/src/cryptography/hazmat/backends/__init__.py
+++ b/src/cryptography/hazmat/backends/__init__.py
@@ -17,3 +17,10 @@ def default_backend():
         _default_backend = backend
 
     return _default_backend
+
+
+def _get_backend(backend):
+    if backend is None:
+        return default_backend()
+    else:
+        return backend

--- a/src/cryptography/hazmat/primitives/kdf/concatkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/concatkdf.py
@@ -13,6 +13,7 @@ from cryptography.exceptions import (
     UnsupportedAlgorithm,
     _Reasons,
 )
+from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import HMACBackend
 from cryptography.hazmat.backends.interfaces import HashBackend
 from cryptography.hazmat.primitives import constant_time, hashes, hmac
@@ -53,7 +54,8 @@ def _concatkdf_derive(key_material, length, auxfn, otherinfo):
 
 @utils.register_interface(KeyDerivationFunction)
 class ConcatKDFHash(object):
-    def __init__(self, algorithm, length, otherinfo, backend):
+    def __init__(self, algorithm, length, otherinfo, backend=None):
+        backend = _get_backend(backend)
 
         _common_args_checks(algorithm, length, otherinfo)
         self._algorithm = algorithm
@@ -88,7 +90,8 @@ class ConcatKDFHash(object):
 
 @utils.register_interface(KeyDerivationFunction)
 class ConcatKDFHMAC(object):
-    def __init__(self, algorithm, length, salt, otherinfo, backend):
+    def __init__(self, algorithm, length, salt, otherinfo, backend=None):
+        backend = _get_backend(backend)
 
         _common_args_checks(algorithm, length, otherinfo)
         self._algorithm = algorithm

--- a/src/cryptography/hazmat/primitives/kdf/hkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/hkdf.py
@@ -13,6 +13,7 @@ from cryptography.exceptions import (
     UnsupportedAlgorithm,
     _Reasons,
 )
+from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import HMACBackend
 from cryptography.hazmat.primitives import constant_time, hmac
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
@@ -20,7 +21,8 @@ from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
 @utils.register_interface(KeyDerivationFunction)
 class HKDF(object):
-    def __init__(self, algorithm, length, salt, info, backend):
+    def __init__(self, algorithm, length, salt, info, backend=None):
+        backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):
             raise UnsupportedAlgorithm(
                 "Backend object does not implement HMACBackend.",
@@ -56,7 +58,8 @@ class HKDF(object):
 
 @utils.register_interface(KeyDerivationFunction)
 class HKDFExpand(object):
-    def __init__(self, algorithm, length, info, backend):
+    def __init__(self, algorithm, length, info, backend=None):
+        backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):
             raise UnsupportedAlgorithm(
                 "Backend object does not implement HMACBackend.",

--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
@@ -15,6 +15,7 @@ from cryptography.exceptions import (
     UnsupportedAlgorithm,
     _Reasons,
 )
+from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import HMACBackend
 from cryptography.hazmat.primitives import constant_time, hashes, hmac
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
@@ -42,8 +43,9 @@ class KBKDFHMAC(object):
         label,
         context,
         fixed,
-        backend,
+        backend=None,
     ):
+        backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):
             raise UnsupportedAlgorithm(
                 "Backend object does not implement HMACBackend.",

--- a/src/cryptography/hazmat/primitives/kdf/pbkdf2.py
+++ b/src/cryptography/hazmat/primitives/kdf/pbkdf2.py
@@ -11,6 +11,7 @@ from cryptography.exceptions import (
     UnsupportedAlgorithm,
     _Reasons,
 )
+from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import PBKDF2HMACBackend
 from cryptography.hazmat.primitives import constant_time
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
@@ -18,7 +19,8 @@ from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
 @utils.register_interface(KeyDerivationFunction)
 class PBKDF2HMAC(object):
-    def __init__(self, algorithm, length, salt, iterations, backend):
+    def __init__(self, algorithm, length, salt, iterations, backend=None):
+        backend = _get_backend(backend)
         if not isinstance(backend, PBKDF2HMACBackend):
             raise UnsupportedAlgorithm(
                 "Backend object does not implement PBKDF2HMACBackend.",

--- a/src/cryptography/hazmat/primitives/kdf/scrypt.py
+++ b/src/cryptography/hazmat/primitives/kdf/scrypt.py
@@ -13,6 +13,7 @@ from cryptography.exceptions import (
     UnsupportedAlgorithm,
     _Reasons,
 )
+from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import ScryptBackend
 from cryptography.hazmat.primitives import constant_time
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
@@ -25,7 +26,8 @@ _MEM_LIMIT = sys.maxsize // 2
 
 @utils.register_interface(KeyDerivationFunction)
 class Scrypt(object):
-    def __init__(self, salt, length, n, r, p, backend):
+    def __init__(self, salt, length, n, r, p, backend=None):
+        backend = _get_backend(backend)
         if not isinstance(backend, ScryptBackend):
             raise UnsupportedAlgorithm(
                 "Backend object does not implement ScryptBackend.",

--- a/src/cryptography/hazmat/primitives/kdf/x963kdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/x963kdf.py
@@ -13,6 +13,7 @@ from cryptography.exceptions import (
     UnsupportedAlgorithm,
     _Reasons,
 )
+from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import HashBackend
 from cryptography.hazmat.primitives import constant_time, hashes
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
@@ -24,7 +25,8 @@ def _int_to_u32be(n):
 
 @utils.register_interface(KeyDerivationFunction)
 class X963KDF(object):
-    def __init__(self, algorithm, length, sharedinfo, backend):
+    def __init__(self, algorithm, length, sharedinfo, backend=None):
+        backend = _get_backend(backend)
 
         max_len = algorithm.digest_size * (2 ** 32 - 1)
         if length > max_len:

--- a/tests/hazmat/backends/test_no_backend.py
+++ b/tests/hazmat/backends/test_no_backend.py
@@ -1,0 +1,16 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import absolute_import, division, print_function
+
+from cryptography.hazmat.backends import _get_backend, default_backend
+
+
+def test_get_backend_no_backend():
+    assert _get_backend(None) is default_backend()
+
+
+def test_get_backend():
+    faux_backend = object()
+    assert _get_backend(faux_backend) is faux_backend


### PR DESCRIPTION
Refs #3881 

This makes all the KDF backend arguments optional. This is marked as WIP because we should talk about testing. If we want to continue to support hypothetical backends (which in this case are more like LibreSSL or BoringSSL) we need a way to mark these `no_backend` tests to be skipped.

This PR does not change the examples to not include the backend argument. That should be changed at a later date once we've had this optional for a year or so.