### PR TITLE
Experiment with Furo (documentation theme)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,11 +20,6 @@ import os
 import sys
 
 try:
-    import sphinx_rtd_theme
-except ImportError:
-    sphinx_rtd_theme = None
-
-try:
     from sphinxcontrib import spelling
 except ImportError:
     spelling = None
@@ -119,12 +114,8 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-
-if sphinx_rtd_theme:
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-else:
-    html_theme = "default"
+html_theme = "furo"
+html_title = "cryptography"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ try:
             ],
             "docs": [
                 "sphinx >= 1.6.5,!=1.8.0,!=3.1.0,!=3.1.1",
-                "sphinx_rtd_theme",
+                "furo",
             ],
             "docstest": [
                 "doc8",


### PR DESCRIPTION
This is an attempt from me to see how [Furo](https://pradyunsg.me/furo/) (a Sphinx documentation theme that I wrote) looks with slightly more "beefy" documentation (i.e. cryptography's docs).

My main reason/excuse for filing this PR is that it's the only way to see the documentation built with RTD embeds (the ad stuff and version selector) since cryptography's PRs' docs also get built on RTD. Please don't mind me experimenting on your repository -- I'm planning to close this PR once I'm done with the experimenting.

OTOH, if y'all like how Furo looks, let me know and I'll keep it in mind that this PR should be something mergable. :)
