### PR TITLE
port 3.4.6 changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -89,7 +89,7 @@ Changelog
 * **SECURITY ISSUE:** Fixed a bug where certain sequences of ``update()`` calls
   when symmetrically encrypting very large payloads (>2GB) could result in an
   integer overflow, leading to buffer overflows. *CVE-2020-36242* **Update:**
-  This fix is a workaround for *CVE-2021-23840* in OpenSSL, fixed in OpenSSL 
+  This fix is a workaround for *CVE-2021-23840* in OpenSSL, fixed in OpenSSL
   1.1.1j.
 
 .. _v3-3-1:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ Changelog
 
  .. note:: This version is not yet released and is under active development.
 
+.. _v3-4-6:
+
+3.4.6 - 2021-02-16
+~~~~~~~~~~~~~~~~~~
+
+* Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
+  OpenSSL 1.1.1j.
+
 .. _v3-4-5:
 
 3.4.5 - 2021-02-13
@@ -80,7 +88,9 @@ Changelog
 
 * **SECURITY ISSUE:** Fixed a bug where certain sequences of ``update()`` calls
   when symmetrically encrypting very large payloads (>2GB) could result in an
-  integer overflow, leading to buffer overflows. *CVE-2020-36242*
+  integer overflow, leading to buffer overflows. *CVE-2020-36242* **Update:**
+  This fix is a workaround for *CVE-2021-23840* in OpenSSL, fixed in OpenSSL 
+  1.1.1j.
 
 .. _v3-3-1:
 


### PR DESCRIPTION
Also link CVE-2020-36242 to CVE-2021-23840 since our 3.3.2 security fix is just a workaround for the OpenSSL issue.