### PR TITLE
typehint x509.base

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,4 @@ exclude_lines =
     @abc.abstractmethod
     @abc.abstractproperty
     @typing.overload
+    if typing.TYPE_CHECKING

--- a/src/cryptography/hazmat/backends/__init__.py
+++ b/src/cryptography/hazmat/backends/__init__.py
@@ -9,7 +9,7 @@ from cryptography.hazmat.backends.interfaces import Backend
 _default_backend: typing.Optional[Backend] = None
 
 
-def default_backend():
+def default_backend() -> Backend:
     global _default_backend
 
     if _default_backend is None:

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -8,14 +8,16 @@ import typing
 
 from cryptography.hazmat._types import _PRIVATE_KEY_TYPES
 from cryptography.hazmat.primitives import hashes
-from cryptography.x509.base import Certificate
-from cryptography.x509.base import CertificateBuilder
-from cryptography.x509.base import CertificateRevocationList
-from cryptography.x509.base import CertificateRevocationListBuilder
-from cryptography.x509.base import CertificateSigningRequest
-from cryptography.x509.base import CertificateSigningRequestBuilder
-from cryptography.x509.base import RevokedCertificate
-from cryptography.x509.base import RevokedCertificateBuilder
+from cryptography.x509.base import (
+    Certificate,
+    CertificateBuilder,
+    CertificateRevocationList,
+    CertificateRevocationListBuilder,
+    CertificateSigningRequest,
+    CertificateSigningRequestBuilder,
+    RevokedCertificate,
+    RevokedCertificateBuilder,
+)
 from cryptography.x509.name import Name
 
 

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -6,19 +6,21 @@
 import abc
 import typing
 
-from cryptography.hazmat._types import _PRIVATE_KEY_TYPES
-from cryptography.hazmat.primitives import hashes
-from cryptography.x509.base import (
-    Certificate,
-    CertificateBuilder,
-    CertificateRevocationList,
-    CertificateRevocationListBuilder,
-    CertificateSigningRequest,
-    CertificateSigningRequestBuilder,
-    RevokedCertificate,
-    RevokedCertificateBuilder,
-)
-from cryptography.x509.name import Name
+
+if typing.TYPE_CHECKING:
+    from cryptography.hazmat._types import _PRIVATE_KEY_TYPES
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.x509.base import (
+        Certificate,
+        CertificateBuilder,
+        CertificateRevocationList,
+        CertificateRevocationListBuilder,
+        CertificateSigningRequest,
+        CertificateSigningRequestBuilder,
+        RevokedCertificate,
+        RevokedCertificateBuilder,
+    )
+    from cryptography.x509.name import Name
 
 
 class CipherBackend(metaclass=abc.ABCMeta):
@@ -277,25 +279,25 @@ class DERSerializationBackend(metaclass=abc.ABCMeta):
 
 class X509Backend(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def load_pem_x509_certificate(self, data: bytes) -> Certificate:
+    def load_pem_x509_certificate(self, data: bytes) -> "Certificate":
         """
         Load an X.509 certificate from PEM encoded data.
         """
 
     @abc.abstractmethod
-    def load_der_x509_certificate(self, data: bytes) -> Certificate:
+    def load_der_x509_certificate(self, data: bytes) -> "Certificate":
         """
         Load an X.509 certificate from DER encoded data.
         """
 
     @abc.abstractmethod
-    def load_der_x509_csr(self, data: bytes) -> CertificateSigningRequest:
+    def load_der_x509_csr(self, data: bytes) -> "CertificateSigningRequest":
         """
         Load an X.509 CSR from DER encoded data.
         """
 
     @abc.abstractmethod
-    def load_pem_x509_csr(self, data: bytes) -> CertificateSigningRequest:
+    def load_pem_x509_csr(self, data: bytes) -> "CertificateSigningRequest":
         """
         Load an X.509 CSR from PEM encoded data.
         """
@@ -303,10 +305,10 @@ class X509Backend(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def create_x509_csr(
         self,
-        builder: CertificateSigningRequestBuilder,
-        private_key: _PRIVATE_KEY_TYPES,
-        algorithm: typing.Optional[hashes.HashAlgorithm],
-    ) -> CertificateSigningRequest:
+        builder: "CertificateSigningRequestBuilder",
+        private_key: "_PRIVATE_KEY_TYPES",
+        algorithm: typing.Optional["hashes.HashAlgorithm"],
+    ) -> "CertificateSigningRequest":
         """
         Create and sign an X.509 CSR from a CSR builder object.
         """
@@ -314,10 +316,10 @@ class X509Backend(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def create_x509_certificate(
         self,
-        builder: CertificateBuilder,
-        private_key: _PRIVATE_KEY_TYPES,
-        algorithm: typing.Optional[hashes.HashAlgorithm],
-    ) -> Certificate:
+        builder: "CertificateBuilder",
+        private_key: "_PRIVATE_KEY_TYPES",
+        algorithm: typing.Optional["hashes.HashAlgorithm"],
+    ) -> "Certificate":
         """
         Create and sign an X.509 certificate from a CertificateBuilder object.
         """
@@ -325,10 +327,10 @@ class X509Backend(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def create_x509_crl(
         self,
-        builder: CertificateRevocationListBuilder,
-        private_key: _PRIVATE_KEY_TYPES,
-        algorithm: typing.Optional[hashes.HashAlgorithm],
-    ) -> CertificateRevocationList:
+        builder: "CertificateRevocationListBuilder",
+        private_key: "_PRIVATE_KEY_TYPES",
+        algorithm: typing.Optional["hashes.HashAlgorithm"],
+    ) -> "CertificateRevocationList":
         """
         Create and sign an X.509 CertificateRevocationList from a
         CertificateRevocationListBuilder object.
@@ -336,27 +338,27 @@ class X509Backend(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def create_x509_revoked_certificate(
-        self, builder: RevokedCertificateBuilder
-    ) -> RevokedCertificate:
+        self, builder: "RevokedCertificateBuilder"
+    ) -> "RevokedCertificate":
         """
         Create a RevokedCertificate object from a RevokedCertificateBuilder
         object.
         """
 
     @abc.abstractmethod
-    def x509_name_bytes(self, name: Name) -> bytes:
+    def x509_name_bytes(self, name: "Name") -> bytes:
         """
         Compute the DER encoded bytes of an X509 Name object.
         """
 
     @abc.abstractmethod
-    def load_pem_x509_crl(self, data: bytes) -> CertificateRevocationList:
+    def load_pem_x509_crl(self, data: bytes) -> "CertificateRevocationList":
         """
         Load an X.509 CRL from PEM encoded data.
         """
 
     @abc.abstractmethod
-    def load_der_x509_crl(self, data: bytes) -> CertificateRevocationList:
+    def load_der_x509_crl(self, data: bytes) -> "CertificateRevocationList":
         """
         Load an X.509 CRL from DER encoded data.
         """

--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -4,6 +4,19 @@
 
 
 import abc
+import typing
+
+from cryptography.hazmat._types import _PRIVATE_KEY_TYPES
+from cryptography.hazmat.primitives import hashes
+from cryptography.x509.base import Certificate
+from cryptography.x509.base import CertificateBuilder
+from cryptography.x509.base import CertificateRevocationList
+from cryptography.x509.base import CertificateRevocationListBuilder
+from cryptography.x509.base import CertificateSigningRequest
+from cryptography.x509.base import CertificateSigningRequestBuilder
+from cryptography.x509.base import RevokedCertificate
+from cryptography.x509.base import RevokedCertificateBuilder
+from cryptography.x509.name import Name
 
 
 class CipherBackend(metaclass=abc.ABCMeta):
@@ -262,69 +275,86 @@ class DERSerializationBackend(metaclass=abc.ABCMeta):
 
 class X509Backend(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def load_pem_x509_certificate(self, data):
+    def load_pem_x509_certificate(self, data: bytes) -> Certificate:
         """
         Load an X.509 certificate from PEM encoded data.
         """
 
     @abc.abstractmethod
-    def load_der_x509_certificate(self, data):
+    def load_der_x509_certificate(self, data: bytes) -> Certificate:
         """
         Load an X.509 certificate from DER encoded data.
         """
 
     @abc.abstractmethod
-    def load_der_x509_csr(self, data):
+    def load_der_x509_csr(self, data: bytes) -> CertificateSigningRequest:
         """
         Load an X.509 CSR from DER encoded data.
         """
 
     @abc.abstractmethod
-    def load_pem_x509_csr(self, data):
+    def load_pem_x509_csr(self, data: bytes) -> CertificateSigningRequest:
         """
         Load an X.509 CSR from PEM encoded data.
         """
 
     @abc.abstractmethod
-    def create_x509_csr(self, builder, private_key, algorithm):
+    def create_x509_csr(
+        self,
+        builder: CertificateSigningRequestBuilder,
+        private_key: _PRIVATE_KEY_TYPES,
+        algorithm: typing.Optional[hashes.HashAlgorithm],
+    ) -> CertificateSigningRequest:
         """
         Create and sign an X.509 CSR from a CSR builder object.
         """
 
     @abc.abstractmethod
-    def create_x509_certificate(self, builder, private_key, algorithm):
+    def create_x509_certificate(
+        self,
+        builder: CertificateBuilder,
+        private_key: _PRIVATE_KEY_TYPES,
+        algorithm: typing.Optional[hashes.HashAlgorithm],
+    ) -> Certificate:
         """
         Create and sign an X.509 certificate from a CertificateBuilder object.
         """
 
     @abc.abstractmethod
-    def create_x509_crl(self, builder, private_key, algorithm):
+    def create_x509_crl(
+        self,
+        builder: CertificateRevocationListBuilder,
+        private_key: _PRIVATE_KEY_TYPES,
+        algorithm: typing.Optional[hashes.HashAlgorithm],
+    ) -> CertificateRevocationList:
         """
         Create and sign an X.509 CertificateRevocationList from a
         CertificateRevocationListBuilder object.
         """
 
     @abc.abstractmethod
-    def create_x509_revoked_certificate(self, builder):
+    def create_x509_revoked_certificate(
+        self, builder: RevokedCertificateBuilder
+    ) -> RevokedCertificate:
         """
         Create a RevokedCertificate object from a RevokedCertificateBuilder
         object.
         """
 
     @abc.abstractmethod
-    def x509_name_bytes(self, name):
+    def x509_name_bytes(self, name: Name) -> bytes:
         """
         Compute the DER encoded bytes of an X509 Name object.
         """
 
     @abc.abstractmethod
-    def load_pem_x509_crl(self, data):
+    def load_pem_x509_crl(self, data: bytes) -> CertificateRevocationList:
         """
         Load an X.509 CRL from PEM encoded data.
         """
 
     @abc.abstractmethod
-    def load_der_x509_crl(self, data):
+    def load_der_x509_crl(self, data: bytes) -> CertificateRevocationList:
         """
         Load an X.509 CRL from DER encoded data.
         """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -928,7 +928,10 @@ class Backend(BackendInterface):
 
         # Set subject public key.
         public_key = private_key.public_key()
-        res = self._lib.X509_REQ_set_pubkey(x509_req, public_key._evp_pkey)
+        res = self._lib.X509_REQ_set_pubkey(
+            x509_req,
+            public_key._evp_pkey  # type: ignore[union-attr]
+        )
         self.openssl_assert(res == 1)
 
         # Add extensions.
@@ -968,7 +971,11 @@ class Backend(BackendInterface):
             self.openssl_assert(res == 1)
 
         # Sign the request using the requester's private key.
-        res = self._lib.X509_REQ_sign(x509_req, private_key._evp_pkey, evp_md)
+        res = self._lib.X509_REQ_sign(
+            x509_req,
+            private_key._evp_pkey,  # type: ignore[union-attr]
+            evp_md
+        )
         if res == 0:
             errors = self._consume_errors_with_text()
             raise ValueError("Signing failed", errors)
@@ -1042,7 +1049,11 @@ class Backend(BackendInterface):
         self.openssl_assert(res == 1)
 
         # Sign the certificate with the issuer's private key.
-        res = self._lib.X509_sign(x509_cert, private_key._evp_pkey, evp_md)
+        res = self._lib.X509_sign(
+            x509_cert,
+            private_key._evp_pkey,  # type: ignore[union-attr]
+            evp_md
+        )
         if res == 0:
             errors = self._consume_errors_with_text()
             raise ValueError("Signing failed", errors)
@@ -1129,7 +1140,11 @@ class Backend(BackendInterface):
             res = self._lib.X509_CRL_add0_revoked(x509_crl, revoked)
             self.openssl_assert(res == 1)
 
-        res = self._lib.X509_CRL_sign(x509_crl, private_key._evp_pkey, evp_md)
+        res = self._lib.X509_CRL_sign(
+            x509_crl,
+            private_key._evp_pkey,  # type: ignore[union-attr]
+            evp_md
+        )
         if res == 0:
             errors = self._consume_errors_with_text()
             raise ValueError("Signing failed", errors)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -970,6 +970,8 @@ class Backend(BackendInterface):
     def create_x509_certificate(self, builder, private_key, algorithm):
         if not isinstance(builder, x509.CertificateBuilder):
             raise TypeError("Builder type mismatch.")
+        if builder._public_key is None:
+            raise TypeError("Builder has no public key.")
         self._x509_check_signature_params(private_key, algorithm)
 
         # Resolve the signature algorithm.

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -929,8 +929,7 @@ class Backend(BackendInterface):
         # Set subject public key.
         public_key = private_key.public_key()
         res = self._lib.X509_REQ_set_pubkey(
-            x509_req,
-            public_key._evp_pkey  # type: ignore[union-attr]
+            x509_req, public_key._evp_pkey  # type: ignore[union-attr]
         )
         self.openssl_assert(res == 1)
 
@@ -972,9 +971,7 @@ class Backend(BackendInterface):
 
         # Sign the request using the requester's private key.
         res = self._lib.X509_REQ_sign(
-            x509_req,
-            private_key._evp_pkey,  # type: ignore[union-attr]
-            evp_md
+            x509_req, private_key._evp_pkey, evp_md  # type: ignore[union-attr]
         )
         if res == 0:
             errors = self._consume_errors_with_text()
@@ -1052,7 +1049,7 @@ class Backend(BackendInterface):
         res = self._lib.X509_sign(
             x509_cert,
             private_key._evp_pkey,  # type: ignore[union-attr]
-            evp_md
+            evp_md,
         )
         if res == 0:
             errors = self._consume_errors_with_text()
@@ -1141,9 +1138,7 @@ class Backend(BackendInterface):
             self.openssl_assert(res == 1)
 
         res = self._lib.X509_CRL_sign(
-            x509_crl,
-            private_key._evp_pkey,  # type: ignore[union-attr]
-            evp_md
+            x509_crl, private_key._evp_pkey, evp_md  # type: ignore[union-attr]
         )
         if res == 0:
             errors = self._consume_errors_with_text()

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -204,8 +204,7 @@ class _RevokedCertificate(x509.RevokedCertificate):
         )
 
 
-@utils.register_interface(x509.CertificateRevocationList)
-class _CertificateRevocationList(object):
+class _CertificateRevocationList(x509.CertificateRevocationList):
     def __init__(self, backend, x509_crl):
         self._backend = backend
         self._x509_crl = x509_crl
@@ -385,8 +384,7 @@ class _CertificateRevocationList(object):
         return True
 
 
-@utils.register_interface(x509.CertificateSigningRequest)
-class _CertificateSigningRequest(object):
+class _CertificateSigningRequest(x509.CertificateSigningRequest):
     def __init__(self, backend, x509_req):
         self._backend = backend
         self._x509_req = x509_req

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -255,7 +255,9 @@ class _CertificateRevocationList(x509.CertificateRevocationList):
             )
 
     @property
-    def signature_hash_algorithm(self) -> hashes.HashAlgorithm:
+    def signature_hash_algorithm(
+        self,
+    ) -> typing.Optional[hashes.HashAlgorithm]:
         oid = self.signature_algorithm_oid
         try:
             return x509._SIG_OIDS_TO_HASH[oid]
@@ -414,7 +416,9 @@ class _CertificateSigningRequest(x509.CertificateSigningRequest):
         return _decode_x509_name(self._backend, subject)
 
     @property
-    def signature_hash_algorithm(self) -> hashes.HashAlgorithm:
+    def signature_hash_algorithm(
+        self,
+    ) -> typing.Optional[hashes.HashAlgorithm]:
         oid = self.signature_algorithm_oid
         try:
             return x509._SIG_OIDS_TO_HASH[oid]

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -255,9 +255,7 @@ class _CertificateRevocationList(x509.CertificateRevocationList):
             )
 
     @property
-    def signature_hash_algorithm(
-        self,
-    ) -> typing.Optional[hashes.HashAlgorithm]:
+    def signature_hash_algorithm(self) -> hashes.HashAlgorithm:
         oid = self.signature_algorithm_oid
         try:
             return x509._SIG_OIDS_TO_HASH[oid]
@@ -416,9 +414,7 @@ class _CertificateSigningRequest(x509.CertificateSigningRequest):
         return _decode_x509_name(self._backend, subject)
 
     @property
-    def signature_hash_algorithm(
-        self,
-    ) -> typing.Optional[hashes.HashAlgorithm]:
+    def signature_hash_algorithm(self) -> hashes.HashAlgorithm:
         oid = self.signature_algorithm_oid
         try:
             return x509._SIG_OIDS_TO_HASH[oid]

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -9,7 +9,6 @@ import os
 import typing
 from enum import Enum
 
-from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat._types import _PRIVATE_KEY_TYPES, _PUBLIC_KEY_TYPES
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
@@ -23,6 +22,7 @@ from cryptography.hazmat.primitives.asymmetric import (
 )
 from cryptography.x509.extensions import Extension, ExtensionType, Extensions
 from cryptography.x509.name import Name
+from cryptography.x509.oid import ObjectIdentifier
 
 
 _EARLIEST_UTC_TIME = datetime.datetime(1950, 1, 1)
@@ -462,15 +462,6 @@ class CertificateSigningRequestBuilder(object):
         """
         Creates an empty X.509 certificate request (v1).
         """
-        if extensions is None:
-            extensions = []
-        else:
-            extensions = list(extensions)
-        if attributes is None:
-            attributes = []
-        else:
-            attributes = list(attributes)
-
         self._subject_name = subject_name
         self._extensions = extensions
         self._attributes = attributes
@@ -553,11 +544,6 @@ class CertificateBuilder(object):
         not_valid_after: typing.Optional[datetime.datetime] = None,
         extensions: typing.List[Extension[ExtensionType]] = [],
     ) -> None:
-        if extensions is None:
-            extensions = []
-        else:
-            extensions = list(extensions)
-
         self._version = Version.v3
         self._issuer_name = issuer_name
         self._subject_name = subject_name
@@ -792,15 +778,6 @@ class CertificateRevocationListBuilder(object):
         extensions: typing.List[Extension[ExtensionType]] = [],
         revoked_certificates: typing.List[RevokedCertificate] = [],
     ):
-        if extensions is None:
-            extensions = []
-        else:
-            extensions = list(extensions)
-        if revoked_certificates is None:
-            revoked_certificates = []
-        else:
-            revoked_certificates = list(revoked_certificates)
-
         self._issuer_name = issuer_name
         self._last_update = last_update
         self._next_update = next_update
@@ -932,11 +909,6 @@ class RevokedCertificateBuilder(object):
         revocation_date: typing.Optional[datetime.datetime] = None,
         extensions: typing.List[Extension[ExtensionType]] = [],
     ):
-        if extensions is None:
-            extensions = []
-        else:
-            extensions = list(extensions)
-
         self._serial_number = serial_number
         self._revocation_date = revocation_date
         self._extensions = extensions

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -29,13 +29,14 @@ _EARLIEST_UTC_TIME = datetime.datetime(1950, 1, 1)
 
 
 class AttributeNotFound(Exception):
-    def __init__(self, msg, oid):
+    def __init__(self, msg: str, oid: ObjectIdentifier) -> None:
         super(AttributeNotFound, self).__init__(msg)
         self.oid = oid
 
 
 def _reject_duplicate_extension(
-    extension: Extension, extensions: typing.List[Extension]
+    extension: Extension[ExtensionType],
+    extensions: typing.List[Extension[ExtensionType]],
 ) -> None:
     # This is quadratic in the number of extensions
     for e in extensions:
@@ -73,7 +74,7 @@ class Version(Enum):
 
 
 class InvalidVersion(Exception):
-    def __init__(self, msg, parsed_version):
+    def __init__(self, msg: str, parsed_version: typing.Any):
         super(InvalidVersion, self).__init__(msg)
         self.parsed_version = parsed_version
 
@@ -294,14 +295,24 @@ class CertificateRevocationList(metaclass=abc.ABCMeta):
         Number of revoked certificates in the CRL.
         """
 
+    @typing.overload
+    def __getitem__(self, idx: int) -> RevokedCertificate:
+        ...
+
+    @typing.overload
+    def __getitem__(self, idx: slice) -> typing.List[RevokedCertificate]:
+        ...
+
     @abc.abstractmethod
-    def __getitem__(self, idx):
+    def __getitem__(
+        self, idx: typing.Union[int, slice]
+    ) -> typing.Union[RevokedCertificate, typing.List[RevokedCertificate]]:
         """
         Returns a revoked certificate (or slice of revoked certificates).
         """
 
     @abc.abstractmethod
-    def __iter__(self):
+    def __iter__(self) -> typing.Iterator[RevokedCertificate]:
         """
         Iterator over the revoked certificates
         """
@@ -512,16 +523,25 @@ class CertificateSigningRequestBuilder(object):
 
 
 class CertificateBuilder(object):
+    _extensions: typing.List[Extension[ExtensionType]]
+
     def __init__(
         self,
-        issuer_name=None,
-        subject_name=None,
-        public_key=None,
-        serial_number=None,
-        not_valid_before=None,
-        not_valid_after=None,
-        extensions=[],
+        issuer_name: typing.Optional[Name] = None,
+        subject_name: typing.Optional[Name] = None,
+        public_key: typing.Optional[_PUBLIC_KEY_TYPES] = None,
+        serial_number: typing.Optional[int] = None,
+        not_valid_before: typing.Optional[datetime.datetime] = None,
+        not_valid_after: typing.Optional[datetime.datetime] = None,
+        extensions: typing.Optional[
+            typing.Iterable[Extension[ExtensionType]]
+        ] = None,
     ) -> None:
+        if extensions is None:
+            extensions = []
+        else:
+            extensions = list(extensions)
+
         self._version = Version.v3
         self._issuer_name = issuer_name
         self._subject_name = subject_name
@@ -745,14 +765,30 @@ class CertificateBuilder(object):
 
 
 class CertificateRevocationListBuilder(object):
+    _extensions: typing.List[Extension[ExtensionType]]
+    _revoked_certificates: typing.List[RevokedCertificate]
+
     def __init__(
         self,
-        issuer_name=None,
-        last_update=None,
-        next_update=None,
-        extensions=[],
-        revoked_certificates=[],
+        issuer_name: typing.Optional[Name] = None,
+        last_update: typing.Optional[datetime.datetime] = None,
+        next_update: typing.Optional[datetime.datetime] = None,
+        extensions: typing.Optional[
+            typing.Iterable[Extension[ExtensionType]]
+        ] = None,
+        revoked_certificates: typing.Optional[
+            typing.Iterable[RevokedCertificate]
+        ] = None,
     ):
+        if extensions is None:
+            extensions = []
+        else:
+            extensions = list(extensions)
+        if revoked_certificates is None:
+            revoked_certificates = []
+        else:
+            revoked_certificates = list(revoked_certificates)
+
         self._issuer_name = issuer_name
         self._last_update = last_update
         self._next_update = next_update
@@ -879,8 +915,18 @@ class CertificateRevocationListBuilder(object):
 
 class RevokedCertificateBuilder(object):
     def __init__(
-        self, serial_number=None, revocation_date=None, extensions=[]
+        self,
+        serial_number: typing.Optional[int] = None,
+        revocation_date: typing.Optional[datetime.datetime] = None,
+        extensions: typing.Optional[
+            typing.Iterable[Extension[ExtensionType]]
+        ] = None,
     ):
+        if extensions is None:
+            extensions = []
+        else:
+            extensions = list(extensions)
+
         self._serial_number = serial_number
         self._revocation_date = revocation_date
         self._extensions = extensions

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -229,7 +229,9 @@ class CertificateRevocationList(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractproperty
-    def signature_hash_algorithm(self) -> hashes.HashAlgorithm:
+    def signature_hash_algorithm(
+        self,
+    ) -> typing.Optional[hashes.HashAlgorithm]:
         """
         Returns a HashAlgorithm corresponding to the type of the digest signed
         in the certificate.
@@ -356,7 +358,9 @@ class CertificateSigningRequest(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractproperty
-    def signature_hash_algorithm(self) -> hashes.HashAlgorithm:
+    def signature_hash_algorithm(
+        self,
+    ) -> typing.Optional[hashes.HashAlgorithm]:
         """
         Returns a HashAlgorithm corresponding to the type of the digest signed
         in the certificate.

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -74,7 +74,7 @@ class Version(Enum):
 
 
 class InvalidVersion(Exception):
-    def __init__(self, msg: str, parsed_version: typing.Any):
+    def __init__(self, msg: str, parsed_version: int) -> None:
         super(InvalidVersion, self).__init__(msg)
         self.parsed_version = parsed_version
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -9,6 +9,7 @@ import os
 import typing
 from enum import Enum
 
+from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat._types import _PRIVATE_KEY_TYPES, _PUBLIC_KEY_TYPES
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
@@ -22,7 +23,6 @@ from cryptography.hazmat.primitives.asymmetric import (
 )
 from cryptography.x509.extensions import Extension, ExtensionType, Extensions
 from cryptography.x509.name import Name
-from cryptography.x509.oid import ObjectIdentifier
 
 
 _EARLIEST_UTC_TIME = datetime.datetime(1950, 1, 1)
@@ -449,10 +449,28 @@ def load_der_x509_crl(
 
 
 class CertificateSigningRequestBuilder(object):
-    def __init__(self, subject_name=None, extensions=[], attributes=[]):
+    def __init__(
+        self,
+        subject_name: typing.Optional[Name] = None,
+        extensions: typing.Optional[
+            typing.Iterable[Extension[ExtensionType]]
+        ] = None,
+        attributes: typing.Optional[
+            typing.Iterable[typing.Tuple[ObjectIdentifier, bytes]]
+        ] = None,
+    ):
         """
         Creates an empty X.509 certificate request (v1).
         """
+        if extensions is None:
+            extensions = []
+        else:
+            extensions = list(extensions)
+        if attributes is None:
+            attributes = []
+        else:
+            attributes = list(attributes)
+
         self._subject_name = subject_name
         self._extensions = extensions
         self._attributes = attributes

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -478,7 +478,9 @@ class TestOpenSSLSignX509Certificate(object):
 
         with pytest.raises(TypeError):
             backend.create_x509_certificate(
-                object(), private_key, DummyHashAlgorithm()
+                object(),  # type: ignore[arg-type]
+                private_key,
+                DummyHashAlgorithm(),
             )
 
 
@@ -488,7 +490,9 @@ class TestOpenSSLSignX509CSR(object):
 
         with pytest.raises(TypeError):
             backend.create_x509_csr(
-                object(), private_key, DummyHashAlgorithm()
+                object(),  # type: ignore[arg-type]
+                private_key,
+                DummyHashAlgorithm(),
             )
 
 
@@ -497,13 +501,19 @@ class TestOpenSSLSignX509CertificateRevocationList(object):
         private_key = RSA_KEY_2048.private_key(backend)
 
         with pytest.raises(TypeError):
-            backend.create_x509_crl(object(), private_key, hashes.SHA256())
+            backend.create_x509_crl(
+                object(),  # type: ignore[arg-type]
+                private_key,
+                hashes.SHA256(),
+            )
 
 
 class TestOpenSSLCreateRevokedCertificate(object):
     def test_invalid_builder(self):
         with pytest.raises(TypeError):
-            backend.create_x509_revoked_certificate(object())
+            backend.create_x509_revoked_certificate(
+                object()  # type: ignore[arg-type]
+            )
 
 
 class TestOpenSSLSerializationWithOpenSSL(object):

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -483,6 +483,17 @@ class TestOpenSSLSignX509Certificate(object):
                 DummyHashAlgorithm(),
             )
 
+    def test_builder_requires_public_key(self):
+        builder = x509.CertificateBuilder()
+        private_key = RSA_KEY_2048.private_key(backend)
+
+        with pytest.raises(TypeError):
+            backend.create_x509_certificate(
+                builder,
+                private_key,
+                DummyHashAlgorithm(),
+            )
+
 
 class TestOpenSSLSignX509CSR(object):
     def test_requires_csr_builder(self):


### PR DESCRIPTION
Add typehints to `cryptography.x509.base` and also at least typehint the interfaces used by this module:

```
$ mypy --strict src/cryptography/x509/base.py 
Success: no issues found in 1 source file
```

**Request for comments:** There are still some mypy errors, even in normal mode, (almost) all of this nature:

```
$ mypy src/cryptography/ vectors/cryptography_vectors/ tests/
src/cryptography/hazmat/backends/openssl/backend.py:931: error: Item "Ed25519PublicKey" of "Union[Ed25519PublicKey, Ed448PublicKey, RSAPublicKey, DSAPublicKey, EllipticCurvePublicKey]" has no attribute "_evp_pkey"  [union-attr]
...
```

The issue here is (as far as I could reverse-engineer):

1. `x509.CertificateSigningRequestBuilder.private_key` (that line 931) is now type hinted to `cryptography.hazmat._types._PRIVATE_KEY_TYPES`, which is the _interfaces_ in `cryptography.hazmat.primitives.asymmetric` (that's the whole purpose of that PR, after all).
2. The `public_key()` method also returns the _interfaces_ of the corresponding public keys.
3. So `public_key` in line 930 is typehinted to that interface class.
4. But the interface class does _not_ define the `_evp_pkey` property, the concrete implementation for OpenSSL does.

We could typehint the `private_key` parameter in the concrete implementation to the concrete classes - but that would violated parameter type contravariance and mypy would again complain. We could simply cast the variable to the concrete implementation (with an actual typecheck before, maybe). Or maybe something completely else?