### PR TITLE
Fix broken links

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1368,8 +1368,9 @@ class Backend(object):
         if x509 == self._ffi.NULL:
             self._consume_errors()
             raise ValueError(
-                "Unable to load certificate. See https://cryptography.io/en/la"
-                "test/faq.html#why-can-t-i-import-my-pem-file for more details."
+                "Unable to load certificate. See https://cryptography.io/en/"
+                "latest/faq.html#why-can-t-i-import-my-pem-file for more"
+                " details."
             )
 
         x509 = self._ffi.gc(x509, self._lib.X509_free)
@@ -1394,7 +1395,8 @@ class Backend(object):
             self._consume_errors()
             raise ValueError(
                 "Unable to load CRL. See https://cryptography.io/en/la"
-                "test/faq.html#why-can-t-i-import-my-pem-file for more details."
+                "test/faq.html#why-can-t-i-import-my-pem-file for more"
+                " details."
             )
 
         x509_crl = self._ffi.gc(x509_crl, self._lib.X509_CRL_free)
@@ -1418,8 +1420,9 @@ class Backend(object):
         if x509_req == self._ffi.NULL:
             self._consume_errors()
             raise ValueError(
-                "Unable to load request. See https://cryptography.io/en/la"
-                "test/faq.html#why-can-t-i-import-my-pem-file for more details."
+                "Unable to load request. See https://cryptography.io/en/"
+                "latest/faq.html#why-can-t-i-import-my-pem-file for more"
+                " details."
             )
 
         x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1369,7 +1369,7 @@ class Backend(object):
             self._consume_errors()
             raise ValueError(
                 "Unable to load certificate. See https://cryptography.io/en/la"
-                "test/faq/#why-can-t-i-import-my-pem-file for more details."
+                "test/faq.html#why-can-t-i-import-my-pem-file for more details."
             )
 
         x509 = self._ffi.gc(x509, self._lib.X509_free)
@@ -1394,7 +1394,7 @@ class Backend(object):
             self._consume_errors()
             raise ValueError(
                 "Unable to load CRL. See https://cryptography.io/en/la"
-                "test/faq/#why-can-t-i-import-my-pem-file for more details."
+                "test/faq.html#why-can-t-i-import-my-pem-file for more details."
             )
 
         x509_crl = self._ffi.gc(x509_crl, self._lib.X509_CRL_free)
@@ -1419,7 +1419,7 @@ class Backend(object):
             self._consume_errors()
             raise ValueError(
                 "Unable to load request. See https://cryptography.io/en/la"
-                "test/faq/#why-can-t-i-import-my-pem-file for more details."
+                "test/faq.html#why-can-t-i-import-my-pem-file for more details."
             )
 
         x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)


### PR DESCRIPTION
The FAQ links result in a 404, `faq/` needs to be replaced with `faq.html` to fix that.