### PR TITLE
Remove unused X509 verification flags bindings

### DIFF
--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -18,7 +18,6 @@ typedef STACK_OF(X509_OBJECT) Cryptography_STACK_OF_X509_OBJECT;
 """
 
 TYPES = """
-static const long Cryptography_HAS_102_VERIFICATION;
 static const long Cryptography_HAS_110_VERIFICATION_PARAMS;
 static const long Cryptography_HAS_X509_STORE_CTX_GET_ISSUER;
 
@@ -90,12 +89,6 @@ static const int X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE;
 static const int X509_V_ERR_UNSUPPORTED_CONSTRAINT_SYNTAX;
 static const int X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
 static const int X509_V_ERR_CRL_PATH_VALIDATION_ERROR;
-static const int X509_V_ERR_SUITE_B_INVALID_VERSION;
-static const int X509_V_ERR_SUITE_B_INVALID_ALGORITHM;
-static const int X509_V_ERR_SUITE_B_INVALID_CURVE;
-static const int X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM;
-static const int X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED;
-static const int X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256;
 static const int X509_V_ERR_HOSTNAME_MISMATCH;
 static const int X509_V_ERR_EMAIL_MISMATCH;
 static const int X509_V_ERR_IP_ADDRESS_MISMATCH;
@@ -118,9 +111,6 @@ static const long X509_V_FLAG_EXTENDED_CRL_SUPPORT;
 static const long X509_V_FLAG_USE_DELTAS;
 static const long X509_V_FLAG_CHECK_SS_SIGNATURE;
 static const long X509_V_FLAG_TRUSTED_FIRST;
-static const long X509_V_FLAG_SUITEB_128_LOS_ONLY;
-static const long X509_V_FLAG_SUITEB_192_LOS;
-static const long X509_V_FLAG_SUITEB_128_LOS;
 static const long X509_V_FLAG_PARTIAL_CHAIN;
 static const long X509_V_FLAG_NO_ALT_CHAINS;
 static const long X509_V_FLAG_NO_CHECK_TIME;
@@ -224,21 +214,6 @@ void X509_STORE_set_get_issuer(X509_STORE *, X509_STORE_CTX_get_issuer_fn);
 """
 
 CUSTOMIZATIONS = """
-#if !CRYPTOGRAPHY_IS_LIBRESSL
-static const long Cryptography_HAS_102_VERIFICATION = 1;
-#else
-static const long Cryptography_HAS_102_VERIFICATION = 0;
-static const long X509_V_ERR_SUITE_B_INVALID_VERSION = 0;
-static const long X509_V_ERR_SUITE_B_INVALID_ALGORITHM = 0;
-static const long X509_V_ERR_SUITE_B_INVALID_CURVE = 0;
-static const long X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM = 0;
-static const long X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED = 0;
-static const long X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256 = 0;
-static const long X509_V_FLAG_SUITEB_128_LOS_ONLY = 0;
-static const long X509_V_FLAG_SUITEB_192_LOS = 0;
-static const long X509_V_FLAG_SUITEB_128_LOS = 0;
-#endif
-
 #if CRYPTOGRAPHY_IS_LIBRESSL
 static const long Cryptography_HAS_110_VERIFICATION_PARAMS = 0;
 #ifndef X509_CHECK_FLAG_NEVER_CHECK_SUBJECT

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -31,20 +31,6 @@ def cryptography_has_ssl3_method():
     ]
 
 
-def cryptography_has_102_verification():
-    return [
-        "X509_V_ERR_SUITE_B_INVALID_VERSION",
-        "X509_V_ERR_SUITE_B_INVALID_ALGORITHM",
-        "X509_V_ERR_SUITE_B_INVALID_CURVE",
-        "X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM",
-        "X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED",
-        "X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256",
-        "X509_V_FLAG_SUITEB_128_LOS_ONLY",
-        "X509_V_FLAG_SUITEB_192_LOS",
-        "X509_V_FLAG_SUITEB_128_LOS",
-    ]
-
-
 def cryptography_has_110_verification_params():
     return ["X509_CHECK_FLAG_NEVER_CHECK_SUBJECT"]
 
@@ -280,7 +266,6 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_RSA_OAEP_MD": cryptography_has_rsa_oaep_md,
     "Cryptography_HAS_RSA_OAEP_LABEL": cryptography_has_rsa_oaep_label,
     "Cryptography_HAS_SSL3_METHOD": cryptography_has_ssl3_method,
-    "Cryptography_HAS_102_VERIFICATION": cryptography_has_102_verification,
     "Cryptography_HAS_110_VERIFICATION_PARAMS": (
         cryptography_has_110_verification_params
     ),


### PR DESCRIPTION
These don't appear to be used in pyopenssl or cryptography.io. One less source of conditionals.