### PR TITLE
GCM IV size limits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ Changelog
 
 * **BACKWARDS INCOMPATIBLE:** Support for Python 3.5 has been removed due to
   low usage and maintenance burden.
+* **BACKWARDS INCOMPATIBLE:** The
+  :class:`~cryptography.hazmat.primitives.ciphers.modes.GCM` and
+  :class:`~cryptography.hazmat.primitives.ciphers.aead.AESGCM` now require
+  64-bit to 1024-bit (8 byte to 128 byte) initialization vectors. This change
+  is to conform with an upcoming OpenSSL release that will no longer support
+  sizes outside this window.
 
 .. _v3-2-1:
 

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -170,5 +170,5 @@ class AESGCM(object):
         utils._check_byteslike("nonce", nonce)
         utils._check_bytes("data", data)
         utils._check_bytes("associated_data", associated_data)
-        if len(nonce) == 0:
-            raise ValueError("Nonce must be at least 1 byte")
+        if len(nonce) < 8 or len(nonce) > 128:
+            raise ValueError("Nonce must be between 8 and 128 bytes")

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -196,12 +196,14 @@ class GCM(object):
     _MAX_AAD_BYTES = (2 ** 64) // 8
 
     def __init__(self, initialization_vector, tag=None, min_tag_length=16):
-        # len(initialization_vector) must in [1, 2 ** 64), but it's impossible
-        # to actually construct a bytes object that large, so we don't check
-        # for it
+        # OpenSSL 3.0.0 constrains GCM IVs to [64, 1024] bits inclusive
+        # This is a sane limit anyway so we'll enforce it here.
         utils._check_byteslike("initialization_vector", initialization_vector)
-        if len(initialization_vector) == 0:
-            raise ValueError("initialization_vector must be at least 1 byte")
+        if len(initialization_vector) < 8 or len(initialization_vector) > 128:
+            raise ValueError(
+                "initialization_vector must be between 8 and 128 bytes (64 "
+                "and 1024 bits)."
+            )
         self._initialization_vector = initialization_vector
         if tag is not None:
             utils._check_bytes("tag", tag)

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -380,6 +380,9 @@ class TestAESGCM(object):
     def test_vectors(self, backend, vector):
         nonce = binascii.unhexlify(vector["iv"])
 
+        if len(nonce) < 8:
+            pytest.skip("GCM does not support less than 64-bit IVs")
+
         if backend._fips_enabled and len(nonce) != 12:
             # Red Hat disables non-96-bit IV support as part of its FIPS
             # patches.
@@ -420,6 +423,11 @@ class TestAESGCM(object):
 
     @pytest.mark.parametrize("length", [7, 129])
     def test_invalid_nonce_length(self, length, backend):
+        if backend._fips_enabled:
+            # Red Hat disables non-96-bit IV support as part of its FIPS
+            # patches.
+            pytest.skip("Non-96-bit IVs unsupported in FIPS mode.")
+
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         with pytest.raises(ValueError):

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -418,11 +418,12 @@ class TestAESGCM(object):
         with pytest.raises(TypeError):
             aesgcm.decrypt(nonce, data, associated_data)
 
-    def test_invalid_nonce_length(self, backend):
+    @pytest.mark.parametrize("length", [7, 129])
+    def test_invalid_nonce_length(self, length, backend):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         with pytest.raises(ValueError):
-            aesgcm.encrypt(b"", b"hi", None)
+            aesgcm.encrypt(b"\x00" * length, b"hi", None)
 
     def test_bad_key(self, backend):
         with pytest.raises(TypeError):

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -197,7 +197,12 @@ class TestAESModeGCM(object):
         assert pt == data
 
     @pytest.mark.parametrize("size", [8, 128])
-    def test_gcm_min_max_iv(self, size):
+    def test_gcm_min_max_iv(self, size, backend):
+        if backend._fips_enabled:
+            # Red Hat disables non-96-bit IV support as part of its FIPS
+            # patches.
+            pytest.skip("Non-96-bit IVs unsupported in FIPS mode.")
+
         key = os.urandom(16)
         iv = b"\x00" * size
 

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -207,16 +207,12 @@ class TestAESModeGCM(object):
         iv = b"\x00" * size
 
         payload = b"data"
-        encryptor = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv)
-        ).encryptor()
+        encryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).encryptor()
         ct = encryptor.update(payload)
         encryptor.finalize()
         tag = encryptor.tag
 
-        decryptor = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv)
-        ).decryptor()
+        decryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).decryptor()
         pt = decryptor.update(ct)
 
         decryptor.finalize_with_tag(tag)

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -195,3 +195,24 @@ class TestAESModeGCM(object):
         dec.authenticate_additional_data(bytearray(b"foo"))
         pt = dec.update(ct) + dec.finalize()
         assert pt == data
+
+    @pytest.mark.parametrize("size", [8, 128])
+    def test_gcm_min_max_iv(self, size):
+        key = os.urandom(16)
+        iv = b"\x00" * size
+
+        payload = b"data"
+        encryptor = base.Cipher(
+            algorithms.AES(key), modes.GCM(iv)
+        ).encryptor()
+        ct = encryptor.update(payload)
+        encryptor.finalize()
+        tag = encryptor.tag
+
+        decryptor = base.Cipher(
+            algorithms.AES(key), modes.GCM(iv)
+        ).decryptor()
+        pt = decryptor.update(ct)
+
+        decryptor.finalize_with_tag(tag)
+        assert pt == payload

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -72,6 +72,13 @@ class TestAESXTS(object):
             ciphers.Cipher(AES(b"0" * 16), modes.XTS(b"0" * 16), backend)
 
 
+class TestGCM(object):
+    @pytest.mark.parametrize("size", [7, 129])
+    def test_gcm_min_max(self, size):
+        with pytest.raises(ValueError):
+            modes.GCM(b"0" * size)
+
+
 class TestCamellia(object):
     @pytest.mark.parametrize(
         ("key", "keysize"),

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -86,6 +86,10 @@ def generate_aead_test(
 
 
 def aead_test(backend, cipher_factory, mode_factory, params):
+    if mode_factory is GCM and len(params["iv"]) < 16:
+        # 16 because this is hex encoded data
+        pytest.skip("Less than 64-bit IVs are no longer supported")
+
     if (
         mode_factory is GCM
         and backend._fips_enabled

--- a/tests/wycheproof/test_aes.py
+++ b/tests/wycheproof/test_aes.py
@@ -54,6 +54,11 @@ def test_aes_gcm(backend, wycheproof):
     msg = binascii.unhexlify(wycheproof.testcase["msg"])
     ct = binascii.unhexlify(wycheproof.testcase["ct"])
     tag = binascii.unhexlify(wycheproof.testcase["tag"])
+    if len(iv) < 8 or len(iv) > 128:
+        pytest.skip(
+            "Less than 64-bit IVs (and greater than 1024-bit) are no longer "
+            "supported"
+        )
     if backend._fips_enabled and len(iv) != 12:
         # Red Hat disables non-96-bit IV support as part of its FIPS
         # patches.
@@ -97,6 +102,12 @@ def test_aes_gcm_aead_api(backend, wycheproof):
     msg = binascii.unhexlify(wycheproof.testcase["msg"])
     ct = binascii.unhexlify(wycheproof.testcase["ct"])
     tag = binascii.unhexlify(wycheproof.testcase["tag"])
+    if len(iv) < 8 or len(iv) > 128:
+        pytest.skip(
+            "Less than 64-bit IVs (and greater than 1024-bit) are no longer "
+            "supported"
+        )
+
     if backend._fips_enabled and len(iv) != 12:
         # Red Hat disables non-96-bit IV support as part of its FIPS
         # patches.

--- a/tests/wycheproof/test_aes.py
+++ b/tests/wycheproof/test_aes.py
@@ -78,9 +78,6 @@ def test_aes_gcm(backend, wycheproof):
         dec.authenticate_additional_data(aad)
         computed_msg = dec.update(ct) + dec.finalize()
         assert computed_msg == msg
-    elif len(iv) == 0:
-        with pytest.raises(ValueError):
-            Cipher(algorithms.AES(key), modes.GCM(iv), backend)
     else:
         dec = Cipher(
             algorithms.AES(key),
@@ -118,9 +115,6 @@ def test_aes_gcm_aead_api(backend, wycheproof):
         assert computed_ct == ct + tag
         computed_msg = aesgcm.decrypt(iv, ct + tag, aad)
         assert computed_msg == msg
-    elif len(iv) == 0:
-        with pytest.raises(ValueError):
-            aesgcm.encrypt(iv, msg, aad)
     else:
         with pytest.raises(InvalidTag):
             aesgcm.decrypt(iv, ct + tag, aad)


### PR DESCRIPTION
OpenSSL 3.0.0 is going to enforce these size limits so we might as well put them in now.