### PR TITLE
make Extension a generic class (fixes #5830)

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/decode_asn1.py
+++ b/src/cryptography/hazmat/backends/openssl/decode_asn1.py
@@ -5,6 +5,7 @@
 
 import datetime
 import ipaddress
+import typing
 
 from cryptography import x509
 from cryptography.hazmat._der import DERReader, INTEGER, NULL, SEQUENCE
@@ -185,7 +186,7 @@ class _X509ExtensionParser(object):
         self._backend = backend
 
     def parse(self, x509_obj):
-        extensions = []
+        extensions: typing.List[x509.Extension[x509.ExtensionType]] = []
         seen_oids = set()
         for i in range(self.ext_count(x509_obj)):
             ext = self.get_ext(x509_obj, i)

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -33,6 +33,8 @@ from cryptography.x509.oid import (
     ObjectIdentifier,
 )
 
+ExtensionTypeVar = typing.TypeVar("ExtensionTypeVar", bound="ExtensionType")
+
 
 def _key_identifier_from_public_key(public_key: _PUBLIC_KEY_TYPES) -> bytes:
     if isinstance(public_key, RSAPublicKey):
@@ -108,17 +110,19 @@ class ExtensionType(metaclass=abc.ABCMeta):
 
 
 class Extensions(object):
-    def __init__(self, extensions: typing.List["Extension"]):
+    def __init__(self, extensions: typing.List["Extension[ExtensionType]"]):
         self._extensions = extensions
 
-    def get_extension_for_oid(self, oid: ObjectIdentifier) -> "Extension":
+    def get_extension_for_oid(
+        self, oid: ObjectIdentifier
+    ) -> "Extension[ExtensionType]":
         for ext in self:
             if ext.oid == oid:
                 return ext
 
         raise ExtensionNotFound("No {} extension was found".format(oid), oid)
 
-    def get_extension_for_class(self, extclass) -> "Extension":
+    def get_extension_for_class(self, extclass) -> "Extension[ExtensionType]":
         if extclass is UnrecognizedExtension:
             raise TypeError(
                 "UnrecognizedExtension can't be used with "
@@ -1220,9 +1224,9 @@ class NameConstraints(ExtensionType):
     excluded_subtrees = utils.read_only_property("_excluded_subtrees")
 
 
-class Extension(object):
+class Extension(typing.Generic[ExtensionTypeVar]):
     def __init__(
-        self, oid: ObjectIdentifier, critical: bool, value: ExtensionType
+        self, oid: ObjectIdentifier, critical: bool, value: ExtensionTypeVar
     ):
         if not isinstance(oid, ObjectIdentifier):
             raise TypeError(


### PR DESCRIPTION
That was simpler then expected (I was expecting more mypy errors).

One thing to note: For the `Extensions` (plural) class, typeshed does this:

```
    def __init__(self, general_names: List[Extension[Any]]) -> None: ...
```

while I do the slightly more specific:

```
def __init__(self, extensions: typing.List["Extension[ExtensionType]"]):
```