### PR TITLE
fix Python 2 CryptographyDeprecationWarning guide

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -16,7 +16,7 @@ If your pytest setup follows the best practices of failing on
 emitted warnings (``filterwarnings = error``), you may ignore it
 by adding the following line at the end of the list::
 
-   ignore:Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.:UserWarning:cryptography
+   ignore:Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.:UserWarning
 
 **Note:** Using ``cryptography.utils.CryptographyDeprecationWarning``
 is not possible here because specifying it triggers


### PR DESCRIPTION
the previous guide didn't work for me, here's a little demo: https://github.com/graingert/crypto_deprecation_demo