### PR TITLE
changes to support typing backend

### DIFF
--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -378,3 +378,9 @@ class ScryptBackend(metaclass=abc.ABCMeta):
         """
         Return bytes derived from provided Scrypt parameters.
         """
+
+    @abc.abstractmethod
+    def scrypt_supported(self):
+        """
+        Return True if Scrypt is supported.
+        """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -161,22 +161,21 @@ class _RC2(object):
     pass
 
 
-@utils.register_interface(CipherBackend)
-@utils.register_interface(CMACBackend)
-@utils.register_interface(DERSerializationBackend)
-@utils.register_interface(DHBackend)
-@utils.register_interface(DSABackend)
-@utils.register_interface(EllipticCurveBackend)
-@utils.register_interface(HashBackend)
-@utils.register_interface(HMACBackend)
-@utils.register_interface(PBKDF2HMACBackend)
-@utils.register_interface(RSABackend)
-@utils.register_interface(PEMSerializationBackend)
-@utils.register_interface(X509Backend)
-@utils.register_interface_if(
-    binding.Binding().lib.Cryptography_HAS_SCRYPT, ScryptBackend
-)
-class Backend(object):
+class Backend(
+    CipherBackend,
+    CMACBackend,
+    DERSerializationBackend,
+    DHBackend,
+    DSABackend,
+    EllipticCurveBackend,
+    HashBackend,
+    HMACBackend,
+    PBKDF2HMACBackend,
+    RSABackend,
+    PEMSerializationBackend,
+    ScryptBackend,
+    X509Backend,
+):
     """
     OpenSSL API binding interfaces.
     """
@@ -342,6 +341,9 @@ class Backend(object):
 
         evp_md = self._evp_md_from_algorithm(algorithm)
         return evp_md != self._ffi.NULL
+
+    def scrypt_supported(self):
+        return self._lib.Cryptography_HAS_SCRYPT == 1
 
     def hmac_supported(self, algorithm):
         return self.hash_supported(algorithm)

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -44,6 +44,10 @@ def test_memory_limit_skip():
     _skip_if_memory_limited(2 ** 31, {"p": 16, "r": 64, "n": 1024})
 
 
+@pytest.mark.supported(
+    only_if=lambda backend: backend.scrypt_supported(),
+    skip_message="Does not support Scrypt",
+)
 @pytest.mark.requires_backend_interface(interface=ScryptBackend)
 class TestScrypt(object):
     @pytest.mark.parametrize("params", vectors)


### PR DESCRIPTION
This gets rid of the conditional backend type registration. We could therefore delete `register_interface_if` but I'm a bit concerned it might be used elsewhere. Perhaps we should deprecate it in a separate PR.