### PR TITLE
protect against integer overfows in release rust

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,3 +14,4 @@ crate-type = ["cdylib"]
 
 [profile.release]
 lto = "thin"
+overflow-checks = true


### PR DESCRIPTION
this would have categorically prevented CVE-2020-36242 (if the code had been written in Rust)