### PR TITLE
Typehint x509.base (only)

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -991,7 +991,8 @@ class Backend(BackendInterface):
 
         # Set the subject's public key.
         res = self._lib.X509_set_pubkey(
-            x509_cert, builder._public_key._evp_pkey
+            x509_cert,
+            builder._public_key._evp_pkey  # type: ignore[union-attr]
         )
         self.openssl_assert(res == 1)
 
@@ -1101,7 +1102,9 @@ class Backend(BackendInterface):
         for revoked_cert in builder._revoked_certificates:
             # Duplicating because the X509_CRL takes ownership and will free
             # this memory when X509_CRL_free is called.
-            revoked = self._lib.X509_REVOKED_dup(revoked_cert._x509_revoked)
+            revoked = self._lib.X509_REVOKED_dup(
+                revoked_cert._x509_revoked  # type: ignore[attr-defined]
+            )
             self.openssl_assert(revoked != self._ffi.NULL)
             res = self._lib.X509_CRL_add0_revoked(x509_crl, revoked)
             self.openssl_assert(res == 1)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -992,7 +992,7 @@ class Backend(BackendInterface):
         # Set the subject's public key.
         res = self._lib.X509_set_pubkey(
             x509_cert,
-            builder._public_key._evp_pkey  # type: ignore[union-attr]
+            builder._public_key._evp_pkey,  # type: ignore[union-attr]
         )
         self.openssl_assert(res == 1)
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -9,7 +9,6 @@ import os
 import typing
 from enum import Enum
 
-from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat._types import _PRIVATE_KEY_TYPES, _PUBLIC_KEY_TYPES
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
@@ -23,6 +22,7 @@ from cryptography.hazmat.primitives.asymmetric import (
 )
 from cryptography.x509.extensions import Extension, ExtensionType, Extensions
 from cryptography.x509.name import Name
+from cryptography.x509.oid import ObjectIdentifier
 
 
 _EARLIEST_UTC_TIME = datetime.datetime(1950, 1, 1)

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -456,25 +456,12 @@ class CertificateSigningRequestBuilder(object):
     def __init__(
         self,
         subject_name: typing.Optional[Name] = None,
-        extensions: typing.Optional[
-            typing.Iterable[Extension[ExtensionType]]
-        ] = None,
-        attributes: typing.Optional[
-            typing.Iterable[typing.Tuple[ObjectIdentifier, bytes]]
-        ] = None,
+        extensions: typing.List[Extension[ExtensionType]] = [],
+        attributes: typing.List[typing.Tuple[ObjectIdentifier, bytes]] = [],
     ):
         """
         Creates an empty X.509 certificate request (v1).
         """
-        if extensions is None:
-            extensions = []
-        else:
-            extensions = list(extensions)
-        if attributes is None:
-            attributes = []
-        else:
-            attributes = list(attributes)
-
         self._subject_name = subject_name
         self._extensions = extensions
         self._attributes = attributes
@@ -555,15 +542,8 @@ class CertificateBuilder(object):
         serial_number: typing.Optional[int] = None,
         not_valid_before: typing.Optional[datetime.datetime] = None,
         not_valid_after: typing.Optional[datetime.datetime] = None,
-        extensions: typing.Optional[
-            typing.Iterable[Extension[ExtensionType]]
-        ] = None,
+        extensions: typing.List[Extension[ExtensionType]] = [],
     ) -> None:
-        if extensions is None:
-            extensions = []
-        else:
-            extensions = list(extensions)
-
         self._version = Version.v3
         self._issuer_name = issuer_name
         self._subject_name = subject_name
@@ -795,22 +775,9 @@ class CertificateRevocationListBuilder(object):
         issuer_name: typing.Optional[Name] = None,
         last_update: typing.Optional[datetime.datetime] = None,
         next_update: typing.Optional[datetime.datetime] = None,
-        extensions: typing.Optional[
-            typing.Iterable[Extension[ExtensionType]]
-        ] = None,
-        revoked_certificates: typing.Optional[
-            typing.Iterable[RevokedCertificate]
-        ] = None,
+        extensions: typing.List[Extension[ExtensionType]] = [],
+        revoked_certificates: typing.List[RevokedCertificate] = [],
     ):
-        if extensions is None:
-            extensions = []
-        else:
-            extensions = list(extensions)
-        if revoked_certificates is None:
-            revoked_certificates = []
-        else:
-            revoked_certificates = list(revoked_certificates)
-
         self._issuer_name = issuer_name
         self._last_update = last_update
         self._next_update = next_update
@@ -940,15 +907,8 @@ class RevokedCertificateBuilder(object):
         self,
         serial_number: typing.Optional[int] = None,
         revocation_date: typing.Optional[datetime.datetime] = None,
-        extensions: typing.Optional[
-            typing.Iterable[Extension[ExtensionType]]
-        ] = None,
+        extensions: typing.List[Extension[ExtensionType]] = [],
     ):
-        if extensions is None:
-            extensions = []
-        else:
-            extensions = list(extensions)
-
         self._serial_number = serial_number
         self._revocation_date = revocation_date
         self._extensions = extensions

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -9,6 +9,7 @@ import os
 import typing
 from enum import Enum
 
+from cryptography.hazmat._oid import ObjectIdentifier
 from cryptography.hazmat._types import _PRIVATE_KEY_TYPES, _PUBLIC_KEY_TYPES
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
@@ -22,20 +23,20 @@ from cryptography.hazmat.primitives.asymmetric import (
 )
 from cryptography.x509.extensions import Extension, ExtensionType, Extensions
 from cryptography.x509.name import Name
-from cryptography.x509.oid import ObjectIdentifier
 
 
 _EARLIEST_UTC_TIME = datetime.datetime(1950, 1, 1)
 
 
 class AttributeNotFound(Exception):
-    def __init__(self, msg, oid):
+    def __init__(self, msg: str, oid: ObjectIdentifier) -> None:
         super(AttributeNotFound, self).__init__(msg)
         self.oid = oid
 
 
 def _reject_duplicate_extension(
-    extension: Extension, extensions: typing.List[Extension]
+    extension: Extension[ExtensionType],
+    extensions: typing.List[Extension[ExtensionType]],
 ) -> None:
     # This is quadratic in the number of extensions
     for e in extensions:
@@ -73,7 +74,7 @@ class Version(Enum):
 
 
 class InvalidVersion(Exception):
-    def __init__(self, msg, parsed_version):
+    def __init__(self, msg: str, parsed_version: int) -> None:
         super(InvalidVersion, self).__init__(msg)
         self.parsed_version = parsed_version
 
@@ -228,7 +229,9 @@ class CertificateRevocationList(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractproperty
-    def signature_hash_algorithm(self) -> hashes.HashAlgorithm:
+    def signature_hash_algorithm(
+        self,
+    ) -> typing.Optional[hashes.HashAlgorithm]:
         """
         Returns a HashAlgorithm corresponding to the type of the digest signed
         in the certificate.
@@ -294,14 +297,24 @@ class CertificateRevocationList(metaclass=abc.ABCMeta):
         Number of revoked certificates in the CRL.
         """
 
+    @typing.overload
+    def __getitem__(self, idx: int) -> RevokedCertificate:
+        ...
+
+    @typing.overload
+    def __getitem__(self, idx: slice) -> typing.List[RevokedCertificate]:
+        ...
+
     @abc.abstractmethod
-    def __getitem__(self, idx):
+    def __getitem__(
+        self, idx: typing.Union[int, slice]
+    ) -> typing.Union[RevokedCertificate, typing.List[RevokedCertificate]]:
         """
         Returns a revoked certificate (or slice of revoked certificates).
         """
 
     @abc.abstractmethod
-    def __iter__(self):
+    def __iter__(self) -> typing.Iterator[RevokedCertificate]:
         """
         Iterator over the revoked certificates
         """
@@ -345,7 +358,9 @@ class CertificateSigningRequest(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractproperty
-    def signature_hash_algorithm(self) -> hashes.HashAlgorithm:
+    def signature_hash_algorithm(
+        self,
+    ) -> typing.Optional[hashes.HashAlgorithm]:
         """
         Returns a HashAlgorithm corresponding to the type of the digest signed
         in the certificate.
@@ -438,10 +453,28 @@ def load_der_x509_crl(
 
 
 class CertificateSigningRequestBuilder(object):
-    def __init__(self, subject_name=None, extensions=[], attributes=[]):
+    def __init__(
+        self,
+        subject_name: typing.Optional[Name] = None,
+        extensions: typing.Optional[
+            typing.Iterable[Extension[ExtensionType]]
+        ] = None,
+        attributes: typing.Optional[
+            typing.Iterable[typing.Tuple[ObjectIdentifier, bytes]]
+        ] = None,
+    ):
         """
         Creates an empty X.509 certificate request (v1).
         """
+        if extensions is None:
+            extensions = []
+        else:
+            extensions = list(extensions)
+        if attributes is None:
+            attributes = []
+        else:
+            attributes = list(attributes)
+
         self._subject_name = subject_name
         self._extensions = extensions
         self._attributes = attributes
@@ -512,16 +545,25 @@ class CertificateSigningRequestBuilder(object):
 
 
 class CertificateBuilder(object):
+    _extensions: typing.List[Extension[ExtensionType]]
+
     def __init__(
         self,
-        issuer_name=None,
-        subject_name=None,
-        public_key=None,
-        serial_number=None,
-        not_valid_before=None,
-        not_valid_after=None,
-        extensions=[],
+        issuer_name: typing.Optional[Name] = None,
+        subject_name: typing.Optional[Name] = None,
+        public_key: typing.Optional[_PUBLIC_KEY_TYPES] = None,
+        serial_number: typing.Optional[int] = None,
+        not_valid_before: typing.Optional[datetime.datetime] = None,
+        not_valid_after: typing.Optional[datetime.datetime] = None,
+        extensions: typing.Optional[
+            typing.Iterable[Extension[ExtensionType]]
+        ] = None,
     ) -> None:
+        if extensions is None:
+            extensions = []
+        else:
+            extensions = list(extensions)
+
         self._version = Version.v3
         self._issuer_name = issuer_name
         self._subject_name = subject_name
@@ -745,14 +787,30 @@ class CertificateBuilder(object):
 
 
 class CertificateRevocationListBuilder(object):
+    _extensions: typing.List[Extension[ExtensionType]]
+    _revoked_certificates: typing.List[RevokedCertificate]
+
     def __init__(
         self,
-        issuer_name=None,
-        last_update=None,
-        next_update=None,
-        extensions=[],
-        revoked_certificates=[],
+        issuer_name: typing.Optional[Name] = None,
+        last_update: typing.Optional[datetime.datetime] = None,
+        next_update: typing.Optional[datetime.datetime] = None,
+        extensions: typing.Optional[
+            typing.Iterable[Extension[ExtensionType]]
+        ] = None,
+        revoked_certificates: typing.Optional[
+            typing.Iterable[RevokedCertificate]
+        ] = None,
     ):
+        if extensions is None:
+            extensions = []
+        else:
+            extensions = list(extensions)
+        if revoked_certificates is None:
+            revoked_certificates = []
+        else:
+            revoked_certificates = list(revoked_certificates)
+
         self._issuer_name = issuer_name
         self._last_update = last_update
         self._next_update = next_update
@@ -879,8 +937,18 @@ class CertificateRevocationListBuilder(object):
 
 class RevokedCertificateBuilder(object):
     def __init__(
-        self, serial_number=None, revocation_date=None, extensions=[]
+        self,
+        serial_number: typing.Optional[int] = None,
+        revocation_date: typing.Optional[datetime.datetime] = None,
+        extensions: typing.Optional[
+            typing.Iterable[Extension[ExtensionType]]
+        ] = None,
     ):
+        if extensions is None:
+            extensions = []
+        else:
+            extensions = list(extensions)
+
         self._serial_number = serial_number
         self._revocation_date = revocation_date
         self._extensions = extensions

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -10,6 +10,7 @@ import copy
 import datetime
 import ipaddress
 import os
+import typing
 
 import pytest
 
@@ -3615,8 +3616,11 @@ class TestCertificateSigningRequestBuilder(object):
         assert list(subject) == [
             x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Texas"),
         ]
-        basic_constraints = request.extensions.get_extension_for_oid(
-            ExtensionOID.BASIC_CONSTRAINTS
+        basic_constraints = typing.cast(
+            "x509.Extension[x509.BasicConstraints]",
+            request.extensions.get_extension_for_oid(
+                ExtensionOID.BASIC_CONSTRAINTS
+            ),
         )
         assert basic_constraints.value.ca is True
         assert basic_constraints.value.path_length == 2
@@ -3653,8 +3657,11 @@ class TestCertificateSigningRequestBuilder(object):
         assert list(subject) == [
             x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Texas"),
         ]
-        basic_constraints = request.extensions.get_extension_for_oid(
-            ExtensionOID.BASIC_CONSTRAINTS
+        basic_constraints = typing.cast(
+            "x509.Extension[x509.BasicConstraints]",
+            request.extensions.get_extension_for_oid(
+                ExtensionOID.BASIC_CONSTRAINTS
+            ),
         )
         assert basic_constraints.value.ca is True
         assert basic_constraints.value.path_length == 2

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -3617,7 +3617,7 @@ class TestCertificateSigningRequestBuilder(object):
             x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Texas"),
         ]
         basic_constraints = typing.cast(
-            "x509.Extension[x509.BasicConstraints]",
+            x509.Extension[x509.BasicConstraints],
             request.extensions.get_extension_for_oid(
                 ExtensionOID.BASIC_CONSTRAINTS
             ),
@@ -3658,7 +3658,7 @@ class TestCertificateSigningRequestBuilder(object):
             x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Texas"),
         ]
         basic_constraints = typing.cast(
-            "x509.Extension[x509.BasicConstraints]",
+            x509.Extension[x509.BasicConstraints],
             request.extensions.get_extension_for_oid(
                 ExtensionOID.BASIC_CONSTRAINTS
             ),


### PR DESCRIPTION
As requested in #5899, splitting this up into separate PRs.

The type cast in the test is now necessary because requests.extensions is now known to be `x509.Extensions`, so now mypy knows it's ExtensionType, but not which one.

But the mypy errors from #5899 remain, with the backend essentially using the public interface as tyehint, but using internal properties of the OpenSSL implementation. Should I ignore? do something else?