### PR TITLE
chunking didn't actually work

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives.ciphers import modes
 class _CipherContext(object):
     _ENCRYPT = 1
     _DECRYPT = 0
-    _MAX_CHUNK_SIZE = 2 ** 31
+    _MAX_CHUNK_SIZE = 2 ** 31 - 1
 
     def __init__(self, backend, cipher, mode, operation):
         self._backend = backend

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -333,3 +333,12 @@ class TestCipherUpdateInto(object):
         decbuf = bytearray(527)
         decprocessed = decryptor.update_into(buf[:processed], decbuf)
         assert decbuf[:decprocessed] == pt
+
+    def test_max_chunk_size_fits_in_int32(self, backend):
+        # max chunk must fit in signed int32 or else a call large enough to
+        # cause chunking will result in the very OverflowError we want to
+        # avoid with chunking.
+        key = b"\x00" * 16
+        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        encryptor = c.encryptor()
+        backend._ffi.new("int *", encryptor._ctx._MAX_CHUNK_SIZE)


### PR DESCRIPTION
We now reach into the bowels of our ciphercontext to make sure the max chunk size doesn't itself cause an `OverflowError`.

@alex it does not escape me that if we had directly tested this without monkeypatching (as you wanted) we wouldn't have had this bug. But it still takes 4GB of RAM to test this directly and that's too much. 😭 