### PR TITLE
more typing

### DIFF
--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -13,6 +13,7 @@ import typing
 from cryptography import utils
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import hashes, padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.hmac import HMAC
@@ -26,7 +27,7 @@ _MAX_CLOCK_SKEW = 60
 
 
 class Fernet(object):
-    def __init__(self, key: bytes, backend=None):
+    def __init__(self, key: bytes, backend: typing.Optional[Backend] = None):
         backend = _get_backend(backend)
 
         key = base64.urlsafe_b64decode(key)

--- a/src/cryptography/hazmat/backends/__init__.py
+++ b/src/cryptography/hazmat/backends/__init__.py
@@ -4,7 +4,9 @@
 
 import typing
 
-_default_backend: typing.Any = None
+from cryptography.hazmat.backends.interfaces import Backend
+
+_default_backend: typing.Optional[Backend] = None
 
 
 def default_backend():
@@ -18,10 +20,7 @@ def default_backend():
     return _default_backend
 
 
-T = typing.TypeVar("T")
-
-
-def _get_backend(backend: typing.Optional[T]) -> T:
+def _get_backend(backend: typing.Optional[Backend]) -> Backend:
     if backend is None:
         return default_backend()
     else:

--- a/src/cryptography/hazmat/backends/__init__.py
+++ b/src/cryptography/hazmat/backends/__init__.py
@@ -18,7 +18,10 @@ def default_backend():
     return _default_backend
 
 
-def _get_backend(backend):
+T = typing.TypeVar("T")
+
+
+def _get_backend(backend: typing.Optional[T]) -> T:
     if backend is None:
         return default_backend()
     else:

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -317,6 +317,18 @@ class X509Backend(metaclass=abc.ABCMeta):
         Compute the DER encoded bytes of an X509 Name object.
         """
 
+    @abc.abstractmethod
+    def load_pem_x509_crl(self, data):
+        """
+        Load an X.509 CRL from PEM encoded data.
+        """
+
+    @abc.abstractmethod
+    def load_der_x509_crl(self, data):
+        """
+        Load an X.509 CRL from DER encoded data.
+        """
+
 
 class DHBackend(metaclass=abc.ABCMeta):
     @abc.abstractmethod
@@ -383,4 +395,55 @@ class ScryptBackend(metaclass=abc.ABCMeta):
     def scrypt_supported(self):
         """
         Return True if Scrypt is supported.
+        """
+
+
+# This is the catch-all for future backend methods and inherits all the
+# other interfaces as well so we can just use Backend for typing.
+class Backend(
+    CipherBackend,
+    CMACBackend,
+    DERSerializationBackend,
+    DHBackend,
+    DSABackend,
+    EllipticCurveBackend,
+    HashBackend,
+    HMACBackend,
+    PBKDF2HMACBackend,
+    RSABackend,
+    PEMSerializationBackend,
+    ScryptBackend,
+    X509Backend,
+    metaclass=abc.ABCMeta,
+):
+    @abc.abstractmethod
+    def load_pem_pkcs7_certificates(self, data):
+        """
+        Returns a list of x509.Certificate
+        """
+
+    @abc.abstractmethod
+    def load_der_pkcs7_certificates(self, data):
+        """
+        Returns a list of x509.Certificate
+        """
+
+    @abc.abstractmethod
+    def pkcs7_sign(self, builder, encoding, options):
+        """
+        Returns bytes
+        """
+
+    @abc.abstractmethod
+    def load_key_and_certificates_from_pkcs12(self, data, password):
+        """
+        Returns a tuple of (key, cert, [certs])
+        """
+
+    @abc.abstractmethod
+    def serialize_key_and_certificates_to_pkcs12(
+        self, name, key, cert, cas, encryption_algorithm
+    ):
+        """
+        Returns bytes
         """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -18,21 +18,7 @@ from cryptography.hazmat._der import (
     encode_der,
     encode_der_integer,
 )
-from cryptography.hazmat.backends.interfaces import (
-    CMACBackend,
-    CipherBackend,
-    DERSerializationBackend,
-    DHBackend,
-    DSABackend,
-    EllipticCurveBackend,
-    HMACBackend,
-    HashBackend,
-    PBKDF2HMACBackend,
-    PEMSerializationBackend,
-    RSABackend,
-    ScryptBackend,
-    X509Backend,
-)
+from cryptography.hazmat.backends.interfaces import Backend as BackendInterface
 from cryptography.hazmat.backends.openssl import aead
 from cryptography.hazmat.backends.openssl.ciphers import _CipherContext
 from cryptography.hazmat.backends.openssl.cmac import _CMACContext
@@ -161,21 +147,7 @@ class _RC2(object):
     pass
 
 
-class Backend(
-    CipherBackend,
-    CMACBackend,
-    DERSerializationBackend,
-    DHBackend,
-    DSABackend,
-    EllipticCurveBackend,
-    HashBackend,
-    HMACBackend,
-    PBKDF2HMACBackend,
-    RSABackend,
-    PEMSerializationBackend,
-    ScryptBackend,
-    X509Backend,
-):
+class Backend(BackendInterface):
     """
     OpenSSL API binding interfaces.
     """

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -7,19 +7,22 @@ import abc
 import typing
 
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import serialization
 
 
 _MIN_MODULUS_SIZE = 512
 
 
-def generate_parameters(generator, key_size, backend=None) -> "DHParameters":
+def generate_parameters(
+    generator: int, key_size: int, backend: typing.Optional[Backend] = None
+) -> "DHParameters":
     backend = _get_backend(backend)
     return backend.generate_dh_parameters(generator, key_size)
 
 
 class DHParameterNumbers(object):
-    def __init__(self, p: int, g: int, q: typing.Optional[int] = None):
+    def __init__(self, p: int, g: int, q: typing.Optional[int] = None) -> None:
         if not isinstance(p, int) or not isinstance(g, int):
             raise TypeError("p and g must be integers")
         if q is not None and not isinstance(q, int):
@@ -48,7 +51,9 @@ class DHParameterNumbers(object):
     def __ne__(self, other):
         return not self == other
 
-    def parameters(self, backend=None):
+    def parameters(
+        self, backend: typing.Optional[Backend] = None
+    ) -> "DHParameters":
         backend = _get_backend(backend)
         return backend.load_dh_parameter_numbers(self)
 
@@ -58,7 +63,7 @@ class DHParameterNumbers(object):
 
 
 class DHPublicNumbers(object):
-    def __init__(self, y, parameter_numbers: DHParameterNumbers):
+    def __init__(self, y: int, parameter_numbers: DHParameterNumbers) -> None:
         if not isinstance(y, int):
             raise TypeError("y must be an integer.")
 
@@ -82,7 +87,9 @@ class DHPublicNumbers(object):
     def __ne__(self, other):
         return not self == other
 
-    def public_key(self, backend=None) -> "DHPublicKey":
+    def public_key(
+        self, backend: typing.Optional[Backend] = None
+    ) -> "DHPublicKey":
         backend = _get_backend(backend)
         return backend.load_dh_public_numbers(self)
 
@@ -91,7 +98,7 @@ class DHPublicNumbers(object):
 
 
 class DHPrivateNumbers(object):
-    def __init__(self, x, public_numbers: DHPublicNumbers):
+    def __init__(self, x: int, public_numbers: DHPublicNumbers) -> None:
         if not isinstance(x, int):
             raise TypeError("x must be an integer.")
 
@@ -115,7 +122,9 @@ class DHPrivateNumbers(object):
     def __ne__(self, other):
         return not self == other
 
-    def private_key(self, backend=None) -> "DHPrivateKey":
+    def private_key(
+        self, backend: typing.Optional[Backend] = None
+    ) -> "DHPrivateKey":
         backend = _get_backend(backend)
         return backend.load_dh_private_numbers(self)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -7,6 +7,7 @@ import abc
 import typing
 
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import _serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import (
     AsymmetricSignatureContext,
@@ -136,7 +137,7 @@ class DSAPublicKey(metaclass=abc.ABCMeta):
         signature: bytes,
         data: bytes,
         algorithm: typing.Union[asym_utils.Prehashed, hashes.HashAlgorithm],
-    ):
+    ) -> None:
         """
         Verifies the signature of the data.
         """
@@ -164,7 +165,9 @@ class DSAParameterNumbers(object):
     q = property(lambda self: self._q)
     g = property(lambda self: self._g)
 
-    def parameters(self, backend=None) -> DSAParameters:
+    def parameters(
+        self, backend: typing.Optional[Backend] = None
+    ) -> DSAParameters:
         backend = _get_backend(backend)
         return backend.load_dsa_parameter_numbers(self)
 
@@ -200,7 +203,9 @@ class DSAPublicNumbers(object):
     y = property(lambda self: self._y)
     parameter_numbers = property(lambda self: self._parameter_numbers)
 
-    def public_key(self, backend=None) -> DSAPublicKey:
+    def public_key(
+        self, backend: typing.Optional[Backend] = None
+    ) -> DSAPublicKey:
         backend = _get_backend(backend)
         return backend.load_dsa_public_numbers(self)
 
@@ -238,7 +243,9 @@ class DSAPrivateNumbers(object):
     x = property(lambda self: self._x)
     public_numbers = property(lambda self: self._public_numbers)
 
-    def private_key(self, backend=None) -> DSAPrivateKey:
+    def private_key(
+        self, backend: typing.Optional[Backend] = None
+    ) -> DSAPrivateKey:
         backend = _get_backend(backend)
         return backend.load_dsa_private_numbers(self)
 
@@ -254,17 +261,21 @@ class DSAPrivateNumbers(object):
         return not self == other
 
 
-def generate_parameters(key_size: int, backend=None) -> DSAParameters:
+def generate_parameters(
+    key_size: int, backend: typing.Optional[Backend] = None
+) -> DSAParameters:
     backend = _get_backend(backend)
     return backend.generate_dsa_parameters(key_size)
 
 
-def generate_private_key(key_size: int, backend=None) -> DSAPrivateKey:
+def generate_private_key(
+    key_size: int, backend: typing.Optional[Backend] = None
+) -> DSAPrivateKey:
     backend = _get_backend(backend)
     return backend.generate_dsa_private_key_and_parameters(key_size)
 
 
-def _check_dsa_parameters(parameters: DSAParameterNumbers):
+def _check_dsa_parameters(parameters: DSAParameterNumbers) -> None:
     if parameters.p.bit_length() not in [1024, 2048, 3072, 4096]:
         raise ValueError(
             "p must be exactly 1024, 2048, 3072, or 4096 bits long"
@@ -276,7 +287,7 @@ def _check_dsa_parameters(parameters: DSAParameterNumbers):
         raise ValueError("g, p don't satisfy 1 < g < p.")
 
 
-def _check_dsa_private_numbers(numbers: DSAPrivateNumbers):
+def _check_dsa_private_numbers(numbers: DSAPrivateNumbers) -> None:
     parameters = numbers.public_numbers.parameter_numbers
     _check_dsa_parameters(parameters)
     if numbers.x <= 0 or numbers.x >= parameters.q:

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -10,6 +10,7 @@ import warnings
 from cryptography import utils
 from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import _serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import (
     AsymmetricSignatureContext,
@@ -104,7 +105,7 @@ class EllipticCurvePrivateKey(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def sign(
         self,
-        data,
+        data: bytes,
         signature_algorithm: EllipticCurveSignatureAlgorithm,
     ) -> bytes:
         """
@@ -340,14 +341,16 @@ class ECDSA(EllipticCurveSignatureAlgorithm):
 
 
 def generate_private_key(
-    curve: EllipticCurve, backend=None
+    curve: EllipticCurve, backend: typing.Optional[Backend] = None
 ) -> EllipticCurvePrivateKey:
     backend = _get_backend(backend)
     return backend.generate_elliptic_curve_private_key(curve)
 
 
 def derive_private_key(
-    private_value: int, curve: EllipticCurve, backend=None
+    private_value: int,
+    curve: EllipticCurve,
+    backend: typing.Optional[Backend] = None,
 ) -> EllipticCurvePrivateKey:
     backend = _get_backend(backend)
     if not isinstance(private_value, int):
@@ -374,7 +377,9 @@ class EllipticCurvePublicNumbers(object):
         self._x = x
         self._curve = curve
 
-    def public_key(self, backend=None) -> EllipticCurvePublicKey:
+    def public_key(
+        self, backend: typing.Optional[Backend] = None
+    ) -> EllipticCurvePublicKey:
         backend = _get_backend(backend)
         return backend.load_elliptic_curve_public_numbers(self)
 
@@ -466,7 +471,9 @@ class EllipticCurvePrivateNumbers(object):
         self._private_value = private_value
         self._public_numbers = public_numbers
 
-    def private_key(self, backend=None) -> EllipticCurvePrivateKey:
+    def private_key(
+        self, backend: typing.Optional[Backend] = None
+    ) -> EllipticCurvePrivateKey:
         backend = _get_backend(backend)
         return backend.load_elliptic_curve_private_numbers(self)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ed25519.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ed25519.py
@@ -80,7 +80,7 @@ class Ed25519PrivateKey(metaclass=abc.ABCMeta):
         encoding: _serialization.Encoding,
         format: _serialization.PrivateFormat,
         encryption_algorithm: _serialization.KeySerializationEncryption,
-    ):
+    ) -> bytes:
         """
         The serialized bytes of the private key.
         """

--- a/src/cryptography/hazmat/primitives/asymmetric/ed448.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ed448.py
@@ -33,7 +33,7 @@ class Ed448PublicKey(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def verify(self, signature: bytes, data: bytes):
+    def verify(self, signature: bytes, data: bytes) -> None:
         """
         Verify the signature.
         """
@@ -81,7 +81,7 @@ class Ed448PrivateKey(metaclass=abc.ABCMeta):
         encoding: _serialization.Encoding,
         format: _serialization.PrivateFormat,
         encryption_algorithm: _serialization.KeySerializationEncryption,
-    ):
+    ) -> bytes:
         """
         The serialized bytes of the private key.
         """

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -9,7 +9,7 @@ from math import gcd
 
 from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import RSABackend
+from cryptography.hazmat.backends.interfaces import Backend, RSABackend
 from cryptography.hazmat.primitives import _serialization, hashes
 from cryptography.hazmat.primitives._asymmetric import AsymmetricPadding
 from cryptography.hazmat.primitives.asymmetric import (
@@ -146,7 +146,9 @@ RSAPublicKeyWithSerialization = RSAPublicKey
 
 
 def generate_private_key(
-    public_exponent: int, key_size: int, backend=None
+    public_exponent: int,
+    key_size: int,
+    backend: typing.Optional[Backend] = None,
 ) -> RSAPrivateKey:
     backend = _get_backend(backend)
     if not isinstance(backend, RSABackend):
@@ -361,7 +363,9 @@ class RSAPrivateNumbers(object):
     iqmp = property(lambda self: self._iqmp)
     public_numbers = property(lambda self: self._public_numbers)
 
-    def private_key(self, backend=None) -> RSAPrivateKey:
+    def private_key(
+        self, backend: typing.Optional[Backend] = None
+    ) -> RSAPrivateKey:
         backend = _get_backend(backend)
         return backend.load_rsa_private_numbers(self)
 
@@ -407,7 +411,9 @@ class RSAPublicNumbers(object):
     e = property(lambda self: self._e)
     n = property(lambda self: self._n)
 
-    def public_key(self, backend=None) -> RSAPublicKey:
+    def public_key(
+        self, backend: typing.Optional[Backend] = None
+    ) -> RSAPublicKey:
         backend = _get_backend(backend)
         return backend.load_rsa_public_numbers(self)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/x448.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x448.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives import _serialization
 
 class X448PublicKey(metaclass=abc.ABCMeta):
     @classmethod
-    def from_public_bytes(cls, data) -> "X448PublicKey":
+    def from_public_bytes(cls, data: bytes) -> "X448PublicKey":
         from cryptography.hazmat.backends.openssl.backend import backend
 
         if not backend.x448_supported():

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -136,14 +136,16 @@ class AESCCM(object):
             backend, self, nonce, data, associated_data, self._tag_length
         )
 
-    def _validate_lengths(self, nonce: bytes, data_len: int):
+    def _validate_lengths(self, nonce: bytes, data_len: int) -> None:
         # For information about computing this, see
         # https://tools.ietf.org/html/rfc3610#section-2.1
         l_val = 15 - len(nonce)
         if 2 ** (8 * l_val) < data_len:
             raise ValueError("Data too long for nonce")
 
-    def _check_params(self, nonce: bytes, data: bytes, associated_data: bytes):
+    def _check_params(
+        self, nonce: bytes, data: bytes, associated_data: bytes
+    ) -> None:
         utils._check_byteslike("nonce", nonce)
         utils._check_bytes("data", data)
         utils._check_bytes("associated_data", associated_data)

--- a/src/cryptography/hazmat/primitives/ciphers/algorithms.py
+++ b/src/cryptography/hazmat/primitives/ciphers/algorithms.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives.ciphers import (
 from cryptography.hazmat.primitives.ciphers.modes import ModeWithNonce
 
 
-def _verify_key_size(algorithm: CipherAlgorithm, key: bytes):
+def _verify_key_size(algorithm: CipherAlgorithm, key: bytes) -> bytes:
     # Verify that the key is instance of bytes
     utils._check_byteslike("key", key)
 

--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -15,7 +15,7 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import CipherBackend
+from cryptography.hazmat.backends.interfaces import Backend, CipherBackend
 from cryptography.hazmat.primitives._cipheralgorithm import CipherAlgorithm
 from cryptography.hazmat.primitives.ciphers import modes
 
@@ -81,7 +81,7 @@ class Cipher(object):
         self,
         algorithm: CipherAlgorithm,
         mode: typing.Optional[modes.Mode],
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
         if not isinstance(backend, CipherBackend):
@@ -161,7 +161,7 @@ class _AEADCipherContext(object):
         self._tag = None
         self._updated = False
 
-    def _check_limit(self, data_size: int):
+    def _check_limit(self, data_size: int) -> None:
         if self._ctx is None:
             raise AlreadyFinalized("Context was already finalized.")
         self._updated = True

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -7,9 +7,7 @@ import abc
 import typing
 
 from cryptography import utils
-from cryptography.hazmat.primitives._cipheralgorithm import (
-    BlockCipherAlgorithm, CipherAlgorithm
-)
+from cryptography.hazmat.primitives._cipheralgorithm import CipherAlgorithm
 
 
 class Mode(metaclass=abc.ABCMeta):

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -7,7 +7,9 @@ import abc
 import typing
 
 from cryptography import utils
-from cryptography.hazmat.primitives._cipheralgorithm import CipherAlgorithm
+from cryptography.hazmat.primitives._cipheralgorithm import (
+    BlockCipherAlgorithm, CipherAlgorithm
+)
 
 
 class Mode(metaclass=abc.ABCMeta):
@@ -73,7 +75,7 @@ def _check_iv_length(self, algorithm):
         )
 
 
-def _check_nonce_length(nonce: bytes, name: str, algorithm):
+def _check_nonce_length(nonce: bytes, name: str, algorithm) -> None:
     if len(nonce) * 8 != algorithm.block_size:
         raise ValueError(
             "Invalid nonce size ({}) for {}.".format(len(nonce), name)
@@ -114,7 +116,7 @@ class XTS(Mode, ModeWithTweak):
     def tweak(self) -> bytes:
         return self._tweak
 
-    def validate_for_algorithm(self, algorithm: CipherAlgorithm):
+    def validate_for_algorithm(self, algorithm: CipherAlgorithm) -> None:
         if algorithm.key_size not in (256, 512):
             raise ValueError(
                 "The XTS specification requires a 256-bit key for AES-128-XTS"
@@ -181,7 +183,7 @@ class CTR(Mode, ModeWithNonce):
     def nonce(self) -> bytes:
         return self._nonce
 
-    def validate_for_algorithm(self, algorithm: CipherAlgorithm):
+    def validate_for_algorithm(self, algorithm: CipherAlgorithm) -> None:
         _check_aes_key_length(self, algorithm)
         _check_nonce_length(self.nonce, self.name, algorithm)
 
@@ -227,5 +229,5 @@ class GCM(Mode, ModeWithInitializationVector, ModeWithAuthenticationTag):
     def initialization_vector(self) -> bytes:
         return self._initialization_vector
 
-    def validate_for_algorithm(self, algorithm: CipherAlgorithm):
+    def validate_for_algorithm(self, algorithm: CipherAlgorithm) -> None:
         _check_aes_key_length(self, algorithm)

--- a/src/cryptography/hazmat/primitives/cmac.py
+++ b/src/cryptography/hazmat/primitives/cmac.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import typing
+
 from cryptography import utils
 from cryptography.exceptions import (
     AlreadyFinalized,
@@ -10,13 +12,16 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import CMACBackend
+from cryptography.hazmat.backends.interfaces import Backend, CMACBackend
 from cryptography.hazmat.primitives import ciphers
 
 
 class CMAC(object):
     def __init__(
-        self, algorithm: ciphers.BlockCipherAlgorithm, backend=None, ctx=None
+        self,
+        algorithm: ciphers.BlockCipherAlgorithm,
+        backend: typing.Optional[Backend] = None,
+        ctx=None,
     ):
         backend = _get_backend(backend)
         if not isinstance(backend, CMACBackend):

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -12,7 +12,7 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import HashBackend
+from cryptography.hazmat.backends.interfaces import Backend, HashBackend
 
 
 class HashAlgorithm(metaclass=abc.ABCMeta):
@@ -69,7 +69,12 @@ class ExtendableOutputFunction(metaclass=abc.ABCMeta):
 
 
 class Hash(HashContext):
-    def __init__(self, algorithm: HashAlgorithm, backend=None, ctx=None):
+    def __init__(
+        self,
+        algorithm: HashAlgorithm,
+        backend: typing.Optional[Backend] = None,
+        ctx: typing.Optional["HashContext"] = None,
+    ):
         backend = _get_backend(backend)
         if not isinstance(backend, HashBackend):
             raise UnsupportedAlgorithm(

--- a/src/cryptography/hazmat/primitives/hmac.py
+++ b/src/cryptography/hazmat/primitives/hmac.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import typing
+
 from cryptography import utils
 from cryptography.exceptions import (
     AlreadyFinalized,
@@ -10,7 +12,7 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import HMACBackend
+from cryptography.hazmat.backends.interfaces import Backend, HMACBackend
 from cryptography.hazmat.primitives import hashes
 
 
@@ -19,7 +21,7 @@ class HMAC(hashes.HashContext):
         self,
         key: bytes,
         algorithm: hashes.HashAlgorithm,
-        backend=None,
+        backend: typing.Optional[Backend] = None,
         ctx=None,
     ):
         backend = _get_backend(backend)

--- a/src/cryptography/hazmat/primitives/kdf/concatkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/concatkdf.py
@@ -14,8 +14,11 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import HMACBackend
-from cryptography.hazmat.backends.interfaces import HashBackend
+from cryptography.hazmat.backends.interfaces import (
+    Backend,
+    HMACBackend,
+    HashBackend,
+)
 from cryptography.hazmat.primitives import constant_time, hashes, hmac
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
@@ -28,7 +31,7 @@ def _common_args_checks(
     algorithm: hashes.HashAlgorithm,
     length: int,
     otherinfo: typing.Optional[bytes],
-):
+) -> None:
     max_length = algorithm.digest_size * (2 ** 32 - 1)
     if length > max_length:
         raise ValueError(
@@ -67,7 +70,7 @@ class ConcatKDFHash(KeyDerivationFunction):
         algorithm: hashes.HashAlgorithm,
         length: int,
         otherinfo: typing.Optional[bytes],
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
 
@@ -107,7 +110,7 @@ class ConcatKDFHMAC(KeyDerivationFunction):
         length: int,
         salt: typing.Optional[bytes],
         otherinfo: typing.Optional[bytes],
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
 

--- a/src/cryptography/hazmat/primitives/kdf/hkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/hkdf.py
@@ -13,7 +13,7 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import HMACBackend
+from cryptography.hazmat.backends.interfaces import Backend, HMACBackend
 from cryptography.hazmat.primitives import constant_time, hashes, hmac
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
@@ -25,7 +25,7 @@ class HKDF(KeyDerivationFunction):
         length: int,
         salt: typing.Optional[bytes],
         info: typing.Optional[bytes],
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):
@@ -67,7 +67,7 @@ class HKDFExpand(KeyDerivationFunction):
         algorithm: hashes.HashAlgorithm,
         length: int,
         info: typing.Optional[bytes],
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):

--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
@@ -14,7 +14,7 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import HMACBackend
+from cryptography.hazmat.backends.interfaces import Backend, HMACBackend
 from cryptography.hazmat.primitives import constant_time, hashes, hmac
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
@@ -40,7 +40,7 @@ class KBKDFHMAC(KeyDerivationFunction):
         label: typing.Optional[bytes],
         context: typing.Optional[bytes],
         fixed: typing.Optional[bytes],
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):

--- a/src/cryptography/hazmat/primitives/kdf/pbkdf2.py
+++ b/src/cryptography/hazmat/primitives/kdf/pbkdf2.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import typing
+
 from cryptography import utils
 from cryptography.exceptions import (
     AlreadyFinalized,
@@ -11,7 +13,7 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import PBKDF2HMACBackend
+from cryptography.hazmat.backends.interfaces import Backend, PBKDF2HMACBackend
 from cryptography.hazmat.primitives import constant_time, hashes
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
@@ -23,7 +25,7 @@ class PBKDF2HMAC(KeyDerivationFunction):
         length: int,
         salt: bytes,
         iterations: int,
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
         if not isinstance(backend, PBKDF2HMACBackend):

--- a/src/cryptography/hazmat/primitives/kdf/scrypt.py
+++ b/src/cryptography/hazmat/primitives/kdf/scrypt.py
@@ -4,6 +4,7 @@
 
 
 import sys
+import typing
 
 from cryptography import utils
 from cryptography.exceptions import (
@@ -13,7 +14,7 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import ScryptBackend
+from cryptography.hazmat.backends.interfaces import Backend, ScryptBackend
 from cryptography.hazmat.primitives import constant_time
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
@@ -25,7 +26,13 @@ _MEM_LIMIT = sys.maxsize // 2
 
 class Scrypt(KeyDerivationFunction):
     def __init__(
-        self, salt: bytes, length: int, n: int, r: int, p: int, backend=None
+        self,
+        salt: bytes,
+        length: int,
+        n: int,
+        r: int,
+        p: int,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
         if not isinstance(backend, ScryptBackend):

--- a/src/cryptography/hazmat/primitives/kdf/x963kdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/x963kdf.py
@@ -14,7 +14,7 @@ from cryptography.exceptions import (
     _Reasons,
 )
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import HashBackend
+from cryptography.hazmat.backends.interfaces import Backend, HashBackend
 from cryptography.hazmat.primitives import constant_time, hashes
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
@@ -29,7 +29,7 @@ class X963KDF(KeyDerivationFunction):
         algorithm: hashes.HashAlgorithm,
         length: int,
         sharedinfo: typing.Optional[bytes],
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
 

--- a/src/cryptography/hazmat/primitives/keywrap.py
+++ b/src/cryptography/hazmat/primitives/keywrap.py
@@ -7,6 +7,7 @@ import struct
 import typing
 
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.modes import ECB
@@ -14,7 +15,10 @@ from cryptography.hazmat.primitives.constant_time import bytes_eq
 
 
 def _wrap_core(
-    wrapping_key: bytes, a: bytes, r: typing.List[bytes], backend
+    wrapping_key: bytes,
+    a: bytes,
+    r: typing.List[bytes],
+    backend: Backend,
 ) -> bytes:
     # RFC 3394 Key Wrap - 2.2.1 (index method)
     encryptor = Cipher(AES(wrapping_key), ECB(), backend).encryptor()
@@ -37,7 +41,9 @@ def _wrap_core(
 
 
 def aes_key_wrap(
-    wrapping_key: bytes, key_to_wrap: bytes, backend=None
+    wrapping_key: bytes,
+    key_to_wrap: bytes,
+    backend: typing.Optional[Backend] = None,
 ) -> bytes:
     backend = _get_backend(backend)
     if len(wrapping_key) not in [16, 24, 32]:
@@ -55,7 +61,10 @@ def aes_key_wrap(
 
 
 def _unwrap_core(
-    wrapping_key: bytes, a: bytes, r: typing.List[bytes], backend
+    wrapping_key: bytes,
+    a: bytes,
+    r: typing.List[bytes],
+    backend: Backend,
 ) -> typing.Tuple[bytes, typing.List[bytes]]:
     # Implement RFC 3394 Key Unwrap - 2.2.2 (index method)
     decryptor = Cipher(AES(wrapping_key), ECB(), backend).decryptor()
@@ -80,7 +89,9 @@ def _unwrap_core(
 
 
 def aes_key_wrap_with_padding(
-    wrapping_key: bytes, key_to_wrap: bytes, backend=None
+    wrapping_key: bytes,
+    key_to_wrap: bytes,
+    backend: typing.Optional[Backend] = None,
 ) -> bytes:
     backend = _get_backend(backend)
     if len(wrapping_key) not in [16, 24, 32]:
@@ -102,7 +113,9 @@ def aes_key_wrap_with_padding(
 
 
 def aes_key_unwrap_with_padding(
-    wrapping_key: bytes, wrapped_key: bytes, backend=None
+    wrapping_key: bytes,
+    wrapped_key: bytes,
+    backend: typing.Optional[Backend] = None,
 ) -> bytes:
     backend = _get_backend(backend)
     if len(wrapped_key) < 16:
@@ -147,7 +160,9 @@ def aes_key_unwrap_with_padding(
 
 
 def aes_key_unwrap(
-    wrapping_key: bytes, wrapped_key: bytes, backend=None
+    wrapping_key: bytes,
+    wrapped_key: bytes,
+    backend: typing.Optional[Backend] = None,
 ) -> bytes:
     backend = _get_backend(backend)
     if len(wrapped_key) < 24:

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -10,38 +10,51 @@ from cryptography.hazmat._types import (
     _PUBLIC_KEY_TYPES,
 )
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives.asymmetric import dh
 
 
 def load_pem_private_key(
-    data: bytes, password: typing.Optional[bytes], backend=None
+    data: bytes,
+    password: typing.Optional[bytes],
+    backend: typing.Optional[Backend] = None,
 ) -> _PRIVATE_KEY_TYPES:
     backend = _get_backend(backend)
     return backend.load_pem_private_key(data, password)
 
 
-def load_pem_public_key(data: bytes, backend=None) -> _PUBLIC_KEY_TYPES:
+def load_pem_public_key(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> _PUBLIC_KEY_TYPES:
     backend = _get_backend(backend)
     return backend.load_pem_public_key(data)
 
 
-def load_pem_parameters(data: bytes, backend=None) -> "dh.DHParameters":
+def load_pem_parameters(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> "dh.DHParameters":
     backend = _get_backend(backend)
     return backend.load_pem_parameters(data)
 
 
 def load_der_private_key(
-    data: bytes, password: typing.Optional[bytes], backend=None
+    data: bytes,
+    password: typing.Optional[bytes],
+    backend: typing.Optional[Backend] = None,
 ) -> _PRIVATE_KEY_TYPES:
     backend = _get_backend(backend)
     return backend.load_der_private_key(data, password)
 
 
-def load_der_public_key(data: bytes, backend=None) -> _PUBLIC_KEY_TYPES:
+def load_der_public_key(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> _PUBLIC_KEY_TYPES:
     backend = _get_backend(backend)
     return backend.load_der_public_key(data)
 
 
-def load_der_parameters(data: bytes, backend=None) -> "dh.DHParameters":
+def load_der_parameters(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> "dh.DHParameters":
     backend = _get_backend(backend)
     return backend.load_der_parameters(data)

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -66,7 +66,7 @@ def serialize_key_and_certificates(
     if key is None and cert is None and not cas:
         raise ValueError("You must supply at least one of key, cert, or cas")
 
-    backend: Backend = _get_backend(None)
+    backend = _get_backend(None)
     return backend.serialize_key_and_certificates_to_pkcs12(
         name, key, cert, cas, encryption_algorithm
     )

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -6,6 +6,7 @@ import typing
 
 from cryptography import x509
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 
@@ -18,7 +19,9 @@ _ALLOWED_PKCS12_TYPES = typing.Union[
 
 
 def load_key_and_certificates(
-    data: bytes, password: typing.Optional[bytes], backend=None
+    data: bytes,
+    password: typing.Optional[bytes],
+    backend: typing.Optional[Backend] = None,
 ) -> typing.Tuple[
     typing.Optional[_ALLOWED_PKCS12_TYPES],
     typing.Optional[x509.Certificate],
@@ -63,7 +66,7 @@ def serialize_key_and_certificates(
     if key is None and cert is None and not cas:
         raise ValueError("You must supply at least one of key, cert, or cas")
 
-    backend = _get_backend(None)
+    backend: Backend = _get_backend(None)
     return backend.serialize_key_and_certificates_to_pkcs12(
         name, key, cert, cas, encryption_algorithm
     )

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -7,18 +7,19 @@ from enum import Enum
 
 from cryptography import x509
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.utils import _check_byteslike
 
 
 def load_pem_pkcs7_certificates(data: bytes) -> typing.List[x509.Certificate]:
-    backend = _get_backend(None)
+    backend: Backend = _get_backend(None)
     return backend.load_pem_pkcs7_certificates(data)
 
 
 def load_der_pkcs7_certificates(data: bytes) -> typing.List[x509.Certificate]:
-    backend = _get_backend(None)
+    backend: Backend = _get_backend(None)
     return backend.load_der_pkcs7_certificates(data)
 
 
@@ -104,7 +105,7 @@ class PKCS7SignatureBuilder(object):
         self,
         encoding: serialization.Encoding,
         options: typing.Iterable[PKCS7Options],
-        backend=None,
+        backend: typing.Optional[Backend] = None,
     ) -> bytes:
         if len(self._signers) == 0:
             raise ValueError("Must have at least one signer")

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -14,12 +14,12 @@ from cryptography.utils import _check_byteslike
 
 
 def load_pem_pkcs7_certificates(data: bytes) -> typing.List[x509.Certificate]:
-    backend: Backend = _get_backend(None)
+    backend = _get_backend(None)
     return backend.load_pem_pkcs7_certificates(data)
 
 
 def load_der_pkcs7_certificates(data: bytes) -> typing.List[x509.Certificate]:
-    backend: Backend = _get_backend(None)
+    backend = _get_backend(None)
     return backend.load_der_pkcs7_certificates(data)
 
 

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -475,7 +475,9 @@ _SSH_PRIVATE_KEY_TYPES = typing.Union[
 
 
 def load_ssh_private_key(
-    data: bytes, password: typing.Optional[bytes], backend=None
+    data: bytes,
+    password: typing.Optional[bytes],
+    backend: typing.Optional[Backend] = None,
 ) -> _SSH_PRIVATE_KEY_TYPES:
     """Load private key from OpenSSH custom encoding."""
     utils._check_byteslike("data", data)
@@ -553,7 +555,7 @@ def load_ssh_private_key(
 def serialize_ssh_private_key(
     private_key: _SSH_PRIVATE_KEY_TYPES,
     password: typing.Optional[bytes] = None,
-):
+) -> bytes:
     """Serialize private key with OpenSSH custom encoding."""
     if password is not None:
         utils._check_bytes("password", password)
@@ -643,7 +645,9 @@ _SSH_PUBLIC_KEY_TYPES = typing.Union[
 ]
 
 
-def load_ssh_public_key(data: bytes, backend=None) -> _SSH_PUBLIC_KEY_TYPES:
+def load_ssh_public_key(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> _SSH_PUBLIC_KEY_TYPES:
     """Load public key from OpenSSH one-line format."""
     backend = _get_backend(backend)
     utils._check_byteslike("data", data)

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -13,6 +13,7 @@ from base64 import encodebytes as _base64_encode
 from cryptography import utils
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed25519, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.serialization import (
@@ -584,7 +585,7 @@ def serialize_ssh_private_key(
         salt = os.urandom(16)
         f_kdfoptions.put_sshstr(salt)
         f_kdfoptions.put_u32(rounds)
-        backend = _get_backend(None)
+        backend: Backend = _get_backend(None)
         ciph = _init_cipher(ciphername, password, salt, rounds, backend)
     else:
         ciphername = kdfname = _NONE

--- a/src/cryptography/hazmat/primitives/twofactor/hotp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/hotp.py
@@ -10,7 +10,7 @@ from urllib.parse import quote, urlencode
 
 from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import HMACBackend
+from cryptography.hazmat.backends.interfaces import Backend, HMACBackend
 from cryptography.hazmat.primitives import constant_time, hmac
 from cryptography.hazmat.primitives.hashes import SHA1, SHA256, SHA512
 from cryptography.hazmat.primitives.twofactor import InvalidToken
@@ -24,7 +24,7 @@ def _generate_uri(
     type_name: str,
     account_name: str,
     issuer: typing.Optional[str],
-    extra_parameters,
+    extra_parameters: typing.List[typing.Tuple[str, int]],
 ) -> str:
     parameters = [
         ("digits", hotp._length),
@@ -55,9 +55,9 @@ class HOTP(object):
         key: bytes,
         length: int,
         algorithm: _ALLOWED_HASH_TYPES,
-        backend=None,
+        backend: typing.Optional[Backend] = None,
         enforce_key_length: bool = True,
-    ):
+    ) -> None:
         backend = _get_backend(backend)
         if not isinstance(backend, HMACBackend):
             raise UnsupportedAlgorithm(

--- a/src/cryptography/hazmat/primitives/twofactor/totp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/totp.py
@@ -6,7 +6,7 @@ import typing
 
 from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.backends import _get_backend
-from cryptography.hazmat.backends.interfaces import HMACBackend
+from cryptography.hazmat.backends.interfaces import Backend, HMACBackend
 from cryptography.hazmat.primitives import constant_time
 from cryptography.hazmat.primitives.twofactor import InvalidToken
 from cryptography.hazmat.primitives.twofactor.hotp import (
@@ -23,7 +23,7 @@ class TOTP(object):
         length: int,
         algorithm: _ALLOWED_HASH_TYPES,
         time_step: int,
-        backend=None,
+        backend: typing.Optional[Backend] = None,
         enforce_key_length: bool = True,
     ):
         backend = _get_backend(backend)

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -24,12 +24,12 @@ PersistentlyDeprecated2019 = CryptographyDeprecationWarning
 DeprecatedIn34 = CryptographyDeprecationWarning
 
 
-def _check_bytes(name: str, value: bytes):
+def _check_bytes(name: str, value: bytes) -> None:
     if not isinstance(value, bytes):
         raise TypeError("{} must be bytes".format(name))
 
 
-def _check_byteslike(name: str, value: bytes):
+def _check_byteslike(name: str, value: bytes) -> None:
     try:
         memoryview(value)
     except TypeError:

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -11,6 +11,7 @@ from enum import Enum
 
 from cryptography.hazmat._types import _PRIVATE_KEY_TYPES, _PUBLIC_KEY_TYPES
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import (
     dsa,
@@ -35,7 +36,7 @@ class AttributeNotFound(Exception):
 
 def _reject_duplicate_extension(
     extension: Extension, extensions: typing.List[Extension]
-):
+) -> None:
     # This is quadratic in the number of extensions
     for e in extensions:
         if e.oid == extension.oid:
@@ -45,7 +46,7 @@ def _reject_duplicate_extension(
 def _reject_duplicate_attribute(
     oid: ObjectIdentifier,
     attributes: typing.List[typing.Tuple[ObjectIdentifier, bytes]],
-):
+) -> None:
     # This is quadratic in the number of attributes
     for attr_oid, _ in attributes:
         if attr_oid == oid:
@@ -394,32 +395,44 @@ class CertificateSigningRequest(metaclass=abc.ABCMeta):
         """
 
 
-def load_pem_x509_certificate(data: bytes, backend=None) -> Certificate:
+def load_pem_x509_certificate(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> Certificate:
     backend = _get_backend(backend)
     return backend.load_pem_x509_certificate(data)
 
 
-def load_der_x509_certificate(data: bytes, backend=None) -> Certificate:
+def load_der_x509_certificate(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> Certificate:
     backend = _get_backend(backend)
     return backend.load_der_x509_certificate(data)
 
 
-def load_pem_x509_csr(data: bytes, backend=None) -> CertificateSigningRequest:
+def load_pem_x509_csr(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> CertificateSigningRequest:
     backend = _get_backend(backend)
     return backend.load_pem_x509_csr(data)
 
 
-def load_der_x509_csr(data: bytes, backend=None) -> CertificateSigningRequest:
+def load_der_x509_csr(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> CertificateSigningRequest:
     backend = _get_backend(backend)
     return backend.load_der_x509_csr(data)
 
 
-def load_pem_x509_crl(data: bytes, backend=None) -> CertificateRevocationList:
+def load_pem_x509_crl(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> CertificateRevocationList:
     backend = _get_backend(backend)
     return backend.load_pem_x509_crl(data)
 
 
-def load_der_x509_crl(data: bytes, backend=None) -> CertificateRevocationList:
+def load_der_x509_crl(
+    data: bytes, backend: typing.Optional[Backend] = None
+) -> CertificateRevocationList:
     backend = _get_backend(backend)
     return backend.load_der_x509_crl(data)
 
@@ -433,7 +446,7 @@ class CertificateSigningRequestBuilder(object):
         self._extensions = extensions
         self._attributes = attributes
 
-    def subject_name(self, name: Name):
+    def subject_name(self, name: Name) -> "CertificateSigningRequestBuilder":
         """
         Sets the certificate requestor's distinguished name.
         """
@@ -445,7 +458,9 @@ class CertificateSigningRequestBuilder(object):
             name, self._extensions, self._attributes
         )
 
-    def add_extension(self, extval: ExtensionType, critical: bool):
+    def add_extension(
+        self, extval: ExtensionType, critical: bool
+    ) -> "CertificateSigningRequestBuilder":
         """
         Adds an X.509 extension to the certificate request.
         """
@@ -461,7 +476,9 @@ class CertificateSigningRequestBuilder(object):
             self._attributes,
         )
 
-    def add_attribute(self, oid: ObjectIdentifier, value: bytes):
+    def add_attribute(
+        self, oid: ObjectIdentifier, value: bytes
+    ) -> "CertificateSigningRequestBuilder":
         """
         Adds an X.509 attribute with an OID and associated value.
         """
@@ -482,8 +499,8 @@ class CertificateSigningRequestBuilder(object):
     def sign(
         self,
         private_key: _PRIVATE_KEY_TYPES,
-        algorithm: hashes.HashAlgorithm,
-        backend=None,
+        algorithm: typing.Optional[hashes.HashAlgorithm],
+        backend: typing.Optional[Backend] = None,
     ) -> CertificateSigningRequest:
         """
         Signs the request using the requestor's private key.
@@ -504,7 +521,7 @@ class CertificateBuilder(object):
         not_valid_before=None,
         not_valid_after=None,
         extensions=[],
-    ):
+    ) -> None:
         self._version = Version.v3
         self._issuer_name = issuer_name
         self._subject_name = subject_name
@@ -514,7 +531,7 @@ class CertificateBuilder(object):
         self._not_valid_after = not_valid_after
         self._extensions = extensions
 
-    def issuer_name(self, name: Name):
+    def issuer_name(self, name: Name) -> "CertificateBuilder":
         """
         Sets the CA's distinguished name.
         """
@@ -532,7 +549,7 @@ class CertificateBuilder(object):
             self._extensions,
         )
 
-    def subject_name(self, name: Name):
+    def subject_name(self, name: Name) -> "CertificateBuilder":
         """
         Sets the requestor's distinguished name.
         """
@@ -553,7 +570,7 @@ class CertificateBuilder(object):
     def public_key(
         self,
         key: _PUBLIC_KEY_TYPES,
-    ):
+    ) -> "CertificateBuilder":
         """
         Sets the requestor's public key (as found in the signing request).
         """
@@ -584,7 +601,7 @@ class CertificateBuilder(object):
             self._extensions,
         )
 
-    def serial_number(self, number: int):
+    def serial_number(self, number: int) -> "CertificateBuilder":
         """
         Sets the certificate serial number.
         """
@@ -611,7 +628,9 @@ class CertificateBuilder(object):
             self._extensions,
         )
 
-    def not_valid_before(self, time: datetime.datetime):
+    def not_valid_before(
+        self, time: datetime.datetime
+    ) -> "CertificateBuilder":
         """
         Sets the certificate activation time.
         """
@@ -640,7 +659,7 @@ class CertificateBuilder(object):
             self._extensions,
         )
 
-    def not_valid_after(self, time: datetime.datetime):
+    def not_valid_after(self, time: datetime.datetime) -> "CertificateBuilder":
         """
         Sets the certificate expiration time.
         """
@@ -672,7 +691,9 @@ class CertificateBuilder(object):
             self._extensions,
         )
 
-    def add_extension(self, extval: ExtensionType, critical: bool):
+    def add_extension(
+        self, extval: ExtensionType, critical: bool
+    ) -> "CertificateBuilder":
         """
         Adds an X.509 extension to the certificate.
         """
@@ -695,8 +716,8 @@ class CertificateBuilder(object):
     def sign(
         self,
         private_key: _PRIVATE_KEY_TYPES,
-        algorithm: hashes.HashAlgorithm,
-        backend=None,
+        algorithm: typing.Optional[hashes.HashAlgorithm],
+        backend: typing.Optional[Backend] = None,
     ) -> Certificate:
         """
         Signs the certificate using the CA's private key.
@@ -738,7 +759,9 @@ class CertificateRevocationListBuilder(object):
         self._extensions = extensions
         self._revoked_certificates = revoked_certificates
 
-    def issuer_name(self, issuer_name: Name):
+    def issuer_name(
+        self, issuer_name: Name
+    ) -> "CertificateRevocationListBuilder":
         if not isinstance(issuer_name, Name):
             raise TypeError("Expecting x509.Name object.")
         if self._issuer_name is not None:
@@ -751,7 +774,9 @@ class CertificateRevocationListBuilder(object):
             self._revoked_certificates,
         )
 
-    def last_update(self, last_update: datetime.datetime):
+    def last_update(
+        self, last_update: datetime.datetime
+    ) -> "CertificateRevocationListBuilder":
         if not isinstance(last_update, datetime.datetime):
             raise TypeError("Expecting datetime object.")
         if self._last_update is not None:
@@ -773,7 +798,9 @@ class CertificateRevocationListBuilder(object):
             self._revoked_certificates,
         )
 
-    def next_update(self, next_update: datetime.datetime):
+    def next_update(
+        self, next_update: datetime.datetime
+    ) -> "CertificateRevocationListBuilder":
         if not isinstance(next_update, datetime.datetime):
             raise TypeError("Expecting datetime object.")
         if self._next_update is not None:
@@ -795,7 +822,9 @@ class CertificateRevocationListBuilder(object):
             self._revoked_certificates,
         )
 
-    def add_extension(self, extval: ExtensionType, critical: bool):
+    def add_extension(
+        self, extval: ExtensionType, critical: bool
+    ) -> "CertificateRevocationListBuilder":
         """
         Adds an X.509 extension to the certificate revocation list.
         """
@@ -812,7 +841,9 @@ class CertificateRevocationListBuilder(object):
             self._revoked_certificates,
         )
 
-    def add_revoked_certificate(self, revoked_certificate: RevokedCertificate):
+    def add_revoked_certificate(
+        self, revoked_certificate: RevokedCertificate
+    ) -> "CertificateRevocationListBuilder":
         """
         Adds a revoked certificate to the CRL.
         """
@@ -830,8 +861,8 @@ class CertificateRevocationListBuilder(object):
     def sign(
         self,
         private_key: _PRIVATE_KEY_TYPES,
-        algorithm: hashes.HashAlgorithm,
-        backend=None,
+        algorithm: typing.Optional[hashes.HashAlgorithm],
+        backend: typing.Optional[Backend] = None,
     ) -> CertificateRevocationList:
         backend = _get_backend(backend)
         if self._issuer_name is None:
@@ -854,7 +885,7 @@ class RevokedCertificateBuilder(object):
         self._revocation_date = revocation_date
         self._extensions = extensions
 
-    def serial_number(self, number: int):
+    def serial_number(self, number: int) -> "RevokedCertificateBuilder":
         if not isinstance(number, int):
             raise TypeError("Serial number must be of integral type.")
         if self._serial_number is not None:
@@ -872,7 +903,9 @@ class RevokedCertificateBuilder(object):
             number, self._revocation_date, self._extensions
         )
 
-    def revocation_date(self, time: datetime.datetime):
+    def revocation_date(
+        self, time: datetime.datetime
+    ) -> "RevokedCertificateBuilder":
         if not isinstance(time, datetime.datetime):
             raise TypeError("Expecting datetime object.")
         if self._revocation_date is not None:
@@ -886,7 +919,9 @@ class RevokedCertificateBuilder(object):
             self._serial_number, time, self._extensions
         )
 
-    def add_extension(self, extval: ExtensionType, critical: bool):
+    def add_extension(
+        self, extval: ExtensionType, critical: bool
+    ) -> "RevokedCertificateBuilder":
         if not isinstance(extval, ExtensionType):
             raise TypeError("extension must be an ExtensionType")
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -933,7 +933,9 @@ class RevokedCertificateBuilder(object):
             self._extensions + [extension],
         )
 
-    def build(self, backend=None) -> RevokedCertificate:
+    def build(
+        self, backend: typing.Optional[Backend] = None
+    ) -> RevokedCertificate:
         backend = _get_backend(backend)
         if self._serial_number is None:
             raise ValueError("A revoked certificate must have a serial number")

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -6,6 +6,7 @@ import typing
 from enum import Enum
 
 from cryptography.hazmat.backends import _get_backend
+from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.x509.oid import NameOID, ObjectIdentifier
 
 
@@ -233,7 +234,7 @@ class Name(object):
     def rdns(self) -> typing.List[RelativeDistinguishedName]:
         return self._attributes
 
-    def public_bytes(self, backend=None) -> bytes:
+    def public_bytes(self, backend: typing.Optional[Backend] = None) -> bytes:
         backend = _get_backend(backend)
         return backend.x509_name_bytes(self)
 

--- a/tests/hazmat/backends/test_no_backend.py
+++ b/tests/hazmat/backends/test_no_backend.py
@@ -12,4 +12,4 @@ def test_get_backend_no_backend():
 
 def test_get_backend():
     faux_backend = object()
-    assert _get_backend(faux_backend) is faux_backend
+    assert _get_backend(faux_backend) is faux_backend  # type: ignore[arg-type]

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -205,7 +205,7 @@ def test_invalid_backend():
         ciphers.Cipher(
             AES(b"AAAAAAAAAAAAAAAA"),
             modes.ECB(),
-            pretend_backend  # type: ignore[arg-type]
+            pretend_backend,  # type: ignore[arg-type]
         )
 
 

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -202,7 +202,11 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        ciphers.Cipher(AES(b"AAAAAAAAAAAAAAAA"), modes.ECB(), pretend_backend)
+        ciphers.Cipher(
+            AES(b"AAAAAAAAAAAAAAAA"),
+            modes.ECB(),
+            pretend_backend  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/test_cmac.py
+++ b/tests/hazmat/primitives/test_cmac.py
@@ -217,4 +217,4 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        CMAC(AES(key), pretend_backend)
+        CMAC(AES(key), pretend_backend)  # type: ignore[arg-type]

--- a/tests/hazmat/primitives/test_concatkdf.py
+++ b/tests/hazmat/primitives/test_concatkdf.py
@@ -298,6 +298,17 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        ConcatKDFHash(hashes.SHA256(), 16, None, pretend_backend)
+        ConcatKDFHash(
+            hashes.SHA256(),
+            16,
+            None,
+            pretend_backend,  # type: ignore[arg-type]
+        )
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        ConcatKDFHMAC(hashes.SHA256(), 16, None, None, pretend_backend)
+        ConcatKDFHMAC(
+            hashes.SHA256(),
+            16,
+            None,
+            None,
+            pretend_backend,  # type: ignore[arg-type]
+        )

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -82,7 +82,7 @@ def test_dh_numbers():
         dh.DHPublicNumbers(1, None)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError):
-        dh.DHPublicNumbers(None, params)
+        dh.DHPublicNumbers(None, params)  # type:ignore[arg-type]
 
     private = dh.DHPrivateNumbers(1, public)
 
@@ -93,7 +93,7 @@ def test_dh_numbers():
         dh.DHPrivateNumbers(1, None)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError):
-        dh.DHPrivateNumbers(None, public)
+        dh.DHPrivateNumbers(None, public)  # type:ignore[arg-type]
 
 
 def test_dh_parameter_numbers_equality():
@@ -585,7 +585,7 @@ class TestDHPrivateKeySerialization(object):
         key = parameters.generate_private_key()
         with pytest.raises(TypeError):
             key.private_bytes(
-                "notencoding",
+                "notencoding",  # type:ignore[arg-type]
                 serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption(),
             )
@@ -596,7 +596,7 @@ class TestDHPrivateKeySerialization(object):
         with pytest.raises(ValueError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",
+                "invalidformat",  # type:ignore[arg-type]
                 serialization.NoEncryption(),
             )
 
@@ -607,7 +607,7 @@ class TestDHPrivateKeySerialization(object):
             key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.PKCS8,
-                "notanencalg",
+                "notanencalg",  # type:ignore[arg-type]
             )
 
     def test_private_bytes_unsupported_encryption_type(self, backend):
@@ -735,7 +735,8 @@ class TestDHPublicKeySerialization(object):
         key = parameters.generate_private_key().public_key()
         with pytest.raises(TypeError):
             key.public_bytes(
-                "notencoding", serialization.PublicFormat.SubjectPublicKeyInfo
+                "notencoding",  # type:ignore[arg-type]
+                serialization.PublicFormat.SubjectPublicKeyInfo,
             )
 
     def test_public_bytes_pkcs1_unsupported(self, backend):
@@ -888,13 +889,17 @@ class TestDHParameterSerialization(object):
         parameters = FFDH3072_P.parameters(backend)
         with pytest.raises(TypeError):
             parameters.parameter_bytes(
-                "notencoding", serialization.ParameterFormat.PKCS3
+                "notencoding",  # type:ignore[arg-type]
+                serialization.ParameterFormat.PKCS3,
             )
 
     def test_parameter_bytes_invalid_format(self, backend):
         parameters = FFDH3072_P.parameters(backend)
         with pytest.raises(ValueError):
-            parameters.parameter_bytes(serialization.Encoding.PEM, "notformat")
+            parameters.parameter_bytes(
+                serialization.Encoding.PEM,
+                "notformat",  # type: ignore[arg-type]
+            )
 
     def test_parameter_bytes_openssh_unsupported(self, backend):
         parameters = FFDH3072_P.parameters(backend)

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -159,7 +159,7 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        hashes.Hash(hashes.SHA1(), pretend_backend)
+        hashes.Hash(hashes.SHA1(), pretend_backend)  # type:ignore[arg-type]
 
 
 def test_buffer_protocol_hash(backend):

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -217,7 +217,15 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        HKDF(hashes.SHA256(), 16, None, None, pretend_backend)
+        HKDF(
+            hashes.SHA256(),
+            16,
+            None,
+            None,
+            pretend_backend,  # type:ignore[arg-type]
+        )
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        HKDFExpand(hashes.SHA256(), 16, None, pretend_backend)
+        HKDFExpand(
+            hashes.SHA256(), 16, None, pretend_backend  # type:ignore[arg-type]
+        )

--- a/tests/hazmat/primitives/test_hmac.py
+++ b/tests/hazmat/primitives/test_hmac.py
@@ -94,4 +94,6 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        hmac.HMAC(b"key", hashes.SHA1(), pretend_backend)
+        hmac.HMAC(
+            b"key", hashes.SHA1(), pretend_backend  # type:ignore[arg-type]
+        )

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -268,7 +268,7 @@ class TestKBKDFHMAC(object):
                 b"label",
                 b"context",
                 None,
-                backend=object(),
+                backend=object(),  # type: ignore[arg-type]
             )
 
     def test_unicode_error_label(self, backend):

--- a/tests/hazmat/primitives/test_pbkdf2hmac.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac.py
@@ -67,4 +67,10 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, pretend_backend)
+        PBKDF2HMAC(
+            hashes.SHA1(),
+            20,
+            b"salt",
+            10,
+            pretend_backend,  # type:ignore[arg-type]
+        )

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -381,7 +381,9 @@ def test_rsa_generate_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        rsa.generate_private_key(65537, 2048, pretend_backend)
+        rsa.generate_private_key(
+            65537, 2048, pretend_backend  # type:ignore[arg-type]
+        )
 
 
 class TestRSASignature(object):

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -84,7 +84,7 @@ class TestScrypt(object):
                 work_factor,
                 block_size,
                 parallelization_factor,
-                backend,
+                backend,  # type: ignore[arg-type]
             )
 
     def test_salt_not_bytes(self, backend):

--- a/tests/hazmat/primitives/test_x963kdf.py
+++ b/tests/hazmat/primitives/test_x963kdf.py
@@ -116,4 +116,9 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        X963KDF(hashes.SHA256(), 16, None, pretend_backend)
+        X963KDF(
+            hashes.SHA256(),
+            16,
+            None,
+            pretend_backend,  # type: ignore[arg-type]
+        )

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -120,4 +120,6 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        HOTP(secret, 8, hashes.SHA1(), pretend_backend)
+        HOTP(
+            secret, 8, hashes.SHA1(), pretend_backend  # type: ignore[arg-type]
+        )

--- a/tests/hazmat/primitives/twofactor/test_totp.py
+++ b/tests/hazmat/primitives/twofactor/test_totp.py
@@ -155,4 +155,10 @@ def test_invalid_backend():
     pretend_backend = object()
 
     with raises_unsupported_algorithm(_Reasons.BACKEND_MISSING_INTERFACE):
-        TOTP(secret, 8, hashes.SHA1(), 30, pretend_backend)
+        TOTP(
+            secret,
+            8,
+            hashes.SHA1(),
+            30,
+            pretend_backend,  # type: ignore[arg-type]
+        )

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -60,8 +60,7 @@ from ..hazmat.primitives.test_ec import _skip_curve_unsupported
 from ..utils import load_nist_vectors, load_vectors_from_file
 
 
-@utils.register_interface(x509.ExtensionType)
-class DummyExtension(object):
+class DummyExtension(x509.ExtensionType):
     oid = x509.ObjectIdentifier("1.2.3.4")
 
 
@@ -1683,10 +1682,14 @@ class TestRSACertificateRequest(object):
         basic_constraints = cert.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is False
         assert basic_constraints.value.path_length is None
         subject_alternative_name = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        )
+        assert isinstance(
+            subject_alternative_name.value, x509.SubjectAlternativeName
         )
         assert list(subject_alternative_name.value) == [
             x509.DNSName("cryptography.io"),
@@ -2498,10 +2501,14 @@ class TestCertificateBuilder(object):
         basic_constraints = cert.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is False
         assert basic_constraints.value.path_length is None
         subject_alternative_name = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        )
+        assert isinstance(
+            subject_alternative_name.value, x509.SubjectAlternativeName
         )
         assert list(subject_alternative_name.value) == [
             x509.DNSName("cryptography.io"),
@@ -2545,10 +2552,14 @@ class TestCertificateBuilder(object):
         basic_constraints = cert.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is False
         assert basic_constraints.value.path_length is None
         subject_alternative_name = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        )
+        assert isinstance(
+            subject_alternative_name.value, x509.SubjectAlternativeName
         )
         assert list(subject_alternative_name.value) == [
             x509.DNSName("cryptography.io"),
@@ -2600,10 +2611,14 @@ class TestCertificateBuilder(object):
         basic_constraints = cert.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is False
         assert basic_constraints.value.path_length is None
         subject_alternative_name = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        )
+        assert isinstance(
+            subject_alternative_name.value, x509.SubjectAlternativeName
         )
         assert list(subject_alternative_name.value) == [
             x509.DNSName("cryptography.io"),
@@ -2635,6 +2650,7 @@ class TestCertificateBuilder(object):
         )
 
         cert = builder.sign(issuer_private_key, hashes.SHA256(), backend)
+        assert cert.signature_hash_algorithm is not None
         issuer_private_key.public_key().verify(
             cert.signature,
             cert.tbs_certificate_bytes,
@@ -2693,10 +2709,14 @@ class TestCertificateBuilder(object):
         basic_constraints = cert.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is False
         assert basic_constraints.value.path_length is None
         subject_alternative_name = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        )
+        assert isinstance(
+            subject_alternative_name.value, x509.SubjectAlternativeName
         )
         assert list(subject_alternative_name.value) == [
             x509.DNSName("cryptography.io"),
@@ -2728,6 +2748,7 @@ class TestCertificateBuilder(object):
         )
 
         cert = builder.sign(issuer_private_key, hashes.SHA256(), backend)
+        assert cert.signature_hash_algorithm is not None
         issuer_private_key.public_key().verify(
             cert.signature,
             cert.tbs_certificate_bytes,
@@ -3230,6 +3251,7 @@ class TestCertificateBuilder(object):
         basic_constraints = request.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.path_length is None
 
     @pytest.mark.parametrize(
@@ -3273,7 +3295,9 @@ class TestCertificateSigningRequestBuilder(object):
             x509.Name([])
         )
         with pytest.raises(TypeError):
-            builder.sign(private_key, "NotAHash", backend)
+            builder.sign(
+                private_key, "NotAHash", backend  # type: ignore[arg-type]
+            )
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.ed25519_supported(),
@@ -3373,6 +3397,7 @@ class TestCertificateSigningRequestBuilder(object):
         basic_constraints = request.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is True
         assert basic_constraints.value.path_length == 2
 
@@ -3518,6 +3543,7 @@ class TestCertificateSigningRequestBuilder(object):
         basic_constraints = request.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is False
         assert basic_constraints.value.path_length is None
 
@@ -3553,6 +3579,7 @@ class TestCertificateSigningRequestBuilder(object):
         basic_constraints = request.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is True
         assert basic_constraints.value.path_length == 2
 
@@ -3657,6 +3684,7 @@ class TestCertificateSigningRequestBuilder(object):
         basic_constraints = request.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is True
         assert basic_constraints.value.path_length == 2
 
@@ -3800,11 +3828,13 @@ class TestCertificateSigningRequestBuilder(object):
         basic_constraints = request.extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
         )
+        assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is True
         assert basic_constraints.value.path_length == 2
         ext = request.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
+        assert isinstance(ext.value, x509.SubjectAlternativeName)
         assert list(ext.value) == [x509.DNSName("cryptography.io")]
 
     def test_add_attributes(self, backend):

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -341,6 +341,7 @@ class TestCertificateRevocationListBuilder(object):
         assert len(crl.extensions) == 1
         ext1 = crl.extensions.get_extension_for_class(x509.FreshestCRL)
         assert ext1.critical is False
+        assert isinstance(ext1.value, x509.FreshestCRL)
         assert isinstance(ext1.value[0], x509.DistributionPoint)
         assert ext1.value[0].full_name is not None
         uri = ext1.value[0].full_name[0]
@@ -411,7 +412,9 @@ class TestCertificateRevocationListBuilder(object):
         )
 
         with pytest.raises(TypeError):
-            builder.sign(private_key, object(), backend)
+            builder.sign(
+                private_key, object(), backend  # type: ignore[arg-type]
+            )
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.ed25519_supported(),
@@ -437,7 +440,11 @@ class TestCertificateRevocationListBuilder(object):
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, object(), backend)
+            builder.sign(
+                private_key,
+                object(),  # type:ignore[arg-type]
+                backend,
+            )
         with pytest.raises(ValueError):
             builder.sign(private_key, hashes.SHA256(), backend)
 
@@ -465,7 +472,11 @@ class TestCertificateRevocationListBuilder(object):
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, object(), backend)
+            builder.sign(
+                private_key,
+                object(),  # type:ignore[arg-type]
+                backend,
+            )
         with pytest.raises(ValueError):
             builder.sign(private_key, hashes.SHA256(), backend)
 


### PR DESCRIPTION
This adds a bunch of typing for backend args. To do this it needed to define interfaces. Both ones that were incomplete and ones entirely missing.

We briefly talked about this in IRC but do we want to move from `PKCS12Backend` and `PKCS7Backend` to just `BaseBackend` and stick all future methods on that for now?

All of this helps get us closer to `disallow_incomplete_defs = True`.