### PR TITLE
update docs to not use backends

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -229,7 +229,6 @@ password through a key derivation function such as
     >>> import base64
     >>> import os
     >>> from cryptography.fernet import Fernet
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import hashes
     >>> from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
     >>> password = b"password"
@@ -239,7 +238,6 @@ password through a key derivation function such as
     ...     length=32,
     ...     salt=salt,
     ...     iterations=100000,
-    ...     backend=default_backend()
     ... )
     >>> key = base64.urlsafe_b64encode(kdf.derive(password))
     >>> f = Fernet(key)

--- a/docs/hazmat/primitives/asymmetric/dh.rst
+++ b/docs/hazmat/primitives/asymmetric/dh.rst
@@ -31,13 +31,11 @@ present.
 
 .. code-block:: pycon
 
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import hashes
     >>> from cryptography.hazmat.primitives.asymmetric import dh
     >>> from cryptography.hazmat.primitives.kdf.hkdf import HKDF
     >>> # Generate some parameters. These can be reused.
-    >>> parameters = dh.generate_parameters(generator=2, key_size=2048,
-    ...                                     backend=default_backend())
+    >>> parameters = dh.generate_parameters(generator=2, key_size=2048)
     >>> # Generate a private key for use in the exchange.
     >>> server_private_key = parameters.generate_private_key()
     >>> # In a real handshake the peer is a remote client. For this
@@ -51,7 +49,6 @@ present.
     ...     length=32,
     ...     salt=None,
     ...     info=b'handshake data',
-    ...     backend=default_backend()
     ... ).derive(shared_key)
     >>> # And now we can demonstrate that the handshake performed in the
     >>> # opposite direction gives the same final value
@@ -63,7 +60,6 @@ present.
     ...     length=32,
     ...     salt=None,
     ...     info=b'handshake data',
-    ...     backend=default_backend()
     ... ).derive(same_shared_key)
     >>> derived_key == same_derived_key
 
@@ -75,13 +71,11 @@ example of the ephemeral form:
 
 .. code-block:: pycon
 
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import hashes
     >>> from cryptography.hazmat.primitives.asymmetric import dh
     >>> from cryptography.hazmat.primitives.kdf.hkdf import HKDF
     >>> # Generate some parameters. These can be reused.
-    >>> parameters = dh.generate_parameters(generator=2, key_size=2048,
-    ...                                     backend=default_backend())
+    >>> parameters = dh.generate_parameters(generator=2, key_size=2048)
     >>> # Generate a private key for use in the exchange.
     >>> private_key = parameters.generate_private_key()
     >>> # In a real handshake the peer_public_key will be received from the
@@ -96,7 +90,6 @@ example of the ephemeral form:
     ...     length=32,
     ...     salt=None,
     ...     info=b'handshake data',
-    ...     backend=default_backend()
     ... ).derive(shared_key)
     >>> # For the next handshake we MUST generate another private key, but
     >>> # we can reuse the parameters.
@@ -108,7 +101,6 @@ example of the ephemeral form:
     ...     length=32,
     ...     salt=None,
     ...     info=b'handshake data',
-    ...     backend=default_backend()
     ... ).derive(shared_key_2)
 
 To assemble a :class:`~DHParameters` and a :class:`~DHPublicKey` from
@@ -118,9 +110,9 @@ example, if **p**, **g**, and **y** are :class:`int` objects received from a
 peer::
 
     pn = dh.DHParameterNumbers(p, g)
-    parameters = pn.parameters(default_backend())
+    parameters = pn.parameters()
     peer_public_numbers = dh.DHPublicNumbers(y, pn)
-    peer_public_key = peer_public_numbers.public_key(default_backend())
+    peer_public_key = peer_public_numbers.public_key()
 
 
 See also the :class:`~cryptography.hazmat.backends.interfaces.DHBackend`

--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -78,12 +78,10 @@ instance.
 
 .. doctest::
 
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import hashes
     >>> from cryptography.hazmat.primitives.asymmetric import dsa
     >>> private_key = dsa.generate_private_key(
     ...     key_size=1024,
-    ...     backend=default_backend()
     ... )
     >>> data = b"this is some data I'd like to sign"
     >>> signature = private_key.sign(
@@ -103,7 +101,7 @@ separately and pass that value using
 
     >>> from cryptography.hazmat.primitives.asymmetric import utils
     >>> chosen_hash = hashes.SHA256()
-    >>> hasher = hashes.Hash(chosen_hash, default_backend())
+    >>> hasher = hashes.Hash(chosen_hash)
     >>> hasher.update(b"data & ")
     >>> hasher.update(b"more data")
     >>> digest = hasher.finalize()
@@ -146,7 +144,7 @@ separately and pass that value using
 .. doctest::
 
     >>> chosen_hash = hashes.SHA256()
-    >>> hasher = hashes.Hash(chosen_hash, default_backend())
+    >>> hasher = hashes.Hash(chosen_hash)
     >>> hasher.update(b"data & ")
     >>> hasher.update(b"more data")
     >>> digest = hasher.finalize()

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -56,11 +56,10 @@ Elliptic Curve Signature Algorithms
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.asymmetric import ec
         >>> private_key = ec.generate_private_key(
-        ...     ec.SECP384R1(), default_backend()
+        ...     ec.SECP384R1()
         ... )
         >>> data = b"this is some data I'd like to sign"
         >>> signature = private_key.sign(
@@ -80,7 +79,7 @@ Elliptic Curve Signature Algorithms
 
         >>> from cryptography.hazmat.primitives.asymmetric import utils
         >>> chosen_hash = hashes.SHA256()
-        >>> hasher = hashes.Hash(chosen_hash, default_backend())
+        >>> hasher = hashes.Hash(chosen_hash)
         >>> hasher.update(b"data & ")
         >>> hasher.update(b"more data")
         >>> digest = hasher.finalize()
@@ -112,7 +111,7 @@ Elliptic Curve Signature Algorithms
     .. doctest::
 
         >>> chosen_hash = hashes.SHA256()
-        >>> hasher = hashes.Hash(chosen_hash, default_backend())
+        >>> hasher = hashes.Hash(chosen_hash)
         >>> hasher.update(b"data & ")
         >>> hasher.update(b"more data")
         >>> digest = hasher.finalize()
@@ -270,18 +269,17 @@ Elliptic Curve Key Exchange algorithm
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.asymmetric import ec
         >>> from cryptography.hazmat.primitives.kdf.hkdf import HKDF
         >>> # Generate a private key for use in the exchange.
         >>> server_private_key = ec.generate_private_key(
-        ...     ec.SECP384R1(), default_backend()
+        ...     ec.SECP384R1()
         ... )
         >>> # In a real handshake the peer is a remote client. For this
         >>> # example we'll generate another local private key though.
         >>> peer_private_key = ec.generate_private_key(
-        ...     ec.SECP384R1(), default_backend()
+        ...     ec.SECP384R1()
         ... )
         >>> shared_key = server_private_key.exchange(
         ...     ec.ECDH(), peer_private_key.public_key())
@@ -291,7 +289,6 @@ Elliptic Curve Key Exchange algorithm
         ...     length=32,
         ...     salt=None,
         ...     info=b'handshake data',
-        ...     backend=default_backend()
         ... ).derive(shared_key)
         >>> # And now we can demonstrate that the handshake performed in the
         >>> # opposite direction gives the same final value
@@ -303,7 +300,6 @@ Elliptic Curve Key Exchange algorithm
         ...     length=32,
         ...     salt=None,
         ...     info=b'handshake data',
-        ...     backend=default_backend()
         ... ).derive(same_shared_key)
         >>> derived_key == same_derived_key
         True
@@ -316,19 +312,18 @@ Elliptic Curve Key Exchange algorithm
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.asymmetric import ec
         >>> from cryptography.hazmat.primitives.kdf.hkdf import HKDF
         >>> # Generate a private key for use in the exchange.
         >>> private_key = ec.generate_private_key(
-        ...     ec.SECP384R1(), default_backend()
+        ...     ec.SECP384R1()
         ... )
         >>> # In a real handshake the peer_public_key will be received from the
         >>> # other party. For this example we'll generate another private key
         >>> # and get a public key from that.
         >>> peer_public_key = ec.generate_private_key(
-        ...     ec.SECP384R1(), default_backend()
+        ...     ec.SECP384R1()
         ... ).public_key()
         >>> shared_key = private_key.exchange(ec.ECDH(), peer_public_key)
         >>> # Perform key derivation.
@@ -337,14 +332,13 @@ Elliptic Curve Key Exchange algorithm
         ...     length=32,
         ...     salt=None,
         ...     info=b'handshake data',
-        ...     backend=default_backend()
         ... ).derive(shared_key)
         >>> # For the next handshake we MUST generate another private key.
         >>> private_key_2 = ec.generate_private_key(
-        ...     ec.SECP384R1(), default_backend()
+        ...     ec.SECP384R1()
         ... )
         >>> peer_public_key_2 = ec.generate_private_key(
-        ...     ec.SECP384R1(), default_backend()
+        ...     ec.SECP384R1()
         ... ).public_key()
         >>> shared_key_2 = private_key_2.exchange(ec.ECDH(), peer_public_key_2)
         >>> derived_key_2 = HKDF(
@@ -352,7 +346,6 @@ Elliptic Curve Key Exchange algorithm
         ...     length=32,
         ...     salt=None,
         ...     info=b'handshake data',
-        ...     backend=default_backend()
         ... ).derive(shared_key_2)
 
 Elliptic Curves
@@ -787,11 +780,10 @@ This sample demonstrates how to generate a private key and serialize it.
 
 .. doctest::
 
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import serialization
     >>> from cryptography.hazmat.primitives.asymmetric import ec
 
-    >>> private_key = ec.generate_private_key(ec.SECP384R1(), default_backend())
+    >>> private_key = ec.generate_private_key(ec.SECP384R1())
 
     >>> serialized_private = private_key.private_bytes(
     ...     encoding=serialization.Encoding.PEM,
@@ -831,14 +823,12 @@ in PEM format.
 
     >>> loaded_public_key = serialization.load_pem_public_key(
     ...     serialized_public,
-    ...     backend=default_backend()
     ... )
 
     >>> loaded_private_key = serialization.load_pem_private_key(
     ...     serialized_private,
     ...     # or password=None, if in plain text
     ...     password=b'testpassword',
-    ...     backend=default_backend()
     ... )
 
 

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -32,12 +32,10 @@ mathematical properties`_.
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives.asymmetric import rsa
         >>> private_key = rsa.generate_private_key(
         ...     public_exponent=65537,
         ...     key_size=2048,
-        ...     backend=default_backend()
         ... )
 
     :param int public_exponent: The public exponent of the new key.
@@ -68,14 +66,12 @@ markers), you can load it:
 
 .. code-block:: pycon
 
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import serialization
 
     >>> with open("path/to/key.pem", "rb") as key_file:
     ...     private_key = serialization.load_pem_private_key(
     ...         key_file.read(),
     ...         password=None,
-    ...         backend=default_backend()
     ...     )
 
 Serialized keys may optionally be encrypted on disk using a password. In this
@@ -171,7 +167,7 @@ separately and pass that value using
 
     >>> from cryptography.hazmat.primitives.asymmetric import utils
     >>> chosen_hash = hashes.SHA256()
-    >>> hasher = hashes.Hash(chosen_hash, default_backend())
+    >>> hasher = hashes.Hash(chosen_hash)
     >>> hasher.update(b"data & ")
     >>> hasher.update(b"more data")
     >>> digest = hasher.finalize()
@@ -221,7 +217,7 @@ separately and pass that value using
 .. doctest::
 
     >>> chosen_hash = hashes.SHA256()
-    >>> hasher = hashes.Hash(chosen_hash, default_backend())
+    >>> hasher = hashes.Hash(chosen_hash)
     >>> hasher.update(b"data & ")
     >>> hasher.update(b"more data")
     >>> digest = hasher.finalize()

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -88,10 +88,9 @@ methods.
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives.asymmetric import dsa, rsa
         >>> from cryptography.hazmat.primitives.serialization import load_pem_private_key
-        >>> key = load_pem_private_key(pem_data, password=None, backend=default_backend())
+        >>> key = load_pem_private_key(pem_data, password=None)
         >>> if isinstance(key, rsa.RSAPrivateKey):
         ...     signature = sign_with_rsa_key(key, message)
         ... elif isinstance(key, dsa.DSAPrivateKey):
@@ -173,7 +172,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
     .. doctest::
 
         >>> from cryptography.hazmat.primitives.serialization import load_pem_public_key
-        >>> key = load_pem_public_key(public_pem_data, backend=default_backend())
+        >>> key = load_pem_public_key(public_pem_data)
         >>> isinstance(key, rsa.RSAPublicKey)
         True
 
@@ -208,7 +207,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
 
         >>> from cryptography.hazmat.primitives.serialization import load_pem_parameters
         >>> from cryptography.hazmat.primitives.asymmetric import dh
-        >>> parameters = load_pem_parameters(parameters_pem_data, backend=default_backend())
+        >>> parameters = load_pem_parameters(parameters_pem_data)
         >>> isinstance(parameters, dh.DHParameters)
         True
 
@@ -274,10 +273,9 @@ the rest.
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives.asymmetric import rsa
         >>> from cryptography.hazmat.primitives.serialization import load_der_private_key
-        >>> key = load_der_private_key(der_data, password=None, backend=default_backend())
+        >>> key = load_der_private_key(der_data, password=None)
         >>> isinstance(key, rsa.RSAPrivateKey)
         True
 
@@ -310,10 +308,9 @@ the rest.
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives.asymmetric import rsa
         >>> from cryptography.hazmat.primitives.serialization import load_der_public_key
-        >>> key = load_der_public_key(public_der_data, backend=default_backend())
+        >>> key = load_der_public_key(public_der_data)
         >>> isinstance(key, rsa.RSAPublicKey)
         True
 
@@ -341,10 +338,9 @@ the rest.
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives.asymmetric import dh
         >>> from cryptography.hazmat.primitives.serialization import load_der_parameters
-        >>> parameters = load_der_parameters(parameters_der_data, backend=default_backend())
+        >>> parameters = load_der_parameters(parameters_der_data)
         >>> isinstance(parameters, dh.DHParameters)
         True
 

--- a/docs/hazmat/primitives/asymmetric/utils.rst
+++ b/docs/hazmat/primitives/asymmetric/utils.rst
@@ -57,7 +57,6 @@ Asymmetric Utilities
     .. doctest::
 
         >>> import hashlib
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.asymmetric import (
         ...    padding, rsa, utils
@@ -65,7 +64,6 @@ Asymmetric Utilities
         >>> private_key = rsa.generate_private_key(
         ...     public_exponent=65537,
         ...     key_size=2048,
-        ...     backend=default_backend()
         ... )
         >>> prehashed_msg = hashlib.sha256(b"A message I want to sign").digest()
         >>> signature = private_key.sign(

--- a/docs/hazmat/primitives/asymmetric/x25519.rst
+++ b/docs/hazmat/primitives/asymmetric/x25519.rst
@@ -21,7 +21,6 @@ present.
 
 .. doctest::
 
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import hashes
     >>> from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
     >>> from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -39,7 +38,6 @@ present.
     ...     length=32,
     ...     salt=None,
     ...     info=b'handshake data',
-    ...     backend=default_backend()
     ... ).derive(shared_key)
     >>> # For the next handshake we MUST generate another private key.
     >>> private_key_2 = X25519PrivateKey.generate()
@@ -50,7 +48,6 @@ present.
     ...     length=32,
     ...     salt=None,
     ...     info=b'handshake data',
-    ...     backend=default_backend()
     ... ).derive(shared_key_2)
 
 Key interfaces

--- a/docs/hazmat/primitives/asymmetric/x448.rst
+++ b/docs/hazmat/primitives/asymmetric/x448.rst
@@ -21,7 +21,6 @@ present.
 
 .. doctest::
 
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import hashes
     >>> from cryptography.hazmat.primitives.asymmetric.x448 import X448PrivateKey
     >>> from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -39,7 +38,6 @@ present.
     ...     length=32,
     ...     salt=None,
     ...     info=b'handshake data',
-    ...     backend=default_backend()
     ... ).derive(shared_key)
     >>> # For the next handshake we MUST generate another private key.
     >>> private_key_2 = X448PrivateKey.generate()
@@ -50,7 +48,6 @@ present.
     ...     length=32,
     ...     salt=None,
     ...     info=b'handshake data',
-    ...     backend=default_backend()
     ... ).derive(shared_key_2)
 
 Key interfaces

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -20,9 +20,8 @@ Message digests (Hashing)
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
-        >>> digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+        >>> digest = hashes.Hash(hashes.SHA256())
         >>> digest.update(b"abc")
         >>> digest.update(b"123")
         >>> digest.finalize()

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -55,8 +55,6 @@ PBKDF2
         >>> import os
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> # Salts should be randomly generated
         >>> salt = os.urandom(16)
         >>> # derive
@@ -65,7 +63,6 @@ PBKDF2
         ...     length=32,
         ...     salt=salt,
         ...     iterations=100000,
-        ...     backend=backend
         ... )
         >>> key = kdf.derive(b"my great password")
         >>> # verify
@@ -74,7 +71,6 @@ PBKDF2
         ...     length=32,
         ...     salt=salt,
         ...     iterations=100000,
-        ...     backend=backend
         ... )
         >>> kdf.verify(b"my great password", key)
 
@@ -159,8 +155,6 @@ Scrypt
 
         >>> import os
         >>> from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> salt = os.urandom(16)
         >>> # derive
         >>> kdf = Scrypt(
@@ -169,7 +163,6 @@ Scrypt
         ...     n=2**14,
         ...     r=8,
         ...     p=1,
-        ...     backend=backend
         ... )
         >>> key = kdf.derive(b"my great password")
         >>> # verify
@@ -179,7 +172,6 @@ Scrypt
         ...     n=2**14,
         ...     r=8,
         ...     p=1,
-        ...     backend=backend
         ... )
         >>> kdf.verify(b"my great password", key)
 
@@ -276,21 +268,17 @@ ConcatKDF
         >>> import os
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.kdf.concatkdf import ConcatKDFHash
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> otherinfo = b"concatkdf-example"
         >>> ckdf = ConcatKDFHash(
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     otherinfo=otherinfo,
-        ...     backend=backend
         ... )
         >>> key = ckdf.derive(b"input key")
         >>> ckdf = ConcatKDFHash(
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     otherinfo=otherinfo,
-        ...     backend=backend
         ... )
         >>> ckdf.verify(b"input key", key)
 
@@ -364,8 +352,6 @@ ConcatKDF
         >>> import os
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.kdf.concatkdf import ConcatKDFHMAC
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> salt = os.urandom(16)
         >>> otherinfo = b"concatkdf-example"
         >>> ckdf = ConcatKDFHMAC(
@@ -373,7 +359,6 @@ ConcatKDF
         ...     length=32,
         ...     salt=salt,
         ...     otherinfo=otherinfo,
-        ...     backend=backend
         ... )
         >>> key = ckdf.derive(b"input key")
         >>> ckdf = ConcatKDFHMAC(
@@ -381,7 +366,6 @@ ConcatKDF
         ...     length=32,
         ...     salt=salt,
         ...     otherinfo=otherinfo,
-        ...     backend=backend
         ... )
         >>> ckdf.verify(b"input key", key)
 
@@ -468,8 +452,6 @@ HKDF
         >>> import os
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> salt = os.urandom(16)
         >>> info = b"hkdf-example"
         >>> hkdf = HKDF(
@@ -477,7 +459,6 @@ HKDF
         ...     length=32,
         ...     salt=salt,
         ...     info=info,
-        ...     backend=backend
         ... )
         >>> key = hkdf.derive(b"input key")
         >>> hkdf = HKDF(
@@ -485,7 +466,6 @@ HKDF
         ...     length=32,
         ...     salt=salt,
         ...     info=info,
-        ...     backend=backend
         ... )
         >>> hkdf.verify(b"input key", key)
 
@@ -575,22 +555,18 @@ HKDF
         >>> import os
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.kdf.hkdf import HKDFExpand
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> info = b"hkdf-example"
         >>> key_material = os.urandom(16)
         >>> hkdf = HKDFExpand(
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     info=info,
-        ...     backend=backend
         ... )
         >>> key = hkdf.derive(key_material)
         >>> hkdf = HKDFExpand(
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     info=info,
-        ...     backend=backend
         ... )
         >>> hkdf.verify(key_material, key)
 
@@ -676,8 +652,6 @@ KBKDF
         >>> from cryptography.hazmat.primitives.kdf.kbkdf import (
         ...    CounterLocation, KBKDFHMAC, Mode
         ... )
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> label = b"KBKDF HMAC Label"
         >>> context = b"KBKDF HMAC Context"
         >>> kdf = KBKDFHMAC(
@@ -690,7 +664,6 @@ KBKDF
         ...     label=label,
         ...     context=context,
         ...     fixed=None,
-        ...     backend=backend
         ... )
         >>> key = kdf.derive(b"input key")
         >>> kdf = KBKDFHMAC(
@@ -703,7 +676,6 @@ KBKDF
         ...     label=label,
         ...     context=context,
         ...     fixed=None,
-        ...     backend=backend
         ... )
         >>> kdf.verify(b"input key", key)
 
@@ -835,21 +807,17 @@ X963KDF
         >>> import os
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.kdf.x963kdf import X963KDF
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> sharedinfo = b"ANSI X9.63 Example"
         >>> xkdf = X963KDF(
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     sharedinfo=sharedinfo,
-        ...     backend=backend
         ... )
         >>> key = xkdf.derive(b"input key")
         >>> xkdf = X963KDF(
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     sharedinfo=sharedinfo,
-        ...     backend=backend
         ... )
         >>> xkdf.verify(b"input key", key)
 

--- a/docs/hazmat/primitives/mac/cmac.rst
+++ b/docs/hazmat/primitives/mac/cmac.rst
@@ -26,10 +26,9 @@ A subset of CMAC with the AES-128 algorithm is described in :rfc:`4493`.
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import cmac
         >>> from cryptography.hazmat.primitives.ciphers import algorithms
-        >>> c = cmac.CMAC(algorithms.AES(key), backend=default_backend())
+        >>> c = cmac.CMAC(algorithms.AES(key))
         >>> c.update(b"message to authenticate")
         >>> c.finalize()
         b'CT\x1d\xc8\x0e\x15\xbe4e\xdb\xb6\x84\xca\xd9Xk'
@@ -47,7 +46,7 @@ A subset of CMAC with the AES-128 algorithm is described in :rfc:`4493`.
 
     .. doctest::
 
-        >>> c = cmac.CMAC(algorithms.AES(key), backend=default_backend())
+        >>> c = cmac.CMAC(algorithms.AES(key))
         >>> c.update(b"message to authenticate")
         >>> c.verify(b"an incorrect signature")
         Traceback (most recent call last):

--- a/docs/hazmat/primitives/mac/hmac.rst
+++ b/docs/hazmat/primitives/mac/hmac.rst
@@ -27,9 +27,8 @@ of a message.
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes, hmac
-        >>> h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
+        >>> h = hmac.HMAC(key, hashes.SHA256())
         >>> h.update(b"message to hash")
         >>> h.finalize()
         b'#F\xdaI\x8b"e\xc4\xf1\xbb\x9a\x8fc\xff\xf5\xdex.\xbc\xcd/+\x8a\x86\x1d\x84\'\xc3\xa6\x1d\xd8J'
@@ -47,7 +46,7 @@ of a message.
 
     .. doctest::
 
-        >>> h = hmac.HMAC(key, hashes.SHA256(), backend=default_backend())
+        >>> h = hmac.HMAC(key, hashes.SHA256())
         >>> h.update(b"message to hash")
         >>> h.verify(b"an incorrect signature")
         Traceback (most recent call last):

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -33,11 +33,9 @@ it fits your needs before implementing anything using this module.**
 
         >>> import os
         >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> backend = default_backend()
         >>> key = os.urandom(32)
         >>> iv = os.urandom(16)
-        >>> cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=backend)
+        >>> cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
         >>> encryptor = cipher.encryptor()
         >>> ct = encryptor.update(b"a secret message") + encryptor.finalize()
         >>> decryptor = cipher.decryptor()
@@ -147,10 +145,9 @@ Algorithms
     .. doctest::
 
         >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-        >>> from cryptography.hazmat.backends import default_backend
         >>> nonce = os.urandom(16)
         >>> algorithm = algorithms.ChaCha20(key, nonce)
-        >>> cipher = Cipher(algorithm, mode=None, backend=default_backend())
+        >>> cipher = Cipher(algorithm, mode=None)
         >>> encryptor = cipher.encryptor()
         >>> ct = encryptor.update(b"a secret message")
         >>> decryptor = cipher.decryptor()
@@ -231,9 +228,8 @@ Weak ciphers
     .. doctest::
 
         >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-        >>> from cryptography.hazmat.backends import default_backend
         >>> algorithm = algorithms.ARC4(key)
-        >>> cipher = Cipher(algorithm, mode=None, backend=default_backend())
+        >>> cipher = Cipher(algorithm, mode=None)
         >>> encryptor = cipher.encryptor()
         >>> ct = encryptor.update(b"a secret message")
         >>> decryptor = cipher.decryptor()
@@ -425,7 +421,6 @@ Modes
 
         import os
 
-        from cryptography.hazmat.backends import default_backend
         from cryptography.hazmat.primitives.ciphers import (
             Cipher, algorithms, modes
         )
@@ -439,7 +434,6 @@ Modes
             encryptor = Cipher(
                 algorithms.AES(key),
                 modes.GCM(iv),
-                backend=default_backend()
             ).encryptor()
 
             # associated_data will be authenticated but not encrypted,
@@ -458,7 +452,6 @@ Modes
             decryptor = Cipher(
                 algorithms.AES(key),
                 modes.GCM(iv, tag),
-                backend=default_backend()
             ).decryptor()
 
             # We put associated_data back in or the tag will fail to verify
@@ -595,11 +588,9 @@ Interfaces
 
             >>> import os
             >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-            >>> from cryptography.hazmat.backends import default_backend
-            >>> backend = default_backend()
             >>> key = os.urandom(32)
             >>> iv = os.urandom(16)
-            >>> cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=backend)
+            >>> cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
             >>> encryptor = cipher.encryptor()
             >>> # the buffer needs to be at least len(data) + n - 1 where n is cipher/mode block size in bytes
             >>> buf = bytearray(31)

--- a/docs/hazmat/primitives/twofactor.rst
+++ b/docs/hazmat/primitives/twofactor.rst
@@ -33,11 +33,10 @@ codes (HMAC).
     .. doctest::
 
         >>> import os
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives.twofactor.hotp import HOTP
         >>> from cryptography.hazmat.primitives.hashes import SHA1
         >>> key = os.urandom(20)
-        >>> hotp = HOTP(key, 6, SHA1(), backend=default_backend())
+        >>> hotp = HOTP(key, 6, SHA1())
         >>> hotp_value = hotp.generate(0)
         >>> hotp.verify(hotp_value, 0)
 
@@ -129,7 +128,7 @@ similar to the following code.
         assert look_ahead >= 0
         correct_counter = None
 
-        otp = HOTP(key, 6, default_backend())
+        otp = HOTP(key, 6)
         for count in range(counter, counter + look_ahead):
             try:
                 otp.verify(hotp, count)
@@ -155,11 +154,10 @@ similar to the following code.
 
         >>> import os
         >>> import time
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives.twofactor.totp import TOTP
         >>> from cryptography.hazmat.primitives.hashes import SHA1
         >>> key = os.urandom(20)
-        >>> totp = TOTP(key, 8, SHA1(), 30, backend=default_backend())
+        >>> totp = TOTP(key, 8, SHA1(), 30)
         >>> time_value = time.time()
         >>> totp_value = totp.generate(time_value)
         >>> totp.verify(totp_value, time_value)

--- a/docs/x509/ocsp.rst
+++ b/docs/x509/ocsp.rst
@@ -167,12 +167,11 @@ Creating Requests
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import serialization
         >>> from cryptography.hazmat.primitives.hashes import SHA1
         >>> from cryptography.x509 import load_pem_x509_certificate, ocsp
-        >>> cert = load_pem_x509_certificate(pem_cert, default_backend())
-        >>> issuer = load_pem_x509_certificate(pem_issuer, default_backend())
+        >>> cert = load_pem_x509_certificate(pem_cert)
+        >>> issuer = load_pem_x509_certificate(pem_issuer)
         >>> builder = ocsp.OCSPRequestBuilder()
         >>> # SHA1 is in this example because RFC 5019 mandates its use.
         >>> builder = builder.add_certificate(cert, issuer, SHA1())
@@ -315,13 +314,12 @@ Creating Responses
     .. doctest::
 
         >>> import datetime
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes, serialization
         >>> from cryptography.x509 import load_pem_x509_certificate, ocsp
-        >>> cert = load_pem_x509_certificate(pem_cert, default_backend())
-        >>> issuer = load_pem_x509_certificate(pem_issuer, default_backend())
-        >>> responder_cert = load_pem_x509_certificate(pem_responder_cert, default_backend())
-        >>> responder_key = serialization.load_pem_private_key(pem_responder_key, None, default_backend())
+        >>> cert = load_pem_x509_certificate(pem_cert)
+        >>> issuer = load_pem_x509_certificate(pem_issuer)
+        >>> responder_cert = load_pem_x509_certificate(pem_responder_cert)
+        >>> responder_key = serialization.load_pem_private_key(pem_responder_key, None)
         >>> builder = ocsp.OCSPResponseBuilder()
         >>> # SHA1 is in this example because RFC 5019 mandates its use.
         >>> builder = builder.add_response(
@@ -350,7 +348,6 @@ Creating Responses
 
     .. doctest::
 
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes, serialization
         >>> from cryptography.x509 import load_pem_x509_certificate, ocsp
         >>> response = ocsp.OCSPResponseBuilder.build_unsuccessful(

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -168,8 +168,7 @@ Loading Certificates
     .. doctest::
 
         >>> from cryptography import x509
-        >>> from cryptography.hazmat.backends import default_backend
-        >>> cert = x509.load_pem_x509_certificate(pem_data, default_backend())
+        >>> cert = x509.load_pem_x509_certificate(pem_data)
         >>> cert.serial_number
         2
 
@@ -212,9 +211,8 @@ Loading Certificate Revocation Lists
     .. doctest::
 
         >>> from cryptography import x509
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
-        >>> crl = x509.load_pem_x509_crl(pem_crl_data, default_backend())
+        >>> crl = x509.load_pem_x509_crl(pem_crl_data)
         >>> isinstance(crl.signature_hash_algorithm, hashes.SHA256)
         True
 
@@ -258,9 +256,8 @@ Loading Certificate Signing Requests
     .. doctest::
 
         >>> from cryptography import x509
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
-        >>> csr = x509.load_pem_x509_csr(pem_req_data, default_backend())
+        >>> csr = x509.load_pem_x509_csr(pem_req_data)
         >>> isinstance(csr.signature_hash_algorithm, hashes.SHA256)
         True
 
@@ -474,8 +471,8 @@ X.509 Certificate Object
 
            >>> from cryptography.hazmat.primitives.serialization import load_pem_public_key
            >>> from cryptography.hazmat.primitives.asymmetric import padding
-           >>> issuer_public_key = load_pem_public_key(pem_issuer_public_key, default_backend())
-           >>> cert_to_check = x509.load_pem_x509_certificate(pem_data_to_check, default_backend())
+           >>> issuer_public_key = load_pem_public_key(pem_issuer_public_key)
+           >>> cert_to_check = x509.load_pem_x509_certificate(pem_data_to_check)
            >>> issuer_public_key.verify(
            ...     cert_to_check.signature,
            ...     cert_to_check.tbs_certificate_bytes,
@@ -671,7 +668,6 @@ X.509 Certificate Builder
     .. doctest::
 
         >>> from cryptography import x509
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.asymmetric import rsa
         >>> from cryptography.x509.oid import NameOID
@@ -680,7 +676,6 @@ X.509 Certificate Builder
         >>> private_key = rsa.generate_private_key(
         ...     public_exponent=65537,
         ...     key_size=2048,
-        ...     backend=default_backend()
         ... )
         >>> public_key = private_key.public_key()
         >>> builder = x509.CertificateBuilder()
@@ -705,7 +700,6 @@ X.509 Certificate Builder
         ... )
         >>> certificate = builder.sign(
         ...     private_key=private_key, algorithm=hashes.SHA256(),
-        ...     backend=default_backend()
         ... )
         >>> isinstance(certificate, x509.Certificate)
         True
@@ -945,7 +939,6 @@ X.509 Certificate Revocation List Builder
     .. doctest::
 
         >>> from cryptography import x509
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.asymmetric import rsa
         >>> from cryptography.x509.oid import NameOID
@@ -954,7 +947,6 @@ X.509 Certificate Revocation List Builder
         >>> private_key = rsa.generate_private_key(
         ...     public_exponent=65537,
         ...     key_size=2048,
-        ...     backend=default_backend()
         ... )
         >>> builder = x509.CertificateRevocationListBuilder()
         >>> builder = builder.issuer_name(x509.Name([
@@ -966,11 +958,10 @@ X.509 Certificate Revocation List Builder
         ...     333
         ... ).revocation_date(
         ...     datetime.datetime.today()
-        ... ).build(default_backend())
+        ... ).build()
         >>> builder = builder.add_revoked_certificate(revoked_cert)
         >>> crl = builder.sign(
         ...     private_key=private_key, algorithm=hashes.SHA256(),
-        ...     backend=default_backend()
         ... )
         >>> len(crl)
         1
@@ -1107,12 +1098,11 @@ X.509 Revoked Certificate Builder
     .. doctest::
 
         >>> from cryptography import x509
-        >>> from cryptography.hazmat.backends import default_backend
         >>> import datetime
         >>> builder = x509.RevokedCertificateBuilder()
         >>> builder = builder.revocation_date(datetime.datetime.today())
         >>> builder = builder.serial_number(3333)
-        >>> revoked_certificate = builder.build(default_backend())
+        >>> revoked_certificate = builder.build()
         >>> isinstance(revoked_certificate, x509.RevokedCertificate)
         True
 
@@ -1161,14 +1151,12 @@ X.509 CSR (Certificate Signing Request) Builder Object
     .. doctest::
 
         >>> from cryptography import x509
-        >>> from cryptography.hazmat.backends import default_backend
         >>> from cryptography.hazmat.primitives import hashes
         >>> from cryptography.hazmat.primitives.asymmetric import rsa
         >>> from cryptography.x509.oid import AttributeOID, NameOID
         >>> private_key = rsa.generate_private_key(
         ...     public_exponent=65537,
         ...     key_size=2048,
-        ...     backend=default_backend()
         ... )
         >>> builder = x509.CertificateSigningRequestBuilder()
         >>> builder = builder.subject_name(x509.Name([
@@ -1181,7 +1169,7 @@ X.509 CSR (Certificate Signing Request) Builder Object
         ...     AttributeOID.CHALLENGE_PASSWORD, b"changeit"
         ... )
         >>> request = builder.sign(
-        ...     private_key, hashes.SHA256(), default_backend()
+        ...     private_key, hashes.SHA256()
         ... )
         >>> isinstance(request, x509.CertificateSigningRequest)
         True
@@ -1907,8 +1895,7 @@ X.509 Extensions
         .. doctest::
 
             >>> from cryptography import x509
-            >>> from cryptography.hazmat.backends import default_backend
-            >>> issuer_cert = x509.load_pem_x509_certificate(pem_data, default_backend())
+            >>> issuer_cert = x509.load_pem_x509_certificate(pem_data)
             >>> x509.AuthorityKeyIdentifier.from_issuer_public_key(issuer_cert.public_key())
             <AuthorityKeyIdentifier(key_identifier=b'X\x01\x84$\x1b\xbc+R\x94J=\xa5\x10r\x14Q\xf5\xaf:\xc9', authority_cert_issuer=None, authority_cert_serial_number=None)>
 
@@ -1937,8 +1924,7 @@ X.509 Extensions
         .. doctest::
 
             >>> from cryptography import x509
-            >>> from cryptography.hazmat.backends import default_backend
-            >>> issuer_cert = x509.load_pem_x509_certificate(pem_data, default_backend())
+            >>> issuer_cert = x509.load_pem_x509_certificate(pem_data)
             >>> ski_ext = issuer_cert.extensions.get_extension_for_class(x509.SubjectKeyIdentifier)
             >>> x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(ski_ext.value)
             <AuthorityKeyIdentifier(key_identifier=b'X\x01\x84$\x1b\xbc+R\x94J=\xa5\x10r\x14Q\xf5\xaf:\xc9', authority_cert_issuer=None, authority_cert_serial_number=None)>
@@ -1985,8 +1971,7 @@ X.509 Extensions
         .. doctest::
 
             >>> from cryptography import x509
-            >>> from cryptography.hazmat.backends import default_backend
-            >>> csr = x509.load_pem_x509_csr(pem_req_data, default_backend())
+            >>> csr = x509.load_pem_x509_csr(pem_req_data)
             >>> x509.SubjectKeyIdentifier.from_public_key(csr.public_key())
             <SubjectKeyIdentifier(digest=b'\x8c"\x98\xe2\xb5\xbf]\xe8*2\xf8\xd2\'?\x00\xd2\xc7#\xe4c')>
 
@@ -2021,9 +2006,8 @@ X.509 Extensions
         .. doctest::
 
             >>> from cryptography import x509
-            >>> from cryptography.hazmat.backends import default_backend
             >>> from cryptography.hazmat.primitives import hashes
-            >>> cert = x509.load_pem_x509_certificate(cryptography_cert_pem, default_backend())
+            >>> cert = x509.load_pem_x509_certificate(cryptography_cert_pem)
             >>> # Get the subjectAltName extension from the certificate
             >>> ext = cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
             >>> # Get the dNSName entries from the SAN extension

--- a/docs/x509/tutorial.rst
+++ b/docs/x509/tutorial.rst
@@ -27,14 +27,12 @@ are the most common types of keys on the web right now):
 
 .. code-block:: pycon
 
-    >>> from cryptography.hazmat.backends import default_backend
     >>> from cryptography.hazmat.primitives import serialization
     >>> from cryptography.hazmat.primitives.asymmetric import rsa
     >>> # Generate our key
     >>> key = rsa.generate_private_key(
     ...     public_exponent=65537,
     ...     key_size=2048,
-    ...     backend=default_backend()
     ... )
     >>> # Write our key to disk for safe keeping
     >>> with open("path/to/store/key.pem", "wb") as f:
@@ -76,7 +74,7 @@ a few details:
     ...     ]),
     ...     critical=False,
     ... # Sign the CSR with our private key.
-    ... ).sign(key, hashes.SHA256(), default_backend())
+    ... ).sign(key, hashes.SHA256())
     >>> # Write our CSR out to disk.
     >>> with open("path/to/csr.pem", "wb") as f:
     ...     f.write(csr.public_bytes(serialization.Encoding.PEM))
@@ -105,7 +103,6 @@ Like generating a CSR, we start with creating a new private key:
     >>> key = rsa.generate_private_key(
     ...     public_exponent=65537,
     ...     key_size=2048,
-    ...     backend=default_backend()
     ... )
     >>> # Write our key to disk for safe keeping
     >>> with open("path/to/store/key.pem", "wb") as f:
@@ -145,7 +142,7 @@ Then we generate the certificate itself:
     ...     x509.SubjectAlternativeName([x509.DNSName(u"localhost")]),
     ...     critical=False,
     ... # Sign our certificate with our private key
-    ... ).sign(key, hashes.SHA256(), default_backend())
+    ... ).sign(key, hashes.SHA256())
     >>> # Write our certificate out to disk.
     >>> with open("path/to/certificate.pem", "wb") as f:
     ...     f.write(cert.public_bytes(serialization.Encoding.PEM))


### PR DESCRIPTION
We shouldn't merge this just yet so we minimize confusion. I've enabled a few older docs builds now too so it's possible to see the older docs, but until 3.1 ships we shouldn't merge this as long as we have our primary docs set to `latest`.