### PR TITLE
Alternative: Build Arm64 wheels via github wheel-builder action with docker buildx

### DIFF
--- a/.github/workflows/Dockerfile_aarch64
+++ b/.github/workflows/Dockerfile_aarch64
@@ -1,0 +1,16 @@
+FROM pyca/cryptography-manylinux2014_aarch64 as build
+MAINTAINER Python Cryptographic Authority
+
+ARG PYTHON
+ARG CRYPTOGRAPHY_VERSION
+ENV PYTHON=${PYTHON}
+ENV CRYPTOGRAPHY_VERSION=${CRYPTOGRAPHY_VERSION}
+
+WORKDIR /root
+ADD .github/workflows/build-wheels-aarch64.sh /root/build-wheels-aarch64.sh
+CMD cd /root/
+RUN chmod +x build-wheels-aarch64.sh
+RUN ./build-wheels-aarch64.sh
+
+FROM scratch as release
+COPY --from=build /root/wheelhouse /wheelhouse

--- a/.github/workflows/build-wheels-aarch64.sh
+++ b/.github/workflows/build-wheels-aarch64.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+set -e
+
+/opt/python/${PYTHON}/bin/python -m virtualenv .venv
+.venv/bin/pip install -U pip wheel cffi six ipaddress
+.venv/bin/pip download cryptography==${CRYPTOGRAPHY_VERSION} --no-deps --no-binary cryptography
+tar zxvf cryptography*.tar.gz
+mkdir tmpwheelhouse
+
+REGEX="cp3([0-9])*"
+if [[ "${PYTHON}" =~ $REGEX ]]; then
+  PY_LIMITED_API="--py-limited-api=cp3${BASH_REMATCH[1]}"
+fi
+cd cryptography*
+LDFLAGS="-L/opt/pyca/cryptography/openssl/lib" \
+CFLAGS="-I/opt/pyca/cryptography/openssl/include -Wl,--exclude-libs,ALL" \
+../.venv/bin/python setup.py bdist_wheel $PY_LIMITED_API && mv dist/cryptography*.whl ../tmpwheelhouse
+cd ../
+
+auditwheel repair --plat manylinux2014_aarch64 tmpwheelhouse/cryptograp*.whl -w wheelhouse
+
+# execstack not available on manylinux2014_aarch64. Commented out for now
+#unzip wheelhouse/*.whl -d execstack.check
+
+#results=$(execstack execstack.check/cryptography/hazmat/bindings/*.so)
+#count=$(echo "$results" | grep -c '^X' || true)
+#if [ "$count" -ne 0 ]; then
+#  exit 1
+#else
+#  exit 0
+#fi
+
+.venv/bin/pip install cryptography --no-index -f wheelhouse/
+.venv/bin/python -c "from cryptography.hazmat.backends.openssl.backend import backend;print('Loaded: ' + backend.openssl_version_text());print('Linked Against: ' + backend._ffi.string(backend._lib.OPENSSL_VERSION_TEXT).decode('ascii'))"

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -51,6 +51,40 @@ jobs:
         with:
           name: "cryptography-${{ github.event.inputs.version }}-${{ matrix.MANYLINUX.NAME }}-${{ matrix.PYTHON }}"
           path: cryptography-wheelhouse/
+  
+  # Since github actions do not offer arm64 builders, we use Docker buildx to do the build
+  # and dump the artifacts to a folder.
+  manylinux_aarch64:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PYTHON: ["cp35-cp35m", "cp36-cp36m", "cp37-cp37m", "cp38-cp38", "cp39-cp39"]
+        MANYLINUX:
+          - NAME: manylinux2014_aarch64
+            CONTAINER: "gwblake/cryptography-manylinux2014_aarch64:latest"
+    name: "${{ matrix.PYTHON }} for ${{ matrix.MANYLINUX.NAME }}"
+    steps:
+      - uses: actions/checkout@master
+      - name: Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3.3.0
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      - name: Pull the container
+        run: docker pull ${{ matrix.MANYLINUX.CONTAINER }}
+      - name: Build our container with the wheel in in
+        run: >
+          docker buildx build --platform linux/arm64 
+          -t crypto-wheelhouse_aarch64-${{ matrix.PYTHON }} --output tmpwheelhouse --build-arg PYTHON=${{ matrix.PYTHON }}
+          --build-arg CRYPTOGRAPHY_VERSION=${{ github.event.inputs.version }} -f .github/workflows/Dockerfile_aarch64 .
+      - name: Extract wheelhouse folder from dumped container
+        run: |
+          mv tmpwheelhouse/wheelhouse cryptography-wheelhouse
+      - uses: actions/upload-artifact@v1
+        with:
+          name: "cryptography-${{ github.event.inputs.version }}-${{ matrix.MANYLINUX.NAME }}-${{ matrix.PYTHON }}"
+          path: cryptography-wheelhouse/
 
   macos:
     runs-on: macos-latest


### PR DESCRIPTION
I know that the devs have invested quite a bit of time and effort with @ianw getting OpenDev up and running, and thanks a ton for getting Arm wheels building!

But, just wanted to present this as an alternative for wheel building so all the binaries drop into one place for x86 (win, mac, manylinux) and arm64 (manylinux) for simplified upstreaming.  What's in this PR:

- `manylinux_aarch64` job in wheel-builder.yml that builds the arm64 python3 wheels on manylinux2014_aarch64 using docker buildx, takes ~6 minutes.
- Dockerfile_aarch64 that builds the wheels and then extracts just the wheels to copy out
- build-wheels-aarch64.sh, bash script run inside docker that builds and tests the wheels in the same way as the x86 wheels.

At the very least, this can teach others some new tricks with using Docker and buildx to work around missing native platform support on the CI system of choice where applicable.  (Obviously emulation cannot replace native testing for this project's extensive unit testing!)