### PR TITLE
generate unrecognizedextension when failing to parse

### DIFF
--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -612,8 +612,10 @@ class TestRevokedCertificate(object):
             backend,
         )
 
-        with pytest.raises(ValueError):
-            crl[0].extensions
+        ext = crl[0].extensions
+        assert len(ext) == 1
+        assert isinstance(ext[0].value, x509.UnrecognizedExtension)
+        assert ext[0].value.value == b''
 
     def test_indexing(self, backend):
         crl = _load_cert(

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -5709,8 +5709,16 @@ class TestInvalidExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        with pytest.raises(ValueError):
-            cert.extensions
+        ext = cert.extensions.get_extension_for_oid(
+            x509.ExtensionOID.CERTIFICATE_POLICIES
+        )
+        assert len(cert.extensions) == 1
+        assert isinstance(ext.value, x509.UnrecognizedExtension)
+        assert ext.oid == x509.ExtensionOID.CERTIFICATE_POLICIES
+        assert ext.value.value == (
+            b'0301\x06\x0b`\x86H\x01\xe09\x01\x02\x03\x04\x010"0 \x06\x08+'
+            b'\x06\x01\x05\x05\x07\x02\x02\x16\x14http://other.com/cps'
+        )
 
 
 class TestOCSPNonce(object):


### PR DESCRIPTION
Rather than raising an exception we now return the DER payload inside an
UnrecognizedExtension. When you compile OpenSSL without support for
certain things (like no-ocsp) it doesn't know how to parse some
extensions. Rather than error, it makes more sense to return the DER to
the caller and let them sort it out.

refs #5345 