### PR TITLE
Bugfix/issue 5889 typehint get values for types

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -23,8 +23,18 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.x509.certificate_transparency import (
     SignedCertificateTimestamp,
 )
-from cryptography.x509.general_name import GeneralName, IPAddress, OtherName
-from cryptography.x509.name import RelativeDistinguishedName
+from cryptography.x509.general_name import (
+    DNSName,
+    DirectoryName,
+    GeneralName,
+    IPAddress,
+    OtherName,
+    RFC822Name,
+    RegisteredID,
+    UniformResourceIdentifier,
+    _IPADDRESS_TYPES,
+)
+from cryptography.x509.name import Name, RelativeDistinguishedName
 from cryptography.x509.oid import (
     CRLEntryExtensionOID,
     ExtensionOID,
@@ -1389,15 +1399,67 @@ class GeneralNames(object):
 
     __len__, __iter__, __getitem__ = _make_sequence_methods("_general_names")
 
+    @typing.overload
     def get_values_for_type(
-        self, type: typing.Type[GeneralName]
-    ) -> typing.List[GeneralName]:
+        self,
+        type: typing.Union[
+            typing.Type[DNSName],
+            typing.Type[UniformResourceIdentifier],
+            typing.Type[RFC822Name],
+        ],
+    ) -> typing.List[str]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self,
+        type: typing.Type[DirectoryName],
+    ) -> typing.List[Name]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self,
+        type: typing.Type[RegisteredID],
+    ) -> typing.List[ObjectIdentifier]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self, type: typing.Type[IPAddress]
+    ) -> typing.List[_IPADDRESS_TYPES]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self, type: typing.Type[OtherName]
+    ) -> typing.List[OtherName]:
+        ...
+
+    def get_values_for_type(
+        self,
+        type: typing.Union[
+            typing.Type[DNSName],
+            typing.Type[DirectoryName],
+            typing.Type[IPAddress],
+            typing.Type[OtherName],
+            typing.Type[RFC822Name],
+            typing.Type[RegisteredID],
+            typing.Type[UniformResourceIdentifier],
+        ],
+    ) -> typing.Union[
+        typing.List[_IPADDRESS_TYPES],
+        typing.List[str],
+        typing.List[OtherName],
+        typing.List[Name],
+        typing.List[ObjectIdentifier],
+    ]:
         # Return the value of each GeneralName, except for OtherName instances
         # which we return directly because it has two important properties not
         # just one value.
         objs = (i for i in self if isinstance(i, type))
         if type != OtherName:
-            objs = (i.value for i in objs)
+            return [i.value for i in objs]
         return list(objs)
 
     def __repr__(self) -> str:

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -1486,9 +1486,61 @@ class SubjectAlternativeName(ExtensionType):
 
     __len__, __iter__, __getitem__ = _make_sequence_methods("_general_names")
 
+    @typing.overload
     def get_values_for_type(
-        self, type: typing.Type[GeneralName]
-    ) -> typing.List[GeneralName]:
+        self,
+        type: typing.Union[
+            typing.Type[DNSName],
+            typing.Type[UniformResourceIdentifier],
+            typing.Type[RFC822Name],
+        ],
+    ) -> typing.List[str]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self,
+        type: typing.Type[DirectoryName],
+    ) -> typing.List[Name]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self,
+        type: typing.Type[RegisteredID],
+    ) -> typing.List[ObjectIdentifier]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self, type: typing.Type[IPAddress]
+    ) -> typing.List[_IPADDRESS_TYPES]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self, type: typing.Type[OtherName]
+    ) -> typing.List[OtherName]:
+        ...
+
+    def get_values_for_type(
+        self,
+        type: typing.Union[
+            typing.Type[DNSName],
+            typing.Type[DirectoryName],
+            typing.Type[IPAddress],
+            typing.Type[OtherName],
+            typing.Type[RFC822Name],
+            typing.Type[RegisteredID],
+            typing.Type[UniformResourceIdentifier],
+        ],
+    ) -> typing.Union[
+        typing.List[_IPADDRESS_TYPES],
+        typing.List[str],
+        typing.List[OtherName],
+        typing.List[Name],
+        typing.List[ObjectIdentifier],
+    ]:
         return self._general_names.get_values_for_type(type)
 
     def __repr__(self) -> str:
@@ -1515,9 +1567,61 @@ class IssuerAlternativeName(ExtensionType):
 
     __len__, __iter__, __getitem__ = _make_sequence_methods("_general_names")
 
+    @typing.overload
     def get_values_for_type(
-        self, type: typing.Type[GeneralName]
-    ) -> typing.List[GeneralName]:
+        self,
+        type: typing.Union[
+            typing.Type[DNSName],
+            typing.Type[UniformResourceIdentifier],
+            typing.Type[RFC822Name],
+        ],
+    ) -> typing.List[str]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self,
+        type: typing.Type[DirectoryName],
+    ) -> typing.List[Name]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self,
+        type: typing.Type[RegisteredID],
+    ) -> typing.List[ObjectIdentifier]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self, type: typing.Type[IPAddress]
+    ) -> typing.List[_IPADDRESS_TYPES]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self, type: typing.Type[OtherName]
+    ) -> typing.List[OtherName]:
+        ...
+
+    def get_values_for_type(
+        self,
+        type: typing.Union[
+            typing.Type[DNSName],
+            typing.Type[DirectoryName],
+            typing.Type[IPAddress],
+            typing.Type[OtherName],
+            typing.Type[RFC822Name],
+            typing.Type[RegisteredID],
+            typing.Type[UniformResourceIdentifier],
+        ],
+    ) -> typing.Union[
+        typing.List[_IPADDRESS_TYPES],
+        typing.List[str],
+        typing.List[OtherName],
+        typing.List[Name],
+        typing.List[ObjectIdentifier],
+    ]:
         return self._general_names.get_values_for_type(type)
 
     def __repr__(self) -> str:
@@ -1544,9 +1648,61 @@ class CertificateIssuer(ExtensionType):
 
     __len__, __iter__, __getitem__ = _make_sequence_methods("_general_names")
 
+    @typing.overload
     def get_values_for_type(
-        self, type: typing.Type[GeneralName]
-    ) -> typing.List[GeneralName]:
+        self,
+        type: typing.Union[
+            typing.Type[DNSName],
+            typing.Type[UniformResourceIdentifier],
+            typing.Type[RFC822Name],
+        ],
+    ) -> typing.List[str]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self,
+        type: typing.Type[DirectoryName],
+    ) -> typing.List[Name]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self,
+        type: typing.Type[RegisteredID],
+    ) -> typing.List[ObjectIdentifier]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self, type: typing.Type[IPAddress]
+    ) -> typing.List[_IPADDRESS_TYPES]:
+        ...
+
+    @typing.overload
+    def get_values_for_type(
+        self, type: typing.Type[OtherName]
+    ) -> typing.List[OtherName]:
+        ...
+
+    def get_values_for_type(
+        self,
+        type: typing.Union[
+            typing.Type[DNSName],
+            typing.Type[DirectoryName],
+            typing.Type[IPAddress],
+            typing.Type[OtherName],
+            typing.Type[RFC822Name],
+            typing.Type[RegisteredID],
+            typing.Type[UniformResourceIdentifier],
+        ],
+    ) -> typing.Union[
+        typing.List[_IPADDRESS_TYPES],
+        typing.List[str],
+        typing.List[OtherName],
+        typing.List[Name],
+        typing.List[ObjectIdentifier],
+    ]:
         return self._general_names.get_values_for_type(type)
 
     def __repr__(self) -> str:

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -23,6 +23,12 @@ _GENERAL_NAMES = {
     7: "iPAddress",
     8: "registeredID",
 }
+_IPADDRESS_TYPES = typing.Union[
+    ipaddress.IPv4Address,
+    ipaddress.IPv6Address,
+    ipaddress.IPv4Network,
+    ipaddress.IPv6Network,
+]
 
 
 class UnsupportedGeneralNameType(Exception):
@@ -228,15 +234,7 @@ class RegisteredID(GeneralName):
 
 
 class IPAddress(GeneralName):
-    def __init__(
-        self,
-        value: typing.Union[
-            ipaddress.IPv4Address,
-            ipaddress.IPv6Address,
-            ipaddress.IPv4Network,
-            ipaddress.IPv6Network,
-        ],
-    ):
+    def __init__(self, value: _IPADDRESS_TYPES):
         if not isinstance(
             value,
             (
@@ -255,14 +253,7 @@ class IPAddress(GeneralName):
         self._value = value
 
     @property
-    def value(
-        self,
-    ) -> typing.Union[
-        ipaddress.IPv4Address,
-        ipaddress.IPv6Address,
-        ipaddress.IPv4Network,
-        ipaddress.IPv6Network,
-    ]:
+    def value(self) -> _IPADDRESS_TYPES:
         return self._value
 
     def __repr__(self) -> str:

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -46,7 +46,7 @@ class GeneralName(metaclass=abc.ABCMeta):
 
 
 class RFC822Name(GeneralName):
-    def __init__(self, value: str):
+    def __init__(self, value: str) -> None:
         if isinstance(value, str):
             try:
                 value.encode("ascii")
@@ -94,7 +94,7 @@ class RFC822Name(GeneralName):
 
 
 class DNSName(GeneralName):
-    def __init__(self, value: str):
+    def __init__(self, value: str) -> None:
         if isinstance(value, str):
             try:
                 value.encode("ascii")
@@ -136,7 +136,7 @@ class DNSName(GeneralName):
 
 
 class UniformResourceIdentifier(GeneralName):
-    def __init__(self, value: str):
+    def __init__(self, value: str) -> None:
         if isinstance(value, str):
             try:
                 value.encode("ascii")
@@ -180,7 +180,7 @@ class UniformResourceIdentifier(GeneralName):
 
 
 class DirectoryName(GeneralName):
-    def __init__(self, value: Name):
+    def __init__(self, value: Name) -> None:
         if not isinstance(value, Name):
             raise TypeError("value must be a Name")
 
@@ -207,7 +207,7 @@ class DirectoryName(GeneralName):
 
 
 class RegisteredID(GeneralName):
-    def __init__(self, value: ObjectIdentifier):
+    def __init__(self, value: ObjectIdentifier) -> None:
         if not isinstance(value, ObjectIdentifier):
             raise TypeError("value must be an ObjectIdentifier")
 
@@ -234,7 +234,7 @@ class RegisteredID(GeneralName):
 
 
 class IPAddress(GeneralName):
-    def __init__(self, value: _IPADDRESS_TYPES):
+    def __init__(self, value: _IPADDRESS_TYPES) -> None:
         if not isinstance(
             value,
             (
@@ -273,7 +273,7 @@ class IPAddress(GeneralName):
 
 
 class OtherName(GeneralName):
-    def __init__(self, type_id: ObjectIdentifier, value: bytes):
+    def __init__(self, type_id: ObjectIdentifier, value: bytes) -> None:
         if not isinstance(type_id, ObjectIdentifier):
             raise TypeError("type_id must be an ObjectIdentifier")
         if not isinstance(value, bytes):

--- a/src/cryptography/x509/oid.py
+++ b/src/cryptography/x509/oid.py
@@ -265,3 +265,18 @@ _OID_NAMES = {
     OCSPExtensionOID.NONCE: "OCSPNonce",
     AttributeOID.CHALLENGE_PASSWORD: "challengePassword",
 }
+
+
+__all__ = [
+    "AttributeOID",
+    "AuthorityInformationAccessOID",
+    "CRLEntryExtensionOID",
+    "CertificatePoliciesOID",
+    "ExtendedKeyUsageOID",
+    "ExtensionOID",
+    "NameOID",
+    "OCSPExtensionOID",
+    "ObjectIdentifier",
+    "SignatureAlgorithmOID",
+    "SubjectInformationAccessOID",
+]


### PR DESCRIPTION
Fixes #5889.

Properly typehint `get_values_for_type`. I also added a type alias for the different ip address/network types.

One RFC definitely here: note the `__all__` in `x509.oid`. The issue here is (again) the implicit re-export of `ObjectIdentifier` that mypy doesn't like, breaking type hinting for OIDs:

```
from cryptography.x509.oid import ObjectIdentifier
oid = ObjectIdentifier("1.2.3")
reveal_type(oid)  # that's Any!
```

The same happens when you import from `cryptography.x509.ObjectIdentifier` - the canonical location - because __init__.py also imports from the "wrong" location, as do a few other places in the code.

The other way to do this would be to consistently import from `cryptography.hazmat._oid` throughout the source code.