### PR TITLE
add prelim python 3.9 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - {VERSION: "2.7", TOXENV: "py27", EXTRA_CFLAGS: ""}
           - {VERSION: "3.5", TOXENV: "py35", EXTRA_CFLAGS: ""}
           - {VERSION: "3.8", TOXENV: "py38", EXTRA_CFLAGS: "-DUSE_OSRANDOM_RNG_FOR_TESTING"}
+          - {VERSION: "3.9.0-rc.1", TOXENV: "py39"}
     name: "Python ${{ matrix.PYTHON.VERSION }} on macOS"
     steps:
       - uses: actions/checkout@master
@@ -63,6 +64,7 @@ jobs:
           - {VERSION: "3.6", TOXENV: "py36", MSVC_VERSION: "2019", CL_FLAGS: ""}
           - {VERSION: "3.7", TOXENV: "py37", MSVC_VERSION: "2019", CL_FLAGS: ""}
           - {VERSION: "3.8", TOXENV: "py38", MSVC_VERSION: "2019", CL_FLAGS: "/D USE_OSRANDOM_RNG_FOR_TESTING"}
+          - {VERSION: "3.9.0-rc.1", TOXENV: "py39", MSVC_VERSION: "2019", CL_FLAGS: ""}
     name: "Python ${{ matrix.PYTHON.VERSION }} on ${{ matrix.WINDOWS.WINDOWS }}"
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
 
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           architecture: ${{ matrix.WINDOWS.ARCH }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
         # Setting 'python' is just to make travis's UI a bit prettier
         - python: 3.6
           env: TOXENV=py36
+        - python: 3.9-dev
+          env: TOXENV=py39
           # Travis lists available Pythons (including PyPy) by arch and distro here:
           # https://docs.travis-ci.com/user/languages/python/#python-versions
         - python: pypy2.7-7.3.1


### PR DESCRIPTION
fixes #5463 

Once 3.9 is out we can update these jobs and remove the 3.8 macOS job since we're testing primarily on 2.7, lowest-supported-3.x and latest 3.x on that platform to keep our CI size under control. Maybe we should consider doing that for Windows as well, but that can be a future PR.