### PR TITLE
fix signature of EllipticCurvePublicKey.verify()

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -176,7 +176,7 @@ class EllipticCurvePublicKey(metaclass=abc.ABCMeta):
         self,
         signature: bytes,
         data: bytes,
-        algorithm: EllipticCurveSignatureAlgorithm,
+        signature_algorithm: EllipticCurveSignatureAlgorithm,
     ) -> None:
         """
         Verifies the signature of the data.


### PR DESCRIPTION
The signature change was introduced in https://github.com/pyca/cryptography/pull/5729 but is inconsistent with respect to related methods, breaks backward compatibility and compatibility with the OpenSSL backend (and maybe other backends) when named arguments are used.
The issue is present for all versions >= 3.4.