### PR TITLE
correct buffer overflows cause by integer overflow in openssl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
   linux-distros:
     runs-on: ubuntu-latest
-    container: ${{ matrix.IMAGE.IMAGE }}
+    container: ghcr.io/${{ matrix.IMAGE.IMAGE }}
     strategy:
       matrix:
         IMAGE:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           - {IMAGE: "pyca/cryptography-runner-centos8-fips", TOXENV: "py36", FIPS: true}
           - {IMAGE: "pyca/cryptography-runner-stretch", TOXENV: "py27"}
           - {IMAGE: "pyca/cryptography-runner-buster", TOXENV: "py37"}
-          - {IMAGE: "pyca/cryptography-runner-bullseye", TOXENV: "py38"}
+          - {IMAGE: "pyca/cryptography-runner-bullseye", TOXENV: "py39"}
           - {IMAGE: "pyca/cryptography-runner-sid", TOXENV: "py39"}
           - {IMAGE: "pyca/cryptography-runner-ubuntu-bionic", TOXENV: "py36"}
           - {IMAGE: "pyca/cryptography-runner-ubuntu-focal", TOXENV: "py38"}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   manylinux:
     runs-on: ubuntu-latest
-    container: ${{ matrix.MANYLINUX.CONTAINER }}
+    container: ghcr.io/${{ matrix.MANYLINUX.CONTAINER }}
     strategy:
       matrix:
         PYTHON: ["cp27-cp27m", "cp27-cp27mu", "cp36-cp36m"]

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -44,7 +44,7 @@
     vars:
       wheel_builds:
         - platform: manylinux2014_aarch64
-          image: pyca/cryptography-manylinux2014_aarch64
+          image: ghcr.io/pyca/cryptography-manylinux2014_aarch64
           pythons:
             - cp36-cp36m
 
@@ -55,13 +55,13 @@
     vars:
       wheel_builds:
         - platform: manylinux1_x86_64
-          image: pyca/cryptography-manylinux1:x86_64
+          image: ghcr.io/pyca/cryptography-manylinux1:x86_64
           pythons:
             - cp27-cp27m
             - cp27-cp27mu
             - cp36-cp36m
         - platform: manylinux2010_x86_64
-          image: pyca/cryptography-manylinux2010:x86_64
+          image: ghcr.io/pyca/cryptography-manylinux2010:x86_64
           pythons:
             - cp27-cp27m
             - cp27-cp27mu

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. _v3-3-2:
+
+3.3.2 - 2021-02-07
+~~~~~~~~~~~~~~~~~~
+
+* **SECURITY ISSUE:** Fixed a bug where certain sequences of ``update()`` calls
+  when symmetrically encrypting very large payloads (>2GB) could result in an
+  integer overflow, leading to buffer overflows. *CVE-2020-36242*
+
 .. _v3-3-1:
 
 3.3.1 - 2020-12-09

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Cryptography"
-copyright = "2013-2020, Individual Contributors"
+copyright = "2013-2021, Individual Contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -22,10 +22,10 @@ __summary__ = (
 )
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "3.3.1"
+__version__ = "3.3.2"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"
 
 __license__ = "BSD or Apache License, Version 2.0"
-__copyright__ = "Copyright 2013-2020 {}".format(__author__)
+__copyright__ = "Copyright 2013-2021 {}".format(__author__)

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives.ciphers import modes
 class _CipherContext(object):
     _ENCRYPT = 1
     _DECRYPT = 0
-    _MAX_CHUNK_SIZE = 2 ** 31 - 1
+    _MAX_CHUNK_SIZE = 2 ** 30 - 1
 
     def __init__(self, backend, cipher, mode, operation):
         self._backend = backend

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -20,10 +20,10 @@ __summary__ = "Test vectors for the cryptography package."
 
 __uri__ = "https://github.com/pyca/cryptography"
 
-__version__ = "3.3.1"
+__version__ = "3.3.2"
 
 __author__ = "The cryptography developers"
 __email__ = "cryptography-dev@python.org"
 
 __license__ = "BSD or Apache License, Version 2.0"
-__copyright__ = "Copyright 2013-2020 %s" % __author__
+__copyright__ = "Copyright 2013-2021 %s" % __author__


### PR DESCRIPTION
frustratingly, there is no test for this -- that's because testing this
requires allocating more memory than is available in CI.

fixes #5615.