### PR TITLE
Make get_extension_for_class() a generic function

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -130,8 +130,8 @@ class Extensions(object):
         raise ExtensionNotFound("No {} extension was found".format(oid), oid)
 
     def get_extension_for_class(
-        self, extclass: typing.Type[ExtensionType]
-    ) -> "Extension[ExtensionType]":
+        self, extclass: typing.Type[ExtensionTypeVar]
+    ) -> "Extension[ExtensionTypeVar]":
         if extclass is UnrecognizedExtension:
             raise TypeError(
                 "UnrecognizedExtension can't be used with "


### PR DESCRIPTION
Make `get_extension_for_class()` a generic function. This way e.g. `get_extension_for_class(x509.BasicConstraints)` will let mypy know it returns `Extension[BasicConstraints]`.

For example, using this code:

```
cert = x509.load_pem_x509_certificate(b'')
  
bc = cert.extensions.get_extension_for_class(x509.BasicConstraints)
reveal_type(bc)
reveal_type(bc.value.path_length)
```

**Without the patch**,  mypy reveals:

```
$ mypy example.py
example.py:6: note: Revealed type is 'cryptography.x509.extensions.Extension[cryptography.x509.extensions.ExtensionType]'
example.py:7: error: "ExtensionType" has no attribute "path_length"  [attr-defined]
example.py:7: note: Revealed type is 'Any'
```

But **with** the patch, you get the much better:

```
$ mypy example.py
example.py:6: note: Revealed type is 'cryptography.x509.extensions.Extension[cryptography.x509.extensions.BasicConstraints*]'
example.py:7: note: Revealed type is 'Union[builtins.int, None]'
```