### PR TITLE
Added missing tls bindings for new OpenSSL APIs

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -25,6 +25,7 @@ static const long Cryptography_HAS_PSK;
 static const long Cryptography_HAS_VERIFIED_CHAIN;
 static const long Cryptography_HAS_KEYLOG;
 static const long Cryptography_HAS_GET_PROTO_VERSION;
+static const long Cryptography_HAS_SET_PROTO_VERSION;
 
 /* Internally invented symbol to tell us if SSL_MODE_RELEASE_BUFFERS is
  * supported
@@ -695,5 +696,16 @@ long (*SSL_get_min_proto_version)(SSL *) = NULL;
 long (*SSL_get_max_proto_version)(SSL *) = NULL;
 #else
 static const long Cryptography_HAS_GET_PROTO_VERSION = 1;
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110 && !CRYPTOGRAPHY_IS_LIBRESSL
+static const long Cryptography_HAS_SET_PROTO_VERSION = 0;
+
+long (*SSL_CTX_set_min_proto_version)(SSL_CTX *) = NULL;
+long (*SSL_CTX_set_max_proto_version)(SSL_CTX *) = NULL;
+long (*SSL_set_min_proto_version)(SSL *) = NULL;
+long (*SSL_set_max_proto_version)(SSL *) = NULL;
+#else
+static const long Cryptography_HAS_SET_PROTO_VERSION = 1;
 #endif
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -271,6 +271,15 @@ def cryptography_has_get_proto_version():
     ]
 
 
+def cryptography_has_set_proto_version():
+    return [
+        "SSL_CTX_set_min_proto_version",
+        "SSL_CTX_set_max_proto_version",
+        "SSL_set_min_proto_version",
+        "SSL_set_max_proto_version",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -319,4 +328,5 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_VERIFIED_CHAIN": cryptography_has_verified_chain,
     "Cryptography_HAS_SRTP": cryptography_has_srtp,
     "Cryptography_HAS_GET_PROTO_VERSION": cryptography_has_get_proto_version,
+    "Cryptography_HAS_SET_PROTO_VERSION": cryptography_has_set_proto_version,
 }


### PR DESCRIPTION
patches #5595 
re-adds setter interfaces not carried over from #5483 