### PR TITLE
make the regexes for branches more strict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
 branches:
     only:
         - master
-        - /\d+\.\d+\.x/
-        - /\d+\.\d+(\.\d+)?/
+        - /^\d+\.\d+\.x$/
+        - /^\d+\.\d+(\.\d+)?$/
 
 matrix:
     include:


### PR DESCRIPTION
We don't want them to build when dependabot makes a branch like dependabot/github_actions/actions/upload-artifact-v2.2.0.