### PR TITLE
Add key_identifier property to SubjectKeyIdentifier

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1945,6 +1945,15 @@ X.509 Extensions
         Returns
         :attr:`~cryptography.x509.oid.ExtensionOID.SUBJECT_KEY_IDENTIFIER`.
 
+    .. attribute:: key_identifier
+
+        .. versionadded:: 35.0.0
+
+        :type: bytes
+
+        A value derived from the public key used to verify the certificate's
+        signature.
+
     .. attribute:: digest
 
         :type: bytes

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -288,6 +288,10 @@ class SubjectKeyIdentifier(ExtensionType):
     def digest(self) -> bytes:
         return self._digest
 
+    @property
+    def key_identifier(self) -> bytes:
+        return self._digest
+
     def __repr__(self):
         return "<SubjectKeyIdentifier(digest={0!r})>".format(self.digest)
 

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -994,6 +994,7 @@ class TestSubjectKeyIdentifier(object):
         value = binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         ski = x509.SubjectKeyIdentifier(value)
         assert ski.digest == value
+        assert ski.key_identifier == value
 
     def test_repr(self):
         ski = x509.SubjectKeyIdentifier(


### PR DESCRIPTION
Add a `key_identifier` property to `SubjectKeyIdentifier` to be consistent with `AuthorityKeyIdentifier`. Fix #5848