### PR TITLE
More PKCS8 v2 encryption options

### DIFF
--- a/src/_cffi_src/openssl/nid.py
+++ b/src/_cffi_src/openssl/nid.py
@@ -24,6 +24,11 @@ static const int NID_subject_alt_name;
 static const int NID_crl_reason;
 
 static const int NID_pkcs7_signed;
+
+static const int NID_hmacWithSHA1;
+static const int NID_hmacWithSHA256;
+static const int NID_hmacWithSHA384;
+static const int NID_hmacWithSHA512;
 """
 
 FUNCTIONS = """

--- a/src/_cffi_src/openssl/pem.py
+++ b/src/_cffi_src/openssl/pem.py
@@ -27,6 +27,9 @@ int PEM_write_bio_PKCS8PrivateKey(BIO *, EVP_PKEY *, const EVP_CIPHER *,
 int i2d_PKCS8PrivateKey_bio(BIO *, EVP_PKEY *, const EVP_CIPHER *,
                             char *, int, pem_password_cb *, void *);
 
+int PEM_write_bio_PKCS8(BIO *, X509_SIG *);
+int i2d_PKCS8_bio(BIO *, X509_SIG *);
+
 int i2d_PKCS7_bio(BIO *, PKCS7 *);
 PKCS7 *d2i_PKCS7_bio(BIO *, PKCS7 **);
 

--- a/src/_cffi_src/openssl/pkcs12.py
+++ b/src/_cffi_src/openssl/pkcs12.py
@@ -27,7 +27,17 @@ PKCS12 *PKCS12_create(char *, char *, EVP_PKEY *, X509 *,
 void X509_SIG_free(X509_SIG *);
 X509_SIG *PKCS8_set0_pbe(const char *, int, PKCS8_PRIV_KEY_INFO *,
                          X509_ALGOR *);
+/* LibreSSL does not have PKCS8_set0_pbe() */
+X509_SIG *PKCS8_encrypt(int, const EVP_CIPHER *, const char *, int,
+                        unsigned char *, int, int, PKCS8_PRIV_KEY_INFO *);
 """
 
 CUSTOMIZATIONS = """
+#if !CRYPTOGRAPHY_IS_LIBRESSL
+static const long Cryptography_HAS_PKCS8_SET0_PBE = 1;
+#else
+static const long Cryptography_HAS_PKCS8_SET0_PBE = 0;
+X509_SIG* (*PKCS8_set0_pbe)(const char *, int, PKCS8_PRIV_KEY_INFO *,
+                            X509_ALGOR *) = NULL;
+#endif
 """

--- a/src/_cffi_src/openssl/pkcs12.py
+++ b/src/_cffi_src/openssl/pkcs12.py
@@ -12,6 +12,8 @@ typedef ... PKCS12;
 typedef ... X509_SIG;
 
 static const int PKCS12_DEFAULT_ITER;
+
+static const int Cryptography_HAS_PKCS8_SET0_PBE;
 """
 
 FUNCTIONS = """
@@ -27,7 +29,6 @@ PKCS12 *PKCS12_create(char *, char *, EVP_PKEY *, X509 *,
 void X509_SIG_free(X509_SIG *);
 X509_SIG *PKCS8_set0_pbe(const char *, int, PKCS8_PRIV_KEY_INFO *,
                          X509_ALGOR *);
-/* LibreSSL does not have PKCS8_set0_pbe() */
 X509_SIG *PKCS8_encrypt(int, const EVP_CIPHER *, const char *, int,
                         unsigned char *, int, int, PKCS8_PRIV_KEY_INFO *);
 """

--- a/src/_cffi_src/openssl/pkcs12.py
+++ b/src/_cffi_src/openssl/pkcs12.py
@@ -9,6 +9,9 @@ INCLUDES = """
 
 TYPES = """
 typedef ... PKCS12;
+typedef ... X509_SIG;
+
+static const int PKCS12_DEFAULT_ITER;
 """
 
 FUNCTIONS = """
@@ -20,6 +23,10 @@ int PKCS12_parse(PKCS12 *, const char *, EVP_PKEY **, X509 **,
                  Cryptography_STACK_OF_X509 **);
 PKCS12 *PKCS12_create(char *, char *, EVP_PKEY *, X509 *,
                       Cryptography_STACK_OF_X509 *, int, int, int, int, int);
+
+void X509_SIG_free(X509_SIG *);
+X509_SIG *PKCS8_set0_pbe(const char *, int, PKCS8_PRIV_KEY_INFO *,
+                         X509_ALGOR *);
 """
 
 CUSTOMIZATIONS = """

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -273,6 +273,14 @@ int i2d_re_X509_REQ_tbs(X509_REQ *, unsigned char **);
 int i2d_re_X509_CRL_tbs(X509_CRL *, unsigned char **);
 void X509_REQ_get0_signature(const X509_REQ *, const ASN1_BIT_STRING **,
                              const X509_ALGOR **);
+
+void PKCS8_PRIV_KEY_INFO_free(PKCS8_PRIV_KEY_INFO *);
+PKCS8_PRIV_KEY_INFO *EVP_PKEY2PKCS8(EVP_PKEY *);
+
+void X509_ALGOR_free(X509_ALGOR *);
+X509_ALGOR *PKCS5_pbe2_set(const EVP_CIPHER *, int, unsigned char *, int);
+X509_ALGOR *PKCS5_pbe2_set_iv(const EVP_CIPHER *, int, unsigned char *, int,
+                              unsigned char *, int);
 """
 
 CUSTOMIZATIONS = """

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -75,6 +75,9 @@ class KeySerializationEncryption(metaclass=abc.ABCMeta):
 
 @utils.register_interface(KeySerializationEncryption)
 class BestAvailableEncryption(object):
+    _cipher = b"aes-256-cbc"
+    _prf = b"HMAC-SHA256"
+
     def __init__(self, password):
         if not isinstance(password, bytes) or len(password) == 0:
             raise ValueError("Password must be 1 or more bytes.")


### PR DESCRIPTION
Very rough PoC for enhanced KeySerializationEncryption. @bhoefer2015 has asked me to look into the matter. The code in ``_private_key_pkcs8`` is based on OpenSSL's ``apps/pkcs8.c``. I haven't figured out a good user-facing API yet.

- [ ] public API
- [ ] documentation
- [ ] tests
- [ ] fix / work around LibreSSL APIs

Fixes: #4272
Signed-off-by: Christian Heimes <cheimes@redhat.com>