### PR TITLE
re-add a few engine bindings for advanced users

### DIFF
--- a/src/_cffi_src/openssl/engine.py
+++ b/src/_cffi_src/openssl/engine.py
@@ -10,6 +10,7 @@ INCLUDES = """
 
 TYPES = """
 typedef ... ENGINE;
+typedef ... UI_METHOD;
 
 static const long Cryptography_HAS_ENGINE;
 """
@@ -25,6 +26,12 @@ int ENGINE_ctrl_cmd(ENGINE *, const char *, long, void *, void (*)(void), int);
 int ENGINE_free(ENGINE *);
 const char *ENGINE_get_name(const ENGINE *);
 
+// These bindings are unused by cryptography or pyOpenSSL but are present
+// for advanced users who need them.
+int ENGINE_ctrl_cmd_string(ENGINE *, const char *, const char *, int);
+void ENGINE_load_builtin_engines(void);
+EVP_PKEY *ENGINE_load_private_key(ENGINE *, const char *, UI_METHOD *, void *);
+EVP_PKEY *ENGINE_load_public_key(ENGINE *, const char *, UI_METHOD *, void *);
 """
 
 CUSTOMIZATIONS = """
@@ -43,6 +50,14 @@ int (*ENGINE_ctrl_cmd)(ENGINE *, const char *, long, void *,
 int (*ENGINE_free)(ENGINE *) = NULL;
 const char *(*ENGINE_get_id)(const ENGINE *) = NULL;
 const char *(*ENGINE_get_name)(const ENGINE *) = NULL;
+
+int (*ENGINE_ctrl_cmd_string)(ENGINE *, const char *, const char *,
+                              int) = NULL;
+void (*ENGINE_load_builtin_engines)(void) = NULL;
+EVP_PKEY *(*ENGINE_load_private_key)(ENGINE *, const char *, UI_METHOD *,
+                                     void *) = NULL;
+EVP_PKEY *(*ENGINE_load_public_key)(ENGINE *, const char *,
+                                    UI_METHOD *, void *) = NULL;
 
 #else
 static const long Cryptography_HAS_ENGINE = 1;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -270,6 +270,10 @@ def cryptography_has_engine():
         "ENGINE_free",
         "ENGINE_get_name",
         "Cryptography_add_osrandom_engine",
+        "ENGINE_ctrl_cmd_string",
+        "ENGINE_load_builtin_engines",
+        "ENGINE_load_private_key",
+        "ENGINE_load_public_key",
     ]
 
 


### PR DESCRIPTION
For users who are capable of compiling cryptography against custom openssl and properly using these functions this hopefully allows PKCS11 usage through OpenSSL engines.

We've seen quite a few requests for this to be re-added over the past year, OpenSSL 3.0 is not coming out quickly (and providers won't replace engines immediately), and since we now support `no-engine` the maintenance burden here should be manageable.

Note that we are not directly supporting the use of this, merely providing the escape hatch for advanced users. If there are additional bindings that are missing please let us know, although we won't add functions that have equivalents already (e.g. `EVP_sha256() is not needed because you can get the `EVP_MD *` via a call to `EVP_get_digestbyname`).