### PR TITLE
Import serialization early to break cyclic import

### DIFF
--- a/src/cryptography/hazmat/primitives/__init__.py
+++ b/src/cryptography/hazmat/primitives/__init__.py
@@ -1,3 +1,6 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+
+# break import cycle, see https://github.com/pyca/cryptography/issues/5794
+from . import serialization


### PR DESCRIPTION
Fixes: https://github.com/pyca/cryptography/issues/5794
Signed-off-by: Christian Heimes <cheimes@redhat.com>