### PR TITLE
Make the OpenSSL signature recovery function available from Python

### DIFF
--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -101,6 +101,9 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *, unsigned char *, size_t *,
 int EVP_PKEY_verify_init(EVP_PKEY_CTX *);
 int EVP_PKEY_verify(EVP_PKEY_CTX *, const unsigned char *, size_t,
                     const unsigned char *, size_t);
+int EVP_PKEY_verify_recover_init(EVP_PKEY_CTX *);
+int EVP_PKEY_verify_recover(EVP_PKEY_CTX *, unsigned char *,
+                            size_t *, const unsigned char *, size_t);
 int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *);
 int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *);
 


### PR DESCRIPTION
There is a sometimes a need to recover the RSA signature data in order to parse its format. This is used with non-standard signature formats. Since this is an exotic case, the support was added only at the low level through the OpenSSL lib wrapper, without high level API support in hazmat.