### PR TITLE
Add support for SM4 symmetric block cipher

### DIFF
--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -196,6 +196,19 @@ Algorithms
         :term:`bits` in length.
     :type key: :term:`bytes-like`
 
+.. class:: SM4(key)
+
+    .. versionadded:: 35.0.0
+
+    SM4 is a block cipher developed by the Chinese Government and standardized
+    in the `GB/T 32907-2016`_. It is used in the Chinese WAPI
+    (Wired Authentication and Privacy Infrastructure) standard. (An English
+    description is available at `draft-ribose-cfrg-sm4-10`_.)
+
+    :param key: The secret key. This must be kept secret. ``128``
+        :term:`bits` in length.
+    :type key: :term:`bytes-like`
+
 Weak ciphers
 ------------
 
@@ -815,3 +828,5 @@ Exceptions
 .. _`International Data Encryption Algorithm`: https://en.wikipedia.org/wiki/International_Data_Encryption_Algorithm
 .. _`OpenPGP`: https://www.openpgp.org/
 .. _`disk encryption`: https://en.wikipedia.org/wiki/Disk_encryption_theory#XTS
+.. _`GB/T 32907-2016`: http://www.cnnic.cn/gcjsyj/qyjsyj/mmsfbz/sm4/201312/t20131204_43341.htm
+.. _`draft-ribose-cfrg-sm4-10`: https://tools.ietf.org/html/draft-ribose-cfrg-sm4-10

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -135,6 +135,7 @@ from cryptography.hazmat.primitives.ciphers.algorithms import (
     ChaCha20,
     IDEA,
     SEED,
+    SM4,
     TripleDES,
 )
 from cryptography.hazmat.primitives.ciphers.modes import (
@@ -411,6 +412,10 @@ class Backend(object):
             ChaCha20, type(None), GetCipherByName("chacha20")
         )
         self.register_cipher_adapter(AES, XTS, _get_xts_cipher)
+        for mode_cls in [ECB, CBC, OFB, CFB, CTR]:
+            self.register_cipher_adapter(
+                SM4, mode_cls, GetCipherByName("sm4-{mode.name}")
+            )
 
     def _register_x509_ext_parsers(self):
         ext_handlers = _EXTENSION_HANDLERS_BASE.copy()

--- a/src/cryptography/hazmat/primitives/ciphers/algorithms.py
+++ b/src/cryptography/hazmat/primitives/ciphers/algorithms.py
@@ -153,3 +153,16 @@ class ChaCha20(CipherAlgorithm, ModeWithNonce):
     @property
     def key_size(self) -> int:
         return len(self.key) * 8
+
+
+class SM4(CipherAlgorithm, BlockCipherAlgorithm):
+    name = "SM4"
+    block_size = 128
+    key_sizes = frozenset([128])
+
+    def __init__(self, key: bytes):
+        self.key = _verify_key_size(self, key)
+
+    @property
+    def key_size(self) -> int:
+        return len(self.key) * 8

--- a/tests/hazmat/primitives/test_sm4.py
+++ b/tests/hazmat/primitives/test_sm4.py
@@ -1,0 +1,99 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+import binascii
+import os
+
+import pytest
+
+from cryptography.hazmat.backends.interfaces import CipherBackend
+from cryptography.hazmat.primitives.ciphers import algorithms, modes
+
+from .utils import generate_encrypt_test
+from ...utils import load_nist_vectors
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.cipher_supported(
+        algorithms.SM4(b"\x00" * 16), modes.ECB()
+    ),
+    skip_message="Does not support SM4 ECB",
+)
+@pytest.mark.requires_backend_interface(interface=CipherBackend)
+class TestSM4ModeECB(object):
+    test_ecb = generate_encrypt_test(
+        load_nist_vectors,
+        os.path.join("ciphers", "SM4"),
+        ["draft-ribose-cfrg-sm4-10-ecb.txt"],
+        lambda key, **kwargs: algorithms.SM4(binascii.unhexlify((key))),
+        lambda **kwargs: modes.ECB(),
+    )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.cipher_supported(
+        algorithms.SM4(b"\x00" * 16), modes.CBC(b"\x00" * 16)
+    ),
+    skip_message="Does not support SM4 CBC",
+)
+@pytest.mark.requires_backend_interface(interface=CipherBackend)
+class TestSM4ModeCBC(object):
+    test_cbc = generate_encrypt_test(
+        load_nist_vectors,
+        os.path.join("ciphers", "SM4"),
+        ["draft-ribose-cfrg-sm4-10-cbc.txt"],
+        lambda key, **kwargs: algorithms.SM4(binascii.unhexlify((key))),
+        lambda iv, **kwargs: modes.CBC(binascii.unhexlify(iv)),
+    )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.cipher_supported(
+        algorithms.SM4(b"\x00" * 16), modes.OFB(b"\x00" * 16)
+    ),
+    skip_message="Does not support SM4 OFB",
+)
+@pytest.mark.requires_backend_interface(interface=CipherBackend)
+class TestSM4ModeOFB(object):
+    test_ofb = generate_encrypt_test(
+        load_nist_vectors,
+        os.path.join("ciphers", "SM4"),
+        ["draft-ribose-cfrg-sm4-10-ofb.txt"],
+        lambda key, **kwargs: algorithms.SM4(binascii.unhexlify((key))),
+        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+    )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.cipher_supported(
+        algorithms.SM4(b"\x00" * 16), modes.CFB(b"\x00" * 16)
+    ),
+    skip_message="Does not support SM4 CFB",
+)
+@pytest.mark.requires_backend_interface(interface=CipherBackend)
+class TestSM4ModeCFB(object):
+    test_cfb = generate_encrypt_test(
+        load_nist_vectors,
+        os.path.join("ciphers", "SM4"),
+        ["draft-ribose-cfrg-sm4-10-cfb.txt"],
+        lambda key, **kwargs: algorithms.SM4(binascii.unhexlify((key))),
+        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+    )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.cipher_supported(
+        algorithms.SM4(b"\x00" * 16), modes.CTR(b"\x00" * 16)
+    ),
+    skip_message="Does not support SM4 CTR",
+)
+@pytest.mark.requires_backend_interface(interface=CipherBackend)
+class TestSM4ModeCTR(object):
+    test_cfb = generate_encrypt_test(
+        load_nist_vectors,
+        os.path.join("ciphers", "SM4"),
+        ["draft-ribose-cfrg-sm4-10-ctr.txt"],
+        lambda key, **kwargs: algorithms.SM4(binascii.unhexlify((key))),
+        lambda iv, **kwargs: modes.CTR(binascii.unhexlify(iv)),
+    )

--- a/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-cbc.txt
+++ b/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-cbc.txt
@@ -1,0 +1,17 @@
+# Vectors from draft-ribose-cfrg-sm4-10.txt. Reformatted to work with the NIST loader
+# SM4 CBC
+[ENCRYPT]
+
+# A.2.2.1
+COUNT = 0
+KEY = 0123456789abcdeffedcba9876543210
+PLAINTEXT = aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffaaaaaaaabbbbbbbb
+IV = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = 78ebb11cc40b0a48312aaeb2040244cb4cb7016951909226979b0d15dc6a8f6d
+
+# A.2.2.2
+COUNT = 1
+KEY = fedcba98765432100123456789abcdef
+PLAINTEXT = aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffaaaaaaaabbbbbbbb
+IV = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = 0d3a6ddc2d21c698857215587b7bb59a91f2c147911a4144665e1fa1d40bae38

--- a/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-cfb.txt
+++ b/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-cfb.txt
@@ -1,0 +1,17 @@
+# Vectors from draft-ribose-cfrg-sm4-10.txt. Reformatted to work with the NIST loader
+# SM4 CFB
+[ENCRYPT]
+
+# A.2.4.1
+COUNT = 0
+KEY = 0123456789abcdeffedcba9876543210
+PLAINTEXT = aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffaaaaaaaabbbbbbbb
+IV = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = ac3236cb861dd316e6413b4e3c7524b769d4c54ed433b9a0346009beb37b2b3f
+
+# A.2.4.2
+COUNT = 1
+KEY = fedcba98765432100123456789abcdef
+PLAINTEXT = aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffaaaaaaaabbbbbbbb
+IV = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = 5dcccd25a84ba16560d7f265887068490d9b86ff20c3bfe115ffa02ca6192cc5

--- a/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-ctr.txt
+++ b/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-ctr.txt
@@ -1,0 +1,17 @@
+# Vectors from draft-ribose-cfrg-sm4-10.txt. Reformatted to work with the NIST loader
+# SM4 CTR
+[ENCRYPT]
+
+# A.2.5.1
+COUNT = 0
+KEY = 0123456789abcdeffedcba9876543210
+PLAINTEXT = aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccccccccccddddddddddddddddeeeeeeeeeeeeeeeeffffffffffffffffaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb
+IV = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = ac3236cb970cc20791364c395a1342d1a3cbc1878c6f30cd074cce385cdd70c7f234bc0e24c11980fd1286310ce37b926e02fcd0faa0baf38b2933851d824514
+
+# A.2.5.2
+COUNT = 1
+KEY = fedcba98765432100123456789abcdef
+PLAINTEXT = aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccccccccccddddddddddddddddeeeeeeeeeeeeeeeeffffffffffffffffaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb
+IV = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = 5dcccd25b95ab07417a08512ee160e2f8f661521cbbab44cc87138445bc29e5c0ae0297205d62704173b21239b887f6c8cb5b800917a2488284bde9e16ea2906

--- a/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-ecb.txt
+++ b/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-ecb.txt
@@ -1,0 +1,28 @@
+# Vectors from draft-ribose-cfrg-sm4-10.txt. Reformatted to work with the NIST loader
+# Originally from GB/T 32907-2016 Example 1
+# SM4 ECB
+[ENCRYPT]
+
+# A.1.1/A.1.2
+COUNT = 0
+KEY = 0123456789abcdeffedcba9876543210
+PLAINTEXT = 0123456789abcdeffedcba9876543210
+CIPHERTEXT = 681edf34d206965e86b3e94f536e4246
+
+# A.1.4/A.1.5
+COUNT = 1
+KEY = fedcba98765432100123456789abcdef
+PLAINTEXT = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = f766678f13f01adeac1b3ea955adb594
+
+# A.2.1.1
+COUNT = 2
+KEY = 0123456789abcdeffedcba9876543210
+PLAINTEXT = aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffaaaaaaaabbbbbbbb
+CIPHERTEXT = 5ec8143de509cff7b5179f8f474b86192f1d305a7fb17df985f81c8482192304
+
+# A.2.1.2
+COUNT = 3
+KEY = fedcba98765432100123456789abcdef
+PLAINTEXT = aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffaaaaaaaabbbbbbbb
+CIPHERTEXT = c5876897e4a59bbba72a10c83872245b12dd90bc2d200692b529a4155ac9e600

--- a/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-ofb.txt
+++ b/vectors/cryptography_vectors/ciphers/SM4/draft-ribose-cfrg-sm4-10-ofb.txt
@@ -1,0 +1,17 @@
+# Vectors from draft-ribose-cfrg-sm4-10.txt. Reformatted to work with the NIST loader
+# SM4 OFB
+[ENCRYPT]
+
+# A.2.3.1
+COUNT = 0
+KEY = 0123456789abcdeffedcba9876543210
+PLAINTEXT = aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffaaaaaaaabbbbbbbb
+IV = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = ac3236cb861dd316e6413b4e3c7524b71d01aca2487ca582cbf5463e6698539b
+
+# A.2.3.2
+COUNT = 1
+KEY = fedcba98765432100123456789abcdef
+PLAINTEXT = aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffaaaaaaaabbbbbbbb
+IV = 000102030405060708090a0b0c0d0e0f
+CIPHERTEXT = 5dcccd25a84ba16560d7f2658870684933fa16bd5cd9c856cacaa1e101897a97


### PR DESCRIPTION
This PR includes python classes for SM4, as well as test vectors and documentation.

SM4 is supported in [OpenSSL 1.1.1](https://www.openssl.org/docs/man1.1.1/man3/EVP_sm4_ecb.html).

See also #5833.