### PR TITLE
Generic extension value/typehint x509.Name

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,3 +14,4 @@ source =
 exclude_lines =
     @abc.abstractmethod
     @abc.abstractproperty
+    @typing.overload

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -1350,7 +1350,7 @@ class Extension(typing.Generic[ExtensionTypeVar]):
         return self._critical
 
     @property
-    def value(self) -> ExtensionType:
+    def value(self) -> ExtensionTypeVar:
         return self._value
 
     def __repr__(self) -> str:

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -196,14 +196,32 @@ class RelativeDistinguishedName(object):
 
 
 class Name(object):
-    def __init__(self, attributes):
+    @typing.overload
+    def __init__(self, attributes: typing.Iterable[NameAttribute]) -> None:
+        ...
+
+    @typing.overload
+    def __init__(
+        self, attributes: typing.Iterable[RelativeDistinguishedName]
+    ) -> None:
+        ...
+
+    def __init__(
+        self,
+        attributes: typing.Iterable[
+            typing.Union[NameAttribute, RelativeDistinguishedName]
+        ],
+    ) -> None:
         attributes = list(attributes)
         if all(isinstance(x, NameAttribute) for x in attributes):
             self._attributes = [
-                RelativeDistinguishedName([x]) for x in attributes
+                RelativeDistinguishedName([typing.cast(NameAttribute, x)])
+                for x in attributes
             ]
         elif all(isinstance(x, RelativeDistinguishedName) for x in attributes):
-            self._attributes = attributes
+            self._attributes = typing.cast(
+                typing.List[RelativeDistinguishedName], attributes
+            )
         else:
             raise TypeError(
                 "attributes must be a list of NameAttribute"

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -5019,7 +5019,7 @@ class TestName(object):
 
     def test_not_nameattribute(self):
         with pytest.raises(TypeError):
-            x509.Name(["not-a-NameAttribute"])
+            x509.Name(["not-a-NameAttribute"])  # type: ignore[list-item]
 
     def test_bytes(self, backend):
         name = x509.Name(


### PR DESCRIPTION
First, Make `Extension.value` return a generic value. This way mypy detects what concrete type the value is, not just the more abstract base class. Consider for example this code:

```python
def example(ext: x509.Extension[x509.FreshestCRL]) -> x509.FreshestCRL:
    return ext.value
```

*Without* the patch, the function would have to use `x509.ExtensionType` as return type annotation.

Second, typehint the `x509.Name()`. The `typing.overload` decorator allows mypy to know that the list is either all NameAttribute or all RelativeDistinguishedName, not mixed, see [Function overloading](https://mypy.readthedocs.io/en/stable/more_types.html#function-overloading).