### PR TITLE
Add ssl version constants

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -590,8 +590,11 @@ static const long TLS_ST_OK = 0;
 #if CRYPTOGRAPHY_IS_LIBRESSL
 static const long SSL_OP_NO_DTLSv1 = 0;
 static const long SSL_OP_NO_DTLSv1_2 = 0;
-/* it's not really clear why DTLS1_VERSION is defined, but it is */
-/* don't set this to 0, SSL_CTX_set_min_proto_version(DTLS1_2_VERSION) would silently allow all versions */
+/* it's not really clear why DTLS1_VERSION is defined, but it is. */
+/*
+don't set this to 0,
+SSL_CTX_set_min_proto_version(TLS1_3_VERSION) would silently allow all version
+*/
 static const long DTLS1_2_VERSION = -1;
 long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
 long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
@@ -688,7 +691,10 @@ SRTP_PROTECTION_PROFILE * (*SSL_get_selected_srtp_profile)(SSL *) = NULL;
 
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
 static const long Cryptography_HAS_TLSv1_3 = 0;
-/* don't set this to 0, SSL_CTX_set_min_proto_version(TLS1_3_VERSION) would silently allow all version */
+/*
+don't set this to 0,
+SSL_CTX_set_min_proto_version(TLS1_3_VERSION) would silently allow all version
+*/
 static const long TLS1_3_VERSION = -1;
 static const long SSL_OP_NO_TLSv1_3 = 0;
 static const long SSL_VERIFY_POST_HANDSHAKE = 0;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -683,11 +683,7 @@ SRTP_PROTECTION_PROFILE * (*SSL_get_selected_srtp_profile)(SSL *) = NULL;
 
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
 static const long Cryptography_HAS_TLSv1_3 = 0;
-/*
-don't set this to 0,
-SSL_CTX_set_min_proto_version(TLS1_3_VERSION) would silently allow all version
-*/
-static const long TLS1_3_VERSION = -1;
+static const long TLS1_3_VERSION = 0;
 static const long SSL_OP_NO_TLSv1_3 = 0;
 static const long SSL_VERIFY_POST_HANDSHAKE = 0;
 int (*SSL_CTX_set_ciphersuites)(SSL_CTX *, const char *) = NULL;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -131,6 +131,14 @@ static const long SSL3_RANDOM_SIZE;
 static const long TLS_ST_BEFORE;
 static const long TLS_ST_OK;
 
+static const long SSL3_VERSION;
+static const long TLS1_VERSION;
+static const long TLS1_1_VERSION;
+static const long TLS1_2_VERSION;
+static const long TLS1_3_VERSION;
+static const long DTLS1_VERSION;
+static const long DTLS1_2_VERSION;
+
 typedef ... SSL_METHOD;
 typedef ... SSL_CTX;
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -591,7 +591,8 @@ static const long TLS_ST_OK = 0;
 static const long SSL_OP_NO_DTLSv1 = 0;
 static const long SSL_OP_NO_DTLSv1_2 = 0;
 /* it's not really clear why DTLS1_VERSION is defined, but it is */
-static const long DTLS1_2_VERSION = 0;
+/* don't set this to 0, SSL_CTX_set_min_proto_version(DTLS1_2_VERSION) would silently allow all versions */
+static const long DTLS1_2_VERSION = -1;
 long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
 long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
 #endif
@@ -687,7 +688,8 @@ SRTP_PROTECTION_PROFILE * (*SSL_get_selected_srtp_profile)(SSL *) = NULL;
 
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
 static const long Cryptography_HAS_TLSv1_3 = 0;
-static const long TLS1_3_VERSION = 0;
+/* don't set this to 0, SSL_CTX_set_min_proto_version(TLS1_3_VERSION) would silently allow all version */
+static const long TLS1_3_VERSION = -1;
 static const long SSL_OP_NO_TLSv1_3 = 0;
 static const long SSL_VERIFY_POST_HANDSHAKE = 0;
 int (*SSL_CTX_set_ciphersuites)(SSL_CTX *, const char *) = NULL;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -590,6 +590,8 @@ static const long TLS_ST_OK = 0;
 #if CRYPTOGRAPHY_IS_LIBRESSL
 static const long SSL_OP_NO_DTLSv1 = 0;
 static const long SSL_OP_NO_DTLSv1_2 = 0;
+static const long DTLS1_VERSION = 0;
+static const long DTLS1_2_VERSION = 0;
 long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
 long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
 #endif
@@ -685,6 +687,7 @@ SRTP_PROTECTION_PROFILE * (*SSL_get_selected_srtp_profile)(SSL *) = NULL;
 
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
 static const long Cryptography_HAS_TLSv1_3 = 0;
+static const long TLS1_3_VERSION = 0;
 static const long SSL_OP_NO_TLSv1_3 = 0;
 static const long SSL_VERIFY_POST_HANDSHAKE = 0;
 int (*SSL_CTX_set_ciphersuites)(SSL_CTX *, const char *) = NULL;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -590,7 +590,7 @@ static const long TLS_ST_OK = 0;
 #if CRYPTOGRAPHY_IS_LIBRESSL
 static const long SSL_OP_NO_DTLSv1 = 0;
 static const long SSL_OP_NO_DTLSv1_2 = 0;
-static const long DTLS1_VERSION = 0;
+/* it's not really clear why DTLS1_VERSION is defined, but it is */
 static const long DTLS1_2_VERSION = 0;
 long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
 long (*DTLS_get_link_min_mtu)(SSL *) = NULL;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -136,8 +136,6 @@ static const long TLS1_VERSION;
 static const long TLS1_1_VERSION;
 static const long TLS1_2_VERSION;
 static const long TLS1_3_VERSION;
-static const long DTLS1_VERSION;
-static const long DTLS1_2_VERSION;
 
 typedef ... SSL_METHOD;
 typedef ... SSL_CTX;
@@ -590,12 +588,6 @@ static const long TLS_ST_OK = 0;
 #if CRYPTOGRAPHY_IS_LIBRESSL
 static const long SSL_OP_NO_DTLSv1 = 0;
 static const long SSL_OP_NO_DTLSv1_2 = 0;
-/* it's not really clear why DTLS1_VERSION is defined, but it is. */
-/*
-don't set this to 0,
-SSL_CTX_set_min_proto_version(TLS1_3_VERSION) would silently allow all version
-*/
-static const long DTLS1_2_VERSION = -1;
 long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
 long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
 #endif

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -198,6 +198,7 @@ def cryptography_has_openssl_cleanup():
 
 def cryptography_has_tlsv13():
     return [
+        "TLS1_3_VERSION",
         "SSL_OP_NO_TLSv1_3",
         "SSL_VERIFY_POST_HANDSHAKE",
         "SSL_CTX_set_ciphersuites",


### PR DESCRIPTION
I'm upgrading mitmproxy to use `SSL_CTX_set_min_proto_version` (with the idea to get the changes into pyOpenSSL as well), and it turns out the version constants are not exposed at the moment. :)

`SSL_CTX_set_min_proto_version` landed in https://github.com/pyca/cryptography/pull/5595, see https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_min_proto_version.html for the OpenSSL docs.