### PR TITLE
add pkcs7/smime bindings

### DIFF
--- a/src/_cffi_src/openssl/pkcs7.py
+++ b/src/_cffi_src/openssl/pkcs7.py
@@ -63,8 +63,8 @@ int SMIME_write_PKCS7(BIO *, PKCS7 *, BIO *, int);
 PKCS7_SIGNER_INFO *PKCS7_sign_add_signer(PKCS7 *, X509 *, EVP_PKEY *,
                                          const EVP_MD *, int);
 int PKCS7_final(PKCS7 *, BIO *, int);
-// Included verify due to external consumer, see
-// https://github.com/pyca/cryptography/issues/5433
+/* Included verify due to external consumer, see
+ * https://github.com/pyca/cryptography/issues/5433 */
 int PKCS7_verify(PKCS7 *, Cryptography_STACK_OF_X509 *, X509_STORE *, BIO *,
                  BIO *, int);
 

--- a/src/_cffi_src/openssl/pkcs7.py
+++ b/src/_cffi_src/openssl/pkcs7.py
@@ -64,7 +64,7 @@ PKCS7_SIGNER_INFO *PKCS7_sign_add_signer(PKCS7 *, X509 *, EVP_PKEY *,
                                          const EVP_MD *, int);
 int PKCS7_final(PKCS7 *, BIO *, int);
 /* Included verify due to external consumer, see
- * https://github.com/pyca/cryptography/issues/5433 */
+   https://github.com/pyca/cryptography/issues/5433 */
 int PKCS7_verify(PKCS7 *, Cryptography_STACK_OF_X509 *, X509_STORE *, BIO *,
                  BIO *, int);
 

--- a/src/_cffi_src/openssl/pkcs7.py
+++ b/src/_cffi_src/openssl/pkcs7.py
@@ -24,6 +24,7 @@ typedef struct {
 typedef ... PKCS7_DIGEST;
 typedef ... PKCS7_ENCRYPT;
 typedef ... PKCS7_ENVELOPE;
+typedef ... PKCS7_SIGNER_INFO;
 
 typedef struct {
     ASN1_OBJECT *type;
@@ -51,10 +52,21 @@ static const int PKCS7_NOSMIMECAP;
 static const int PKCS7_NOVERIFY;
 static const int PKCS7_STREAM;
 static const int PKCS7_TEXT;
+static const int PKCS7_PARTIAL;
 """
 
 FUNCTIONS = """
 void PKCS7_free(PKCS7 *);
+PKCS7 *PKCS7_sign(X509 *, EVP_PKEY *, Cryptography_STACK_OF_X509 *,
+                   BIO *, int);
+int SMIME_write_PKCS7(BIO *, PKCS7 *, BIO *, int);
+PKCS7_SIGNER_INFO *PKCS7_sign_add_signer(PKCS7 *, X509 *, EVP_PKEY *,
+                                         const EVP_MD *, int);
+int PKCS7_final(PKCS7 *, BIO *, int);
+// Included verify due to external consumer, see
+// https://github.com/pyca/cryptography/issues/5433
+int PKCS7_verify(PKCS7 *, Cryptography_STACK_OF_X509 *, X509_STORE *, BIO *,
+                 BIO *, int);
 
 int PKCS7_type_is_signed(PKCS7 *);
 int PKCS7_type_is_enveloped(PKCS7 *);


### PR DESCRIPTION
refs #5433 

This re-adds some functions we'll be using shortly for a hazmat SMIME API.