### PR TITLE
remove DSAParametersWithNumbers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1347,7 +1347,7 @@ Changelog
   were moved from ``cryptography.hazmat.primitives.interfaces`` to
   ``cryptography.hazmat.primitives.asymmetric``.
 * :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAParameters`,
-  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAParametersWithNumbers`,
+  ``DSAParametersWithNumbers``,
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`,
   ``DSAPrivateKeyWithNumbers``,
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey` and

--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -267,13 +267,6 @@ Key interfaces
         :return: An instance of
             :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`.
 
-
-.. class:: DSAParametersWithNumbers
-
-    .. versionadded:: 0.5
-
-    Extends :class:`DSAParameters`.
-
     .. method:: parameter_numbers()
 
         Create a

--- a/src/cryptography/hazmat/backends/openssl/dsa.py
+++ b/src/cryptography/hazmat/backends/openssl/dsa.py
@@ -83,7 +83,7 @@ class _DSASignatureContext(object):
         return _dsa_sig_sign(self._backend, self._private_key, data_to_sign)
 
 
-@utils.register_interface(dsa.DSAParametersWithNumbers)
+@utils.register_interface(dsa.DSAParameters)
 class _DSAParameters(object):
     def __init__(self, backend, dsa_cdata):
         self._backend = backend

--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -16,13 +16,14 @@ class DSAParameters(metaclass=abc.ABCMeta):
         Generates and returns a DSAPrivateKey.
         """
 
-
-class DSAParametersWithNumbers(DSAParameters, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def parameter_numbers(self):
         """
         Returns a DSAParameterNumbers.
         """
+
+
+DSAParametersWithNumbers = DSAParameters
 
 
 class DSAPrivateKey(metaclass=abc.ABCMeta):


### PR DESCRIPTION
Merged into DSAParameters, just like we did years ago for everything else. Somehow we missed this one. Keep a backwards compatible alias.