### PR TITLE
add missing verification parameter flags

### DIFF
--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -122,6 +122,8 @@ static const long X509_V_FLAG_SUITEB_128_LOS_ONLY;
 static const long X509_V_FLAG_SUITEB_192_LOS;
 static const long X509_V_FLAG_SUITEB_128_LOS;
 static const long X509_V_FLAG_PARTIAL_CHAIN;
+static const long X509_V_FLAG_NO_ALT_CHAINS;
+static const long X509_V_FLAG_NO_CHECK_TIME;
 
 static const long X509_LU_X509;
 static const long X509_LU_CRL;


### PR DESCRIPTION
Adding 2 missing verification parameter flags:

- `X509_V_FLAG_NO_ALT_CHAINS` If the initial chain is not trusted, do not attempt to build an alternative chain.
- `X509_V_FLAG_NO_CHECK_TIME` Do not check certificate/CRL validity against current time

Corresponding OpenSSL code:
https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/include/openssl/x509_vfy.h#L227-L234
