### PR TITLE
Create py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include LICENSE.PSF
 include README.rst
 
 include pyproject.toml
+recursive-include src py.typed
 
 recursive-include docs *
 recursive-include src/_cffi_src *.py *.c *.h


### PR DESCRIPTION
the changelog lists:

> cryptography now has PEP 484 type hints on nearly all of of its public APIs. Users can begin using them to type check their code with mypy.

but I'm still falling back to typeshed because this file is missing