### PR TITLE
add typehint for ObjectIdentifier._name

### DIFF
--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -64,7 +64,7 @@ class ObjectIdentifier(object):
         return hash(self.dotted_string)
 
     @property
-    def _name(self):
+    def _name(self) -> str:
         # Lazy import to avoid an import cycle
         from cryptography.x509.oid import _OID_NAMES
 


### PR DESCRIPTION
As discussed in #5852, at least add a typehint to `_name`.

Question: I did not want to add this here without asking, but is it wanted to add typehints to other private functions (such as `__repr__`) as well? mypy would warn about these in strict mode. If yes, I can add them to this PR, at least for this module (and would volunteer to add them elsewhere, too).