### PR TITLE
[3.4] Remove setuptools_rust from install requirement (#5779)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,11 @@ with open(os.path.join(src_dir, "cryptography", "__about__.py")) as f:
     exec(f.read(), about)
 
 
-# `setup_requirements` must be kept in sync with `pyproject.toml`
-setup_requirements = ["cffi>=1.12", "setuptools-rust>=0.11.4"]
+# `install_requirements` and `setup_requirements` must be kept in sync with
+# `pyproject.toml`
+setuptools_rust = "setuptools-rust>=0.11.4"
+install_requirements = ["cffi>=1.12"]
+setup_requirements = install_requirements + [setuptools_rust]
 
 if os.environ.get("CRYPTOGRAPHY_DONT_BUILD_RUST"):
     rust_extensions = []
@@ -102,7 +105,7 @@ try:
         ),
         include_package_data=True,
         python_requires=">=3.6",
-        install_requires=setup_requirements,
+        install_requires=install_requirements,
         setup_requires=setup_requirements,
         extras_require={
             "test": [
@@ -124,6 +127,9 @@ try:
                 "pyenchant >= 1.6.11",
                 "twine >= 1.12.0",
                 "sphinxcontrib-spelling >= 4.0.1",
+            ],
+            "sdist": [
+                setuptools_rust,
             ],
             "pep8test": [
                 "black",

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
 extras =
     docs
     docstest
+    sdist
 basepython = python3
 commands =
     sphinx-build -T -W -b html -d {envtmpdir}/doctrees docs docs/_build/html


### PR DESCRIPTION
Fixes: https://github.com/pyca/cryptography/issues/5778
Signed-off-by: Christian Heimes <cheimes@redhat.com>
