### PR TITLE
allow bytes-like for padding

### DIFF
--- a/docs/hazmat/primitives/padding.rst
+++ b/docs/hazmat/primitives/padding.rst
@@ -107,7 +107,8 @@ multiple of the block size.
 
     .. method:: update(data)
 
-        :param bytes data: The data you wish to pass into the context.
+        :param data: The data you wish to pass into the context.
+        :type data: :term:`bytes-like`
         :return bytes: Returns the data that was padded or unpadded.
         :raises TypeError: Raised if data is not bytes.
         :raises cryptography.exceptions.AlreadyFinalized: See :meth:`finalize`.

--- a/src/cryptography/hazmat/primitives/padding.py
+++ b/src/cryptography/hazmat/primitives/padding.py
@@ -40,9 +40,9 @@ def _byte_padding_update(buffer_, data, block_size):
     if buffer_ is None:
         raise AlreadyFinalized("Context was already finalized.")
 
-    utils._check_bytes("data", data)
+    utils._check_byteslike("data", data)
 
-    buffer_ += data
+    buffer_ += bytes(data)
 
     finished_blocks = len(buffer_) // (block_size // 8)
 
@@ -64,9 +64,9 @@ def _byte_unpadding_update(buffer_, data, block_size):
     if buffer_ is None:
         raise AlreadyFinalized("Context was already finalized.")
 
-    utils._check_bytes("data", data)
+    utils._check_byteslike("data", data)
 
-    buffer_ += data
+    buffer_ += bytes(data)
 
     finished_blocks = max(len(buffer_) // (block_size // 8) - 1, 0)
 

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -109,6 +109,18 @@ class TestPKCS7(object):
 
         assert data == b""
 
+    def test_bytearray(self):
+        padder = padding.PKCS7(128).padder()
+        unpadded = bytearray(b"t" * 38)
+        padded = (
+            padder.update(unpadded)
+            + padder.update(unpadded)
+            + padder.finalize()
+        )
+        unpadder = padding.PKCS7(128).unpadder()
+        final = unpadder.update(padded) + unpadder.finalize()
+        assert final == unpadded + unpadded
+
 
 class TestANSIX923(object):
     @pytest.mark.parametrize("size", [127, 4096, -2])
@@ -193,3 +205,15 @@ class TestANSIX923(object):
             unpadder.update(b"")
         with pytest.raises(AlreadyFinalized):
             unpadder.finalize()
+
+    def test_bytearray(self):
+        padder = padding.ANSIX923(128).padder()
+        unpadded = bytearray(b"t" * 38)
+        padded = (
+            padder.update(unpadded)
+            + padder.update(unpadded)
+            + padder.finalize()
+        )
+        unpadder = padding.ANSIX923(128).unpadder()
+        final = unpadder.update(padded) + unpadder.finalize()
+        assert final == unpadded + unpadded


### PR DESCRIPTION
this doesn't improve efficiency in any way (copies galore!), but it does make it consistent between a cipher context and a padding context.

Someone should find the ambition to refactor the padder to eliminate copies, but it won't be me.

Sorta fixes #4805