### PR TITLE
PKCS7SignatureBuilder now supports new option NoCerts when signing

### DIFF
--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -699,6 +699,13 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
         pass ``NoAttributes`` you can't pass ``NoCapabilities`` since
         ``NoAttributes`` removes ``MIMECapabilities`` and more.
 
+    .. attribute:: NoCerts
+
+        Don't include the signer's certificate in the PKCS7 structure. This can
+        reduce the size of the signature but requires that the recipient can
+        obtain the signer's certificate by other means (for example from a
+        previously signed message).
+
 Serialization Formats
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2719,6 +2719,10 @@ class Backend(object):
             signer_flags |= self._lib.PKCS7_NOSMIMECAP
         elif pkcs7.PKCS7Options.NoAttributes in options:
             signer_flags |= self._lib.PKCS7_NOATTR
+
+        if pkcs7.PKCS7Options.NoCerts in options:
+            signer_flags |= self._lib.PKCS7_NOCERTS
+
         for certificate, private_key, hash_algorithm in builder._signers:
             md = self._evp_md_non_null_from_algorithm(hash_algorithm)
             p7signerinfo = self._lib.PKCS7_sign_add_signer(

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -120,3 +120,4 @@ class PKCS7Options(Enum):
     DetachedSignature = "Don't embed data in the PKCS7 structure"
     NoCapabilities = "Don't embed SMIME capabilities"
     NoAttributes = "Don't embed authenticatedAttributes"
+    NoCerts = "Don't embed signer certificate"

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -535,6 +535,23 @@ class TestPKCS7Builder(object):
             backend,
         )
 
+    def test_sign_no_certs(self, backend):
+        data = b"hello world"
+        cert, key = _load_cert_key()
+        builder = (
+            pkcs7.PKCS7SignatureBuilder()
+            .set_data(data)
+            .add_signer(cert, key, hashes.SHA256())
+        )
+
+        options = []
+        sig = builder.sign(serialization.Encoding.DER, options)
+        assert sig.count(cert.public_bytes(serialization.Encoding.DER)) == 1
+
+        options = [pkcs7.PKCS7Options.NoCerts]
+        sig_no = builder.sign(serialization.Encoding.DER, options)
+        assert sig_no.count(cert.public_bytes(serialization.Encoding.DER)) == 0
+
     def test_multiple_signers(self, backend):
         data = b"hello world"
         cert, key = _load_cert_key()


### PR DESCRIPTION
This adds the possibility to add the `PKCS7_NOCERTS` flag/option (as per [PKCS7_sign_add_signer](https://www.openssl.org/docs/man1.0.2/man3/PKCS7_sign_add_signer.html)) in order to exclude the signer's certificate.

```
If PKCS7_NOCERTS is set the signer's certificate will not be included in the PKCS7 structure, the signer's 
certificate must still be supplied in the signcert parameter though. This can reduce the size of the signature 
if the signers certificate can be obtained by other means: for example a previously signed message.
```