### PR TITLE
[3.4] Interface: Make annotation check optional (#5775)

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -77,3 +77,27 @@ class TestVerifyInterface(object):
         # Invoke this to ensure the line is covered
         NonImplementer().property
         verify_interface(SimpleInterface, NonImplementer)
+
+    def test_signature_mismatch(self):
+        class SimpleInterface(metaclass=abc.ABCMeta):
+            @abc.abstractmethod
+            def method(self, other: object) -> int:
+                """Method with signature"""
+
+        class ClassWithoutSignature:
+            def method(self, other):
+                """Method without signature"""
+
+        class ClassWithSignature:
+            def method(self, other: object) -> int:
+                """Method with signature"""
+
+        verify_interface(SimpleInterface, ClassWithoutSignature)
+        verify_interface(SimpleInterface, ClassWithSignature)
+        with pytest.raises(InterfaceNotImplemented):
+            verify_interface(
+                SimpleInterface, ClassWithoutSignature, check_annotations=True
+            )
+        verify_interface(
+            SimpleInterface, ClassWithSignature, check_annotations=True
+        )


### PR DESCRIPTION
Fixes: https://github.com/pyca/cryptography/issues/5774
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Co-authored-by: Stanislav Levin <slev@altlinux.org>
