### PR TITLE
add ObjectIdentifier.name property

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 
  .. note:: This version is not yet released and is under active development.
 
+* Add a ``name`` property to :class:`cryptography.x509.ObjectIdentifier`.
+
 .. _v3-4-6:
 
 3.4.6 - 2021-02-16

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1377,6 +1377,12 @@ X.509 CSR (Certificate Signing Request) Builder Object
 
         The dotted string value of the OID (e.g. ``"2.5.4.3"``)
 
+    .. attribute:: name
+
+        :type: :class:`str`
+
+        The name of the OID (e.g. ``"commonName"`` or ``"extendedKeyUsage"``)
+
 
 .. _general_name_classes:
 

--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -71,5 +71,9 @@ class ObjectIdentifier(object):
         return _OID_NAMES.get(self, "Unknown OID")
 
     @property
+    def name(self) -> str:
+        return self._name
+
+    @property
     def dotted_string(self) -> str:
         return self._dotted_string

--- a/tests/hazmat/test_oid.py
+++ b/tests/hazmat/test_oid.py
@@ -12,6 +12,11 @@ def test_basic_oid():
     assert ObjectIdentifier("1.2.3.4").dotted_string == "1.2.3.4"
 
 
+def test_name():
+    assert ObjectIdentifier("2.5.29.15").name == "keyUsage"
+    assert ObjectIdentifier("2.5.4.3").name == "commonName"
+
+
 def test_oid_constraint():
     # Too short
     with pytest.raises(ValueError):


### PR DESCRIPTION
Add a `name` property to ObjectIdentifiers.

I really don't see why this is just a private property. Both `ObjectIdentifier._name` and `cryptography.x509.oid._OID_NAMES` are private. This makes it impossible to display your own representation of an ObjectID without accessing private APIs.

I do propose leaving the old property in place, as lots of code probably still uses it, including my own code.

PS: Is the changelog really accurate? do you intend to switch to a new versioning scheme in the next release? See Version 35 vs. 3.5.