### PR TITLE
Drop some python-2 specific code

### DIFF
--- a/.github/workflows/download_openssl.py
+++ b/.github/workflows/download_openssl.py
@@ -26,9 +26,7 @@ def get_response(session, url, token):
         return response
     response = session.get(url, headers={"Authorization": "token " + token})
     if response.status_code != 200:
-        raise ValueError(
-            "Got HTTP {} fetching {}: ".format(response.status_code, url)
-        )
+        raise ValueError(f"Got HTTP {response.status_code} fetching {url}: ")
     return response
 
 
@@ -48,7 +46,7 @@ def main(platform, target):
     session.mount("http://", adapter)
 
     token = os.environ["GITHUB_TOKEN"]
-    print("Looking for: {}".format(target))
+    print(f"Looking for: {target}")
     runs_url = (
         "https://api.github.com/repos/pyca/infra/actions/workflows/"
         "{}/runs?branch=master&status=success".format(workflow)
@@ -67,7 +65,7 @@ def main(platform, target):
                 os.path.join(path, artifact["name"])
             )
             return
-    raise ValueError("Didn't find {} in {}".format(target, response))
+    raise ValueError(f"Didn't find {target} in {response}")
 
 
 if __name__ == "__main__":

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/docs/development/custom-vectors/arc4/generate_arc4.py
+++ b/docs/development/custom-vectors/arc4/generate_arc4.py
@@ -79,10 +79,10 @@ def _build_vectors():
                 while current_offset < offset:
                     encryptor.update(plaintext)
                     current_offset += len(plaintext)
-                output.append("\nCOUNT = {}".format(count))
+                output.append(f"\nCOUNT = {count}")
                 count += 1
-                output.append("KEY = {}".format(key))
-                output.append("OFFSET = {}".format(offset))
+                output.append(f"KEY = {key}")
+                output.append(f"OFFSET = {offset}")
                 output.append(
                     "PLAINTEXT = {}".format(binascii.hexlify(plaintext))
                 )

--- a/docs/development/custom-vectors/cast5/generate_cast5.py
+++ b/docs/development/custom-vectors/cast5/generate_cast5.py
@@ -27,7 +27,7 @@ def build_vectors(mode, filename):
     iv = None
     plaintext = None
 
-    with open(filename, "r") as vector_file:
+    with open(filename) as vector_file:
         for line in vector_file:
             line = line.strip()
             if line.startswith("KEY"):

--- a/docs/development/custom-vectors/cast5/generate_cast5.py
+++ b/docs/development/custom-vectors/cast5/generate_cast5.py
@@ -37,17 +37,17 @@ def build_vectors(mode, filename):
                             encrypt(mode, key, iv, plaintext)
                         )
                     )
-                output.append("\nCOUNT = {}".format(count))
+                output.append(f"\nCOUNT = {count}")
                 count += 1
                 name, key = line.split(" = ")
-                output.append("KEY = {}".format(key))
+                output.append(f"KEY = {key}")
             elif line.startswith("IV"):
                 name, iv = line.split(" = ")
                 iv = iv[0:16]
-                output.append("IV = {}".format(iv))
+                output.append(f"IV = {iv}")
             elif line.startswith("PLAINTEXT"):
                 name, plaintext = line.split(" = ")
-                output.append("PLAINTEXT = {}".format(plaintext))
+                output.append(f"PLAINTEXT = {plaintext}")
         output.append(
             "CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext))
         )

--- a/docs/development/custom-vectors/hkdf/generate_hkdf.py
+++ b/docs/development/custom-vectors/hkdf/generate_hkdf.py
@@ -26,7 +26,7 @@ def _build_vectors():
         "IKM = " + binascii.hexlify(IKM).decode("ascii"),
         "salt = ",
         "info = ",
-        "L = {}".format(L),
+        f"L = {L}",
         "OKM = " + binascii.hexlify(OKM).decode("ascii"),
     ]
     return "\n".join(output)

--- a/docs/development/custom-vectors/idea/generate_idea.py
+++ b/docs/development/custom-vectors/idea/generate_idea.py
@@ -17,7 +17,7 @@ def encrypt(mode, key, iv, plaintext):
 
 
 def build_vectors(mode, filename):
-    with open(filename, "r") as f:
+    with open(filename) as f:
         vector_file = f.read().splitlines()
 
     count = 0
@@ -30,23 +30,21 @@ def build_vectors(mode, filename):
         if line.startswith("KEY"):
             if count != 0:
                 output.append(
-                    "CIPHERTEXT = {0}".format(
-                        encrypt(mode, key, iv, plaintext)
-                    )
+                    "CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext))
                 )
-            output.append("\nCOUNT = {0}".format(count))
+            output.append("\nCOUNT = {}".format(count))
             count += 1
             name, key = line.split(" = ")
-            output.append("KEY = {0}".format(key))
+            output.append("KEY = {}".format(key))
         elif line.startswith("IV"):
             name, iv = line.split(" = ")
             iv = iv[0:16]
-            output.append("IV = {0}".format(iv))
+            output.append("IV = {}".format(iv))
         elif line.startswith("PLAINTEXT"):
             name, plaintext = line.split(" = ")
-            output.append("PLAINTEXT = {0}".format(plaintext))
+            output.append("PLAINTEXT = {}".format(plaintext))
 
-    output.append("CIPHERTEXT = {0}".format(encrypt(mode, key, iv, plaintext)))
+    output.append("CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext)))
     return "\n".join(output)
 
 

--- a/docs/development/custom-vectors/idea/generate_idea.py
+++ b/docs/development/custom-vectors/idea/generate_idea.py
@@ -32,17 +32,17 @@ def build_vectors(mode, filename):
                 output.append(
                     "CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext))
                 )
-            output.append("\nCOUNT = {}".format(count))
+            output.append(f"\nCOUNT = {count}")
             count += 1
             name, key = line.split(" = ")
-            output.append("KEY = {}".format(key))
+            output.append(f"KEY = {key}")
         elif line.startswith("IV"):
             name, iv = line.split(" = ")
             iv = iv[0:16]
-            output.append("IV = {}".format(iv))
+            output.append(f"IV = {iv}")
         elif line.startswith("PLAINTEXT"):
             name, plaintext = line.split(" = ")
-            output.append("PLAINTEXT = {}".format(plaintext))
+            output.append(f"PLAINTEXT = {plaintext}")
 
     output.append("CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext)))
     return "\n".join(output)

--- a/docs/development/custom-vectors/idea/verify_idea.py
+++ b/docs/development/custom-vectors/idea/verify_idea.py
@@ -9,7 +9,7 @@ BLOCK_SIZE = 64
 
 def encrypt(mode, key, iv, plaintext):
     encryptor = botan.Cipher(
-        "IDEA/{0}/NoPadding".format(mode), "encrypt", binascii.unhexlify(key)
+        "IDEA/{}/NoPadding".format(mode), "encrypt", binascii.unhexlify(key)
     )
 
     cipher_text = encryptor.cipher(
@@ -19,7 +19,7 @@ def encrypt(mode, key, iv, plaintext):
 
 
 def verify_vectors(mode, filename):
-    with open(filename, "r") as f:
+    with open(filename) as f:
         vector_file = f.read().splitlines()
 
     vectors = load_nist_vectors(vector_file)

--- a/docs/development/custom-vectors/idea/verify_idea.py
+++ b/docs/development/custom-vectors/idea/verify_idea.py
@@ -9,7 +9,7 @@ BLOCK_SIZE = 64
 
 def encrypt(mode, key, iv, plaintext):
     encryptor = botan.Cipher(
-        "IDEA/{}/NoPadding".format(mode), "encrypt", binascii.unhexlify(key)
+        f"IDEA/{mode}/NoPadding", "encrypt", binascii.unhexlify(key)
     )
 
     cipher_text = encryptor.cipher(

--- a/docs/development/custom-vectors/rsa-oaep-sha2/generate_rsa_oaep_sha2.py
+++ b/docs/development/custom-vectors/rsa-oaep-sha2/generate_rsa_oaep_sha2.py
@@ -84,7 +84,7 @@ def build_vectors(mgf1alg, hashalg, filename):
                 ),
             )
             output.append(
-                b"# OAEP Example {0} alg={1} mgf1={2}".format(
+                b"# OAEP Example {} alg={} mgf1={}".format(
                     count, hashalg.name, mgf1alg.name
                 )
             )
@@ -120,5 +120,5 @@ for hashtuple in itertools.product(hashalgs, hashalgs):
 
     write_file(
         build_vectors(hashtuple[0], hashtuple[1], oaep_path),
-        "oaep-{0}-{1}.txt".format(hashtuple[0].name, hashtuple[1].name),
+        "oaep-{}-{}.txt".format(hashtuple[0].name, hashtuple[1].name),
     )

--- a/docs/development/custom-vectors/secp256k1/generate_secp256k1.py
+++ b/docs/development/custom-vectors/secp256k1/generate_secp256k1.py
@@ -19,7 +19,7 @@ HASHLIB_HASH_TYPES = {
 }
 
 
-class TruncatedHash(object):
+class TruncatedHash:
     def __init__(self, hasher):
         self.hasher = hasher
 
@@ -41,7 +41,7 @@ def build_vectors(fips_vectors):
             continue
 
         yield ""
-        yield "[K-256,{0}]".format(digest_algorithm)
+        yield "[K-256,{}]".format(digest_algorithm)
         yield ""
 
         for message in messages:
@@ -57,12 +57,12 @@ def build_vectors(fips_vectors):
 
             r, s = sigdecode_der(signature, None)
 
-            yield "Msg = {0}".format(hexlify(message))
-            yield "d = {0:x}".format(secret_key.privkey.secret_multiplier)
-            yield "Qx = {0:x}".format(public_key.pubkey.point.x())
-            yield "Qy = {0:x}".format(public_key.pubkey.point.y())
-            yield "R = {0:x}".format(r)
-            yield "S = {0:x}".format(s)
+            yield "Msg = {}".format(hexlify(message))
+            yield "d = {:x}".format(secret_key.privkey.secret_multiplier)
+            yield "Qx = {:x}".format(public_key.pubkey.point.x())
+            yield "Qy = {:x}".format(public_key.pubkey.point.y())
+            yield "R = {:x}".format(r)
+            yield "S = {:x}".format(s)
             yield ""
 
 

--- a/docs/development/custom-vectors/secp256k1/generate_secp256k1.py
+++ b/docs/development/custom-vectors/secp256k1/generate_secp256k1.py
@@ -41,7 +41,7 @@ def build_vectors(fips_vectors):
             continue
 
         yield ""
-        yield "[K-256,{}]".format(digest_algorithm)
+        yield f"[K-256,{digest_algorithm}]"
         yield ""
 
         for message in messages:
@@ -58,11 +58,11 @@ def build_vectors(fips_vectors):
             r, s = sigdecode_der(signature, None)
 
             yield "Msg = {}".format(hexlify(message))
-            yield "d = {:x}".format(secret_key.privkey.secret_multiplier)
-            yield "Qx = {:x}".format(public_key.pubkey.point.x())
-            yield "Qy = {:x}".format(public_key.pubkey.point.y())
-            yield "R = {:x}".format(r)
-            yield "S = {:x}".format(s)
+            yield f"d = {secret_key.privkey.secret_multiplier:x}"
+            yield f"Qx = {public_key.pubkey.point.x():x}"
+            yield f"Qy = {public_key.pubkey.point.y():x}"
+            yield f"R = {r:x}"
+            yield f"S = {s:x}"
             yield ""
 
 

--- a/docs/development/custom-vectors/seed/generate_seed.py
+++ b/docs/development/custom-vectors/seed/generate_seed.py
@@ -32,16 +32,16 @@ def build_vectors(mode, filename):
                 output.append(
                     "CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext))
                 )
-            output.append("\nCOUNT = {}".format(count))
+            output.append(f"\nCOUNT = {count}")
             count += 1
             name, key = line.split(" = ")
-            output.append("KEY = {}".format(key))
+            output.append(f"KEY = {key}")
         elif line.startswith("IV"):
             name, iv = line.split(" = ")
-            output.append("IV = {}".format(iv))
+            output.append(f"IV = {iv}")
         elif line.startswith("PLAINTEXT"):
             name, plaintext = line.split(" = ")
-            output.append("PLAINTEXT = {}".format(plaintext))
+            output.append(f"PLAINTEXT = {plaintext}")
 
     output.append("CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext)))
     return "\n".join(output)

--- a/docs/development/custom-vectors/seed/generate_seed.py
+++ b/docs/development/custom-vectors/seed/generate_seed.py
@@ -17,7 +17,7 @@ def encrypt(mode, key, iv, plaintext):
 
 
 def build_vectors(mode, filename):
-    with open(filename, "r") as f:
+    with open(filename) as f:
         vector_file = f.read().splitlines()
 
     count = 0
@@ -30,22 +30,20 @@ def build_vectors(mode, filename):
         if line.startswith("KEY"):
             if count != 0:
                 output.append(
-                    "CIPHERTEXT = {0}".format(
-                        encrypt(mode, key, iv, plaintext)
-                    )
+                    "CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext))
                 )
-            output.append("\nCOUNT = {0}".format(count))
+            output.append("\nCOUNT = {}".format(count))
             count += 1
             name, key = line.split(" = ")
-            output.append("KEY = {0}".format(key))
+            output.append("KEY = {}".format(key))
         elif line.startswith("IV"):
             name, iv = line.split(" = ")
-            output.append("IV = {0}".format(iv))
+            output.append("IV = {}".format(iv))
         elif line.startswith("PLAINTEXT"):
             name, plaintext = line.split(" = ")
-            output.append("PLAINTEXT = {0}".format(plaintext))
+            output.append("PLAINTEXT = {}".format(plaintext))
 
-    output.append("CIPHERTEXT = {0}".format(encrypt(mode, key, iv, plaintext)))
+    output.append("CIPHERTEXT = {}".format(encrypt(mode, key, iv, plaintext)))
     return "\n".join(output)
 
 

--- a/docs/development/custom-vectors/seed/verify_seed.py
+++ b/docs/development/custom-vectors/seed/verify_seed.py
@@ -7,7 +7,7 @@ from tests.utils import load_nist_vectors
 
 def encrypt(mode, key, iv, plaintext):
     encryptor = botan.Cipher(
-        "SEED/{}/NoPadding".format(mode), "encrypt", binascii.unhexlify(key)
+        f"SEED/{mode}/NoPadding", "encrypt", binascii.unhexlify(key)
     )
 
     cipher_text = encryptor.cipher(

--- a/docs/development/custom-vectors/seed/verify_seed.py
+++ b/docs/development/custom-vectors/seed/verify_seed.py
@@ -7,7 +7,7 @@ from tests.utils import load_nist_vectors
 
 def encrypt(mode, key, iv, plaintext):
     encryptor = botan.Cipher(
-        "SEED/{0}/NoPadding".format(mode), "encrypt", binascii.unhexlify(key)
+        "SEED/{}/NoPadding".format(mode), "encrypt", binascii.unhexlify(key)
     )
 
     cipher_text = encryptor.cipher(
@@ -17,7 +17,7 @@ def encrypt(mode, key, iv, plaintext):
 
 
 def verify_vectors(mode, filename):
-    with open(filename, "r") as f:
+    with open(filename) as f:
         vector_file = f.read().splitlines()
 
     vectors = load_nist_vectors(vector_file)

--- a/release.py
+++ b/release.py
@@ -27,7 +27,7 @@ def wait_for_build_complete_github_actions(session, token, run_url):
             run_url,
             headers={
                 "Content-Type": "application/json",
-                "Authorization": "token {}".format(token),
+                "Authorization": f"token {token}",
             },
         )
         response.raise_for_status()
@@ -41,7 +41,7 @@ def download_artifacts_github_actions(session, token, run_url):
         run_url,
         headers={
             "Content-Type": "application/json",
-            "Authorization": "token {}".format(token),
+            "Authorization": f"token {token}",
         },
     )
     response.raise_for_status()
@@ -50,7 +50,7 @@ def download_artifacts_github_actions(session, token, run_url):
         response.json()["artifacts_url"],
         headers={
             "Content-Type": "application/json",
-            "Authorization": "token {}".format(token),
+            "Authorization": f"token {token}",
         },
     )
     response.raise_for_status()
@@ -60,7 +60,7 @@ def download_artifacts_github_actions(session, token, run_url):
             artifact["archive_download_url"],
             headers={
                 "Content-Type": "application/json",
-                "Authorization": "token {}".format(token),
+                "Authorization": f"token {token}",
             },
         )
         with zipfile.ZipFile(io.BytesIO(response.content)) as z:
@@ -88,7 +88,7 @@ def build_github_actions_wheels(token, version):
         headers={
             "Content-Type": "application/json",
             "Accept": "application/vnd.github.v3+json",
-            "Authorization": "token {}".format(token),
+            "Authorization": f"token {token}",
         },
         data=json.dumps({"ref": "master", "inputs": {"version": version}}),
     )
@@ -103,7 +103,7 @@ def build_github_actions_wheels(token, version):
         ),
         headers={
             "Content-Type": "application/json",
-            "Authorization": "token {}".format(token),
+            "Authorization": f"token {token}",
         },
     )
     response.raise_for_status()
@@ -120,14 +120,14 @@ def release(version):
     """
     github_token = getpass.getpass("Github person access token: ")
 
-    run("git", "tag", "-s", version, "-m", "{} release".format(version))
+    run("git", "tag", "-s", version, "-m", f"{version} release")
     run("git", "push", "--tags")
 
     run("python", "setup.py", "sdist")
     run("python", "setup.py", "sdist", "bdist_wheel", cwd="vectors/")
 
-    packages = glob.glob("dist/cryptography-{}*".format(version)) + glob.glob(
-        "vectors/dist/cryptography_vectors-{}*".format(version)
+    packages = glob.glob(f"dist/cryptography-{version}*") + glob.glob(
+        f"vectors/dist/cryptography_vectors-{version}*"
     )
     run("twine", "upload", "-s", *packages)
 

--- a/release.py
+++ b/release.py
@@ -17,7 +17,7 @@ import requests
 
 
 def run(*args, **kwargs):
-    print("[running] {0}".format(list(args)))
+    print("[running] {}".format(list(args)))
     subprocess.check_call(list(args), **kwargs)
 
 
@@ -120,14 +120,14 @@ def release(version):
     """
     github_token = getpass.getpass("Github person access token: ")
 
-    run("git", "tag", "-s", version, "-m", "{0} release".format(version))
+    run("git", "tag", "-s", version, "-m", "{} release".format(version))
     run("git", "push", "--tags")
 
     run("python", "setup.py", "sdist")
     run("python", "setup.py", "sdist", "bdist_wheel", cwd="vectors/")
 
-    packages = glob.glob("dist/cryptography-{0}*".format(version)) + glob.glob(
-        "vectors/dist/cryptography_vectors-{0}*".format(version)
+    packages = glob.glob("dist/cryptography-{}*".format(version)) + glob.glob(
+        "vectors/dist/cryptography_vectors-{}*".format(version)
     )
     run("twine", "upload", "-s", *packages)
 

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -27,4 +27,4 @@ __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"
 
 __license__ = "BSD or Apache License, Version 2.0"
-__copyright__ = "Copyright 2013-2020 {}".format(__author__)
+__copyright__ = f"Copyright 2013-2020 {__author__}"

--- a/src/cryptography/exceptions.py
+++ b/src/cryptography/exceptions.py
@@ -23,7 +23,7 @@ class _Reasons(Enum):
 
 class UnsupportedAlgorithm(Exception):
     def __init__(self, message, reason=None):
-        super(UnsupportedAlgorithm, self).__init__(message)
+        super().__init__(message)
         self._reason = reason
 
 
@@ -49,7 +49,7 @@ class InvalidSignature(Exception):
 
 class InternalError(Exception):
     def __init__(self, msg, err_code):
-        super(InternalError, self).__init__(msg)
+        super().__init__(msg)
         self.err_code = err_code
 
 

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -24,7 +24,7 @@ class InvalidToken(Exception):
 _MAX_CLOCK_SKEW = 60
 
 
-class Fernet(object):
+class Fernet:
     def __init__(self, key, backend=None):
         backend = _get_backend(backend)
 
@@ -141,7 +141,7 @@ class Fernet(object):
         return unpadded
 
 
-class MultiFernet(object):
+class MultiFernet:
     def __init__(self, fernets):
         fernets = list(fernets)
         if not fernets:

--- a/src/cryptography/hazmat/_der.py
+++ b/src/cryptography/hazmat/_der.py
@@ -29,7 +29,7 @@ UTC_TIME = 0x17
 GENERALIZED_TIME = 0x18
 
 
-class DERReader(object):
+class DERReader:
     def __init__(self, data):
         self.data = memoryview(data)
 

--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -6,7 +6,7 @@
 from cryptography import utils
 
 
-class ObjectIdentifier(object):
+class ObjectIdentifier:
     def __init__(self, dotted_string):
         self._dotted_string = dotted_string
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -156,7 +156,7 @@ _MemoryBIO = collections.namedtuple("_MemoryBIO", ["bio", "char_ptr"])
 
 
 # Not actually supported, just used as a marker for some serialization tests.
-class _RC2(object):
+class _RC2:
     pass
 
 
@@ -175,7 +175,7 @@ class _RC2(object):
 @utils.register_interface_if(
     binding.Binding().lib.Cryptography_HAS_SCRYPT, ScryptBackend
 )
-class Backend(object):
+class Backend:
     """
     OpenSSL API binding interfaces.
     """
@@ -2732,7 +2732,7 @@ class Backend(object):
         return self._read_mem_bio(bio_out)
 
 
-class GetCipherByName(object):
+class GetCipherByName:
     def __init__(self, fmt):
         self._fmt = fmt
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1176,7 +1176,7 @@ class Backend:
                 encode = handlers[extension.oid]
             except KeyError:
                 raise NotImplementedError(
-                    "Extension not supported: {}".format(extension.oid)
+                    f"Extension not supported: {extension.oid}"
                 )
 
             ext_struct = encode(self, extension.value)
@@ -1534,7 +1534,7 @@ class Backend:
             return _EllipticCurvePrivateKey(self, ec_cdata, evp_pkey)
         else:
             raise UnsupportedAlgorithm(
-                "Backend object does not support {}.".format(curve.name),
+                f"Backend object does not support {curve.name}.",
                 _Reasons.UNSUPPORTED_ELLIPTIC_CURVE,
             )
 
@@ -1794,7 +1794,7 @@ class Backend:
         curve_nid = self._lib.OBJ_sn2nid(curve_name.encode())
         if curve_nid == self._lib.NID_undef:
             raise UnsupportedAlgorithm(
-                "{} is not a supported elliptic curve".format(curve.name),
+                f"{curve.name} is not a supported elliptic curve",
                 _Reasons.UNSUPPORTED_ELLIPTIC_CURVE,
             )
         return curve_nid

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -49,9 +49,9 @@ class _CipherContext:
 
         evp_cipher = adapter(self._backend, cipher, mode)
         if evp_cipher == self._backend._ffi.NULL:
-            msg = "cipher {0.name} ".format(cipher)
+            msg = f"cipher {cipher.name} "
             if mode is not None:
-                msg += "in {0.name} mode ".format(mode)
+                msg += f"in {mode.name} mode "
             msg += (
                 "is not supported by this backend (Your version of OpenSSL "
                 "may be too old. Current version: {}.)"

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.ciphers import modes
 @utils.register_interface(ciphers.AEADCipherContext)
 @utils.register_interface(ciphers.AEADEncryptionContext)
 @utils.register_interface(ciphers.AEADDecryptionContext)
-class _CipherContext(object):
+class _CipherContext:
     _ENCRYPT = 1
     _DECRYPT = 0
     _MAX_CHUNK_SIZE = 2 ** 31 - 1

--- a/src/cryptography/hazmat/backends/openssl/cmac.py
+++ b/src/cryptography/hazmat/backends/openssl/cmac.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives import constant_time
 from cryptography.hazmat.primitives.ciphers.modes import CBC
 
 
-class _CMACContext(object):
+class _CMACContext:
     def __init__(self, backend, algorithm, ctx=None):
         if not backend.cmac_algorithm_supported(algorithm):
             raise UnsupportedAlgorithm(

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -177,7 +177,7 @@ def _decode_delta_crl_indicator(backend, ext):
     return x509.DeltaCRLIndicator(_asn1_integer_to_int(backend, asn1_int))
 
 
-class _X509ExtensionParser(object):
+class _X509ExtensionParser:
     def __init__(self, backend, ext_count, get_ext, handlers):
         self.ext_count = ext_count
         self.get_ext = get_ext

--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -129,7 +129,7 @@ def _decode_general_name(backend, gn):
             if "1" in bits[prefix:]:
                 raise ValueError("Invalid netmask")
 
-            ip = ipaddress.ip_network(base.exploded + "/{}".format(prefix))
+            ip = ipaddress.ip_network(base.exploded + f"/{prefix}")
         else:
             ip = ipaddress.ip_address(data)
 
@@ -200,7 +200,7 @@ class _X509ExtensionParser:
             )
             if oid in seen_oids:
                 raise x509.DuplicateExtension(
-                    "Duplicate {} extension found".format(oid), oid
+                    f"Duplicate {oid} extension found", oid
                 )
 
             # These OIDs are only supported in OpenSSL 1.1.0+ but we want
@@ -715,7 +715,7 @@ def _decode_crl_reason(backend, enum):
     try:
         return x509.CRLReason(_CRL_ENTRY_REASON_CODE_TO_ENUM[code])
     except KeyError:
-        raise ValueError("Unsupported reason code: {}".format(code))
+        raise ValueError(f"Unsupported reason code: {code}")
 
 
 def _decode_invalidity_date(backend, inv_date):
@@ -773,7 +773,7 @@ def _asn1_string_to_utf8(backend, asn1_string):
     res = backend._lib.ASN1_STRING_to_UTF8(buf, asn1_string)
     if res == -1:
         raise ValueError(
-            "Unsupported ASN1 string type. Type: {}".format(asn1_string.type)
+            f"Unsupported ASN1 string type. Type: {asn1_string.type}"
         )
 
     backend.openssl_assert(buf[0] != backend._ffi.NULL)

--- a/src/cryptography/hazmat/backends/openssl/dh.py
+++ b/src/cryptography/hazmat/backends/openssl/dh.py
@@ -33,7 +33,7 @@ def _dh_cdata_to_parameters(dh_cdata, backend):
 
 
 @utils.register_interface(dh.DHParametersWithSerialization)
-class _DHParameters(object):
+class _DHParameters:
     def __init__(self, backend, dh_cdata):
         self._backend = backend
         self._dh_cdata = dh_cdata
@@ -86,7 +86,7 @@ def _get_dh_num_bits(backend, dh_cdata):
 
 
 @utils.register_interface(dh.DHPrivateKeyWithSerialization)
-class _DHPrivateKey(object):
+class _DHPrivateKey:
     def __init__(self, backend, dh_cdata, evp_pkey):
         self._backend = backend
         self._dh_cdata = dh_cdata
@@ -205,7 +205,7 @@ class _DHPrivateKey(object):
 
 
 @utils.register_interface(dh.DHPublicKeyWithSerialization)
-class _DHPublicKey(object):
+class _DHPublicKey:
     def __init__(self, backend, dh_cdata, evp_pkey):
         self._backend = backend
         self._dh_cdata = dh_cdata

--- a/src/cryptography/hazmat/backends/openssl/dsa.py
+++ b/src/cryptography/hazmat/backends/openssl/dsa.py
@@ -47,7 +47,7 @@ def _dsa_sig_verify(backend, public_key, signature, data):
 
 
 @utils.register_interface(AsymmetricVerificationContext)
-class _DSAVerificationContext(object):
+class _DSAVerificationContext:
     def __init__(self, backend, public_key, signature, algorithm):
         self._backend = backend
         self._public_key = public_key
@@ -68,7 +68,7 @@ class _DSAVerificationContext(object):
 
 
 @utils.register_interface(AsymmetricSignatureContext)
-class _DSASignatureContext(object):
+class _DSASignatureContext:
     def __init__(self, backend, private_key, algorithm):
         self._backend = backend
         self._private_key = private_key
@@ -84,7 +84,7 @@ class _DSASignatureContext(object):
 
 
 @utils.register_interface(dsa.DSAParametersWithNumbers)
-class _DSAParameters(object):
+class _DSAParameters:
     def __init__(self, backend, dsa_cdata):
         self._backend = backend
         self._dsa_cdata = dsa_cdata
@@ -108,7 +108,7 @@ class _DSAParameters(object):
 
 
 @utils.register_interface(dsa.DSAPrivateKeyWithSerialization)
-class _DSAPrivateKey(object):
+class _DSAPrivateKey:
     def __init__(self, backend, dsa_cdata, evp_pkey):
         self._backend = backend
         self._dsa_cdata = dsa_cdata
@@ -198,7 +198,7 @@ class _DSAPrivateKey(object):
 
 
 @utils.register_interface(dsa.DSAPublicKeyWithSerialization)
-class _DSAPublicKey(object):
+class _DSAPublicKey:
     def __init__(self, backend, dsa_cdata, evp_pkey):
         self._backend = backend
         self._dsa_cdata = dsa_cdata

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -105,7 +105,7 @@ def _ecdsa_sig_verify(backend, public_key, signature, data):
 
 
 @utils.register_interface(AsymmetricSignatureContext)
-class _ECDSASignatureContext(object):
+class _ECDSASignatureContext:
     def __init__(self, backend, private_key, algorithm):
         self._backend = backend
         self._private_key = private_key
@@ -121,7 +121,7 @@ class _ECDSASignatureContext(object):
 
 
 @utils.register_interface(AsymmetricVerificationContext)
-class _ECDSAVerificationContext(object):
+class _ECDSAVerificationContext:
     def __init__(self, backend, public_key, signature, algorithm):
         self._backend = backend
         self._public_key = public_key
@@ -139,7 +139,7 @@ class _ECDSAVerificationContext(object):
 
 
 @utils.register_interface(ec.EllipticCurvePrivateKeyWithSerialization)
-class _EllipticCurvePrivateKey(object):
+class _EllipticCurvePrivateKey:
     def __init__(self, backend, ec_key_cdata, evp_pkey):
         self._backend = backend
         self._ec_key = ec_key_cdata
@@ -237,7 +237,7 @@ class _EllipticCurvePrivateKey(object):
 
 
 @utils.register_interface(ec.EllipticCurvePublicKeyWithSerialization)
-class _EllipticCurvePublicKey(object):
+class _EllipticCurvePublicKey:
     def __init__(self, backend, ec_key_cdata, evp_pkey):
         self._backend = backend
         self._ec_key = ec_key_cdata

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -77,7 +77,7 @@ def _sn_to_elliptic_curve(backend, sn):
         return ec._CURVE_TYPES[sn]()
     except KeyError:
         raise UnsupportedAlgorithm(
-            "{} is not a supported elliptic curve".format(sn),
+            f"{sn} is not a supported elliptic curve",
             _Reasons.UNSUPPORTED_ELLIPTIC_CURVE,
         )
 

--- a/src/cryptography/hazmat/backends/openssl/ed25519.py
+++ b/src/cryptography/hazmat/backends/openssl/ed25519.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
 
 
 @utils.register_interface(Ed25519PublicKey)
-class _Ed25519PublicKey(object):
+class _Ed25519PublicKey:
     def __init__(self, backend, evp_pkey):
         self._backend = backend
         self._evp_pkey = evp_pkey
@@ -71,7 +71,7 @@ class _Ed25519PublicKey(object):
 
 
 @utils.register_interface(Ed25519PrivateKey)
-class _Ed25519PrivateKey(object):
+class _Ed25519PrivateKey:
     def __init__(self, backend, evp_pkey):
         self._backend = backend
         self._evp_pkey = evp_pkey

--- a/src/cryptography/hazmat/backends/openssl/ed448.py
+++ b/src/cryptography/hazmat/backends/openssl/ed448.py
@@ -15,7 +15,7 @@ _ED448_SIG_SIZE = 114
 
 
 @utils.register_interface(Ed448PublicKey)
-class _Ed448PublicKey(object):
+class _Ed448PublicKey:
     def __init__(self, backend, evp_pkey):
         self._backend = backend
         self._evp_pkey = evp_pkey
@@ -72,7 +72,7 @@ class _Ed448PublicKey(object):
 
 
 @utils.register_interface(Ed448PrivateKey)
-class _Ed448PrivateKey(object):
+class _Ed448PrivateKey:
     def __init__(self, backend, evp_pkey):
         self._backend = backend
         self._evp_pkey = evp_pkey

--- a/src/cryptography/hazmat/backends/openssl/encode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/encode_asn1.py
@@ -480,7 +480,7 @@ def _encode_general_name_preallocated(backend, name, gn):
         gn.type = backend._lib.GEN_URI
         gn.d.uniformResourceIdentifier = asn1_str
     else:
-        raise ValueError("{} is an unknown GeneralName type".format(name))
+        raise ValueError(f"{name} is an unknown GeneralName type")
 
 
 def _encode_extended_key_usage(backend, extended_key_usage):

--- a/src/cryptography/hazmat/backends/openssl/hashes.py
+++ b/src/cryptography/hazmat/backends/openssl/hashes.py
@@ -9,7 +9,7 @@ from cryptography.hazmat.primitives import hashes
 
 
 @utils.register_interface(hashes.HashContext)
-class _HashContext(object):
+class _HashContext:
     def __init__(self, backend, algorithm, ctx=None):
         self._algorithm = algorithm
 

--- a/src/cryptography/hazmat/backends/openssl/hmac.py
+++ b/src/cryptography/hazmat/backends/openssl/hmac.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives import constant_time, hashes
 
 
 @utils.register_interface(hashes.HashContext)
-class _HMACContext(object):
+class _HMACContext:
     def __init__(self, backend, key, algorithm, ctx=None):
         self._algorithm = algorithm
         self._backend = backend

--- a/src/cryptography/hazmat/backends/openssl/ocsp.py
+++ b/src/cryptography/hazmat/backends/openssl/ocsp.py
@@ -101,7 +101,7 @@ def _hash_algorithm(backend, cert_id):
 
 
 @utils.register_interface(OCSPResponse)
-class _OCSPResponse(object):
+class _OCSPResponse:
     def __init__(self, backend, ocsp_response):
         self._backend = backend
         self._ocsp_response = ocsp_response
@@ -355,7 +355,7 @@ class _OCSPResponse(object):
 
 
 @utils.register_interface(OCSPRequest)
-class _OCSPRequest(object):
+class _OCSPRequest:
     def __init__(self, backend, ocsp_request):
         if backend._lib.OCSP_request_onereq_count(ocsp_request) > 1:
             raise NotImplementedError(

--- a/src/cryptography/hazmat/backends/openssl/ocsp.py
+++ b/src/cryptography/hazmat/backends/openssl/ocsp.py
@@ -96,7 +96,7 @@ def _hash_algorithm(backend, cert_id):
         return _OIDS_TO_HASH[oid]
     except KeyError:
         raise UnsupportedAlgorithm(
-            "Signature algorithm OID: {} not recognized".format(oid)
+            f"Signature algorithm OID: {oid} not recognized"
         )
 
 
@@ -152,7 +152,7 @@ class _OCSPResponse:
             return x509._SIG_OIDS_TO_HASH[oid]
         except KeyError:
             raise UnsupportedAlgorithm(
-                "Signature algorithm OID:{} not recognized".format(oid)
+                f"Signature algorithm OID:{oid} not recognized"
             )
 
     @property

--- a/src/cryptography/hazmat/backends/openssl/poly1305.py
+++ b/src/cryptography/hazmat/backends/openssl/poly1305.py
@@ -11,7 +11,7 @@ _POLY1305_TAG_SIZE = 16
 _POLY1305_KEY_SIZE = 32
 
 
-class _Poly1305Context(object):
+class _Poly1305Context:
     def __init__(self, backend, key):
         self._backend = backend
 

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -67,7 +67,7 @@ def _enc_dec_rsa(backend, key, data, padding):
 
     else:
         raise UnsupportedAlgorithm(
-            "{} is not supported by this backend.".format(padding.name),
+            f"{padding.name} is not supported by this backend.",
             _Reasons.UNSUPPORTED_PADDING,
         )
 
@@ -165,7 +165,7 @@ def _rsa_sig_determine_padding(backend, key, padding, algorithm):
         padding_enum = backend._lib.RSA_PKCS1_PSS_PADDING
     else:
         raise UnsupportedAlgorithm(
-            "{} is not supported by this backend.".format(padding.name),
+            f"{padding.name} is not supported by this backend.",
             _Reasons.UNSUPPORTED_PADDING,
         )
 

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -295,7 +295,7 @@ def _rsa_sig_recover(backend, padding, algorithm, public_key, signature):
 
 
 @utils.register_interface(AsymmetricSignatureContext)
-class _RSASignatureContext(object):
+class _RSASignatureContext:
     def __init__(self, backend, private_key, padding, algorithm):
         self._backend = backend
         self._private_key = private_key
@@ -322,7 +322,7 @@ class _RSASignatureContext(object):
 
 
 @utils.register_interface(AsymmetricVerificationContext)
-class _RSAVerificationContext(object):
+class _RSAVerificationContext:
     def __init__(self, backend, public_key, signature, padding, algorithm):
         self._backend = backend
         self._public_key = public_key
@@ -352,7 +352,7 @@ class _RSAVerificationContext(object):
 
 
 @utils.register_interface(RSAPrivateKeyWithSerialization)
-class _RSAPrivateKey(object):
+class _RSAPrivateKey:
     def __init__(self, backend, rsa_cdata, evp_pkey):
         res = backend._lib.RSA_check_key(rsa_cdata)
         if res != 1:
@@ -452,7 +452,7 @@ class _RSAPrivateKey(object):
 
 
 @utils.register_interface(RSAPublicKeyWithSerialization)
-class _RSAPublicKey(object):
+class _RSAPublicKey:
     def __init__(self, backend, rsa_cdata, evp_pkey):
         self._backend = backend
         self._rsa_cdata = rsa_cdata

--- a/src/cryptography/hazmat/backends/openssl/x25519.py
+++ b/src/cryptography/hazmat/backends/openssl/x25519.py
@@ -16,7 +16,7 @@ _X25519_KEY_SIZE = 32
 
 
 @utils.register_interface(X25519PublicKey)
-class _X25519PublicKey(object):
+class _X25519PublicKey:
     def __init__(self, backend, evp_pkey):
         self._backend = backend
         self._evp_pkey = evp_pkey
@@ -54,7 +54,7 @@ class _X25519PublicKey(object):
 
 
 @utils.register_interface(X25519PrivateKey)
-class _X25519PrivateKey(object):
+class _X25519PrivateKey:
     def __init__(self, backend, evp_pkey):
         self._backend = backend
         self._evp_pkey = evp_pkey

--- a/src/cryptography/hazmat/backends/openssl/x448.py
+++ b/src/cryptography/hazmat/backends/openssl/x448.py
@@ -15,7 +15,7 @@ _X448_KEY_SIZE = 56
 
 
 @utils.register_interface(X448PublicKey)
-class _X448PublicKey(object):
+class _X448PublicKey:
     def __init__(self, backend, evp_pkey):
         self._backend = backend
         self._evp_pkey = evp_pkey
@@ -51,7 +51,7 @@ class _X448PublicKey(object):
 
 
 @utils.register_interface(X448PrivateKey)
-class _X448PrivateKey(object):
+class _X448PrivateKey:
     def __init__(self, backend, evp_pkey):
         self._backend = backend
         self._evp_pkey = evp_pkey

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -37,11 +37,11 @@ class _Certificate:
             self._version = x509.Version.v3
         else:
             raise x509.InvalidVersion(
-                "{} is not a valid X509 version".format(version), version
+                f"{version} is not a valid X509 version", version
             )
 
     def __repr__(self):
-        return "<Certificate(subject={}, ...)>".format(self.subject)
+        return f"<Certificate(subject={self.subject}, ...)>"
 
     def __eq__(self, other):
         if not isinstance(other, x509.Certificate):
@@ -112,7 +112,7 @@ class _Certificate:
             return x509._SIG_OIDS_TO_HASH[oid]
         except KeyError:
             raise UnsupportedAlgorithm(
-                "Signature algorithm OID:{} not recognized".format(oid)
+                f"Signature algorithm OID:{oid} not recognized"
             )
 
     @property
@@ -255,7 +255,7 @@ class _CertificateRevocationList:
             return x509._SIG_OIDS_TO_HASH[oid]
         except KeyError:
             raise UnsupportedAlgorithm(
-                "Signature algorithm OID:{} not recognized".format(oid)
+                f"Signature algorithm OID:{oid} not recognized"
             )
 
     @property
@@ -411,7 +411,7 @@ class _CertificateSigningRequest:
             return x509._SIG_OIDS_TO_HASH[oid]
         except KeyError:
             raise UnsupportedAlgorithm(
-                "Signature algorithm OID:{} not recognized".format(oid)
+                f"Signature algorithm OID:{oid} not recognized"
             )
 
     @property
@@ -490,9 +490,7 @@ class _CertificateSigningRequest:
             self._x509_req, obj, -1
         )
         if pos == -1:
-            raise x509.AttributeNotFound(
-                "No {} attribute was found".format(oid), oid
-            )
+            raise x509.AttributeNotFound(f"No {oid} attribute was found", oid)
 
         attr = self._backend._lib.X509_REQ_get_attr(self._x509_req, pos)
         self._backend.openssl_assert(attr != self._backend._ffi.NULL)

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -25,7 +25,7 @@ from cryptography.x509.name import _ASN1Type
 
 
 @utils.register_interface(x509.Certificate)
-class _Certificate(object):
+class _Certificate:
     def __init__(self, backend, x509_cert):
         self._backend = backend
         self._x509 = x509_cert
@@ -162,7 +162,7 @@ class _Certificate(object):
 
 
 @utils.register_interface(x509.RevokedCertificate)
-class _RevokedCertificate(object):
+class _RevokedCertificate:
     def __init__(self, backend, crl, x509_revoked):
         self._backend = backend
         # The X509_REVOKED_value is a X509_REVOKED * that has
@@ -200,7 +200,7 @@ class _RevokedCertificate(object):
 
 
 @utils.register_interface(x509.CertificateRevocationList)
-class _CertificateRevocationList(object):
+class _CertificateRevocationList:
     def __init__(self, backend, x509_crl):
         self._backend = backend
         self._x509_crl = x509_crl
@@ -373,7 +373,7 @@ class _CertificateRevocationList(object):
 
 
 @utils.register_interface(x509.CertificateSigningRequest)
-class _CertificateSigningRequest(object):
+class _CertificateSigningRequest:
     def __init__(self, backend, x509_req):
         self._backend = backend
         self._x509_req = x509_req
@@ -529,7 +529,7 @@ class _CertificateSigningRequest(object):
 @utils.register_interface(
     x509.certificate_transparency.SignedCertificateTimestamp
 )
-class _SignedCertificateTimestamp(object):
+class _SignedCertificateTimestamp:
     def __init__(self, backend, sct_list, sct):
         self._backend = backend
         # Keep the SCT_LIST that this SCT came from alive.

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -18,7 +18,7 @@ _OpenSSLErrorWithText = collections.namedtuple(
 )
 
 
-class _OpenSSLError(object):
+class _OpenSSLError:
     def __init__(self, code, lib, func, reason):
         self._code = code
         self._lib = lib
@@ -83,7 +83,7 @@ def _openssl_assert(lib, ok, errors=None):
             "OpenSSL try disabling it before reporting a bug. Otherwise "
             "please file an issue at https://github.com/pyca/cryptography/"
             "issues with information on how to reproduce "
-            "this. ({0!r})".format(errors_with_text),
+            "this. ({!r})".format(errors_with_text),
             errors_with_text,
         )
 
@@ -103,7 +103,7 @@ def build_conditional_library(lib, conditional_names):
     return conditional_lib
 
 
-class Binding(object):
+class Binding:
     """
     OpenSSL API wrapper.
     """

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -17,7 +17,7 @@ def generate_parameters(generator, key_size, backend=None):
     return backend.generate_dh_parameters(generator, key_size)
 
 
-class DHPrivateNumbers(object):
+class DHPrivateNumbers:
     def __init__(self, x, public_numbers):
         if not isinstance(x, int):
             raise TypeError("x must be an integer.")
@@ -50,7 +50,7 @@ class DHPrivateNumbers(object):
     x = utils.read_only_property("_x")
 
 
-class DHPublicNumbers(object):
+class DHPublicNumbers:
     def __init__(self, y, parameter_numbers):
         if not isinstance(y, int):
             raise TypeError("y must be an integer.")
@@ -83,7 +83,7 @@ class DHPublicNumbers(object):
     parameter_numbers = utils.read_only_property("_parameter_numbers")
 
 
-class DHParameterNumbers(object):
+class DHParameterNumbers:
     def __init__(self, p, g, q=None):
         if not isinstance(p, int) or not isinstance(g, int):
             raise TypeError("p and g must be integers")

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -95,7 +95,7 @@ class DHParameterNumbers:
 
         if p.bit_length() < _MIN_MODULUS_SIZE:
             raise ValueError(
-                "p (modulus) must be at least {}-bit".format(_MIN_MODULUS_SIZE)
+                f"p (modulus) must be at least {_MIN_MODULUS_SIZE}-bit"
             )
 
         self._p = p

--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -144,7 +144,7 @@ def _check_dsa_private_numbers(numbers):
         raise ValueError("y must be equal to (g ** x % p).")
 
 
-class DSAParameterNumbers(object):
+class DSAParameterNumbers:
     def __init__(self, p, q, g):
         if (
             not isinstance(p, int)
@@ -183,7 +183,7 @@ class DSAParameterNumbers(object):
         )
 
 
-class DSAPublicNumbers(object):
+class DSAPublicNumbers:
     def __init__(self, y, parameter_numbers):
         if not isinstance(y, int):
             raise TypeError("DSAPublicNumbers y argument must be an integer.")
@@ -222,7 +222,7 @@ class DSAPublicNumbers(object):
         )
 
 
-class DSAPrivateNumbers(object):
+class DSAPrivateNumbers:
     def __init__(self, x, public_numbers):
         if not isinstance(x, int):
             raise TypeError("DSAPrivateNumbers x argument must be an integer.")

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -11,7 +11,7 @@ from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat.backends import _get_backend
 
 
-class EllipticCurveOID(object):
+class EllipticCurveOID:
     SECP192R1 = ObjectIdentifier("1.2.840.10045.3.1.1")
     SECP224R1 = ObjectIdentifier("1.3.132.0.33")
     SECP256K1 = ObjectIdentifier("1.3.132.0.10")
@@ -169,115 +169,115 @@ EllipticCurvePublicKeyWithSerialization = EllipticCurvePublicKey
 
 
 @utils.register_interface(EllipticCurve)
-class SECT571R1(object):
+class SECT571R1:
     name = "sect571r1"
     key_size = 570
 
 
 @utils.register_interface(EllipticCurve)
-class SECT409R1(object):
+class SECT409R1:
     name = "sect409r1"
     key_size = 409
 
 
 @utils.register_interface(EllipticCurve)
-class SECT283R1(object):
+class SECT283R1:
     name = "sect283r1"
     key_size = 283
 
 
 @utils.register_interface(EllipticCurve)
-class SECT233R1(object):
+class SECT233R1:
     name = "sect233r1"
     key_size = 233
 
 
 @utils.register_interface(EllipticCurve)
-class SECT163R2(object):
+class SECT163R2:
     name = "sect163r2"
     key_size = 163
 
 
 @utils.register_interface(EllipticCurve)
-class SECT571K1(object):
+class SECT571K1:
     name = "sect571k1"
     key_size = 571
 
 
 @utils.register_interface(EllipticCurve)
-class SECT409K1(object):
+class SECT409K1:
     name = "sect409k1"
     key_size = 409
 
 
 @utils.register_interface(EllipticCurve)
-class SECT283K1(object):
+class SECT283K1:
     name = "sect283k1"
     key_size = 283
 
 
 @utils.register_interface(EllipticCurve)
-class SECT233K1(object):
+class SECT233K1:
     name = "sect233k1"
     key_size = 233
 
 
 @utils.register_interface(EllipticCurve)
-class SECT163K1(object):
+class SECT163K1:
     name = "sect163k1"
     key_size = 163
 
 
 @utils.register_interface(EllipticCurve)
-class SECP521R1(object):
+class SECP521R1:
     name = "secp521r1"
     key_size = 521
 
 
 @utils.register_interface(EllipticCurve)
-class SECP384R1(object):
+class SECP384R1:
     name = "secp384r1"
     key_size = 384
 
 
 @utils.register_interface(EllipticCurve)
-class SECP256R1(object):
+class SECP256R1:
     name = "secp256r1"
     key_size = 256
 
 
 @utils.register_interface(EllipticCurve)
-class SECP256K1(object):
+class SECP256K1:
     name = "secp256k1"
     key_size = 256
 
 
 @utils.register_interface(EllipticCurve)
-class SECP224R1(object):
+class SECP224R1:
     name = "secp224r1"
     key_size = 224
 
 
 @utils.register_interface(EllipticCurve)
-class SECP192R1(object):
+class SECP192R1:
     name = "secp192r1"
     key_size = 192
 
 
 @utils.register_interface(EllipticCurve)
-class BrainpoolP256R1(object):
+class BrainpoolP256R1:
     name = "brainpoolP256r1"
     key_size = 256
 
 
 @utils.register_interface(EllipticCurve)
-class BrainpoolP384R1(object):
+class BrainpoolP384R1:
     name = "brainpoolP384r1"
     key_size = 384
 
 
 @utils.register_interface(EllipticCurve)
-class BrainpoolP512R1(object):
+class BrainpoolP512R1:
     name = "brainpoolP512r1"
     key_size = 512
 
@@ -308,7 +308,7 @@ _CURVE_TYPES = {
 
 
 @utils.register_interface(EllipticCurveSignatureAlgorithm)
-class ECDSA(object):
+class ECDSA:
     def __init__(self, algorithm):
         self._algorithm = algorithm
 
@@ -334,7 +334,7 @@ def derive_private_key(private_value, curve, backend=None):
     return backend.derive_elliptic_curve_private_key(private_value, curve)
 
 
-class EllipticCurvePublicNumbers(object):
+class EllipticCurvePublicNumbers:
     def __init__(self, x, y, curve):
         if not isinstance(x, int) or not isinstance(y, int):
             raise TypeError("x and y must be integers.")
@@ -420,7 +420,7 @@ class EllipticCurvePublicNumbers(object):
         )
 
 
-class EllipticCurvePrivateNumbers(object):
+class EllipticCurvePrivateNumbers:
     def __init__(self, private_value, public_numbers):
         if not isinstance(private_value, int):
             raise TypeError("private_value must be an integer.")
@@ -457,7 +457,7 @@ class EllipticCurvePrivateNumbers(object):
         return hash((self.private_value, self.public_numbers))
 
 
-class ECDH(object):
+class ECDH:
     pass
 
 

--- a/src/cryptography/hazmat/primitives/asymmetric/padding.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/padding.py
@@ -19,12 +19,12 @@ class AsymmetricPadding(metaclass=abc.ABCMeta):
 
 
 @utils.register_interface(AsymmetricPadding)
-class PKCS1v15(object):
+class PKCS1v15:
     name = "EMSA-PKCS1-v1_5"
 
 
 @utils.register_interface(AsymmetricPadding)
-class PSS(object):
+class PSS:
     MAX_LENGTH = object()
     name = "EMSA-PSS"
 
@@ -44,7 +44,7 @@ class PSS(object):
 
 
 @utils.register_interface(AsymmetricPadding)
-class OAEP(object):
+class OAEP:
     name = "EME-OAEP"
 
     def __init__(self, mgf, algorithm, label):
@@ -56,7 +56,7 @@ class OAEP(object):
         self._label = label
 
 
-class MGF1(object):
+class MGF1:
     MAX_LENGTH = object()
 
     def __init__(self, algorithm):

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -264,7 +264,7 @@ def rsa_recover_prime_factors(n, e, d):
     return (p, q)
 
 
-class RSAPrivateNumbers(object):
+class RSAPrivateNumbers:
     def __init__(self, p, q, d, dmp1, dmq1, iqmp, public_numbers):
         if (
             not isinstance(p, int)
@@ -336,7 +336,7 @@ class RSAPrivateNumbers(object):
         )
 
 
-class RSAPublicNumbers(object):
+class RSAPublicNumbers:
     def __init__(self, e, n):
         if not isinstance(e, int) or not isinstance(n, int):
             raise TypeError("RSAPublicNumbers arguments must be integers.")

--- a/src/cryptography/hazmat/primitives/asymmetric/utils.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/utils.py
@@ -29,7 +29,7 @@ def encode_dss_signature(r, s):
     )
 
 
-class Prehashed(object):
+class Prehashed:
     def __init__(self, algorithm):
         if not isinstance(algorithm, hashes.HashAlgorithm):
             raise TypeError("Expected instance of HashAlgorithm.")

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -10,7 +10,7 @@ from cryptography.hazmat.backends.openssl import aead
 from cryptography.hazmat.backends.openssl.backend import backend
 
 
-class ChaCha20Poly1305(object):
+class ChaCha20Poly1305:
     _MAX_SIZE = 2 ** 32
 
     def __init__(self, key):
@@ -58,7 +58,7 @@ class ChaCha20Poly1305(object):
             raise ValueError("Nonce must be 12 bytes")
 
 
-class AESCCM(object):
+class AESCCM:
     _MAX_SIZE = 2 ** 32
 
     def __init__(self, key, tag_length=16):
@@ -125,7 +125,7 @@ class AESCCM(object):
             raise ValueError("Nonce must be between 7 and 13 bytes")
 
 
-class AESGCM(object):
+class AESGCM:
     _MAX_SIZE = 2 ** 32
 
     def __init__(self, key):

--- a/src/cryptography/hazmat/primitives/ciphers/algorithms.py
+++ b/src/cryptography/hazmat/primitives/ciphers/algorithms.py
@@ -27,7 +27,7 @@ def _verify_key_size(algorithm, key):
 
 @utils.register_interface(BlockCipherAlgorithm)
 @utils.register_interface(CipherAlgorithm)
-class AES(object):
+class AES:
     name = "AES"
     block_size = 128
     # 512 added to support AES-256-XTS, which uses 512-bit keys
@@ -43,7 +43,7 @@ class AES(object):
 
 @utils.register_interface(BlockCipherAlgorithm)
 @utils.register_interface(CipherAlgorithm)
-class Camellia(object):
+class Camellia:
     name = "camellia"
     block_size = 128
     key_sizes = frozenset([128, 192, 256])
@@ -58,7 +58,7 @@ class Camellia(object):
 
 @utils.register_interface(BlockCipherAlgorithm)
 @utils.register_interface(CipherAlgorithm)
-class TripleDES(object):
+class TripleDES:
     name = "3DES"
     block_size = 64
     key_sizes = frozenset([64, 128, 192])
@@ -77,7 +77,7 @@ class TripleDES(object):
 
 @utils.register_interface(BlockCipherAlgorithm)
 @utils.register_interface(CipherAlgorithm)
-class Blowfish(object):
+class Blowfish:
     name = "Blowfish"
     block_size = 64
     key_sizes = frozenset(range(32, 449, 8))
@@ -92,7 +92,7 @@ class Blowfish(object):
 
 @utils.register_interface(BlockCipherAlgorithm)
 @utils.register_interface(CipherAlgorithm)
-class CAST5(object):
+class CAST5:
     name = "CAST5"
     block_size = 64
     key_sizes = frozenset(range(40, 129, 8))
@@ -106,7 +106,7 @@ class CAST5(object):
 
 
 @utils.register_interface(CipherAlgorithm)
-class ARC4(object):
+class ARC4:
     name = "RC4"
     key_sizes = frozenset([40, 56, 64, 80, 128, 160, 192, 256])
 
@@ -119,7 +119,7 @@ class ARC4(object):
 
 
 @utils.register_interface(CipherAlgorithm)
-class IDEA(object):
+class IDEA:
     name = "IDEA"
     block_size = 64
     key_sizes = frozenset([128])
@@ -134,7 +134,7 @@ class IDEA(object):
 
 @utils.register_interface(BlockCipherAlgorithm)
 @utils.register_interface(CipherAlgorithm)
-class SEED(object):
+class SEED:
     name = "SEED"
     block_size = 128
     key_sizes = frozenset([128])
@@ -149,7 +149,7 @@ class SEED(object):
 
 @utils.register_interface(CipherAlgorithm)
 @utils.register_interface(ModeWithNonce)
-class ChaCha20(object):
+class ChaCha20:
     name = "ChaCha20"
     key_sizes = frozenset([256])
 

--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -88,7 +88,7 @@ class AEADEncryptionContext(metaclass=abc.ABCMeta):
         """
 
 
-class Cipher(object):
+class Cipher:
     def __init__(self, algorithm, mode, backend=None):
         backend = _get_backend(backend)
         if not isinstance(backend, CipherBackend):
@@ -135,7 +135,7 @@ class Cipher(object):
 
 
 @utils.register_interface(CipherContext)
-class _CipherContext(object):
+class _CipherContext:
     def __init__(self, ctx):
         self._ctx = ctx
 
@@ -160,7 +160,7 @@ class _CipherContext(object):
 @utils.register_interface(AEADCipherContext)
 @utils.register_interface(CipherContext)
 @utils.register_interface(AEADDecryptionContext)
-class _AEADCipherContext(object):
+class _AEADCipherContext:
     def __init__(self, ctx):
         self._ctx = ctx
         self._bytes_processed = 0

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -78,7 +78,7 @@ def _check_iv_and_key_length(self, algorithm):
 
 @utils.register_interface(Mode)
 @utils.register_interface(ModeWithInitializationVector)
-class CBC(object):
+class CBC:
     name = "CBC"
 
     def __init__(self, initialization_vector):
@@ -91,7 +91,7 @@ class CBC(object):
 
 @utils.register_interface(Mode)
 @utils.register_interface(ModeWithTweak)
-class XTS(object):
+class XTS:
     name = "XTS"
 
     def __init__(self, tweak):
@@ -113,7 +113,7 @@ class XTS(object):
 
 
 @utils.register_interface(Mode)
-class ECB(object):
+class ECB:
     name = "ECB"
 
     validate_for_algorithm = _check_aes_key_length
@@ -121,7 +121,7 @@ class ECB(object):
 
 @utils.register_interface(Mode)
 @utils.register_interface(ModeWithInitializationVector)
-class OFB(object):
+class OFB:
     name = "OFB"
 
     def __init__(self, initialization_vector):
@@ -134,7 +134,7 @@ class OFB(object):
 
 @utils.register_interface(Mode)
 @utils.register_interface(ModeWithInitializationVector)
-class CFB(object):
+class CFB:
     name = "CFB"
 
     def __init__(self, initialization_vector):
@@ -147,7 +147,7 @@ class CFB(object):
 
 @utils.register_interface(Mode)
 @utils.register_interface(ModeWithInitializationVector)
-class CFB8(object):
+class CFB8:
     name = "CFB8"
 
     def __init__(self, initialization_vector):
@@ -160,7 +160,7 @@ class CFB8(object):
 
 @utils.register_interface(Mode)
 @utils.register_interface(ModeWithNonce)
-class CTR(object):
+class CTR:
     name = "CTR"
 
     def __init__(self, nonce):
@@ -182,7 +182,7 @@ class CTR(object):
 @utils.register_interface(Mode)
 @utils.register_interface(ModeWithInitializationVector)
 @utils.register_interface(ModeWithAuthenticationTag)
-class GCM(object):
+class GCM:
     name = "GCM"
     _MAX_ENCRYPTED_BYTES = (2 ** 39 - 256) // 8
     _MAX_AAD_BYTES = (2 ** 64) // 8

--- a/src/cryptography/hazmat/primitives/cmac.py
+++ b/src/cryptography/hazmat/primitives/cmac.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.backends.interfaces import CMACBackend
 from cryptography.hazmat.primitives import ciphers
 
 
-class CMAC(object):
+class CMAC:
     def __init__(self, algorithm, backend=None, ctx=None):
         backend = _get_backend(backend)
         if not isinstance(backend, CMACBackend):

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -62,7 +62,7 @@ class ExtendableOutputFunction(metaclass=abc.ABCMeta):
 
 
 @utils.register_interface(HashContext)
-class Hash(object):
+class Hash:
     def __init__(self, algorithm, backend=None, ctx=None):
         backend = _get_backend(backend)
         if not isinstance(backend, HashBackend):
@@ -106,81 +106,81 @@ class Hash(object):
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA1(object):
+class SHA1:
     name = "sha1"
     digest_size = 20
     block_size = 64
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA512_224(object):  # noqa: N801
+class SHA512_224:  # noqa: N801
     name = "sha512-224"
     digest_size = 28
     block_size = 128
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA512_256(object):  # noqa: N801
+class SHA512_256:  # noqa: N801
     name = "sha512-256"
     digest_size = 32
     block_size = 128
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA224(object):
+class SHA224:
     name = "sha224"
     digest_size = 28
     block_size = 64
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA256(object):
+class SHA256:
     name = "sha256"
     digest_size = 32
     block_size = 64
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA384(object):
+class SHA384:
     name = "sha384"
     digest_size = 48
     block_size = 128
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA512(object):
+class SHA512:
     name = "sha512"
     digest_size = 64
     block_size = 128
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA3_224(object):  # noqa: N801
+class SHA3_224:  # noqa: N801
     name = "sha3-224"
     digest_size = 28
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA3_256(object):  # noqa: N801
+class SHA3_256:  # noqa: N801
     name = "sha3-256"
     digest_size = 32
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA3_384(object):  # noqa: N801
+class SHA3_384:  # noqa: N801
     name = "sha3-384"
     digest_size = 48
 
 
 @utils.register_interface(HashAlgorithm)
-class SHA3_512(object):  # noqa: N801
+class SHA3_512:  # noqa: N801
     name = "sha3-512"
     digest_size = 64
 
 
 @utils.register_interface(HashAlgorithm)
 @utils.register_interface(ExtendableOutputFunction)
-class SHAKE128(object):
+class SHAKE128:
     name = "shake128"
 
     def __init__(self, digest_size):
@@ -197,7 +197,7 @@ class SHAKE128(object):
 
 @utils.register_interface(HashAlgorithm)
 @utils.register_interface(ExtendableOutputFunction)
-class SHAKE256(object):
+class SHAKE256:
     name = "shake256"
 
     def __init__(self, digest_size):
@@ -213,14 +213,14 @@ class SHAKE256(object):
 
 
 @utils.register_interface(HashAlgorithm)
-class MD5(object):
+class MD5:
     name = "md5"
     digest_size = 16
     block_size = 64
 
 
 @utils.register_interface(HashAlgorithm)
-class BLAKE2b(object):
+class BLAKE2b:
     name = "blake2b"
     _max_digest_size = 64
     _min_digest_size = 1
@@ -237,7 +237,7 @@ class BLAKE2b(object):
 
 
 @utils.register_interface(HashAlgorithm)
-class BLAKE2s(object):
+class BLAKE2s:
     name = "blake2s"
     block_size = 64
     _max_digest_size = 32

--- a/src/cryptography/hazmat/primitives/hmac.py
+++ b/src/cryptography/hazmat/primitives/hmac.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives import hashes
 
 
 @utils.register_interface(hashes.HashContext)
-class HMAC(object):
+class HMAC:
     def __init__(self, key, algorithm, backend=None, ctx=None):
         backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):

--- a/src/cryptography/hazmat/primitives/kdf/concatkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/concatkdf.py
@@ -26,9 +26,7 @@ def _int_to_u32be(n):
 def _common_args_checks(algorithm, length, otherinfo):
     max_length = algorithm.digest_size * (2 ** 32 - 1)
     if length > max_length:
-        raise ValueError(
-            "Can not derive keys larger than {} bits.".format(max_length)
-        )
+        raise ValueError(f"Can not derive keys larger than {max_length} bits.")
     if otherinfo is not None:
         utils._check_bytes("otherinfo", otherinfo)
 

--- a/src/cryptography/hazmat/primitives/kdf/concatkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/concatkdf.py
@@ -52,7 +52,7 @@ def _concatkdf_derive(key_material, length, auxfn, otherinfo):
 
 
 @utils.register_interface(KeyDerivationFunction)
-class ConcatKDFHash(object):
+class ConcatKDFHash:
     def __init__(self, algorithm, length, otherinfo, backend=None):
         backend = _get_backend(backend)
 
@@ -88,7 +88,7 @@ class ConcatKDFHash(object):
 
 
 @utils.register_interface(KeyDerivationFunction)
-class ConcatKDFHMAC(object):
+class ConcatKDFHMAC:
     def __init__(self, algorithm, length, salt, otherinfo, backend=None):
         backend = _get_backend(backend)
 

--- a/src/cryptography/hazmat/primitives/kdf/hkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/hkdf.py
@@ -71,7 +71,7 @@ class HKDFExpand:
 
         if length > max_length:
             raise ValueError(
-                "Can not derive keys larger than {} octets.".format(max_length)
+                f"Can not derive keys larger than {max_length} octets."
             )
 
         self._length = length

--- a/src/cryptography/hazmat/primitives/kdf/hkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/hkdf.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
 
 @utils.register_interface(KeyDerivationFunction)
-class HKDF(object):
+class HKDF:
     def __init__(self, algorithm, length, salt, info, backend=None):
         backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):
@@ -54,7 +54,7 @@ class HKDF(object):
 
 
 @utils.register_interface(KeyDerivationFunction)
-class HKDFExpand(object):
+class HKDFExpand:
     def __init__(self, algorithm, length, info, backend=None):
         backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):

--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
@@ -28,7 +28,7 @@ class CounterLocation(Enum):
 
 
 @utils.register_interface(KeyDerivationFunction)
-class KBKDFHMAC(object):
+class KBKDFHMAC:
     def __init__(
         self,
         algorithm,

--- a/src/cryptography/hazmat/primitives/kdf/pbkdf2.py
+++ b/src/cryptography/hazmat/primitives/kdf/pbkdf2.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
 
 @utils.register_interface(KeyDerivationFunction)
-class PBKDF2HMAC(object):
+class PBKDF2HMAC:
     def __init__(self, algorithm, length, salt, iterations, backend=None):
         backend = _get_backend(backend)
         if not isinstance(backend, PBKDF2HMACBackend):

--- a/src/cryptography/hazmat/primitives/kdf/scrypt.py
+++ b/src/cryptography/hazmat/primitives/kdf/scrypt.py
@@ -24,7 +24,7 @@ _MEM_LIMIT = sys.maxsize // 2
 
 
 @utils.register_interface(KeyDerivationFunction)
-class Scrypt(object):
+class Scrypt:
     def __init__(self, salt, length, n, r, p, backend=None):
         backend = _get_backend(backend)
         if not isinstance(backend, ScryptBackend):

--- a/src/cryptography/hazmat/primitives/kdf/x963kdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/x963kdf.py
@@ -30,7 +30,7 @@ class X963KDF:
         max_len = algorithm.digest_size * (2 ** 32 - 1)
         if length > max_len:
             raise ValueError(
-                "Can not derive keys larger than {} bits.".format(max_len)
+                f"Can not derive keys larger than {max_len} bits."
             )
         if sharedinfo is not None:
             utils._check_bytes("sharedinfo", sharedinfo)

--- a/src/cryptography/hazmat/primitives/kdf/x963kdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/x963kdf.py
@@ -23,7 +23,7 @@ def _int_to_u32be(n):
 
 
 @utils.register_interface(KeyDerivationFunction)
-class X963KDF(object):
+class X963KDF:
     def __init__(self, algorithm, length, sharedinfo, backend=None):
         backend = _get_backend(backend)
 

--- a/src/cryptography/hazmat/primitives/padding.py
+++ b/src/cryptography/hazmat/primitives/padding.py
@@ -88,7 +88,7 @@ def _byte_unpadding_check(buffer_, block_size, checkfn):
     return buffer_[:-pad_size]
 
 
-class PKCS7(object):
+class PKCS7:
     def __init__(self, block_size):
         _byte_padding_check(block_size)
         self.block_size = block_size
@@ -101,7 +101,7 @@ class PKCS7(object):
 
 
 @utils.register_interface(PaddingContext)
-class _PKCS7PaddingContext(object):
+class _PKCS7PaddingContext:
     def __init__(self, block_size):
         self.block_size = block_size
         # TODO: more copies than necessary, we should use zero-buffer (#193)
@@ -125,7 +125,7 @@ class _PKCS7PaddingContext(object):
 
 
 @utils.register_interface(PaddingContext)
-class _PKCS7UnpaddingContext(object):
+class _PKCS7UnpaddingContext:
     def __init__(self, block_size):
         self.block_size = block_size
         # TODO: more copies than necessary, we should use zero-buffer (#193)
@@ -145,7 +145,7 @@ class _PKCS7UnpaddingContext(object):
         return result
 
 
-class ANSIX923(object):
+class ANSIX923:
     def __init__(self, block_size):
         _byte_padding_check(block_size)
         self.block_size = block_size
@@ -158,7 +158,7 @@ class ANSIX923(object):
 
 
 @utils.register_interface(PaddingContext)
-class _ANSIX923PaddingContext(object):
+class _ANSIX923PaddingContext:
     def __init__(self, block_size):
         self.block_size = block_size
         # TODO: more copies than necessary, we should use zero-buffer (#193)
@@ -182,7 +182,7 @@ class _ANSIX923PaddingContext(object):
 
 
 @utils.register_interface(PaddingContext)
-class _ANSIX923UnpaddingContext(object):
+class _ANSIX923UnpaddingContext:
     def __init__(self, block_size):
         self.block_size = block_size
         # TODO: more copies than necessary, we should use zero-buffer (#193)

--- a/src/cryptography/hazmat/primitives/poly1305.py
+++ b/src/cryptography/hazmat/primitives/poly1305.py
@@ -11,7 +11,7 @@ from cryptography.exceptions import (
 )
 
 
-class Poly1305(object):
+class Poly1305:
     def __init__(self, key):
         from cryptography.hazmat.backends.openssl.backend import backend
 

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -74,7 +74,7 @@ class KeySerializationEncryption(metaclass=abc.ABCMeta):
 
 
 @utils.register_interface(KeySerializationEncryption)
-class BestAvailableEncryption(object):
+class BestAvailableEncryption:
     def __init__(self, password):
         if not isinstance(password, bytes) or len(password) == 0:
             raise ValueError("Password must be 1 or more bytes.")
@@ -83,5 +83,5 @@ class BestAvailableEncryption(object):
 
 
 @utils.register_interface(KeySerializationEncryption)
-class NoEncryption(object):
+class NoEncryption:
     pass

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -22,7 +22,7 @@ def load_der_pkcs7_certificates(data):
     return backend.load_der_pkcs7_certificates(data)
 
 
-class PKCS7SignatureBuilder(object):
+class PKCS7SignatureBuilder:
     def __init__(self, data=None, signers=[], additional_certs=[]):
         self._data = data
         self._signers = signers

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -149,7 +149,7 @@ def _to_mpint(val):
     return utils.int_to_bytes(val, nbytes)
 
 
-class _FragList(object):
+class _FragList:
     """Build recursive structure without data copy."""
 
     def __init__(self, init=None):
@@ -197,7 +197,7 @@ class _FragList(object):
         return buf.tobytes()
 
 
-class _SSHFormatRSA(object):
+class _SSHFormatRSA:
     """Format for RSA keys.
 
     Public:
@@ -259,7 +259,7 @@ class _SSHFormatRSA(object):
         f_priv.put_mpint(private_numbers.q)
 
 
-class _SSHFormatDSA(object):
+class _SSHFormatDSA:
     """Format for DSA keys.
 
     Public:
@@ -321,7 +321,7 @@ class _SSHFormatDSA(object):
             raise ValueError("SSH supports only 1024 bit DSA keys")
 
 
-class _SSHFormatECDSA(object):
+class _SSHFormatECDSA:
     """Format for ECDSA keys.
 
     Public:
@@ -382,7 +382,7 @@ class _SSHFormatECDSA(object):
         f_priv.put_mpint(private_numbers.private_value)
 
 
-class _SSHFormatEd25519(object):
+class _SSHFormatEd25519:
     """Format for Ed25519 keys.
 
     Public:

--- a/src/cryptography/hazmat/primitives/twofactor/hotp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/hotp.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.primitives.twofactor import InvalidToken
 from cryptography.hazmat.primitives.twofactor.utils import _generate_uri
 
 
-class HOTP(object):
+class HOTP:
     def __init__(
         self, key, length, algorithm, backend=None, enforce_key_length=True
     ):

--- a/src/cryptography/hazmat/primitives/twofactor/totp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/totp.py
@@ -12,7 +12,7 @@ from cryptography.hazmat.primitives.twofactor.hotp import HOTP
 from cryptography.hazmat.primitives.twofactor.utils import _generate_uri
 
 
-class TOTP(object):
+class TOTP:
     def __init__(
         self,
         key,

--- a/src/cryptography/hazmat/primitives/twofactor/utils.py
+++ b/src/cryptography/hazmat/primitives/twofactor/utils.py
@@ -22,7 +22,7 @@ def _generate_uri(hotp, type_name, account_name, issuer, extra_parameters):
     uriparts = {
         "type": type_name,
         "label": (
-            "%s:%s" % (quote(issuer), quote(account_name))
+            "{}:{}".format(quote(issuer), quote(account_name))
             if issuer
             else quote(account_name)
         ),

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -25,14 +25,14 @@ DeprecatedIn34 = CryptographyDeprecationWarning
 
 def _check_bytes(name, value):
     if not isinstance(value, bytes):
-        raise TypeError("{} must be bytes".format(name))
+        raise TypeError(f"{name} must be bytes")
 
 
 def _check_byteslike(name, value):
     try:
         memoryview(value)
     except TypeError:
-        raise TypeError("{} must be bytes-like".format(name))
+        raise TypeError(f"{name} must be bytes-like")
 
 
 def read_only_property(name):
@@ -72,7 +72,7 @@ def verify_interface(iface, klass):
     for method in iface.__abstractmethods__:
         if not hasattr(klass, method):
             raise InterfaceNotImplemented(
-                "{} is missing a {!r} method".format(klass, method)
+                f"{klass} is missing a {method!r} method"
             )
         if isinstance(getattr(iface, method), abc.abstractproperty):
             # Can't properly verify these yet.
@@ -126,7 +126,7 @@ def deprecated(value, module_name, message, warning_class):
 
 
 def cached_property(func):
-    cached_name = "_cached_{}".format(func)
+    cached_name = f"_cached_{func}"
     sentinel = object()
 
     def inner(instance):

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -86,14 +86,14 @@ def verify_interface(iface, klass):
             )
 
 
-class _DeprecatedValue(object):
+class _DeprecatedValue:
     def __init__(self, value, message, warning_class):
         self.value = value
         self.message = message
         self.warning_class = warning_class
 
 
-class _ModuleWithDeprecations(object):
+class _ModuleWithDeprecations:
     def __init__(self, module):
         self.__dict__["_module"] = module
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -26,7 +26,7 @@ _EARLIEST_UTC_TIME = datetime.datetime(1950, 1, 1)
 
 class AttributeNotFound(Exception):
     def __init__(self, msg, oid):
-        super(AttributeNotFound, self).__init__(msg)
+        super().__init__(msg)
         self.oid = oid
 
 
@@ -95,7 +95,7 @@ def load_der_x509_crl(data, backend=None):
 
 class InvalidVersion(Exception):
     def __init__(self, msg, parsed_version):
-        super(InvalidVersion, self).__init__(msg)
+        super().__init__(msg)
         self.parsed_version = parsed_version
 
 
@@ -412,7 +412,7 @@ class RevokedCertificate(metaclass=abc.ABCMeta):
         """
 
 
-class CertificateSigningRequestBuilder(object):
+class CertificateSigningRequestBuilder:
     def __init__(self, subject_name=None, extensions=[], attributes=[]):
         """
         Creates an empty X.509 certificate request (v1).
@@ -477,7 +477,7 @@ class CertificateSigningRequestBuilder(object):
         return backend.create_x509_csr(self, private_key, algorithm)
 
 
-class CertificateBuilder(object):
+class CertificateBuilder:
     def __init__(
         self,
         issuer_name=None,
@@ -698,7 +698,7 @@ class CertificateBuilder(object):
         return backend.create_x509_certificate(self, private_key, algorithm)
 
 
-class CertificateRevocationListBuilder(object):
+class CertificateRevocationListBuilder:
     def __init__(
         self,
         issuer_name=None,
@@ -816,7 +816,7 @@ class CertificateRevocationListBuilder(object):
         return backend.create_x509_crl(self, private_key, algorithm)
 
 
-class RevokedCertificateBuilder(object):
+class RevokedCertificateBuilder:
     def __init__(
         self, serial_number=None, revocation_date=None, extensions=[]
     ):

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -87,13 +87,13 @@ def _make_sequence_methods(field_name):
 
 class DuplicateExtension(Exception):
     def __init__(self, msg, oid):
-        super(DuplicateExtension, self).__init__(msg)
+        super().__init__(msg)
         self.oid = oid
 
 
 class ExtensionNotFound(Exception):
     def __init__(self, msg, oid):
-        super(ExtensionNotFound, self).__init__(msg)
+        super().__init__(msg)
         self.oid = oid
 
 
@@ -105,7 +105,7 @@ class ExtensionType(metaclass=abc.ABCMeta):
         """
 
 
-class Extensions(object):
+class Extensions:
     def __init__(self, extensions):
         self._extensions = extensions
 
@@ -139,7 +139,7 @@ class Extensions(object):
 
 
 @utils.register_interface(ExtensionType)
-class CRLNumber(object):
+class CRLNumber:
     oid = ExtensionOID.CRL_NUMBER
 
     def __init__(self, crl_number):
@@ -167,7 +167,7 @@ class CRLNumber(object):
 
 
 @utils.register_interface(ExtensionType)
-class AuthorityKeyIdentifier(object):
+class AuthorityKeyIdentifier:
     oid = ExtensionOID.AUTHORITY_KEY_IDENTIFIER
 
     def __init__(
@@ -259,7 +259,7 @@ class AuthorityKeyIdentifier(object):
 
 
 @utils.register_interface(ExtensionType)
-class SubjectKeyIdentifier(object):
+class SubjectKeyIdentifier:
     oid = ExtensionOID.SUBJECT_KEY_IDENTIFIER
 
     def __init__(self, digest):
@@ -272,7 +272,7 @@ class SubjectKeyIdentifier(object):
     digest = utils.read_only_property("_digest")
 
     def __repr__(self):
-        return "<SubjectKeyIdentifier(digest={0!r})>".format(self.digest)
+        return "<SubjectKeyIdentifier(digest={!r})>".format(self.digest)
 
     def __eq__(self, other):
         if not isinstance(other, SubjectKeyIdentifier):
@@ -288,7 +288,7 @@ class SubjectKeyIdentifier(object):
 
 
 @utils.register_interface(ExtensionType)
-class AuthorityInformationAccess(object):
+class AuthorityInformationAccess:
     oid = ExtensionOID.AUTHORITY_INFORMATION_ACCESS
 
     def __init__(self, descriptions):
@@ -320,7 +320,7 @@ class AuthorityInformationAccess(object):
 
 
 @utils.register_interface(ExtensionType)
-class SubjectInformationAccess(object):
+class SubjectInformationAccess:
     oid = ExtensionOID.SUBJECT_INFORMATION_ACCESS
 
     def __init__(self, descriptions):
@@ -351,7 +351,7 @@ class SubjectInformationAccess(object):
         return hash(tuple(self._descriptions))
 
 
-class AccessDescription(object):
+class AccessDescription:
     def __init__(self, access_method, access_location):
         if not isinstance(access_method, ObjectIdentifier):
             raise TypeError("access_method must be an ObjectIdentifier")
@@ -388,7 +388,7 @@ class AccessDescription(object):
 
 
 @utils.register_interface(ExtensionType)
-class BasicConstraints(object):
+class BasicConstraints:
     oid = ExtensionOID.BASIC_CONSTRAINTS
 
     def __init__(self, ca, path_length):
@@ -430,7 +430,7 @@ class BasicConstraints(object):
 
 
 @utils.register_interface(ExtensionType)
-class DeltaCRLIndicator(object):
+class DeltaCRLIndicator:
     oid = ExtensionOID.DELTA_CRL_INDICATOR
 
     def __init__(self, crl_number):
@@ -458,7 +458,7 @@ class DeltaCRLIndicator(object):
 
 
 @utils.register_interface(ExtensionType)
-class CRLDistributionPoints(object):
+class CRLDistributionPoints:
     oid = ExtensionOID.CRL_DISTRIBUTION_POINTS
 
     def __init__(self, distribution_points):
@@ -494,7 +494,7 @@ class CRLDistributionPoints(object):
 
 
 @utils.register_interface(ExtensionType)
-class FreshestCRL(object):
+class FreshestCRL:
     oid = ExtensionOID.FRESHEST_CRL
 
     def __init__(self, distribution_points):
@@ -529,7 +529,7 @@ class FreshestCRL(object):
         return hash(tuple(self._distribution_points))
 
 
-class DistributionPoint(object):
+class DistributionPoint:
     def __init__(self, full_name, relative_name, reasons, crl_issuer):
         if full_name and relative_name:
             raise ValueError(
@@ -637,7 +637,7 @@ class ReasonFlags(Enum):
 
 
 @utils.register_interface(ExtensionType)
-class PolicyConstraints(object):
+class PolicyConstraints:
     oid = ExtensionOID.POLICY_CONSTRAINTS
 
     def __init__(self, require_explicit_policy, inhibit_policy_mapping):
@@ -698,7 +698,7 @@ class PolicyConstraints(object):
 
 
 @utils.register_interface(ExtensionType)
-class CertificatePolicies(object):
+class CertificatePolicies:
     oid = ExtensionOID.CERTIFICATE_POLICIES
 
     def __init__(self, policies):
@@ -729,7 +729,7 @@ class CertificatePolicies(object):
         return hash(tuple(self._policies))
 
 
-class PolicyInformation(object):
+class PolicyInformation:
     def __init__(self, policy_identifier, policy_qualifiers):
         if not isinstance(policy_identifier, ObjectIdentifier):
             raise TypeError("policy_identifier must be an ObjectIdentifier")
@@ -778,7 +778,7 @@ class PolicyInformation(object):
     policy_qualifiers = utils.read_only_property("_policy_qualifiers")
 
 
-class UserNotice(object):
+class UserNotice:
     def __init__(self, notice_reference, explicit_text):
         if notice_reference and not isinstance(
             notice_reference, NoticeReference
@@ -815,7 +815,7 @@ class UserNotice(object):
     explicit_text = utils.read_only_property("_explicit_text")
 
 
-class NoticeReference(object):
+class NoticeReference:
     def __init__(self, organization, notice_numbers):
         self._organization = organization
         notice_numbers = list(notice_numbers)
@@ -850,7 +850,7 @@ class NoticeReference(object):
 
 
 @utils.register_interface(ExtensionType)
-class ExtendedKeyUsage(object):
+class ExtendedKeyUsage:
     oid = ExtensionOID.EXTENDED_KEY_USAGE
 
     def __init__(self, usages):
@@ -881,7 +881,7 @@ class ExtendedKeyUsage(object):
 
 
 @utils.register_interface(ExtensionType)
-class OCSPNoCheck(object):
+class OCSPNoCheck:
     oid = ExtensionOID.OCSP_NO_CHECK
 
     def __eq__(self, other):
@@ -901,7 +901,7 @@ class OCSPNoCheck(object):
 
 
 @utils.register_interface(ExtensionType)
-class PrecertPoison(object):
+class PrecertPoison:
     oid = ExtensionOID.PRECERT_POISON
 
     def __eq__(self, other):
@@ -921,7 +921,7 @@ class PrecertPoison(object):
 
 
 @utils.register_interface(ExtensionType)
-class TLSFeature(object):
+class TLSFeature:
     oid = ExtensionOID.TLS_FEATURE
 
     def __init__(self, features):
@@ -970,7 +970,7 @@ _TLS_FEATURE_TYPE_TO_ENUM = {x.value: x for x in TLSFeatureType}
 
 
 @utils.register_interface(ExtensionType)
-class InhibitAnyPolicy(object):
+class InhibitAnyPolicy:
     oid = ExtensionOID.INHIBIT_ANY_POLICY
 
     def __init__(self, skip_certs):
@@ -1001,7 +1001,7 @@ class InhibitAnyPolicy(object):
 
 
 @utils.register_interface(ExtensionType)
-class KeyUsage(object):
+class KeyUsage:
     oid = ExtensionOID.KEY_USAGE
 
     def __init__(
@@ -1115,7 +1115,7 @@ class KeyUsage(object):
 
 
 @utils.register_interface(ExtensionType)
-class NameConstraints(object):
+class NameConstraints:
     oid = ExtensionOID.NAME_CONSTRAINTS
 
     def __init__(self, permitted_subtrees, excluded_subtrees):
@@ -1196,7 +1196,7 @@ class NameConstraints(object):
     excluded_subtrees = utils.read_only_property("_excluded_subtrees")
 
 
-class Extension(object):
+class Extension:
     def __init__(self, oid, critical, value):
         if not isinstance(oid, ObjectIdentifier):
             raise TypeError(
@@ -1237,7 +1237,7 @@ class Extension(object):
         return hash((self.oid, self.critical, self.value))
 
 
-class GeneralNames(object):
+class GeneralNames:
     def __init__(self, general_names):
         general_names = list(general_names)
         if not all(isinstance(x, GeneralName) for x in general_names):
@@ -1276,7 +1276,7 @@ class GeneralNames(object):
 
 
 @utils.register_interface(ExtensionType)
-class SubjectAlternativeName(object):
+class SubjectAlternativeName:
     oid = ExtensionOID.SUBJECT_ALTERNATIVE_NAME
 
     def __init__(self, general_names):
@@ -1304,7 +1304,7 @@ class SubjectAlternativeName(object):
 
 
 @utils.register_interface(ExtensionType)
-class IssuerAlternativeName(object):
+class IssuerAlternativeName:
     oid = ExtensionOID.ISSUER_ALTERNATIVE_NAME
 
     def __init__(self, general_names):
@@ -1332,7 +1332,7 @@ class IssuerAlternativeName(object):
 
 
 @utils.register_interface(ExtensionType)
-class CertificateIssuer(object):
+class CertificateIssuer:
     oid = CRLEntryExtensionOID.CERTIFICATE_ISSUER
 
     def __init__(self, general_names):
@@ -1360,7 +1360,7 @@ class CertificateIssuer(object):
 
 
 @utils.register_interface(ExtensionType)
-class CRLReason(object):
+class CRLReason:
     oid = CRLEntryExtensionOID.CRL_REASON
 
     def __init__(self, reason):
@@ -1388,7 +1388,7 @@ class CRLReason(object):
 
 
 @utils.register_interface(ExtensionType)
-class InvalidityDate(object):
+class InvalidityDate:
     oid = CRLEntryExtensionOID.INVALIDITY_DATE
 
     def __init__(self, invalidity_date):
@@ -1418,7 +1418,7 @@ class InvalidityDate(object):
 
 
 @utils.register_interface(ExtensionType)
-class PrecertificateSignedCertificateTimestamps(object):
+class PrecertificateSignedCertificateTimestamps:
     oid = ExtensionOID.PRECERT_SIGNED_CERTIFICATE_TIMESTAMPS
 
     def __init__(self, signed_certificate_timestamps):
@@ -1459,7 +1459,7 @@ class PrecertificateSignedCertificateTimestamps(object):
 
 
 @utils.register_interface(ExtensionType)
-class SignedCertificateTimestamps(object):
+class SignedCertificateTimestamps:
     oid = ExtensionOID.SIGNED_CERTIFICATE_TIMESTAMPS
 
     def __init__(self, signed_certificate_timestamps):
@@ -1498,7 +1498,7 @@ class SignedCertificateTimestamps(object):
 
 
 @utils.register_interface(ExtensionType)
-class OCSPNonce(object):
+class OCSPNonce:
     oid = OCSPExtensionOID.NONCE
 
     def __init__(self, nonce):
@@ -1526,7 +1526,7 @@ class OCSPNonce(object):
 
 
 @utils.register_interface(ExtensionType)
-class IssuingDistributionPoint(object):
+class IssuingDistributionPoint:
     oid = ExtensionOID.ISSUING_DISTRIBUTION_POINT
 
     def __init__(
@@ -1668,7 +1668,7 @@ class IssuingDistributionPoint(object):
 
 
 @utils.register_interface(ExtensionType)
-class UnrecognizedExtension(object):
+class UnrecognizedExtension:
     def __init__(self, oid, value):
         if not isinstance(oid, ObjectIdentifier):
             raise TypeError("oid must be an ObjectIdentifier")

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -114,7 +114,7 @@ class Extensions:
             if ext.oid == oid:
                 return ext
 
-        raise ExtensionNotFound("No {} extension was found".format(oid), oid)
+        raise ExtensionNotFound(f"No {oid} extension was found", oid)
 
     def get_extension_for_class(self, extclass):
         if extclass is UnrecognizedExtension:
@@ -129,13 +129,13 @@ class Extensions:
                 return ext
 
         raise ExtensionNotFound(
-            "No {} extension was found".format(extclass), extclass.oid
+            f"No {extclass} extension was found", extclass.oid
         )
 
     __len__, __iter__, __getitem__ = _make_sequence_methods("_extensions")
 
     def __repr__(self):
-        return "<Extensions({})>".format(self._extensions)
+        return f"<Extensions({self._extensions})>"
 
 
 @utils.register_interface(ExtensionType)
@@ -161,7 +161,7 @@ class CRLNumber:
         return hash(self.crl_number)
 
     def __repr__(self):
-        return "<CRLNumber({})>".format(self.crl_number)
+        return f"<CRLNumber({self.crl_number})>"
 
     crl_number = utils.read_only_property("_crl_number")
 
@@ -272,7 +272,7 @@ class SubjectKeyIdentifier:
     digest = utils.read_only_property("_digest")
 
     def __repr__(self):
-        return "<SubjectKeyIdentifier(digest={!r})>".format(self.digest)
+        return f"<SubjectKeyIdentifier(digest={self.digest!r})>"
 
     def __eq__(self, other):
         if not isinstance(other, SubjectKeyIdentifier):
@@ -304,7 +304,7 @@ class AuthorityInformationAccess:
     __len__, __iter__, __getitem__ = _make_sequence_methods("_descriptions")
 
     def __repr__(self):
-        return "<AuthorityInformationAccess({})>".format(self._descriptions)
+        return f"<AuthorityInformationAccess({self._descriptions})>"
 
     def __eq__(self, other):
         if not isinstance(other, AuthorityInformationAccess):
@@ -336,7 +336,7 @@ class SubjectInformationAccess:
     __len__, __iter__, __getitem__ = _make_sequence_methods("_descriptions")
 
     def __repr__(self):
-        return "<SubjectInformationAccess({})>".format(self._descriptions)
+        return f"<SubjectInformationAccess({self._descriptions})>"
 
     def __eq__(self, other):
         if not isinstance(other, SubjectInformationAccess):
@@ -454,7 +454,7 @@ class DeltaCRLIndicator:
         return hash(self.crl_number)
 
     def __repr__(self):
-        return "<DeltaCRLIndicator(crl_number={0.crl_number})>".format(self)
+        return f"<DeltaCRLIndicator(crl_number={self.crl_number})>"
 
 
 @utils.register_interface(ExtensionType)
@@ -478,7 +478,7 @@ class CRLDistributionPoints:
     )
 
     def __repr__(self):
-        return "<CRLDistributionPoints({})>".format(self._distribution_points)
+        return f"<CRLDistributionPoints({self._distribution_points})>"
 
     def __eq__(self, other):
         if not isinstance(other, CRLDistributionPoints):
@@ -514,7 +514,7 @@ class FreshestCRL:
     )
 
     def __repr__(self):
-        return "<FreshestCRL({})>".format(self._distribution_points)
+        return f"<FreshestCRL({self._distribution_points})>"
 
     def __eq__(self, other):
         if not isinstance(other, FreshestCRL):
@@ -714,7 +714,7 @@ class CertificatePolicies:
     __len__, __iter__, __getitem__ = _make_sequence_methods("_policies")
 
     def __repr__(self):
-        return "<CertificatePolicies({})>".format(self._policies)
+        return f"<CertificatePolicies({self._policies})>"
 
     def __eq__(self, other):
         if not isinstance(other, CertificatePolicies):
@@ -865,7 +865,7 @@ class ExtendedKeyUsage:
     __len__, __iter__, __getitem__ = _make_sequence_methods("_usages")
 
     def __repr__(self):
-        return "<ExtendedKeyUsage({})>".format(self._usages)
+        return f"<ExtendedKeyUsage({self._usages})>"
 
     def __eq__(self, other):
         if not isinstance(other, ExtendedKeyUsage):
@@ -940,7 +940,7 @@ class TLSFeature:
     __len__, __iter__, __getitem__ = _make_sequence_methods("_features")
 
     def __repr__(self):
-        return "<TLSFeature(features={0._features})>".format(self)
+        return f"<TLSFeature(features={self._features})>"
 
     def __eq__(self, other):
         if not isinstance(other, TLSFeature):
@@ -983,7 +983,7 @@ class InhibitAnyPolicy:
         self._skip_certs = skip_certs
 
     def __repr__(self):
-        return "<InhibitAnyPolicy(skip_certs={0.skip_certs})>".format(self)
+        return f"<InhibitAnyPolicy(skip_certs={self.skip_certs})>"
 
     def __eq__(self, other):
         if not isinstance(other, InhibitAnyPolicy):
@@ -1260,7 +1260,7 @@ class GeneralNames:
         return list(objs)
 
     def __repr__(self):
-        return "<GeneralNames({})>".format(self._general_names)
+        return f"<GeneralNames({self._general_names})>"
 
     def __eq__(self, other):
         if not isinstance(other, GeneralNames):
@@ -1288,7 +1288,7 @@ class SubjectAlternativeName:
         return self._general_names.get_values_for_type(type)
 
     def __repr__(self):
-        return "<SubjectAlternativeName({})>".format(self._general_names)
+        return f"<SubjectAlternativeName({self._general_names})>"
 
     def __eq__(self, other):
         if not isinstance(other, SubjectAlternativeName):
@@ -1316,7 +1316,7 @@ class IssuerAlternativeName:
         return self._general_names.get_values_for_type(type)
 
     def __repr__(self):
-        return "<IssuerAlternativeName({})>".format(self._general_names)
+        return f"<IssuerAlternativeName({self._general_names})>"
 
     def __eq__(self, other):
         if not isinstance(other, IssuerAlternativeName):
@@ -1344,7 +1344,7 @@ class CertificateIssuer:
         return self._general_names.get_values_for_type(type)
 
     def __repr__(self):
-        return "<CertificateIssuer({})>".format(self._general_names)
+        return f"<CertificateIssuer({self._general_names})>"
 
     def __eq__(self, other):
         if not isinstance(other, CertificateIssuer):
@@ -1370,7 +1370,7 @@ class CRLReason:
         self._reason = reason
 
     def __repr__(self):
-        return "<CRLReason(reason={})>".format(self._reason)
+        return f"<CRLReason(reason={self._reason})>"
 
     def __eq__(self, other):
         if not isinstance(other, CRLReason):
@@ -1520,7 +1520,7 @@ class OCSPNonce:
         return hash(self.nonce)
 
     def __repr__(self):
-        return "<OCSPNonce(nonce={0.nonce!r})>".format(self)
+        return f"<OCSPNonce(nonce={self.nonce!r})>"
 
     nonce = utils.read_only_property("_nonce")
 

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -27,7 +27,7 @@ _GENERAL_NAMES = {
 
 class UnsupportedGeneralNameType(Exception):
     def __init__(self, msg, type):
-        super(UnsupportedGeneralNameType, self).__init__(msg)
+        super().__init__(msg)
         self.type = type
 
 
@@ -40,7 +40,7 @@ class GeneralName(metaclass=abc.ABCMeta):
 
 
 @utils.register_interface(GeneralName)
-class RFC822Name(object):
+class RFC822Name:
     def __init__(self, value):
         if isinstance(value, str):
             try:
@@ -71,7 +71,7 @@ class RFC822Name(object):
         return instance
 
     def __repr__(self):
-        return "<RFC822Name(value={0!r})>".format(self.value)
+        return "<RFC822Name(value={!r})>".format(self.value)
 
     def __eq__(self, other):
         if not isinstance(other, RFC822Name):
@@ -87,7 +87,7 @@ class RFC822Name(object):
 
 
 @utils.register_interface(GeneralName)
-class DNSName(object):
+class DNSName:
     def __init__(self, value):
         if isinstance(value, str):
             try:
@@ -112,7 +112,7 @@ class DNSName(object):
         return instance
 
     def __repr__(self):
-        return "<DNSName(value={0!r})>".format(self.value)
+        return "<DNSName(value={!r})>".format(self.value)
 
     def __eq__(self, other):
         if not isinstance(other, DNSName):
@@ -128,7 +128,7 @@ class DNSName(object):
 
 
 @utils.register_interface(GeneralName)
-class UniformResourceIdentifier(object):
+class UniformResourceIdentifier:
     def __init__(self, value):
         if isinstance(value, str):
             try:
@@ -153,7 +153,7 @@ class UniformResourceIdentifier(object):
         return instance
 
     def __repr__(self):
-        return "<UniformResourceIdentifier(value={0!r})>".format(self.value)
+        return "<UniformResourceIdentifier(value={!r})>".format(self.value)
 
     def __eq__(self, other):
         if not isinstance(other, UniformResourceIdentifier):
@@ -169,7 +169,7 @@ class UniformResourceIdentifier(object):
 
 
 @utils.register_interface(GeneralName)
-class DirectoryName(object):
+class DirectoryName:
     def __init__(self, value):
         if not isinstance(value, Name):
             raise TypeError("value must be a Name")
@@ -195,7 +195,7 @@ class DirectoryName(object):
 
 
 @utils.register_interface(GeneralName)
-class RegisteredID(object):
+class RegisteredID:
     def __init__(self, value):
         if not isinstance(value, ObjectIdentifier):
             raise TypeError("value must be an ObjectIdentifier")
@@ -221,7 +221,7 @@ class RegisteredID(object):
 
 
 @utils.register_interface(GeneralName)
-class IPAddress(object):
+class IPAddress:
     def __init__(self, value):
         if not isinstance(
             value,
@@ -259,7 +259,7 @@ class IPAddress(object):
 
 
 @utils.register_interface(GeneralName)
-class OtherName(object):
+class OtherName:
     def __init__(self, type_id, value):
         if not isinstance(type_id, ObjectIdentifier):
             raise TypeError("type_id must be an ObjectIdentifier")

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -71,7 +71,7 @@ class RFC822Name:
         return instance
 
     def __repr__(self):
-        return "<RFC822Name(value={!r})>".format(self.value)
+        return f"<RFC822Name(value={self.value!r})>"
 
     def __eq__(self, other):
         if not isinstance(other, RFC822Name):
@@ -112,7 +112,7 @@ class DNSName:
         return instance
 
     def __repr__(self):
-        return "<DNSName(value={!r})>".format(self.value)
+        return f"<DNSName(value={self.value!r})>"
 
     def __eq__(self, other):
         if not isinstance(other, DNSName):
@@ -153,7 +153,7 @@ class UniformResourceIdentifier:
         return instance
 
     def __repr__(self):
-        return "<UniformResourceIdentifier(value={!r})>".format(self.value)
+        return f"<UniformResourceIdentifier(value={self.value!r})>"
 
     def __eq__(self, other):
         if not isinstance(other, UniformResourceIdentifier):
@@ -179,7 +179,7 @@ class DirectoryName:
     value = utils.read_only_property("_value")
 
     def __repr__(self):
-        return "<DirectoryName(value={})>".format(self.value)
+        return f"<DirectoryName(value={self.value})>"
 
     def __eq__(self, other):
         if not isinstance(other, DirectoryName):
@@ -205,7 +205,7 @@ class RegisteredID:
     value = utils.read_only_property("_value")
 
     def __repr__(self):
-        return "<RegisteredID(value={})>".format(self.value)
+        return f"<RegisteredID(value={self.value})>"
 
     def __eq__(self, other):
         if not isinstance(other, RegisteredID):
@@ -243,7 +243,7 @@ class IPAddress:
     value = utils.read_only_property("_value")
 
     def __repr__(self):
-        return "<IPAddress(value={})>".format(self.value)
+        return f"<IPAddress(value={self.value})>"
 
     def __eq__(self, other):
         if not isinstance(other, IPAddress):

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -73,7 +73,7 @@ def _escape_dn_value(val):
     return val
 
 
-class NameAttribute(object):
+class NameAttribute:
     def __init__(self, oid, value, _type=_SENTINEL):
         if not isinstance(oid, ObjectIdentifier):
             raise TypeError(
@@ -119,7 +119,7 @@ class NameAttribute(object):
         dotted string.
         """
         key = _NAMEOID_TO_NAME.get(self.oid, self.oid.dotted_string)
-        return "%s=%s" % (key, _escape_dn_value(self.value))
+        return "{}={}".format(key, _escape_dn_value(self.value))
 
     def __eq__(self, other):
         if not isinstance(other, NameAttribute):
@@ -137,7 +137,7 @@ class NameAttribute(object):
         return "<NameAttribute(oid={0.oid}, value={0.value!r})>".format(self)
 
 
-class RelativeDistinguishedName(object):
+class RelativeDistinguishedName:
     def __init__(self, attributes):
         attributes = list(attributes)
         if not attributes:
@@ -186,7 +186,7 @@ class RelativeDistinguishedName(object):
         return "<RelativeDistinguishedName({})>".format(self.rfc4514_string())
 
 
-class Name(object):
+class Name:
     def __init__(self, attributes):
         attributes = list(attributes)
         if all(isinstance(x, NameAttribute) for x in attributes):
@@ -243,8 +243,7 @@ class Name(object):
 
     def __iter__(self):
         for rdn in self._attributes:
-            for ava in rdn:
-                yield ava
+            yield from rdn
 
     def __len__(self):
         return sum(len(rdn) for rdn in self._attributes)

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -183,7 +183,7 @@ class RelativeDistinguishedName:
         return len(self._attributes)
 
     def __repr__(self):
-        return "<RelativeDistinguishedName({})>".format(self.rfc4514_string())
+        return f"<RelativeDistinguishedName({self.rfc4514_string()})>"
 
 
 class Name:
@@ -250,4 +250,4 @@ class Name:
 
     def __repr__(self):
         rdns = ",".join(attr.rfc4514_string() for attr in self._attributes)
-        return "<Name({})>".format(rdns)
+        return f"<Name({rdns})>"

--- a/src/cryptography/x509/ocsp.py
+++ b/src/cryptography/x509/ocsp.py
@@ -77,7 +77,7 @@ def load_der_ocsp_response(data):
     return backend.load_der_ocsp_response(data)
 
 
-class OCSPRequestBuilder(object):
+class OCSPRequestBuilder:
     def __init__(self, request=None, extensions=[]):
         self._request = request
         self._extensions = extensions
@@ -114,7 +114,7 @@ class OCSPRequestBuilder(object):
         return backend.create_ocsp_request(self)
 
 
-class _SingleResponse(object):
+class _SingleResponse:
     def __init__(
         self,
         cert,
@@ -184,7 +184,7 @@ class _SingleResponse(object):
         self._revocation_reason = revocation_reason
 
 
-class OCSPResponseBuilder(object):
+class OCSPResponseBuilder:
     def __init__(
         self, response=None, responder_id=None, certs=None, extensions=[]
     ):

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -7,7 +7,7 @@ from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat.primitives import hashes
 
 
-class ExtensionOID(object):
+class ExtensionOID:
     SUBJECT_DIRECTORY_ATTRIBUTES = ObjectIdentifier("2.5.29.9")
     SUBJECT_KEY_IDENTIFIER = ObjectIdentifier("2.5.29.14")
     KEY_USAGE = ObjectIdentifier("2.5.29.15")
@@ -37,17 +37,17 @@ class ExtensionOID(object):
     SIGNED_CERTIFICATE_TIMESTAMPS = ObjectIdentifier("1.3.6.1.4.1.11129.2.4.5")
 
 
-class OCSPExtensionOID(object):
+class OCSPExtensionOID:
     NONCE = ObjectIdentifier("1.3.6.1.5.5.7.48.1.2")
 
 
-class CRLEntryExtensionOID(object):
+class CRLEntryExtensionOID:
     CERTIFICATE_ISSUER = ObjectIdentifier("2.5.29.29")
     CRL_REASON = ObjectIdentifier("2.5.29.21")
     INVALIDITY_DATE = ObjectIdentifier("2.5.29.24")
 
 
-class NameOID(object):
+class NameOID:
     COMMON_NAME = ObjectIdentifier("2.5.4.3")
     COUNTRY_NAME = ObjectIdentifier("2.5.4.6")
     LOCALITY_NAME = ObjectIdentifier("2.5.4.7")
@@ -80,7 +80,7 @@ class NameOID(object):
     UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2")
 
 
-class SignatureAlgorithmOID(object):
+class SignatureAlgorithmOID:
     RSA_WITH_MD5 = ObjectIdentifier("1.2.840.113549.1.1.4")
     RSA_WITH_SHA1 = ObjectIdentifier("1.2.840.113549.1.1.5")
     # This is an alternate OID for RSA with SHA1 that is occasionally seen
@@ -129,7 +129,7 @@ _SIG_OIDS_TO_HASH = {
 }
 
 
-class ExtendedKeyUsageOID(object):
+class ExtendedKeyUsageOID:
     SERVER_AUTH = ObjectIdentifier("1.3.6.1.5.5.7.3.1")
     CLIENT_AUTH = ObjectIdentifier("1.3.6.1.5.5.7.3.2")
     CODE_SIGNING = ObjectIdentifier("1.3.6.1.5.5.7.3.3")
@@ -139,22 +139,22 @@ class ExtendedKeyUsageOID(object):
     ANY_EXTENDED_KEY_USAGE = ObjectIdentifier("2.5.29.37.0")
 
 
-class AuthorityInformationAccessOID(object):
+class AuthorityInformationAccessOID:
     CA_ISSUERS = ObjectIdentifier("1.3.6.1.5.5.7.48.2")
     OCSP = ObjectIdentifier("1.3.6.1.5.5.7.48.1")
 
 
-class SubjectInformationAccessOID(object):
+class SubjectInformationAccessOID:
     CA_REPOSITORY = ObjectIdentifier("1.3.6.1.5.5.7.48.5")
 
 
-class CertificatePoliciesOID(object):
+class CertificatePoliciesOID:
     CPS_QUALIFIER = ObjectIdentifier("1.3.6.1.5.5.7.2.1")
     CPS_USER_NOTICE = ObjectIdentifier("1.3.6.1.5.5.7.2.2")
     ANY_POLICY = ObjectIdentifier("2.5.29.32.0")
 
 
-class AttributeOID(object):
+class AttributeOID:
     CHALLENGE_PASSWORD = ObjectIdentifier("1.2.840.113549.1.9.7")
     UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ from .utils import check_backend_support
 def pytest_report_header(config):
     return "\n".join(
         [
-            "OpenSSL: {}".format(openssl_backend.openssl_version_text()),
-            "FIPS Enabled: {}".format(openssl_backend._fips_enabled),
+            f"OpenSSL: {openssl_backend.openssl_version_text()}",
+            f"FIPS Enabled: {openssl_backend._fips_enabled}",
         ]
     )
 

--- a/tests/doubles.py
+++ b/tests/doubles.py
@@ -11,14 +11,14 @@ from cryptography.hazmat.primitives.ciphers.modes import Mode
 
 
 @utils.register_interface(CipherAlgorithm)
-class DummyCipherAlgorithm(object):
+class DummyCipherAlgorithm:
     name = "dummy-cipher"
     block_size = 128
     key_size = None
 
 
 @utils.register_interface(Mode)
-class DummyMode(object):
+class DummyMode:
     name = "dummy-mode"
 
     def validate_for_algorithm(self, algorithm):
@@ -26,17 +26,17 @@ class DummyMode(object):
 
 
 @utils.register_interface(hashes.HashAlgorithm)
-class DummyHashAlgorithm(object):
+class DummyHashAlgorithm:
     name = "dummy-hash"
     block_size = None
     digest_size = None
 
 
 @utils.register_interface(serialization.KeySerializationEncryption)
-class DummyKeySerializationEncryption(object):
+class DummyKeySerializationEncryption:
     pass
 
 
 @utils.register_interface(padding.AsymmetricPadding)
-class DummyAsymmetricPadding(object):
+class DummyAsymmetricPadding:
     name = "dummy-padding"

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -42,7 +42,7 @@ def skip_if_libre_ssl(openssl_version):
         pytest.skip("LibreSSL hard-codes RAND_bytes to use arc4random.")
 
 
-class TestLibreSkip(object):
+class TestLibreSkip:
     def test_skip_no(self):
         assert skip_if_libre_ssl("OpenSSL 1.0.2h  3 May 2016") is None
 
@@ -51,11 +51,11 @@ class TestLibreSkip(object):
             skip_if_libre_ssl("LibreSSL 2.1.6")
 
 
-class DummyMGF(object):
+class DummyMGF:
     _salt_length = 0
 
 
-class TestOpenSSL(object):
+class TestOpenSSL:
     def test_backend_exists(self):
         assert backend
 
@@ -171,7 +171,7 @@ class TestOpenSSL(object):
     reason="Requires OpenSSL with ENGINE support and OpenSSL < 1.1.1d",
 )
 @pytest.mark.skip_fips(reason="osrandom engine disabled for FIPS")
-class TestOpenSSLRandomEngine(object):
+class TestOpenSSLRandomEngine:
     def setup(self):
         # The default RAND engine is global and shared between
         # tests. We make sure that the default engine is osrandom
@@ -300,7 +300,7 @@ class TestOpenSSLRandomEngine(object):
     backend._lib.CRYPTOGRAPHY_NEEDS_OSRANDOM_ENGINE,
     reason="Requires OpenSSL without ENGINE support or OpenSSL >=1.1.1d",
 )
-class TestOpenSSLNoEngine(object):
+class TestOpenSSLNoEngine:
     def test_no_engine_support(self):
         assert (
             backend._ffi.string(backend._lib.Cryptography_osrandom_engine_id)
@@ -318,7 +318,7 @@ class TestOpenSSLNoEngine(object):
         backend.activate_osrandom_engine()
 
 
-class TestOpenSSLRSA(object):
+class TestOpenSSLRSA:
     def test_generate_rsa_parameters_supported(self):
         assert backend.generate_rsa_parameters_supported(1, 1024) is False
         assert backend.generate_rsa_parameters_supported(4, 1024) is False
@@ -465,13 +465,13 @@ class TestOpenSSLRSA(object):
             )
 
 
-class TestOpenSSLCMAC(object):
+class TestOpenSSLCMAC:
     def test_unsupported_cipher(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
             backend.create_cmac_ctx(DummyCipherAlgorithm())
 
 
-class TestOpenSSLSignX509Certificate(object):
+class TestOpenSSLSignX509Certificate:
     def test_requires_certificate_builder(self):
         private_key = RSA_KEY_2048.private_key(backend)
 
@@ -481,7 +481,7 @@ class TestOpenSSLSignX509Certificate(object):
             )
 
 
-class TestOpenSSLSignX509CSR(object):
+class TestOpenSSLSignX509CSR:
     def test_requires_csr_builder(self):
         private_key = RSA_KEY_2048.private_key(backend)
 
@@ -491,7 +491,7 @@ class TestOpenSSLSignX509CSR(object):
             )
 
 
-class TestOpenSSLSignX509CertificateRevocationList(object):
+class TestOpenSSLSignX509CertificateRevocationList:
     def test_invalid_builder(self):
         private_key = RSA_KEY_2048.private_key(backend)
 
@@ -499,13 +499,13 @@ class TestOpenSSLSignX509CertificateRevocationList(object):
             backend.create_x509_crl(object(), private_key, hashes.SHA256())
 
 
-class TestOpenSSLCreateRevokedCertificate(object):
+class TestOpenSSLCreateRevokedCertificate:
     def test_invalid_builder(self):
         with pytest.raises(TypeError):
             backend.create_x509_revoked_certificate(object())
 
 
-class TestOpenSSLSerializationWithOpenSSL(object):
+class TestOpenSSLSerializationWithOpenSSL:
     def test_pem_password_cb(self):
         userdata = backend._ffi.new("CRYPTOGRAPHY_PASSWORD_DATA *")
         pw = b"abcdefg"
@@ -558,14 +558,14 @@ class TestOpenSSLSerializationWithOpenSSL(object):
             )
 
 
-class TestOpenSSLEllipticCurve(object):
+class TestOpenSSLEllipticCurve:
     def test_sn_to_elliptic_curve_not_supported(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_ELLIPTIC_CURVE):
             _sn_to_elliptic_curve(backend, b"fake")
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSAPEMSerialization(object):
+class TestRSAPEMSerialization:
     def test_password_length_limit(self):
         password = b"x" * 1024
         key = RSA_KEY_2048.private_key(backend)
@@ -577,7 +577,7 @@ class TestRSAPEMSerialization(object):
             )
 
 
-class TestGOSTCertificate(object):
+class TestGOSTCertificate:
     def test_numeric_string_x509_name_entry(self):
         cert = _load_cert(
             os.path.join("x509", "e-trust.ru.der"),
@@ -606,7 +606,7 @@ class TestGOSTCertificate(object):
     reason="Requires OpenSSL without EVP_PKEY_DHX (< 1.0.2)",
 )
 @pytest.mark.requires_backend_interface(interface=DHBackend)
-class TestOpenSSLDHSerialization(object):
+class TestOpenSSLDHSerialization:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -129,7 +129,7 @@ def assert_no_memory_leaks(s, argv=[]):
     argv = [
         sys.executable,
         "-c",
-        "{}\n\n{}".format(s, MEMORY_LEAK_SCRIPT),
+        f"{s}\n\n{MEMORY_LEAK_SCRIPT}",
     ] + argv
     # Shell out to a fresh Python process because OpenSSL does not allow you to
     # install new memory hooks after the first malloc/free occurs.

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -163,7 +163,7 @@ def skip_if_memtesting_not_supported():
 
 @pytest.mark.skip_fips(reason="FIPS self-test sets allow_customize = 0")
 @skip_if_memtesting_not_supported()
-class TestAssertNoMemoryLeaks(object):
+class TestAssertNoMemoryLeaks:
     def test_no_leak_no_malloc(self):
         assert_no_memory_leaks(
             textwrap.dedent(
@@ -229,7 +229,7 @@ class TestAssertNoMemoryLeaks(object):
 
 @pytest.mark.skip_fips(reason="FIPS self-test sets allow_customize = 0")
 @skip_if_memtesting_not_supported()
-class TestOpenSSLMemoryLeaks(object):
+class TestOpenSSLMemoryLeaks:
     @pytest.mark.parametrize(
         "path", ["x509/PKITS_data/certs/ValidcRLIssuerTest28EE.crt"]
     )

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.bindings.openssl.binding import (
 )
 
 
-class TestOpenSSL(object):
+class TestOpenSSL:
     def test_binding_loads(self):
         binding = Binding()
         assert binding

--- a/tests/hazmat/primitives/test_3des.py
+++ b/tests/hazmat/primitives/test_3des.py
@@ -26,7 +26,7 @@ from ...utils import load_nist_vectors
     skip_message="Does not support TripleDES CBC",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestTripleDESModeCBC(object):
+class TestTripleDESModeCBC:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "CBC"),
@@ -59,7 +59,7 @@ class TestTripleDESModeCBC(object):
     skip_message="Does not support TripleDES OFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestTripleDESModeOFB(object):
+class TestTripleDESModeOFB:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "OFB"),
@@ -92,7 +92,7 @@ class TestTripleDESModeOFB(object):
     skip_message="Does not support TripleDES CFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestTripleDESModeCFB(object):
+class TestTripleDESModeCFB:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "CFB"),
@@ -125,7 +125,7 @@ class TestTripleDESModeCFB(object):
     skip_message="Does not support TripleDES CFB8",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestTripleDESModeCFB8(object):
+class TestTripleDESModeCFB8:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "CFB"),
@@ -158,7 +158,7 @@ class TestTripleDESModeCFB8(object):
     skip_message="Does not support TripleDES ECB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestTripleDESModeECB(object):
+class TestTripleDESModeECB:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "ECB"),

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -25,7 +25,7 @@ from ...utils import (
 )
 
 
-class FakeData(object):
+class FakeData:
     def __len__(self):
         return 2 ** 32 + 1
 
@@ -53,7 +53,7 @@ def test_chacha20poly1305_unsupported_on_older_openssl(backend):
     reason="Does not support ChaCha20Poly1305",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestChaCha20Poly1305(object):
+class TestChaCha20Poly1305:
     def test_data_too_large(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
@@ -186,7 +186,7 @@ class TestChaCha20Poly1305(object):
 
 
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESCCM(object):
+class TestAESCCM:
     def test_data_too_large(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
@@ -360,7 +360,7 @@ def _load_gcm_vectors():
 
 
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESGCM(object):
+class TestAESGCM:
     def test_data_too_large(self):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -254,7 +254,7 @@ def test_buffer_protocol_alternate_modes(mode, backend):
     data = bytearray(b"sixteen_byte_msg")
     key = algorithms.AES(bytearray(os.urandom(32)))
     if not backend.cipher_supported(key, mode):
-        pytest.skip("AES in {} mode not supported".format(mode.name))
+        pytest.skip(f"AES in {mode.name} mode not supported")
     cipher = base.Cipher(key, mode, backend)
     enc = cipher.encryptor()
     ct = enc.update(data) + enc.finalize()

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -23,7 +23,7 @@ from ...utils import load_nist_vectors
     skip_message="Does not support AES XTS",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESModeXTS(object):
+class TestAESModeXTS:
     @pytest.mark.parametrize(
         "vector",
         # This list comprehension excludes any vector that does not have a
@@ -61,7 +61,7 @@ class TestAESModeXTS(object):
     skip_message="Does not support AES CBC",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESModeCBC(object):
+class TestAESModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "CBC"),
@@ -94,7 +94,7 @@ class TestAESModeCBC(object):
     skip_message="Does not support AES ECB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESModeECB(object):
+class TestAESModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "ECB"),
@@ -127,7 +127,7 @@ class TestAESModeECB(object):
     skip_message="Does not support AES OFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESModeOFB(object):
+class TestAESModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "OFB"),
@@ -160,7 +160,7 @@ class TestAESModeOFB(object):
     skip_message="Does not support AES CFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESModeCFB(object):
+class TestAESModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "CFB"),
@@ -193,7 +193,7 @@ class TestAESModeCFB(object):
     skip_message="Does not support AES CFB8",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESModeCFB8(object):
+class TestAESModeCFB8:
     test_cfb8 = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "CFB"),
@@ -226,7 +226,7 @@ class TestAESModeCFB8(object):
     skip_message="Does not support AES CTR",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESModeCTR(object):
+class TestAESModeCTR:
     test_ctr = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "CTR"),

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -22,7 +22,7 @@ from ...utils import load_nist_vectors
     skip_message="Does not support AES GCM",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESModeGCM(object):
+class TestAESModeGCM:
     test_gcm = generate_aead_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "GCM"),

--- a/tests/hazmat/primitives/test_arc4.py
+++ b/tests/hazmat/primitives/test_arc4.py
@@ -22,7 +22,7 @@ from ...utils import load_nist_vectors
     skip_message="Does not support ARC4",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestARC4(object):
+class TestARC4:
     test_rfc = generate_stream_encryption_test(
         load_nist_vectors,
         os.path.join("ciphers", "ARC4"),

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -25,7 +25,7 @@ from ...utils import raises_unsupported_algorithm
 
 
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCipher(object):
+class TestCipher:
     def test_creates_encryptor(self, backend):
         cipher = Cipher(
             algorithms.AES(binascii.unhexlify(b"0" * 32)),
@@ -49,7 +49,7 @@ class TestCipher(object):
 
 
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCipherContext(object):
+class TestCipherContext:
     def test_use_after_finalize(self, backend):
         cipher = Cipher(
             algorithms.AES(binascii.unhexlify(b"0" * 32)),
@@ -133,7 +133,7 @@ class TestCipherContext(object):
     skip_message="Does not support AES GCM",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAEADCipherContext(object):
+class TestAEADCipherContext:
     test_aead_exceptions = generate_aead_exception_test(
         algorithms.AES,
         modes.GCM,
@@ -145,7 +145,7 @@ class TestAEADCipherContext(object):
 
 
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestModeValidation(object):
+class TestModeValidation:
     def test_cbc(self, backend):
         with pytest.raises(ValueError):
             Cipher(
@@ -191,7 +191,7 @@ class TestModeValidation(object):
             modes.GCM(b"")
 
 
-class TestModesRequireBytes(object):
+class TestModesRequireBytes:
     def test_cbc(self):
         with pytest.raises(TypeError):
             modes.CBC([1] * 16)

--- a/tests/hazmat/primitives/test_blowfish.py
+++ b/tests/hazmat/primitives/test_blowfish.py
@@ -22,7 +22,7 @@ from ...utils import load_nist_vectors
     skip_message="Does not support Blowfish ECB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestBlowfishModeECB(object):
+class TestBlowfishModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
@@ -39,7 +39,7 @@ class TestBlowfishModeECB(object):
     skip_message="Does not support Blowfish CBC",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestBlowfishModeCBC(object):
+class TestBlowfishModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
@@ -56,7 +56,7 @@ class TestBlowfishModeCBC(object):
     skip_message="Does not support Blowfish OFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestBlowfishModeOFB(object):
+class TestBlowfishModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
@@ -73,7 +73,7 @@ class TestBlowfishModeOFB(object):
     skip_message="Does not support Blowfish CFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestBlowfishModeCFB(object):
+class TestBlowfishModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),

--- a/tests/hazmat/primitives/test_camellia.py
+++ b/tests/hazmat/primitives/test_camellia.py
@@ -22,7 +22,7 @@ from ...utils import load_cryptrec_vectors, load_nist_vectors
     skip_message="Does not support Camellia ECB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCamelliaModeECB(object):
+class TestCamelliaModeECB:
     test_ecb = generate_encrypt_test(
         load_cryptrec_vectors,
         os.path.join("ciphers", "Camellia"),
@@ -43,7 +43,7 @@ class TestCamelliaModeECB(object):
     skip_message="Does not support Camellia CBC",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCamelliaModeCBC(object):
+class TestCamelliaModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Camellia"),
@@ -60,7 +60,7 @@ class TestCamelliaModeCBC(object):
     skip_message="Does not support Camellia OFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCamelliaModeOFB(object):
+class TestCamelliaModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Camellia"),
@@ -77,7 +77,7 @@ class TestCamelliaModeOFB(object):
     skip_message="Does not support Camellia CFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCamelliaModeCFB(object):
+class TestCamelliaModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Camellia"),

--- a/tests/hazmat/primitives/test_cast5.py
+++ b/tests/hazmat/primitives/test_cast5.py
@@ -22,12 +22,12 @@ from ...utils import load_nist_vectors
     skip_message="Does not support CAST5 ECB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCAST5ModeECB(object):
+class TestCAST5ModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "CAST5"),
         ["cast5-ecb.txt"],
-        lambda key, **kwargs: algorithms.CAST5(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.CAST5(binascii.unhexlify(key)),
         lambda **kwargs: modes.ECB(),
     )
 
@@ -39,12 +39,12 @@ class TestCAST5ModeECB(object):
     skip_message="Does not support CAST5 CBC",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCAST5ModeCBC(object):
+class TestCAST5ModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "CAST5"),
         ["cast5-cbc.txt"],
-        lambda key, **kwargs: algorithms.CAST5(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.CAST5(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.CBC(binascii.unhexlify(iv)),
     )
 
@@ -56,12 +56,12 @@ class TestCAST5ModeCBC(object):
     skip_message="Does not support CAST5 OFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCAST5ModeOFB(object):
+class TestCAST5ModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "CAST5"),
         ["cast5-ofb.txt"],
-        lambda key, **kwargs: algorithms.CAST5(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.CAST5(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
     )
 
@@ -73,11 +73,11 @@ class TestCAST5ModeOFB(object):
     skip_message="Does not support CAST5 CFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCAST5ModeCFB(object):
+class TestCAST5ModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "CAST5"),
         ["cast5-cfb.txt"],
-        lambda key, **kwargs: algorithms.CAST5(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.CAST5(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
     )

--- a/tests/hazmat/primitives/test_chacha20.py
+++ b/tests/hazmat/primitives/test_chacha20.py
@@ -23,7 +23,7 @@ from ...utils import load_nist_vectors
     skip_message="Does not support ChaCha20",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestChaCha20(object):
+class TestChaCha20:
     @pytest.mark.parametrize(
         "vector",
         _load_all_params(

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -30,7 +30,7 @@ from ...utils import (
 )
 
 
-class TestAES(object):
+class TestAES:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [(b"0" * 32, 128), (b"0" * 48, 192), (b"0" * 64, 256)],
@@ -48,7 +48,7 @@ class TestAES(object):
             AES("0" * 32)
 
 
-class TestAESXTS(object):
+class TestAESXTS:
     @pytest.mark.requires_backend_interface(interface=CipherBackend)
     @pytest.mark.parametrize(
         "mode", (modes.CBC, modes.CTR, modes.CFB, modes.CFB8, modes.OFB)
@@ -71,14 +71,14 @@ class TestAESXTS(object):
             ciphers.Cipher(AES(b"0" * 16), modes.XTS(b"0" * 16), backend)
 
 
-class TestGCM(object):
+class TestGCM:
     @pytest.mark.parametrize("size", [7, 129])
     def test_gcm_min_max(self, size):
         with pytest.raises(ValueError):
             modes.GCM(b"0" * size)
 
 
-class TestCamellia(object):
+class TestCamellia:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [(b"0" * 32, 128), (b"0" * 48, 192), (b"0" * 64, 256)],
@@ -96,7 +96,7 @@ class TestCamellia(object):
             Camellia("0" * 32)
 
 
-class TestTripleDES(object):
+class TestTripleDES:
     @pytest.mark.parametrize("key", [b"0" * 16, b"0" * 32, b"0" * 48])
     def test_key_size(self, key):
         cipher = TripleDES(binascii.unhexlify(key))
@@ -111,7 +111,7 @@ class TestTripleDES(object):
             TripleDES("0" * 16)
 
 
-class TestBlowfish(object):
+class TestBlowfish:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [(b"0" * (keysize // 4), keysize) for keysize in range(32, 449, 8)],
@@ -129,7 +129,7 @@ class TestBlowfish(object):
             Blowfish("0" * 8)
 
 
-class TestCAST5(object):
+class TestCAST5:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [(b"0" * (keysize // 4), keysize) for keysize in range(40, 129, 8)],
@@ -147,7 +147,7 @@ class TestCAST5(object):
             CAST5("0" * 10)
 
 
-class TestARC4(object):
+class TestARC4:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [
@@ -173,7 +173,7 @@ class TestARC4(object):
             ARC4("0" * 10)
 
 
-class TestIDEA(object):
+class TestIDEA:
     def test_key_size(self):
         cipher = IDEA(b"\x00" * 16)
         assert cipher.key_size == 128
@@ -187,7 +187,7 @@ class TestIDEA(object):
             IDEA("0" * 16)
 
 
-class TestSEED(object):
+class TestSEED:
     def test_key_size(self):
         cipher = SEED(b"\x00" * 16)
         assert cipher.key_size == 128
@@ -215,7 +215,7 @@ def test_invalid_backend():
     skip_message="Does not support AES ECB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestCipherUpdateInto(object):
+class TestCipherUpdateInto:
     @pytest.mark.parametrize(
         "params",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_cmac.py
+++ b/tests/hazmat/primitives/test_cmac.py
@@ -49,7 +49,7 @@ fake_key = b"\x00" * 16
 
 
 @pytest.mark.requires_backend_interface(interface=CMACBackend)
-class TestCMAC(object):
+class TestCMAC:
     @pytest.mark.supported(
         only_if=lambda backend: backend.cmac_algorithm_supported(
             AES(fake_key)

--- a/tests/hazmat/primitives/test_concatkdf.py
+++ b/tests/hazmat/primitives/test_concatkdf.py
@@ -18,7 +18,7 @@ from ...utils import raises_unsupported_algorithm
 
 
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestConcatKDFHash(object):
+class TestConcatKDFHash:
     def test_length_limit(self, backend):
         big_length = hashes.SHA256().digest_size * (2 ** 32 - 1) + 1
 
@@ -125,7 +125,7 @@ class TestConcatKDFHash(object):
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestConcatKDFHMAC(object):
+class TestConcatKDFHMAC:
     def test_length_limit(self, backend):
         big_length = hashes.SHA256().digest_size * (2 ** 32 - 1) + 1
 

--- a/tests/hazmat/primitives/test_constant_time.py
+++ b/tests/hazmat/primitives/test_constant_time.py
@@ -8,7 +8,7 @@ import pytest
 from cryptography.hazmat.primitives import constant_time
 
 
-class TestConstantTimeBytesEq(object):
+class TestConstantTimeBytesEq:
     def test_reject_unicode(self):
         with pytest.raises(TypeError):
             constant_time.bytes_eq(b"foo", "foo")

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -140,7 +140,7 @@ def test_dh_public_numbers_equality():
 
 
 @pytest.mark.requires_backend_interface(interface=DHBackend)
-class TestDH(object):
+class TestDH:
     def test_small_key_generate_dh(self, backend):
         with pytest.raises(ValueError):
             dh.generate_parameters(2, 511, backend)
@@ -445,7 +445,7 @@ class TestDH(object):
 @pytest.mark.requires_backend_interface(interface=DHBackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
 @pytest.mark.requires_backend_interface(interface=DERSerializationBackend)
-class TestDHPrivateKeySerialization(object):
+class TestDHPrivateKeySerialization:
     @pytest.mark.parametrize(
         ("encoding", "loader_func"),
         [
@@ -635,7 +635,7 @@ class TestDHPrivateKeySerialization(object):
 @pytest.mark.requires_backend_interface(interface=DHBackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
 @pytest.mark.requires_backend_interface(interface=DERSerializationBackend)
-class TestDHPublicKeySerialization(object):
+class TestDHPublicKeySerialization:
     @pytest.mark.parametrize(
         ("encoding", "loader_func"),
         [
@@ -764,7 +764,7 @@ class TestDHPublicKeySerialization(object):
 @pytest.mark.requires_backend_interface(interface=DHBackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
 @pytest.mark.requires_backend_interface(interface=DERSerializationBackend)
-class TestDHParameterSerialization(object):
+class TestDHParameterSerialization:
     @pytest.mark.parametrize(
         ("encoding", "loader_func"),
         [

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -35,9 +35,7 @@ def _skip_if_dsa_not_supported(backend, algorithm, p, q, g):
     if not backend.dsa_parameters_supported(
         p, q, g
     ) or not backend.dsa_hash_supported(algorithm):
-        pytest.skip(
-            "{} does not support the provided parameters".format(backend)
-        )
+        pytest.skip(f"{backend} does not support the provided parameters")
 
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -47,7 +47,7 @@ def test_skip_if_dsa_not_supported(backend):
 
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
-class TestDSA(object):
+class TestDSA:
     def test_generate_dsa_parameters(self, backend):
         parameters = dsa.generate_parameters(2048, backend)
         assert isinstance(parameters, dsa.DSAParameters)
@@ -377,7 +377,7 @@ class TestDSA(object):
 
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
-class TestDSAVerification(object):
+class TestDSAVerification:
     _algorithms_dict = {
         "SHA1": hashes.SHA1,
         "SHA224": hashes.SHA224,
@@ -485,7 +485,7 @@ class TestDSAVerification(object):
 
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
-class TestDSASignature(object):
+class TestDSASignature:
     _algorithms_dict = {
         "SHA1": hashes.SHA1,
         "SHA224": hashes.SHA224,
@@ -564,7 +564,7 @@ class TestDSASignature(object):
             private_key.sign(digest, prehashed_alg)
 
 
-class TestDSANumbers(object):
+class TestDSANumbers:
     def test_dsa_parameter_numbers(self):
         parameter_numbers = dsa.DSAParameterNumbers(p=1, q=2, g=3)
         assert parameter_numbers.p == 1
@@ -634,7 +634,7 @@ class TestDSANumbers(object):
         )
 
 
-class TestDSANumberEquality(object):
+class TestDSANumberEquality:
     def test_parameter_numbers_eq(self):
         param = dsa.DSAParameterNumbers(1, 2, 3)
         assert param == dsa.DSAParameterNumbers(1, 2, 3)
@@ -688,7 +688,7 @@ class TestDSANumberEquality(object):
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
-class TestDSASerialization(object):
+class TestDSASerialization:
     @pytest.mark.parametrize(
         ("fmt", "password"),
         itertools.product(
@@ -907,7 +907,7 @@ class TestDSASerialization(object):
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
-class TestDSAPEMPublicKeySerialization(object):
+class TestDSAPEMPublicKeySerialization:
     @pytest.mark.parametrize(
         ("key_path", "loader_func", "encoding"),
         [

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -82,13 +82,13 @@ def test_get_curve_for_oid():
 
 
 @utils.register_interface(ec.EllipticCurve)
-class DummyCurve(object):
+class DummyCurve:
     name = "dummy-curve"
     key_size = 1
 
 
 @utils.register_interface(ec.EllipticCurveSignatureAlgorithm)
-class DummySignatureAlgorithm(object):
+class DummySignatureAlgorithm:
     algorithm = None
 
 
@@ -277,7 +277,7 @@ def test_ec_key_key_size(backend):
 
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
-class TestECWithNumbers(object):
+class TestECWithNumbers:
     def test_with_numbers(self, backend, subtests):
         vectors = itertools.product(
             load_vectors_from_file(
@@ -310,7 +310,7 @@ class TestECWithNumbers(object):
 
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
-class TestECDSAVectors(object):
+class TestECDSAVectors:
     def test_signing_with_example_keys(self, backend, subtests):
         vectors = itertools.product(
             load_vectors_from_file(
@@ -626,7 +626,7 @@ class TestECDSAVectors(object):
             public_key.verifier(b"0" * 64, ec.ECDSA(Prehashed(hashes.SHA1())))
 
 
-class TestECNumbersEquality(object):
+class TestECNumbersEquality:
     def test_public_numbers_eq(self):
         pub = ec.EllipticCurvePublicNumbers(1, 2, ec.SECP192R1())
         assert pub == ec.EllipticCurvePublicNumbers(1, 2, ec.SECP192R1())
@@ -665,7 +665,7 @@ class TestECNumbersEquality(object):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
-class TestECSerialization(object):
+class TestECSerialization:
     @pytest.mark.parametrize(
         ("fmt", "password"),
         itertools.product(
@@ -917,7 +917,7 @@ class TestECSerialization(object):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
-class TestEllipticCurvePEMPublicKeySerialization(object):
+class TestEllipticCurvePEMPublicKeySerialization:
     @pytest.mark.parametrize(
         ("key_path", "loader_func", "encoding"),
         [
@@ -1170,7 +1170,7 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
 
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
-class TestECDSAVerification(object):
+class TestECDSAVerification:
     def test_signature_not_bytes(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
         key = ec.generate_private_key(ec.SECP256R1(), backend)
@@ -1182,7 +1182,7 @@ class TestECDSAVerification(object):
 
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
-class TestECDH(object):
+class TestECDH:
     def test_key_exchange_with_vectors(self, backend, subtests):
         vectors = load_vectors_from_file(
             os.path.join(

--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -67,7 +67,7 @@ def test_ed25519_unsupported(backend):
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support",
 )
-class TestEd25519Signing(object):
+class TestEd25519Signing:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -47,7 +47,7 @@ def test_ed448_unsupported(backend):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-class TestEd448Signing(object):
+class TestEd448Signing:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_hash_vectors.py
+++ b/tests/hazmat/primitives/test_hash_vectors.py
@@ -20,7 +20,7 @@ from ...utils import load_hash_vectors, load_nist_vectors
     skip_message="Does not support SHA1",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA1(object):
+class TestSHA1:
     test_sha1 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA1"),
@@ -34,7 +34,7 @@ class TestSHA1(object):
     skip_message="Does not support SHA224",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA224(object):
+class TestSHA224:
     test_sha224 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -48,7 +48,7 @@ class TestSHA224(object):
     skip_message="Does not support SHA256",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA256(object):
+class TestSHA256:
     test_sha256 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -62,7 +62,7 @@ class TestSHA256(object):
     skip_message="Does not support SHA384",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA384(object):
+class TestSHA384:
     test_sha384 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -76,7 +76,7 @@ class TestSHA384(object):
     skip_message="Does not support SHA512",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA512(object):
+class TestSHA512:
     test_sha512 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -90,7 +90,7 @@ class TestSHA512(object):
     skip_message="Does not support SHA512/224",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA512224(object):
+class TestSHA512224:
     test_sha512_224 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -104,7 +104,7 @@ class TestSHA512224(object):
     skip_message="Does not support SHA512/256",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA512256(object):
+class TestSHA512256:
     test_sha512_256 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -118,7 +118,7 @@ class TestSHA512256(object):
     skip_message="Does not support MD5",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestMD5(object):
+class TestMD5:
     test_md5 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "MD5"),
@@ -134,7 +134,7 @@ class TestMD5(object):
     skip_message="Does not support BLAKE2b",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestBLAKE2b(object):
+class TestBLAKE2b:
     test_b2b = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "blake2"),
@@ -150,7 +150,7 @@ class TestBLAKE2b(object):
     skip_message="Does not support BLAKE2s",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestBLAKE2s256(object):
+class TestBLAKE2s256:
     test_b2s = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "blake2"),
@@ -164,7 +164,7 @@ class TestBLAKE2s256(object):
     skip_message="Does not support SHA3_224",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA3224(object):
+class TestSHA3224:
     test_sha3_224 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA3"),
@@ -178,7 +178,7 @@ class TestSHA3224(object):
     skip_message="Does not support SHA3_256",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA3256(object):
+class TestSHA3256:
     test_sha3_256 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA3"),
@@ -192,7 +192,7 @@ class TestSHA3256(object):
     skip_message="Does not support SHA3_384",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA3384(object):
+class TestSHA3384:
     test_sha3_384 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA3"),
@@ -206,7 +206,7 @@ class TestSHA3384(object):
     skip_message="Does not support SHA3_512",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA3512(object):
+class TestSHA3512:
     test_sha3_512 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA3"),
@@ -222,7 +222,7 @@ class TestSHA3512(object):
     skip_message="Does not support SHAKE128",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHAKE128(object):
+class TestSHAKE128:
     test_shake128 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHAKE"),
@@ -254,7 +254,7 @@ class TestSHAKE128(object):
     skip_message="Does not support SHAKE256",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHAKE256(object):
+class TestSHAKE256:
     test_shake256 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHAKE"),

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -17,7 +17,7 @@ from ...utils import raises_unsupported_algorithm
 
 
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestHashContext(object):
+class TestHashContext:
     def test_hash_reject_unicode(self, backend):
         m = hashes.Hash(hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):
@@ -50,7 +50,7 @@ class TestHashContext(object):
     skip_message="Does not support SHA1",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA1(object):
+class TestSHA1:
     test_sha1 = generate_base_hash_test(
         hashes.SHA1(),
         digest_size=20,
@@ -62,7 +62,7 @@ class TestSHA1(object):
     skip_message="Does not support SHA224",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA224(object):
+class TestSHA224:
     test_sha224 = generate_base_hash_test(
         hashes.SHA224(),
         digest_size=28,
@@ -74,7 +74,7 @@ class TestSHA224(object):
     skip_message="Does not support SHA256",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA256(object):
+class TestSHA256:
     test_sha256 = generate_base_hash_test(
         hashes.SHA256(),
         digest_size=32,
@@ -86,7 +86,7 @@ class TestSHA256(object):
     skip_message="Does not support SHA384",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA384(object):
+class TestSHA384:
     test_sha384 = generate_base_hash_test(
         hashes.SHA384(),
         digest_size=48,
@@ -98,7 +98,7 @@ class TestSHA384(object):
     skip_message="Does not support SHA512",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestSHA512(object):
+class TestSHA512:
     test_sha512 = generate_base_hash_test(
         hashes.SHA512(),
         digest_size=64,
@@ -110,7 +110,7 @@ class TestSHA512(object):
     skip_message="Does not support MD5",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestMD5(object):
+class TestMD5:
     test_md5 = generate_base_hash_test(
         hashes.MD5(),
         digest_size=16,
@@ -124,7 +124,7 @@ class TestMD5(object):
     skip_message="Does not support BLAKE2b",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestBLAKE2b(object):
+class TestBLAKE2b:
     test_blake2b = generate_base_hash_test(
         hashes.BLAKE2b(digest_size=64),
         digest_size=64,
@@ -148,7 +148,7 @@ class TestBLAKE2b(object):
     skip_message="Does not support BLAKE2s",
 )
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestBLAKE2s(object):
+class TestBLAKE2s:
     test_blake2s = generate_base_hash_test(
         hashes.BLAKE2s(digest_size=32),
         digest_size=32,
@@ -182,7 +182,7 @@ def test_buffer_protocol_hash(backend):
     )
 
 
-class TestSHAKE(object):
+class TestSHAKE:
     @pytest.mark.parametrize("xof", [hashes.SHAKE128, hashes.SHAKE256])
     def test_invalid_digest_type(self, xof):
         with pytest.raises(TypeError):

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -21,7 +21,7 @@ from ...utils import (
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHKDF(object):
+class TestHKDF:
     def test_length_limit(self, backend):
         big_length = 255 * hashes.SHA256().digest_size + 1
 
@@ -127,7 +127,7 @@ class TestHKDF(object):
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHKDFExpand(object):
+class TestHKDFExpand:
     def test_derive(self, backend):
         prk = binascii.unhexlify(
             b"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"

--- a/tests/hazmat/primitives/test_hkdf_vectors.py
+++ b/tests/hazmat/primitives/test_hkdf_vectors.py
@@ -19,7 +19,7 @@ from ...utils import load_nist_vectors
     skip_message="Does not support SHA1.",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHKDFSHA1(object):
+class TestHKDFSHA1:
     test_hkdfsha1 = generate_hkdf_test(
         load_nist_vectors,
         os.path.join("KDF"),
@@ -33,7 +33,7 @@ class TestHKDFSHA1(object):
     skip_message="Does not support SHA256.",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHKDFSHA256(object):
+class TestHKDFSHA256:
     test_hkdfsha256 = generate_hkdf_test(
         load_nist_vectors,
         os.path.join("KDF"),

--- a/tests/hazmat/primitives/test_hmac.py
+++ b/tests/hazmat/primitives/test_hmac.py
@@ -25,14 +25,14 @@ from ...utils import raises_unsupported_algorithm
     skip_message="Does not support MD5",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMACCopy(object):
+class TestHMACCopy:
     test_copy = generate_base_hmac_test(
         hashes.MD5(),
     )
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMAC(object):
+class TestHMAC:
     def test_hmac_reject_unicode(self, backend):
         h = hmac.HMAC(b"mykey", hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):

--- a/tests/hazmat/primitives/test_hmac_vectors.py
+++ b/tests/hazmat/primitives/test_hmac_vectors.py
@@ -19,7 +19,7 @@ from ...utils import load_hash_vectors
     skip_message="Does not support MD5",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMACMD5(object):
+class TestHMACMD5:
     test_hmac_md5 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -33,7 +33,7 @@ class TestHMACMD5(object):
     skip_message="Does not support SHA1",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMACSHA1(object):
+class TestHMACSHA1:
     test_hmac_sha1 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -47,7 +47,7 @@ class TestHMACSHA1(object):
     skip_message="Does not support SHA224",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMACSHA224(object):
+class TestHMACSHA224:
     test_hmac_sha224 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -61,7 +61,7 @@ class TestHMACSHA224(object):
     skip_message="Does not support SHA256",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMACSHA256(object):
+class TestHMACSHA256:
     test_hmac_sha256 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -75,7 +75,7 @@ class TestHMACSHA256(object):
     skip_message="Does not support SHA384",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMACSHA384(object):
+class TestHMACSHA384:
     test_hmac_sha384 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -89,7 +89,7 @@ class TestHMACSHA384(object):
     skip_message="Does not support SHA512",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMACSHA512(object):
+class TestHMACSHA512:
     test_hmac_sha512 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -105,7 +105,7 @@ class TestHMACSHA512(object):
     skip_message="Does not support BLAKE2",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHMACBLAKE2(object):
+class TestHMACBLAKE2:
     def test_blake2b(self, backend):
         h = hmac.HMAC(b"0" * 64, hashes.BLAKE2b(digest_size=64), backend)
         h.update(b"test")

--- a/tests/hazmat/primitives/test_idea.py
+++ b/tests/hazmat/primitives/test_idea.py
@@ -22,12 +22,12 @@ from ...utils import load_nist_vectors
     skip_message="Does not support IDEA ECB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestIDEAModeECB(object):
+class TestIDEAModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "IDEA"),
         ["idea-ecb.txt"],
-        lambda key, **kwargs: algorithms.IDEA(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.IDEA(binascii.unhexlify(key)),
         lambda **kwargs: modes.ECB(),
     )
 
@@ -39,12 +39,12 @@ class TestIDEAModeECB(object):
     skip_message="Does not support IDEA CBC",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestIDEAModeCBC(object):
+class TestIDEAModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "IDEA"),
         ["idea-cbc.txt"],
-        lambda key, **kwargs: algorithms.IDEA(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.IDEA(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.CBC(binascii.unhexlify(iv)),
     )
 
@@ -56,12 +56,12 @@ class TestIDEAModeCBC(object):
     skip_message="Does not support IDEA OFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestIDEAModeOFB(object):
+class TestIDEAModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "IDEA"),
         ["idea-ofb.txt"],
-        lambda key, **kwargs: algorithms.IDEA(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.IDEA(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
     )
 
@@ -73,11 +73,11 @@ class TestIDEAModeOFB(object):
     skip_message="Does not support IDEA CFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestIDEAModeCFB(object):
+class TestIDEAModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "IDEA"),
         ["idea-cfb.txt"],
-        lambda key, **kwargs: algorithms.IDEA(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.IDEA(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
     )

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -19,7 +19,7 @@ from ...utils import raises_unsupported_algorithm
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestKBKDFHMAC(object):
+class TestKBKDFHMAC:
     def test_invalid_key(self, backend):
         kdf = KBKDFHMAC(
             hashes.SHA256(),

--- a/tests/hazmat/primitives/test_kbkdf_vectors.py
+++ b/tests/hazmat/primitives/test_kbkdf_vectors.py
@@ -14,7 +14,7 @@ from ...utils import load_nist_kbkdf_vectors
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestCounterKDFCounterMode(object):
+class TestCounterKDFCounterMode:
     test_kbkdfctr = generate_kbkdf_counter_mode_test(
         load_nist_kbkdf_vectors,
         os.path.join("KDF"),

--- a/tests/hazmat/primitives/test_keywrap.py
+++ b/tests/hazmat/primitives/test_keywrap.py
@@ -17,7 +17,7 @@ from ...utils import load_nist_vectors
 
 
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESKeyWrap(object):
+class TestAESKeyWrap:
     @pytest.mark.supported(
         only_if=lambda backend: backend.cipher_supported(
             algorithms.AES(b"\x00" * 16), modes.ECB()
@@ -125,7 +125,7 @@ class TestAESKeyWrap(object):
     " is unsupported",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestAESKeyWrapWithPadding(object):
+class TestAESKeyWrapWithPadding:
     def test_wrap(self, backend, subtests):
         params = _load_all_params(
             os.path.join("keywrap", "kwtestvectors"),

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -9,7 +9,7 @@ from cryptography.exceptions import AlreadyFinalized
 from cryptography.hazmat.primitives import padding
 
 
-class TestPKCS7(object):
+class TestPKCS7:
     @pytest.mark.parametrize("size", [127, 4096, -2])
     def test_invalid_block_size(self, size):
         with pytest.raises(ValueError):
@@ -131,7 +131,7 @@ class TestPKCS7(object):
         assert final == unpadded + unpadded
 
 
-class TestANSIX923(object):
+class TestANSIX923:
     @pytest.mark.parametrize("size", [127, 4096, -2])
     def test_invalid_block_size(self, size):
         with pytest.raises(ValueError):

--- a/tests/hazmat/primitives/test_pbkdf2hmac.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac.py
@@ -13,7 +13,7 @@ from ...doubles import DummyHashAlgorithm
 from ...utils import raises_unsupported_algorithm
 
 
-class TestPBKDF2HMAC(object):
+class TestPBKDF2HMAC:
     def test_already_finalized(self, backend):
         kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
         kdf.derive(b"password")

--- a/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
@@ -17,7 +17,7 @@ from ...utils import load_nist_vectors
     skip_message="Does not support SHA1 for PBKDF2HMAC",
 )
 @pytest.mark.requires_backend_interface(interface=PBKDF2HMACBackend)
-class TestPBKDF2HMACSHA1(object):
+class TestPBKDF2HMACSHA1:
     test_pbkdf2_sha1 = generate_pbkdf2_test(
         load_nist_vectors,
         "KDF",

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -22,7 +22,7 @@ from ...doubles import DummyKeySerializationEncryption
 
 
 @pytest.mark.requires_backend_interface(interface=DERSerializationBackend)
-class TestPKCS12Loading(object):
+class TestPKCS12Loading:
     def _test_load_pkcs12_ec_keys(self, filename, password, backend):
         cert = load_vectors_from_file(
             os.path.join("x509", "custom", "ca", "ca.pem"),
@@ -165,7 +165,7 @@ def _load_ca(backend):
     return cert, key
 
 
-class TestPKCS12Creation(object):
+class TestPKCS12Creation:
     @pytest.mark.parametrize("name", [None, b"name"])
     @pytest.mark.parametrize(
         ("encryption_algorithm", "password"),

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -17,7 +17,7 @@ from .utils import load_vectors_from_file
 from ...utils import raises_unsupported_algorithm
 
 
-class TestPKCS7Loading(object):
+class TestPKCS7Loading:
     def test_load_invalid_der_pkcs7(self):
         with pytest.raises(ValueError):
             pkcs7.load_der_pkcs7_certificates(b"nonsense")
@@ -139,7 +139,7 @@ def _load_cert_key():
     return cert, key
 
 
-class TestPKCS7Builder(object):
+class TestPKCS7Builder:
     def test_invalid_data(self):
         builder = pkcs7.PKCS7SignatureBuilder()
         with pytest.raises(TypeError):

--- a/tests/hazmat/primitives/test_poly1305.py
+++ b/tests/hazmat/primitives/test_poly1305.py
@@ -35,7 +35,7 @@ def test_poly1305_unsupported(backend):
     only_if=lambda backend: backend.poly1305_supported(),
     skip_message="Requires OpenSSL with poly1305 support",
 )
-class TestPoly1305(object):
+class TestPoly1305:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -69,7 +69,7 @@ from ...utils import (
 )
 
 
-class DummyMGF(object):
+class DummyMGF:
     _salt_length = 0
 
 
@@ -169,7 +169,7 @@ def test_modular_inverse():
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSA(object):
+class TestRSA:
     @pytest.mark.parametrize(
         ("public_exponent", "key_size"),
         itertools.product(
@@ -390,7 +390,7 @@ def test_rsa_generate_invalid_backend():
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSASignature(object):
+class TestRSASignature:
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.PKCS1v15()
@@ -749,7 +749,7 @@ class TestRSASignature(object):
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSAVerification(object):
+class TestRSAVerification:
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.PKCS1v15()
@@ -1201,7 +1201,7 @@ class TestRSAVerification(object):
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSAPSSMGF1Verification(object):
+class TestRSAPSSMGF1Verification:
     test_rsa_pss_mgf1_sha1 = pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.PSS(
@@ -1339,7 +1339,7 @@ class TestRSAPSSMGF1Verification(object):
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSAPKCS1Verification(object):
+class TestRSAPKCS1Verification:
     test_rsa_pkcs1v15_verify_sha1 = pytest.mark.supported(
         only_if=lambda backend: (
             backend.hash_supported(hashes.SHA1())
@@ -1441,7 +1441,7 @@ class TestRSAPKCS1Verification(object):
     )
 
 
-class TestPSS(object):
+class TestPSS:
     def test_calculate_max_pss_salt_length(self):
         with pytest.raises(TypeError):
             padding.calculate_max_pss_salt_length(object(), hashes.SHA256())
@@ -1472,7 +1472,7 @@ class TestPSS(object):
         assert pss._salt_length == padding.PSS.MAX_LENGTH
 
 
-class TestMGF1(object):
+class TestMGF1:
     def test_invalid_hash_algorithm(self):
         with pytest.raises(TypeError):
             padding.MGF1(b"not_a_hash")
@@ -1483,7 +1483,7 @@ class TestMGF1(object):
         assert mgf._algorithm == algorithm
 
 
-class TestOAEP(object):
+class TestOAEP:
     def test_invalid_algorithm(self):
         mgf = padding.MGF1(hashes.SHA1())
         with pytest.raises(TypeError):
@@ -1491,7 +1491,7 @@ class TestOAEP(object):
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSADecryption(object):
+class TestRSADecryption:
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.PKCS1v15()
@@ -1734,7 +1734,7 @@ class TestRSADecryption(object):
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSAEncryption(object):
+class TestRSAEncryption:
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.OAEP(
@@ -1918,7 +1918,7 @@ class TestRSAEncryption(object):
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSANumbers(object):
+class TestRSANumbers:
     def test_rsa_public_numbers(self):
         public_numbers = rsa.RSAPublicNumbers(e=1, n=15)
         assert public_numbers.e == 1
@@ -2045,7 +2045,7 @@ class TestRSANumbers(object):
         assert repr(num) == "<RSAPublicNumbers(e=1, n=1)>"
 
 
-class TestRSANumbersEquality(object):
+class TestRSANumbersEquality:
     def test_public_numbers_eq(self):
         num = RSAPublicNumbers(1, 2)
         num2 = RSAPublicNumbers(1, 2)
@@ -2110,7 +2110,7 @@ class TestRSANumbersEquality(object):
         assert hash(priv1) != hash(priv3)
 
 
-class TestRSAPrimeFactorRecovery(object):
+class TestRSAPrimeFactorRecovery:
     @pytest.mark.parametrize(
         "vector",
         _flatten_pkcs1_examples(
@@ -2141,7 +2141,7 @@ class TestRSAPrimeFactorRecovery(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
-class TestRSAPrivateKeySerialization(object):
+class TestRSAPrivateKeySerialization:
     @pytest.mark.parametrize(
         ("fmt", "password"),
         itertools.product(
@@ -2330,7 +2330,7 @@ class TestRSAPrivateKeySerialization(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
-class TestRSAPEMPublicKeySerialization(object):
+class TestRSAPEMPublicKeySerialization:
     @pytest.mark.parametrize(
         ("key_path", "loader_func", "encoding", "format"),
         [

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -114,7 +114,7 @@ def _build_oaep_sha2_vectors():
             load_vectors_from_file(
                 os.path.join(
                     base_path,
-                    "oaep-{}-{}.txt".format(mgf1alg.name, oaepalg.name),
+                    f"oaep-{mgf1alg.name}-{oaepalg.name}.txt",
                 ),
                 load_pkcs1_vectors,
             )
@@ -133,9 +133,7 @@ def _skip_pss_hash_algorithm_unsupported(backend, hash_alg):
             mgf=padding.MGF1(hash_alg), salt_length=padding.PSS.MAX_LENGTH
         )
     ):
-        pytest.skip(
-            "Does not support {} in MGF1 using PSS.".format(hash_alg.name)
-        )
+        pytest.skip(f"Does not support {hash_alg.name} in MGF1 using PSS.")
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
@@ -180,11 +178,9 @@ class TestRSA:
     def test_generate_rsa_keys(self, backend, public_exponent, key_size):
         if backend._fips_enabled:
             if key_size < backend._fips_rsa_min_key_size:
-                pytest.skip("Key size not FIPS compliant: {}".format(key_size))
+                pytest.skip(f"Key size not FIPS compliant: {key_size}")
             if public_exponent < backend._fips_rsa_min_public_exponent:
-                pytest.skip(
-                    "Exponent not FIPS compliant: {}".format(public_exponent)
-                )
+                pytest.skip(f"Exponent not FIPS compliant: {public_exponent}")
         skey = rsa.generate_private_key(public_exponent, key_size, backend)
         assert skey.key_size == key_size
 

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -45,7 +45,7 @@ def test_memory_limit_skip():
 
 
 @pytest.mark.requires_backend_interface(interface=ScryptBackend)
-class TestScrypt(object):
+class TestScrypt:
     @pytest.mark.parametrize("params", vectors)
     def test_derive(self, backend, params):
         _skip_if_memory_limited(_MEM_LIMIT, params)

--- a/tests/hazmat/primitives/test_seed.py
+++ b/tests/hazmat/primitives/test_seed.py
@@ -22,12 +22,12 @@ from ...utils import load_nist_vectors
     skip_message="Does not support SEED ECB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestSEEDModeECB(object):
+class TestSEEDModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SEED"),
         ["rfc-4269.txt"],
-        lambda key, **kwargs: algorithms.SEED(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.SEED(binascii.unhexlify(key)),
         lambda **kwargs: modes.ECB(),
     )
 
@@ -39,12 +39,12 @@ class TestSEEDModeECB(object):
     skip_message="Does not support SEED CBC",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestSEEDModeCBC(object):
+class TestSEEDModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SEED"),
         ["rfc-4196.txt"],
-        lambda key, **kwargs: algorithms.SEED(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.SEED(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.CBC(binascii.unhexlify(iv)),
     )
 
@@ -56,12 +56,12 @@ class TestSEEDModeCBC(object):
     skip_message="Does not support SEED OFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestSEEDModeOFB(object):
+class TestSEEDModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SEED"),
         ["seed-ofb.txt"],
-        lambda key, **kwargs: algorithms.SEED(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.SEED(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
     )
 
@@ -73,11 +73,11 @@ class TestSEEDModeOFB(object):
     skip_message="Does not support SEED CFB",
 )
 @pytest.mark.requires_backend_interface(interface=CipherBackend)
-class TestSEEDModeCFB(object):
+class TestSEEDModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SEED"),
         ["seed-cfb.txt"],
-        lambda key, **kwargs: algorithms.SEED(binascii.unhexlify((key))),
+        lambda key, **kwargs: algorithms.SEED(binascii.unhexlify(key)),
         lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
     )

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -62,7 +62,7 @@ def _skip_fips_format(key_path, password, backend):
             pytest.skip("Encrypted PEM_Serialization blocked in FIPS mode")
 
 
-class TestBufferProtocolSerialization(object):
+class TestBufferProtocolSerialization:
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.parametrize(
         ("key_path", "password"),
@@ -115,7 +115,7 @@ class TestBufferProtocolSerialization(object):
 
 
 @pytest.mark.requires_backend_interface(interface=DERSerializationBackend)
-class TestDERSerialization(object):
+class TestDERSerialization:
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.parametrize(
         ("key_path", "password"),
@@ -387,7 +387,7 @@ class TestDERSerialization(object):
 
 
 @pytest.mark.requires_backend_interface(interface=PEMSerializationBackend)
-class TestPEMSerialization(object):
+class TestPEMSerialization:
     @pytest.mark.parametrize(
         ("key_file", "password"),
         [
@@ -972,7 +972,7 @@ class TestPEMSerialization(object):
 
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
-class TestRSASSHSerialization(object):
+class TestRSASSHSerialization:
     def test_load_ssh_public_key_unsupported(self, backend):
         ssh_key = b"ecdsa-sha2-junk AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY="
 
@@ -1085,7 +1085,7 @@ class TestRSASSHSerialization(object):
 
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
-class TestDSSSSHSerialization(object):
+class TestDSSSSHSerialization:
     def test_load_ssh_public_key_dss_too_short(self, backend):
         ssh_key = b"ssh-dss"
 
@@ -1199,7 +1199,7 @@ class TestDSSSSHSerialization(object):
 
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
-class TestECDSASSHSerialization(object):
+class TestECDSASSHSerialization:
     def test_load_ssh_public_key_ecdsa_nist_p256(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
 
@@ -1335,7 +1335,7 @@ class TestECDSASSHSerialization(object):
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support",
 )
-class TestEd25519SSHSerialization(object):
+class TestEd25519SSHSerialization:
     def test_load_ssh_public_key(self, backend):
         ssh_key = (
             b"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG2fgpmpYO61qeAxGd0wgRaN/E4"
@@ -1376,7 +1376,7 @@ class TestEd25519SSHSerialization(object):
             load_ssh_public_key(ssh_key, backend)
 
 
-class TestKeySerializationEncryptionTypes(object):
+class TestKeySerializationEncryptionTypes:
     def test_non_bytes_password(self):
         with pytest.raises(ValueError):
             BestAvailableEncryption(object())
@@ -1390,7 +1390,7 @@ class TestKeySerializationEncryptionTypes(object):
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support",
 )
-class TestEd25519Serialization(object):
+class TestEd25519Serialization:
     def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8-enc.der"),
@@ -1478,7 +1478,7 @@ class TestEd25519Serialization(object):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-class TestX448Serialization(object):
+class TestX448Serialization:
     def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "X448", "x448-pkcs8-enc.der"),
@@ -1569,7 +1569,7 @@ class TestX448Serialization(object):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-class TestX25519Serialization(object):
+class TestX25519Serialization:
     def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "X25519", "x25519-pkcs8-enc.der"),
@@ -1660,7 +1660,7 @@ class TestX25519Serialization(object):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-class TestEd448Serialization(object):
+class TestEd448Serialization:
     def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "Ed448", "ed448-pkcs8-enc.der"),
@@ -1750,7 +1750,7 @@ class TestEd448Serialization(object):
             )
 
 
-class TestDHSerialization(object):
+class TestDHSerialization:
     """Test all options with least-supported key type."""
 
     @pytest.mark.skip_fips(reason="non-FIPS parameters")
@@ -1818,7 +1818,7 @@ class TestDHSerialization(object):
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=DSABackend)
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
-class TestOpenSSHSerialization(object):
+class TestOpenSSHSerialization:
     @pytest.mark.parametrize(
         ("key_file", "cert_file"),
         [

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -41,7 +41,7 @@ def test_x25519_unsupported(backend):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-class TestX25519Exchange(object):
+class TestX25519Exchange:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -41,7 +41,7 @@ def test_x448_unsupported(backend):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-class TestX448Exchange(object):
+class TestX448Exchange:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_x963_vectors.py
+++ b/tests/hazmat/primitives/test_x963_vectors.py
@@ -26,7 +26,7 @@ def _skip_hashfn_unsupported(backend, hashfn):
 
 
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestX963(object):
+class TestX963:
     _algorithms_dict = {
         "SHA-1": hashes.SHA1,
         "SHA-224": hashes.SHA224,

--- a/tests/hazmat/primitives/test_x963kdf.py
+++ b/tests/hazmat/primitives/test_x963kdf.py
@@ -16,7 +16,7 @@ from ...utils import raises_unsupported_algorithm
 
 
 @pytest.mark.requires_backend_interface(interface=HashBackend)
-class TestX963KDF(object):
+class TestX963KDF:
     def test_length_limit(self, backend):
         big_length = hashes.SHA256().digest_size * (2 ** 32 - 1) + 1
 

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -28,7 +28,7 @@ vectors = load_vectors_from_file("twofactor/rfc-4226.txt", load_nist_vectors)
     skip_message="Does not support HMAC-SHA1.",
 )
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestHOTP(object):
+class TestHOTP:
     def test_invalid_key_length(self, backend):
         secret = os.urandom(10)
 

--- a/tests/hazmat/primitives/twofactor/test_totp.py
+++ b/tests/hazmat/primitives/twofactor/test_totp.py
@@ -21,7 +21,7 @@ vectors = load_vectors_from_file("twofactor/rfc-6238.txt", load_nist_vectors)
 
 
 @pytest.mark.requires_backend_interface(interface=HMACBackend)
-class TestTOTP(object):
+class TestTOTP:
     @pytest.mark.supported(
         only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
         skip_message="Does not support HMAC-SHA1.",

--- a/tests/test_cryptography_utils.py
+++ b/tests/test_cryptography_utils.py
@@ -8,11 +8,11 @@ import pytest
 from cryptography import utils
 
 
-class TestCachedProperty(object):
+class TestCachedProperty:
     def test_simple(self):
         accesses = []
 
-        class T(object):
+        class T:
             @utils.cached_property
             def t(self):
                 accesses.append(None)
@@ -34,7 +34,7 @@ class TestCachedProperty(object):
     def test_set(self):
         accesses = []
 
-        class T(object):
+        class T:
             @utils.cached_property
             def t(self):
                 accesses.append(None)

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -45,7 +45,7 @@ def test_default_backend():
     ),
     skip_message="Does not support AES CBC",
 )
-class TestFernet(object):
+class TestFernet:
     @json_parametrize(
         ("secret", "now", "iv", "src", "token"),
         "generate.json",
@@ -156,7 +156,7 @@ class TestFernet(object):
     ),
     skip_message="Does not support AES CBC",
 )
-class TestMultiFernet(object):
+class TestMultiFernet:
     def test_encrypt(self, backend):
         f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         f2 = Fernet(base64.urlsafe_b64encode(b"\x01" * 32), backend=backend)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -18,7 +18,7 @@ def test_register_interface_if_true():
         pass
 
     @register_interface_if(1 == 1, SimpleInterface)
-    class SimpleClass(object):
+    class SimpleClass:
         pass
 
     assert issubclass(SimpleClass, SimpleInterface) is True
@@ -29,20 +29,20 @@ def test_register_interface_if_false():
         pass
 
     @register_interface_if(1 == 2, SimpleInterface)
-    class SimpleClass(object):
+    class SimpleClass:
         pass
 
     assert issubclass(SimpleClass, SimpleInterface) is False
 
 
-class TestVerifyInterface(object):
+class TestVerifyInterface:
     def test_verify_missing_method(self):
         class SimpleInterface(metaclass=abc.ABCMeta):
             @abc.abstractmethod
             def method(self):
                 """A simple method"""
 
-        class NonImplementer(object):
+        class NonImplementer:
             pass
 
         with pytest.raises(InterfaceNotImplemented):
@@ -54,7 +54,7 @@ class TestVerifyInterface(object):
             def method(self, a):
                 """Method with one argument"""
 
-        class NonImplementer(object):
+        class NonImplementer:
             def method(self):
                 """Method with no arguments"""
 
@@ -69,7 +69,7 @@ class TestVerifyInterface(object):
             def property(self):
                 """An abstract property"""
 
-        class NonImplementer(object):
+        class NonImplementer:
             @property
             def property(self):
                 """A concrete property"""

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -12,7 +12,7 @@ import pytest
 from cryptography.utils import deprecated
 
 
-class TestDeprecated(object):
+class TestDeprecated:
     def test_deprecated(self, monkeypatch):
         mod = types.ModuleType("TestDeprecated/test_deprecated")
         monkeypatch.setitem(sys.modules, mod.__name__, mod)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -873,7 +873,7 @@ def load_nist_ccm_vectors(vector_data):
     return data
 
 
-class WycheproofTest(object):
+class WycheproofTest:
     def __init__(self, testfiledata, testgroup, testcase):
         self.testfiledata = testfiledata
         self.testgroup = testgroup

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -103,7 +103,7 @@ def load_cryptrec_vectors(vector_data):
                 {"key": key, "plaintext": pt, "ciphertext": ct}
             )
         else:
-            raise ValueError("Invalid line in file '{}'".format(line))
+            raise ValueError(f"Invalid line in file '{line}'")
     return cryptrec_list
 
 

--- a/tests/wycheproof/test_ecdsa.py
+++ b/tests/wycheproof/test_ecdsa.py
@@ -74,7 +74,7 @@ def test_ecdsa_signature(backend, wycheproof):
     digest = _DIGESTS[wycheproof.testgroup["sha"]]
 
     if not backend.hash_supported(digest):
-        pytest.skip("Hash {} not supported".format(digest))
+        pytest.skip(f"Hash {digest} not supported")
 
     if wycheproof.valid or (
         wycheproof.acceptable and not wycheproof.has_flag("MissingZero")

--- a/tests/wycheproof/test_hmac.py
+++ b/tests/wycheproof/test_hmac.py
@@ -42,7 +42,7 @@ def test_hmac(backend, wycheproof):
     if wycheproof.testgroup["tagSize"] // 8 != hash_algo.digest_size:
         pytest.skip("Truncated HMAC not supported")
     if not backend.hash_supported(hash_algo):
-        pytest.skip("Hash {} not supported".format(hash_algo.name))
+        pytest.skip(f"Hash {hash_algo.name} not supported")
 
     h = hmac.HMAC(
         key=binascii.unhexlify(wycheproof.testcase["key"]),

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -72,7 +72,7 @@ def _generate_root(private_key=None, algorithm=hashes.SHA256()):
     return cert, private_key
 
 
-class TestOCSPRequest(object):
+class TestOCSPRequest:
     def test_bad_request(self):
         with pytest.raises(ValueError):
             ocsp.load_der_ocsp_request(b"invalid")
@@ -141,7 +141,7 @@ class TestOCSPRequest(object):
             req.public_bytes(serialization.Encoding.PEM)
 
 
-class TestOCSPRequestBuilder(object):
+class TestOCSPRequestBuilder:
     def test_add_two_certs(self):
         cert, issuer = _cert_and_issuer()
         builder = ocsp.OCSPRequestBuilder()
@@ -211,7 +211,7 @@ class TestOCSPRequestBuilder(object):
         assert req.extensions[0].critical is critical
 
 
-class TestOCSPResponseBuilder(object):
+class TestOCSPResponseBuilder:
     def test_add_response_twice(self):
         cert, issuer = _cert_and_issuer()
         time = datetime.datetime.now()
@@ -698,7 +698,7 @@ class TestOCSPResponseBuilder(object):
             )
 
 
-class TestSignedCertificateTimestampsExtension(object):
+class TestSignedCertificateTimestampsExtension:
     def test_init(self):
         with pytest.raises(TypeError):
             x509.SignedCertificateTimestamps([object()])
@@ -784,7 +784,7 @@ class TestSignedCertificateTimestampsExtension(object):
         assert hash(sct1) != hash(sct3)
 
 
-class TestOCSPResponse(object):
+class TestOCSPResponse:
     def test_bad_response(self):
         with pytest.raises(ValueError):
             ocsp.load_der_ocsp_response(b"invalid")
@@ -1037,7 +1037,7 @@ class TestOCSPResponse(object):
         assert ext.value == x509.CRLReason(x509.ReasonFlags.unspecified)
 
 
-class TestOCSPEdDSA(object):
+class TestOCSPEdDSA:
     @pytest.mark.supported(
         only_if=lambda backend: backend.ed25519_supported(),
         skip_message="Requires OpenSSL with Ed25519 support / OCSP",

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
@@ -67,12 +66,12 @@ from ..utils import load_nist_vectors, load_vectors_from_file
 
 
 @utils.register_interface(x509.ExtensionType)
-class DummyExtension(object):
+class DummyExtension:
     oid = x509.ObjectIdentifier("1.2.3.4")
 
 
 @utils.register_interface(x509.GeneralName)
-class FakeGeneralName(object):
+class FakeGeneralName:
     def __init__(self, value):
         self._value = value
 
@@ -135,7 +134,7 @@ def _parse_cert(der):
 
 
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestCertificateRevocationList(object):
+class TestCertificateRevocationList:
     def test_load_pem_crl(self, backend):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
@@ -485,7 +484,7 @@ class TestCertificateRevocationList(object):
 
 
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestRevokedCertificate(object):
+class TestRevokedCertificate:
     def test_revoked_basics(self, backend):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
@@ -674,7 +673,7 @@ class TestRevokedCertificate(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestRSACertificate(object):
+class TestRSACertificate:
     def test_load_pem_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
@@ -1249,7 +1248,7 @@ class TestRSACertificate(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestRSACertificateRequest(object):
+class TestRSACertificateRequest:
     @pytest.mark.parametrize(
         ("path", "loader_func"),
         [
@@ -1821,7 +1820,7 @@ class TestRSACertificateRequest(object):
             assert read_next_rdn_value_tag(issuer) == PRINTABLE_STRING
 
 
-class TestCertificateBuilder(object):
+class TestCertificateBuilder:
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)
     def test_checks_for_unsupported_extensions(self, backend):
@@ -3331,7 +3330,7 @@ class TestCertificateBuilder(object):
 
 
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestCertificateSigningRequestBuilder(object):
+class TestCertificateSigningRequestBuilder:
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     def test_sign_invalid_hash_algorithm(self, backend):
         private_key = RSA_KEY_2048.private_key(backend)
@@ -4321,7 +4320,7 @@ class TestCertificateSigningRequestBuilder(object):
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestDSACertificate(object):
+class TestDSACertificate:
     def test_load_dsa_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "dsa_selfsigned_ca.pem"),
@@ -4445,7 +4444,7 @@ class TestDSACertificate(object):
 
 @pytest.mark.requires_backend_interface(interface=DSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestDSACertificateRequest(object):
+class TestDSACertificateRequest:
     @pytest.mark.parametrize(
         ("path", "loader_func"),
         [
@@ -4519,7 +4518,7 @@ class TestDSACertificateRequest(object):
 
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestECDSACertificate(object):
+class TestECDSACertificate:
     def test_load_ecdsa_cert(self, backend):
         _skip_curve_unsupported(backend, ec.SECP384R1())
         cert = _load_cert(
@@ -4610,7 +4609,7 @@ class TestECDSACertificate(object):
 
 @pytest.mark.requires_backend_interface(interface=X509Backend)
 @pytest.mark.requires_backend_interface(interface=EllipticCurveBackend)
-class TestECDSACertificateRequest(object):
+class TestECDSACertificateRequest:
     @pytest.mark.parametrize(
         ("path", "loader_func"),
         [
@@ -4678,7 +4677,7 @@ class TestECDSACertificateRequest(object):
 
 
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestOtherCertificate(object):
+class TestOtherCertificate:
     def test_unsupported_subject_public_key_info(self, backend):
         cert = _load_cert(
             os.path.join(
@@ -4702,7 +4701,7 @@ class TestOtherCertificate(object):
             cert.not_valid_after
 
 
-class TestNameAttribute(object):
+class TestNameAttribute:
     EXPECTED_TYPES = [
         (NameOID.COMMON_NAME, _ASN1Type.UTF8String),
         (NameOID.COUNTRY_NAME, _ASN1Type.PrintableString),
@@ -4807,7 +4806,7 @@ class TestNameAttribute(object):
         assert na.rfc4514_string() == r"ST="
 
 
-class TestRelativeDistinguishedName(object):
+class TestRelativeDistinguishedName:
     def test_init_empty(self):
         with pytest.raises(ValueError):
             x509.RelativeDistinguishedName([])
@@ -4901,7 +4900,7 @@ class TestRelativeDistinguishedName(object):
         assert rdn.get_attributes_for_oid(x509.ObjectIdentifier("1.2.3")) == []
 
 
-class TestObjectIdentifier(object):
+class TestObjectIdentifier:
     def test_eq(self):
         oid1 = x509.ObjectIdentifier("2.999.1")
         oid2 = x509.ObjectIdentifier("2.999.1")
@@ -4948,7 +4947,7 @@ class TestObjectIdentifier(object):
         x509.ObjectIdentifier("2.25.305821105408246119474742976030998643995")
 
 
-class TestName(object):
+class TestName:
     def test_eq(self):
         ava1 = x509.NameAttribute(x509.ObjectIdentifier("2.999.1"), "value1")
         ava2 = x509.NameAttribute(x509.ObjectIdentifier("2.999.2"), "value2")
@@ -5131,7 +5130,7 @@ class TestName(object):
     skip_message="Requires OpenSSL with Ed25519 support",
 )
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestEd25519Certificate(object):
+class TestEd25519Certificate:
     def test_load_pem_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "ed25519", "root-ed25519.pem"),
@@ -5159,7 +5158,7 @@ class TestEd25519Certificate(object):
     skip_message="Requires OpenSSL with Ed448 support",
 )
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestEd448Certificate(object):
+class TestEd448Certificate:
     def test_load_pem_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "ed448", "root-ed448.pem"),
@@ -5175,7 +5174,7 @@ class TestEd448Certificate(object):
 
 
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestSignatureRejection(object):
+class TestSignatureRejection:
     """Test if signing rejects DH keys properly."""
 
     def load_key(self, backend):

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -30,7 +30,7 @@ from ..hazmat.primitives.fixtures_rsa import RSA_KEY_2048, RSA_KEY_512
 from ..hazmat.primitives.test_ec import _skip_curve_unsupported
 
 
-class TestCertificateRevocationListBuilder(object):
+class TestCertificateRevocationListBuilder:
     def test_issuer_name_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
         with pytest.raises(TypeError):

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -52,7 +52,7 @@ def _make_certbuilder(private_key):
     )
 
 
-class TestExtension(object):
+class TestExtension:
     def test_not_an_oid(self):
         bc = x509.BasicConstraints(ca=False, path_length=None)
         with pytest.raises(TypeError):
@@ -109,7 +109,7 @@ class TestExtension(object):
         assert hash(ext1) != hash(ext3)
 
 
-class TestTLSFeature(object):
+class TestTLSFeature:
     def test_not_enum_type(self):
         with pytest.raises(TypeError):
             x509.TLSFeature([3])
@@ -178,7 +178,7 @@ class TestTLSFeature(object):
         assert ext[0] == x509.TLSFeatureType.status_request
 
 
-class TestUnrecognizedExtension(object):
+class TestUnrecognizedExtension:
     def test_invalid_oid(self):
         with pytest.raises(TypeError):
             x509.UnrecognizedExtension("notanoid", b"somedata")
@@ -229,7 +229,7 @@ class TestUnrecognizedExtension(object):
         assert hash(ext1) != hash(ext3)
 
 
-class TestCertificateIssuer(object):
+class TestCertificateIssuer:
     def test_iter_names(self):
         ci = x509.CertificateIssuer(
             [x509.DNSName("cryptography.io"), x509.DNSName("crypto.local")]
@@ -286,7 +286,7 @@ class TestCertificateIssuer(object):
         assert hash(ci1) != hash(ci3)
 
 
-class TestCRLReason(object):
+class TestCRLReason:
     def test_invalid_reason_flags(self):
         with pytest.raises(TypeError):
             x509.CRLReason("notareason")
@@ -315,7 +315,7 @@ class TestCRLReason(object):
         assert repr(reason1) == ("<CRLReason(reason=ReasonFlags.unspecified)>")
 
 
-class TestDeltaCRLIndicator(object):
+class TestDeltaCRLIndicator:
     def test_not_int(self):
         with pytest.raises(TypeError):
             x509.DeltaCRLIndicator("notanint")
@@ -343,7 +343,7 @@ class TestDeltaCRLIndicator(object):
         assert hash(delta1) != hash(delta3)
 
 
-class TestInvalidityDate(object):
+class TestInvalidityDate:
     def test_invalid_invalidity_date(self):
         with pytest.raises(TypeError):
             x509.InvalidityDate("notadate")
@@ -373,7 +373,7 @@ class TestInvalidityDate(object):
         assert hash(invalid1) != hash(invalid3)
 
 
-class TestNoticeReference(object):
+class TestNoticeReference:
     def test_notice_numbers_not_all_int(self):
         with pytest.raises(TypeError):
             x509.NoticeReference("org", [1, 2, "three"])
@@ -416,7 +416,7 @@ class TestNoticeReference(object):
         assert hash(nr) != hash(nr3)
 
 
-class TestUserNotice(object):
+class TestUserNotice:
     def test_notice_reference_invalid(self):
         with pytest.raises(TypeError):
             x509.UserNotice("invalid", None)
@@ -460,7 +460,7 @@ class TestUserNotice(object):
         assert hash(un) != hash(un3)
 
 
-class TestPolicyInformation(object):
+class TestPolicyInformation:
     def test_invalid_policy_identifier(self):
         with pytest.raises(TypeError):
             x509.PolicyInformation("notanoid", None)
@@ -532,7 +532,7 @@ class TestPolicyInformation(object):
 
 
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestCertificatePolicies(object):
+class TestCertificatePolicies:
     def test_invalid_policies(self):
         pq = ["string"]
         pi = x509.PolicyInformation(x509.ObjectIdentifier("1.2.3"), pq)
@@ -629,7 +629,7 @@ class TestCertificatePolicies(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestCertificatePoliciesExtension(object):
+class TestCertificatePoliciesExtension:
     def test_cps_uri_policy_qualifier(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "cp_cps_uri.pem"),
@@ -728,7 +728,7 @@ class TestCertificatePoliciesExtension(object):
         )
 
 
-class TestKeyUsage(object):
+class TestKeyUsage:
     def test_key_agreement_false_encipher_decipher_true(self):
         with pytest.raises(ValueError):
             x509.KeyUsage(
@@ -951,7 +951,7 @@ class TestKeyUsage(object):
         assert hash(ku) != hash(ku3)
 
 
-class TestSubjectKeyIdentifier(object):
+class TestSubjectKeyIdentifier:
     def test_properties(self):
         value = binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         ski = x509.SubjectKeyIdentifier(value)
@@ -1002,7 +1002,7 @@ class TestSubjectKeyIdentifier(object):
         assert hash(ski1) != hash(ski3)
 
 
-class TestAuthorityKeyIdentifier(object):
+class TestAuthorityKeyIdentifier:
     def test_authority_cert_issuer_not_generalname(self):
         with pytest.raises(TypeError):
             x509.AuthorityKeyIdentifier(b"identifier", ["notname"], 3)
@@ -1117,7 +1117,7 @@ class TestAuthorityKeyIdentifier(object):
         assert hash(aki1) != hash(aki3)
 
 
-class TestBasicConstraints(object):
+class TestBasicConstraints:
     def test_ca_not_boolean(self):
         with pytest.raises(TypeError):
             x509.BasicConstraints(ca="notbool", path_length=None)
@@ -1162,7 +1162,7 @@ class TestBasicConstraints(object):
         assert na != object()
 
 
-class TestExtendedKeyUsage(object):
+class TestExtendedKeyUsage:
     def test_not_all_oids(self):
         with pytest.raises(TypeError):
             x509.ExtendedKeyUsage(["notoid"])
@@ -1230,7 +1230,7 @@ class TestExtendedKeyUsage(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestExtensions(object):
+class TestExtensions:
     def test_no_extensions(self, backend):
         cert = _load_cert(
             os.path.join("x509", "verisign_md2_root.pem"),
@@ -1362,7 +1362,7 @@ class TestExtensions(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestBasicConstraintsExtension(object):
+class TestBasicConstraintsExtension:
     def test_ca_true_pathlen_6(self, backend):
         cert = _load_cert(
             os.path.join(
@@ -1453,7 +1453,7 @@ class TestBasicConstraintsExtension(object):
         assert ext.value.ca is False
 
 
-class TestSubjectKeyIdentifierExtension(object):
+class TestSubjectKeyIdentifierExtension:
     @pytest.mark.requires_backend_interface(interface=RSABackend)
     @pytest.mark.requires_backend_interface(interface=X509Backend)
     def test_subject_key_identifier(self, backend):
@@ -1603,7 +1603,7 @@ class TestSubjectKeyIdentifierExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestKeyUsageExtension(object):
+class TestKeyUsageExtension:
     def test_no_key_usage(self, backend):
         cert = _load_cert(
             os.path.join("x509", "verisign_md2_root.pem"),
@@ -1659,7 +1659,7 @@ class TestKeyUsageExtension(object):
         assert ku.crl_sign is True
 
 
-class TestDNSName(object):
+class TestDNSName:
     def test_non_a_label(self):
         with pytest.raises(ValueError):
             x509.DNSName(".\xf5\xe4\xf6\xfc.example.com")
@@ -1689,7 +1689,7 @@ class TestDNSName(object):
         assert hash(n2) == hash(n3)
 
 
-class TestDirectoryName(object):
+class TestDirectoryName:
     def test_not_name(self):
         with pytest.raises(TypeError):
             x509.DirectoryName(b"notaname")
@@ -1739,7 +1739,7 @@ class TestDirectoryName(object):
         assert hash(gn) != hash(gn3)
 
 
-class TestRFC822Name(object):
+class TestRFC822Name:
     def test_repr(self):
         gn = x509.RFC822Name("string")
         assert repr(gn) == "<RFC822Name(value='string')>"
@@ -1783,7 +1783,7 @@ class TestRFC822Name(object):
         assert hash(g1) != hash(g3)
 
 
-class TestUniformResourceIdentifier(object):
+class TestUniformResourceIdentifier:
     def test_equality(self):
         gn = x509.UniformResourceIdentifier("string")
         gn2 = x509.UniformResourceIdentifier("string2")
@@ -1827,7 +1827,7 @@ class TestUniformResourceIdentifier(object):
         assert repr(gn) == ("<UniformResourceIdentifier(value='string')>")
 
 
-class TestRegisteredID(object):
+class TestRegisteredID:
     def test_not_oid(self):
         with pytest.raises(TypeError):
             x509.RegisteredID(b"notanoid")
@@ -1861,7 +1861,7 @@ class TestRegisteredID(object):
         assert hash(gn) != hash(gn3)
 
 
-class TestIPAddress(object):
+class TestIPAddress:
     def test_not_ipaddress(self):
         with pytest.raises(TypeError):
             x509.IPAddress(b"notanipaddress")
@@ -1901,7 +1901,7 @@ class TestIPAddress(object):
         assert hash(gn) != hash(gn3)
 
 
-class TestOtherName(object):
+class TestOtherName:
     def test_invalid_args(self):
         with pytest.raises(TypeError):
             x509.OtherName(b"notanobjectidentifier", b"derdata")
@@ -1945,7 +1945,7 @@ class TestOtherName(object):
         assert hash(gn) != hash(gn3)
 
 
-class TestGeneralNames(object):
+class TestGeneralNames:
     def test_get_values_for_type(self):
         gns = x509.GeneralNames([x509.DNSName("cryptography.io")])
         names = gns.get_values_for_type(x509.DNSName)
@@ -2011,7 +2011,7 @@ class TestGeneralNames(object):
         assert hash(gns) != hash(gns3)
 
 
-class TestIssuerAlternativeName(object):
+class TestIssuerAlternativeName:
     def test_get_values_for_type(self):
         san = x509.IssuerAlternativeName([x509.DNSName("cryptography.io")])
         names = san.get_values_for_type(x509.DNSName)
@@ -2078,7 +2078,7 @@ class TestIssuerAlternativeName(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestRSAIssuerAlternativeNameExtension(object):
+class TestRSAIssuerAlternativeNameExtension:
     def test_uri(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "ian_uri.pem"),
@@ -2093,7 +2093,7 @@ class TestRSAIssuerAlternativeNameExtension(object):
         ]
 
 
-class TestCRLNumber(object):
+class TestCRLNumber:
     def test_eq(self):
         crl_number = x509.CRLNumber(15)
         assert crl_number == x509.CRLNumber(15)
@@ -2119,7 +2119,7 @@ class TestCRLNumber(object):
         assert hash(c1) != hash(c3)
 
 
-class TestSubjectAlternativeName(object):
+class TestSubjectAlternativeName:
     def test_get_values_for_type(self):
         san = x509.SubjectAlternativeName([x509.DNSName("cryptography.io")])
         names = san.get_values_for_type(x509.DNSName)
@@ -2186,7 +2186,7 @@ class TestSubjectAlternativeName(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestRSASubjectAlternativeNameExtension(object):
+class TestRSASubjectAlternativeNameExtension:
     def test_dns_name(self, backend):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.pem"),
@@ -2487,7 +2487,7 @@ class TestRSASubjectAlternativeNameExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestExtendedKeyUsageExtension(object):
+class TestExtendedKeyUsageExtension:
     def test_eku(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "extended_key_usage.pem"),
@@ -2512,7 +2512,7 @@ class TestExtendedKeyUsageExtension(object):
         ] == list(ext.value)
 
 
-class TestAccessDescription(object):
+class TestAccessDescription:
     def test_invalid_access_method(self):
         with pytest.raises(TypeError):
             x509.AccessDescription("notanoid", x509.DNSName("test"))
@@ -2586,7 +2586,7 @@ class TestAccessDescription(object):
         assert hash(ad) != hash(ad3)
 
 
-class TestPolicyConstraints(object):
+class TestPolicyConstraints:
     def test_invalid_explicit_policy(self):
         with pytest.raises(TypeError):
             x509.PolicyConstraints("invalid", None)
@@ -2630,7 +2630,7 @@ class TestPolicyConstraints(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestPolicyConstraintsExtension(object):
+class TestPolicyConstraintsExtension:
     def test_inhibit_policy_mapping(self, backend):
         cert = _load_cert(
             os.path.join("x509", "department-of-state-root.pem"),
@@ -2663,7 +2663,7 @@ class TestPolicyConstraintsExtension(object):
         )
 
 
-class TestAuthorityInformationAccess(object):
+class TestAuthorityInformationAccess:
     def test_invalid_descriptions(self):
         with pytest.raises(TypeError):
             x509.AuthorityInformationAccess(["notanAccessDescription"])
@@ -2847,7 +2847,7 @@ class TestAuthorityInformationAccess(object):
         assert hash(aia) != hash(aia3)
 
 
-class TestSubjectInformationAccess(object):
+class TestSubjectInformationAccess:
     def test_invalid_descriptions(self):
         with pytest.raises(TypeError):
             x509.SubjectInformationAccess(["notanAccessDescription"])
@@ -3026,7 +3026,7 @@ class TestSubjectInformationAccess(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestSubjectInformationAccessExtension(object):
+class TestSubjectInformationAccessExtension:
     def test_sia(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "sia.pem"),
@@ -3057,7 +3057,7 @@ class TestSubjectInformationAccessExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestAuthorityInformationAccessExtension(object):
+class TestAuthorityInformationAccessExtension:
     def test_aia_ocsp_ca_issuers(self, backend):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.pem"),
@@ -3181,7 +3181,7 @@ class TestAuthorityInformationAccessExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestAuthorityKeyIdentifierExtension(object):
+class TestAuthorityKeyIdentifierExtension:
     def test_aki_keyid(self, backend):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.pem"),
@@ -3300,7 +3300,7 @@ class TestAuthorityKeyIdentifierExtension(object):
         assert ext.value == aki
 
 
-class TestNameConstraints(object):
+class TestNameConstraints:
     def test_ipaddress_wrong_type(self):
         with pytest.raises(TypeError):
             x509.NameConstraints(
@@ -3425,7 +3425,7 @@ class TestNameConstraints(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestNameConstraintsExtension(object):
+class TestNameConstraintsExtension:
     def test_permitted_excluded(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "nc_permitted_excluded_2.pem"),
@@ -3568,7 +3568,7 @@ class TestNameConstraintsExtension(object):
         assert result == permitted
 
 
-class TestDistributionPoint(object):
+class TestDistributionPoint:
     def test_distribution_point_full_name_not_general_names(self):
         with pytest.raises(TypeError):
             x509.DistributionPoint(["notgn"], None, None, None)
@@ -3776,7 +3776,7 @@ class TestDistributionPoint(object):
         assert hash(dp) != hash(dp3)
 
 
-class TestFreshestCRL(object):
+class TestFreshestCRL:
     def test_invalid_distribution_points(self):
         with pytest.raises(TypeError):
             x509.FreshestCRL(["notadistributionpoint"])
@@ -4009,7 +4009,7 @@ class TestFreshestCRL(object):
         assert fcrl[2:6:2] == [fcrl[2], fcrl[4]]
 
 
-class TestCRLDistributionPoints(object):
+class TestCRLDistributionPoints:
     def test_invalid_distribution_points(self):
         with pytest.raises(TypeError):
             x509.CRLDistributionPoints(["notadistributionpoint"])
@@ -4266,7 +4266,7 @@ class TestCRLDistributionPoints(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestCRLDistributionPointsExtension(object):
+class TestCRLDistributionPointsExtension:
     def test_fullname_and_crl_issuer(self, backend):
         cert = _load_cert(
             os.path.join(
@@ -4553,7 +4553,7 @@ class TestCRLDistributionPointsExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestFreshestCRLExtension(object):
+class TestFreshestCRLExtension:
     def test_vector(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "freshestcrl.pem"),
@@ -4601,7 +4601,7 @@ class TestFreshestCRLExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestOCSPNoCheckExtension(object):
+class TestOCSPNoCheckExtension:
     def test_nocheck(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "ocsp_nocheck.pem"),
@@ -4637,7 +4637,7 @@ class TestOCSPNoCheckExtension(object):
         assert repr(onc) == "<OCSPNoCheck()>"
 
 
-class TestInhibitAnyPolicy(object):
+class TestInhibitAnyPolicy:
     def test_not_int(self):
         with pytest.raises(TypeError):
             x509.InhibitAnyPolicy("notint")
@@ -4671,7 +4671,7 @@ class TestInhibitAnyPolicy(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestInhibitAnyPolicyExtension(object):
+class TestInhibitAnyPolicyExtension:
     def test_inhibit_any_policy(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "inhibit_any_policy_5.pem"),
@@ -4684,7 +4684,7 @@ class TestInhibitAnyPolicyExtension(object):
         assert iap.skip_certs == 5
 
 
-class TestIssuingDistributionPointExtension(object):
+class TestIssuingDistributionPointExtension:
     @pytest.mark.parametrize(
         ("filename", "expected"),
         [
@@ -5196,7 +5196,7 @@ class TestIssuingDistributionPointExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestPrecertPoisonExtension(object):
+class TestPrecertPoisonExtension:
     def test_load(self, backend):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.precert.pem"),
@@ -5252,7 +5252,7 @@ class TestPrecertPoisonExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestSignedCertificateTimestamps(object):
+class TestSignedCertificateTimestamps:
     @pytest.mark.supported(
         only_if=lambda backend: (backend._lib.Cryptography_HAS_SCT),
         skip_message="Requires CT support",
@@ -5356,7 +5356,7 @@ class TestSignedCertificateTimestamps(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestPrecertificateSignedCertificateTimestampsExtension(object):
+class TestPrecertificateSignedCertificateTimestampsExtension:
     def test_init(self):
         with pytest.raises(TypeError):
             x509.PrecertificateSignedCertificateTimestamps([object()])
@@ -5546,7 +5546,7 @@ class TestPrecertificateSignedCertificateTimestampsExtension(object):
 
 @pytest.mark.requires_backend_interface(interface=RSABackend)
 @pytest.mark.requires_backend_interface(interface=X509Backend)
-class TestInvalidExtension(object):
+class TestInvalidExtension:
     def test_invalid_certificate_policies_data(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "cp_invalid.pem"),
@@ -5557,7 +5557,7 @@ class TestInvalidExtension(object):
             cert.extensions
 
 
-class TestOCSPNonce(object):
+class TestOCSPNonce:
     def test_non_bytes(self):
         with pytest.raises(TypeError):
             x509.OCSPNonce(38)

--- a/tests/x509/test_x509_revokedcertbuilder.py
+++ b/tests/x509/test_x509_revokedcertbuilder.py
@@ -13,7 +13,7 @@ from cryptography import x509
 from cryptography.hazmat.backends.interfaces import X509Backend
 
 
-class TestRevokedCertificateBuilder(object):
+class TestRevokedCertificateBuilder:
     def test_serial_number_must_be_integer(self):
         with pytest.raises(TypeError):
             x509.RevokedCertificateBuilder().serial_number("notanx509name")


### PR DESCRIPTION
- No need to explicitly extend `object` any more.
- Other lesser changes.
- No need to specify source file encoding -- python3 only supports `utf-8`.
- Prefer f-strings, which are a bit safer.