### PR TITLE
we already do this check in other places

### DIFF
--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -179,11 +179,7 @@ class TestDH(object):
         params = dh.DHParameterNumbers(p, int(vector["g"]))
         param = params.parameters(backend)
         key = param.generate_private_key()
-        # This confirms that a key generated with this group
-        # will pass DH_check when we serialize and de-serialize it via
-        # the Numbers path.
-        roundtripped_key = key.private_numbers().private_key(backend)
-        assert key.private_numbers() == roundtripped_key.private_numbers()
+        assert key.private_numbers().public_numbers.parameter_numbers == params
 
     @pytest.mark.skip_fips(reason="non-FIPS parameters")
     @pytest.mark.parametrize(


### PR DESCRIPTION
This test is *incredibly* expensive and we already do roundtrips like this on other DH groups. To make this test less expensive and also more accurate to its name we now verify that the parameters on the generated key match.

For future reference, here is pytest output for how long these tests take on win32:

```
2020-12-09T21:47:38.3326862Z 158.93s call     tests/hazmat/primitives/test_dh.py::TestDH::test_dh_parameters_allows_rfc3526_groups[vector5]
2020-12-09T21:47:38.3329197Z 67.74s call     tests/hazmat/primitives/test_dh.py::TestDH::test_dh_parameters_allows_rfc3526_groups[vector4]
2020-12-09T21:47:38.3332543Z 20.25s call     tests/hazmat/primitives/test_dh.py::TestDH::test_dh_parameters_allows_rfc3526_groups[vector3]
```

On win64:

```
2020-12-09T21:37:49.1875449Z 26.99s call     tests/hazmat/primitives/test_dh.py::TestDH::test_dh_parameters_allows_rfc3526_groups[vector5]
2020-12-09T21:37:49.1879188Z 11.38s call     tests/hazmat/primitives/test_dh.py::TestDH::test_dh_parameters_allows_rfc3526_groups[vector4]
```

On a random linux builder:

```
2020-12-09T21:36:13.9871327Z 18.15s call     tests/hazmat/primitives/test_dh.py::TestDH::test_dh_parameters_allows_rfc3526_groups[vector5]
2020-12-09T21:36:13.9878170Z 7.69s call     tests/hazmat/primitives/test_dh.py::TestDH::test_dh_parameters_allows_rfc3526_groups[vector4]
```