### PR TITLE
don't require errors to be on the stack when loading a key

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1459,8 +1459,7 @@ class Backend(object):
 
         if evp_pkey == self._ffi.NULL:
             if userdata.error != 0:
-                errors = self._consume_errors()
-                self.openssl_assert(errors)
+                self._consume_errors()
                 if userdata.error == -1:
                     raise TypeError(
                         "Password was not given but private key is encrypted"


### PR DESCRIPTION
In OpenSSL 3.0.0 no error is added in many cases for this path and
since we don't do anything with the error anyway we should just
consume and move on