### PR TITLE
PKCS7SignatureBuilder now supports three serializations

### DIFF
--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -620,7 +620,7 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
         ... ).add_signer(
         ...     cert, key, hashes.SHA256()
         ... ).sign(
-        ...     serialization.Encoding.PEM, options
+        ...     serialization.Encoding.SMIME, options
         ... )
         b'...'
 
@@ -649,8 +649,9 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
 
     .. method:: sign(encoding, options, backend=None)
 
-        :param encoding: :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`
-            or :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`.
+        :param encoding: :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`,
+            :attr:`~cryptography.hazmat.primitives.serialization.Encoding.DER`,
+            or :attr:`~cryptography.hazmat.primitives.serialization.Encoding.SMIME`.
 
         :param options: A list of
             :class:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options`.
@@ -670,19 +671,19 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
 
         The text option adds ``text/plain`` headers to an S/MIME message when
         serializing to
-        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM`.
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.SMIME`.
         This option is disallowed with ``DER`` serialization.
 
     .. attribute:: Binary
 
-        S/MIME signing normally converts line endings (LF to CRLF). When
+        Signing normally converts line endings (LF to CRLF). When
         passing this option the data will not be converted.
 
     .. attribute:: DetachedSignature
 
         Don't embed the signed data within the ASN.1. When signing with
-        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.PEM` this
-        also results in the data being added as clear text before the
+        :attr:`~cryptography.hazmat.primitives.serialization.Encoding.SMIME`
+        this also results in the data being added as clear text before the
         PEM encoded structure.
 
     .. attribute:: NoCapabilities
@@ -890,6 +891,12 @@ Serialization Encodings
 
         The format used by elliptic curve point encodings. This is a binary
         format.
+
+    .. attribute:: SMIME
+
+        .. versionadded:: 3.2
+
+        An output format used for PKCS7. This is a text format.
 
 
 Serialization Encryption Types

--- a/src/_cffi_src/openssl/pkcs7.py
+++ b/src/_cffi_src/openssl/pkcs7.py
@@ -60,6 +60,7 @@ void PKCS7_free(PKCS7 *);
 PKCS7 *PKCS7_sign(X509 *, EVP_PKEY *, Cryptography_STACK_OF_X509 *,
                    BIO *, int);
 int SMIME_write_PKCS7(BIO *, PKCS7 *, BIO *, int);
+int PEM_write_bio_PKCS7_stream(BIO *, PKCS7 *, BIO *, int);
 PKCS7_SIGNER_INFO *PKCS7_sign_add_signer(PKCS7 *, X509 *, EVP_PKEY *,
                                          const EVP_MD *, int);
 int PKCS7_final(PKCS7 *, BIO *, int);

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2735,9 +2735,15 @@ class Backend(object):
                 final_flags |= self._lib.PKCS7_BINARY
 
         bio_out = self._create_mem_bio_gc()
-        if encoding is serialization.Encoding.PEM:
+        if encoding is serialization.Encoding.SMIME:
             # This finalizes the structure
             res = self._lib.SMIME_write_PKCS7(
+                bio_out, p7, bio.bio, final_flags
+            )
+        elif encoding is serialization.Encoding.PEM:
+            res = self._lib.PKCS7_final(p7, bio.bio, final_flags)
+            self.openssl_assert(res == 1)
+            res = self._lib.PEM_write_bio_PKCS7_stream(
                 bio_out, p7, bio.bio, final_flags
             )
         else:

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -49,6 +49,7 @@ class Encoding(Enum):
     OpenSSH = "OpenSSH"
     Raw = "Raw"
     X962 = "ANSI X9.62"
+    SMIME = "S/MIME"
 
 
 class PrivateFormat(Enum):

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -71,11 +71,14 @@ class PKCS7SignatureBuilder(object):
         options = list(options)
         if not all(isinstance(x, PKCS7Options) for x in options):
             raise ValueError("options must be from the PKCS7Options enum")
-        if (
-            encoding is not serialization.Encoding.PEM
-            and encoding is not serialization.Encoding.DER
+        if encoding not in (
+            serialization.Encoding.PEM,
+            serialization.Encoding.DER,
+            serialization.Encoding.SMIME,
         ):
-            raise ValueError("Must be PEM or DER from the Encoding enum")
+            raise ValueError(
+                "Must be PEM, DER, or SMIME from the Encoding enum"
+            )
 
         # Text is a meaningless option unless it is accompanied by
         # DetachedSignature
@@ -88,12 +91,12 @@ class PKCS7SignatureBuilder(object):
                 "DetachedSignature"
             )
 
-        if (
-            PKCS7Options.Text in options
-            and encoding is serialization.Encoding.DER
+        if PKCS7Options.Text in options and encoding in (
+            serialization.Encoding.DER,
+            serialization.Encoding.PEM,
         ):
             raise ValueError(
-                "The Text option does nothing when serializing to DER"
+                "The Text option is only available for SMIME serialization"
             )
 
         # No attributes implies no capabilities so we'll error if you try to

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -312,7 +312,7 @@ class TestPKCS7Builder(object):
         _pkcs7_verify(
             serialization.Encoding.PEM,
             sig,
-            data,
+            None,
             [cert],
             options,
             backend,

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -84,10 +84,17 @@ class TestPKCS7Loading(object):
 # We have no public verification API and won't be adding one until we get
 # some requirements from users so this function exists to give us basic
 # verification for the signing tests.
-def _smime_verify(encoding, sig, msg, certs, options, backend):
+def _pkcs7_verify(encoding, sig, msg, certs, options, backend):
     sig_bio = backend._bytes_to_bio(sig)
     if encoding is serialization.Encoding.DER:
         p7 = backend._lib.d2i_PKCS7_bio(sig_bio.bio, backend._ffi.NULL)
+    elif encoding is serialization.Encoding.PEM:
+        p7 = backend._lib.PEM_read_bio_PKCS7(
+            sig_bio.bio,
+            backend._ffi.NULL,
+            backend._ffi.NULL,
+            backend._ffi.NULL,
+        )
     else:
         p7 = backend._lib.SMIME_read_PKCS7(sig_bio.bio, backend._ffi.NULL)
     backend.openssl_assert(p7 != backend._ffi.NULL)
@@ -149,7 +156,7 @@ class TestPKCS7Builder(object):
     def test_sign_no_signer(self):
         builder = pkcs7.PKCS7SignatureBuilder().set_data(b"test")
         with pytest.raises(ValueError):
-            builder.sign(serialization.Encoding.PEM, [])
+            builder.sign(serialization.Encoding.SMIME, [])
 
     def test_sign_no_data(self):
         cert, key = _load_cert_key()
@@ -157,7 +164,7 @@ class TestPKCS7Builder(object):
             cert, key, hashes.SHA256()
         )
         with pytest.raises(ValueError):
-            builder.sign(serialization.Encoding.PEM, [])
+            builder.sign(serialization.Encoding.SMIME, [])
 
     def test_unsupported_hash_alg(self):
         cert, key = _load_cert_key()
@@ -193,7 +200,7 @@ class TestPKCS7Builder(object):
             .add_signer(cert, key, hashes.SHA256())
         )
         with pytest.raises(ValueError):
-            builder.sign(serialization.Encoding.PEM, [b"invalid"])
+            builder.sign(serialization.Encoding.SMIME, [b"invalid"])
 
     def test_sign_invalid_encoding(self):
         cert, key = _load_cert_key()
@@ -214,7 +221,7 @@ class TestPKCS7Builder(object):
         )
         options = [pkcs7.PKCS7Options.Text]
         with pytest.raises(ValueError):
-            builder.sign(serialization.Encoding.PEM, options)
+            builder.sign(serialization.Encoding.SMIME, options)
 
     def test_sign_invalid_options_text_der_encoding(self):
         cert, key = _load_cert_key()
@@ -242,7 +249,7 @@ class TestPKCS7Builder(object):
             pkcs7.PKCS7Options.NoCapabilities,
         ]
         with pytest.raises(ValueError):
-            builder.sign(serialization.Encoding.PEM, options)
+            builder.sign(serialization.Encoding.SMIME, options)
 
     def test_smime_sign_detached(self, backend):
         data = b"hello world"
@@ -254,22 +261,22 @@ class TestPKCS7Builder(object):
             .add_signer(cert, key, hashes.SHA256())
         )
 
-        sig = builder.sign(serialization.Encoding.PEM, options)
+        sig = builder.sign(serialization.Encoding.SMIME, options)
         sig_binary = builder.sign(serialization.Encoding.DER, options)
         # We don't have a generic ASN.1 parser available to us so we instead
         # will assert on specific byte sequences being present based on the
         # parameters chosen above.
         assert b"sha-256" in sig
         # Detached signature means that the signed data is *not* embedded into
-        # the PKCS7 structure itself, but is present in the PEM serialization
+        # the PKCS7 structure itself, but is present in the SMIME serialization
         # as a separate section before the PKCS7 data. So we should expect to
         # have data in sig but not in sig_binary
         assert data in sig
-        _smime_verify(
-            serialization.Encoding.PEM, sig, data, [cert], options, backend
+        _pkcs7_verify(
+            serialization.Encoding.SMIME, sig, data, [cert], options, backend
         )
         assert data not in sig_binary
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig_binary,
             data,
@@ -288,8 +295,28 @@ class TestPKCS7Builder(object):
             .add_signer(cert, key, hashes.SHA256())
         )
 
-        sig = builder.sign(serialization.Encoding.PEM, options)
+        sig = builder.sign(serialization.Encoding.SMIME, options)
         assert bytes(data) in sig
+
+    def test_sign_pem(self, backend):
+        data = b"hello world"
+        cert, key = _load_cert_key()
+        options = []
+        builder = (
+            pkcs7.PKCS7SignatureBuilder()
+            .set_data(data)
+            .add_signer(cert, key, hashes.SHA256())
+        )
+
+        sig = builder.sign(serialization.Encoding.PEM, options)
+        _pkcs7_verify(
+            serialization.Encoding.PEM,
+            sig,
+            data,
+            [cert],
+            options,
+            backend,
+        )
 
     @pytest.mark.parametrize(
         ("hash_alg", "expected_value"),
@@ -300,7 +327,7 @@ class TestPKCS7Builder(object):
             (hashes.SHA512(), b"\x06\t`\x86H\x01e\x03\x04\x02\x03"),
         ],
     )
-    def test_smime_sign_alternate_digests_der(
+    def test_sign_alternate_digests_der(
         self, hash_alg, expected_value, backend
     ):
         data = b"hello world"
@@ -313,7 +340,7 @@ class TestPKCS7Builder(object):
         options = []
         sig = builder.sign(serialization.Encoding.DER, options)
         assert expected_value in sig
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER, sig, None, [cert], options, backend
         )
 
@@ -326,9 +353,7 @@ class TestPKCS7Builder(object):
             (hashes.SHA512(), b"sha-512"),
         ],
     )
-    def test_smime_sign_alternate_digests_detached_pem(
-        self, hash_alg, expected_value
-    ):
+    def test_sign_alternate_digests_detached(self, hash_alg, expected_value):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -337,12 +362,12 @@ class TestPKCS7Builder(object):
             .add_signer(cert, key, hash_alg)
         )
         options = [pkcs7.PKCS7Options.DetachedSignature]
-        sig = builder.sign(serialization.Encoding.PEM, options)
+        sig = builder.sign(serialization.Encoding.SMIME, options)
         # When in detached signature mode the hash algorithm is stored as a
         # byte string like "sha-384".
         assert expected_value in sig
 
-    def test_smime_sign_attached(self, backend):
+    def test_sign_attached(self, backend):
         data = b"hello world"
         cert, key = _load_cert_key()
         options = []
@@ -356,7 +381,7 @@ class TestPKCS7Builder(object):
         # When not passing detached signature the signed data is embedded into
         # the PKCS7 structure itself
         assert data in sig_binary
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig_binary,
             None,
@@ -365,7 +390,7 @@ class TestPKCS7Builder(object):
             backend,
         )
 
-    def test_smime_sign_binary(self, backend):
+    def test_sign_binary(self, backend):
         data = b"hello\nworld"
         cert, key = _load_cert_key()
         builder = (
@@ -382,7 +407,7 @@ class TestPKCS7Builder(object):
         # so data should not be present in sig_no_binary, but should be present
         # in sig_binary
         assert data not in sig_no_binary
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig_no_binary,
             None,
@@ -391,7 +416,7 @@ class TestPKCS7Builder(object):
             backend,
         )
         assert data in sig_binary
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig_binary,
             None,
@@ -400,7 +425,7 @@ class TestPKCS7Builder(object):
             backend,
         )
 
-    def test_smime_sign_smime_canonicalization(self, backend):
+    def test_sign_smime_canonicalization(self, backend):
         data = b"hello\nworld"
         cert, key = _load_cert_key()
         builder = (
@@ -415,7 +440,7 @@ class TestPKCS7Builder(object):
         # so data should not be present in the sig
         assert data not in sig_binary
         assert b"hello\r\nworld" in sig_binary
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig_binary,
             None,
@@ -424,7 +449,7 @@ class TestPKCS7Builder(object):
             backend,
         )
 
-    def test_smime_sign_text(self, backend):
+    def test_sign_text(self, backend):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -437,16 +462,16 @@ class TestPKCS7Builder(object):
             pkcs7.PKCS7Options.Text,
             pkcs7.PKCS7Options.DetachedSignature,
         ]
-        sig_pem = builder.sign(serialization.Encoding.PEM, options)
+        sig_pem = builder.sign(serialization.Encoding.SMIME, options)
         # The text option adds text/plain headers to the S/MIME message
-        # These headers are only relevant in PEM mode, not binary, which is
+        # These headers are only relevant in SMIME mode, not binary, which is
         # just the PKCS7 structure itself.
         assert b"text/plain" in sig_pem
         # When passing the Text option the header is prepended so the actual
         # signed data is this.
         signed_data = b"Content-Type: text/plain\r\n\r\nhello world"
-        _smime_verify(
-            serialization.Encoding.PEM,
+        _pkcs7_verify(
+            serialization.Encoding.SMIME,
             sig_pem,
             signed_data,
             [cert],
@@ -454,7 +479,7 @@ class TestPKCS7Builder(object):
             backend,
         )
 
-    def test_smime_sign_no_capabilities(self, backend):
+    def test_sign_no_capabilities(self, backend):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -474,7 +499,7 @@ class TestPKCS7Builder(object):
         assert b"\x06\t*\x86H\x86\xf7\r\x01\t\x0f" not in sig_binary
         # 1.2.840.113549.1.9.5 signingTime as an ASN.1 DER encoded OID
         assert b"\x06\t*\x86H\x86\xf7\r\x01\t\x05" in sig_binary
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig_binary,
             None,
@@ -483,7 +508,7 @@ class TestPKCS7Builder(object):
             backend,
         )
 
-    def test_smime_sign_no_attributes(self, backend):
+    def test_sign_no_attributes(self, backend):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -501,7 +526,7 @@ class TestPKCS7Builder(object):
         assert b"\x06\t*\x86H\x86\xf7\r\x01\t\x0f" not in sig_binary
         # 1.2.840.113549.1.9.5 signingTime as an ASN.1 DER encoded OID
         assert b"\x06\t*\x86H\x86\xf7\r\x01\t\x05" not in sig_binary
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig_binary,
             None,
@@ -537,7 +562,7 @@ class TestPKCS7Builder(object):
         sig = builder.sign(serialization.Encoding.DER, options)
         # There should be three SHA512 OIDs in this structure
         assert sig.count(b"\x06\t`\x86H\x01e\x03\x04\x02\x03") == 3
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig,
             None,
@@ -574,7 +599,7 @@ class TestPKCS7Builder(object):
         # There should be two SHA384 and two SHA512 OIDs in this structure
         assert sig.count(b"\x06\t`\x86H\x01e\x03\x04\x02\x02") == 2
         assert sig.count(b"\x06\t`\x86H\x01e\x03\x04\x02\x03") == 2
-        _smime_verify(
+        _pkcs7_verify(
             serialization.Encoding.DER,
             sig,
             None,


### PR DESCRIPTION
PEM, DER, and SMIME. SMIME embeds the S/MIME headers and has the detached signature concept.