### PR TITLE
padding: Tip-toe around bytes subclasses.

### DIFF
--- a/src/cryptography/hazmat/primitives/padding.py
+++ b/src/cryptography/hazmat/primitives/padding.py
@@ -42,7 +42,10 @@ def _byte_padding_update(buffer_, data, block_size):
 
     utils._check_byteslike("data", data)
 
-    buffer_ += bytes(data)
+    # six.PY2: Only coerce non-bytes objects to avoid triggering bad behavior
+    # of future's newbytes type. Unconditionally call bytes() after Python 2
+    # support is gone.
+    buffer_ += data if isinstance(data, bytes) else bytes(data)
 
     finished_blocks = len(buffer_) // (block_size // 8)
 
@@ -66,7 +69,10 @@ def _byte_unpadding_update(buffer_, data, block_size):
 
     utils._check_byteslike("data", data)
 
-    buffer_ += bytes(data)
+    # six.PY2: Only coerce non-bytes objects to avoid triggering bad behavior
+    # of future's newbytes type. Unconditionally call bytes() after Python 2
+    # support is gone.
+    buffer_ += data if isinstance(data, bytes) else bytes(data)
 
     finished_blocks = max(len(buffer_) // (block_size // 8) - 1, 0)
 

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -43,6 +43,18 @@ class TestPKCS7(object):
         with pytest.raises(TypeError):
             unpadder.update(u"abc")
 
+    def test_zany_py2_bytes_subclass(self):
+        class mybytes(bytes):  # noqa: N801
+            def __str__(self):
+                return "broken"
+
+        str(mybytes())
+        padder = padding.PKCS7(128).padder()
+        padder.update(mybytes(b"abc"))
+        unpadder = padding.PKCS7(128).unpadder()
+        unpadder.update(mybytes(padder.finalize()))
+        assert unpadder.finalize() == b"abc"
+
     @pytest.mark.parametrize(
         ("size", "unpadded", "padded"),
         [
@@ -153,6 +165,18 @@ class TestANSIX923(object):
         unpadder = padding.ANSIX923(128).unpadder()
         with pytest.raises(TypeError):
             unpadder.update(u"abc")
+
+    def test_zany_py2_bytes_subclass(self):
+        class mybytes(bytes):  # noqa: N801
+            def __str__(self):
+                return "broken"
+
+        str(mybytes())
+        padder = padding.ANSIX923(128).padder()
+        padder.update(mybytes(b"abc"))
+        unpadder = padding.ANSIX923(128).unpadder()
+        unpadder.update(mybytes(padder.finalize()))
+        assert unpadder.finalize() == b"abc"
 
     @pytest.mark.parametrize(
         ("size", "unpadded", "padded"),


### PR DESCRIPTION
This change allows future's newbytes class to be padded again.

Fixes https://github.com/pyca/cryptography/issues/5547.