### PR TITLE
fix XTS less than one block length. fixes #5885

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -145,7 +145,13 @@ class _CipherContext(object):
             res = self._backend._lib.EVP_CipherUpdate(
                 self._ctx, outbuf, outlen, inbuf, inlen
             )
-            self._backend.openssl_assert(res != 0)
+            if res == 0 and isinstance(self._mode, modes.XTS):
+                raise ValueError(
+                    "In XTS mode you must supply at least a full block in the "
+                    "first update call. For AES this is 16 bytes."
+                )
+            else:
+                self._backend.openssl_assert(res != 0)
             data_processed += inlen
             total_out += outlen[0]
 

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -52,6 +52,14 @@ class TestAESModeXTS(object):
                 computed_pt = dec.update(ct) + dec.finalize()
                 assert computed_pt == pt
 
+    def test_xts_too_short(self):
+        key = os.urandom(32)
+        tweak = os.urandom(16)
+        cipher = base.Cipher(algorithms.AES(key), modes.XTS(tweak))
+        enc = cipher.encryptor()
+        with pytest.raises(ValueError):
+            enc.update(b"0" * 15)
+
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -53,8 +53,8 @@ class TestAESModeXTS(object):
                 assert computed_pt == pt
 
     def test_xts_too_short(self):
-        key = os.urandom(32)
-        tweak = os.urandom(16)
+        key = b"thirty_two_byte_keys_are_great!!"
+        tweak = b"\x00" * 16
         cipher = base.Cipher(algorithms.AES(key), modes.XTS(tweak))
         enc = cipher.encryptor()
         with pytest.raises(ValueError):


### PR DESCRIPTION
Note: since we don't track total bytes processed this approach assumes any error in `update` with XTS is the < 1 block issue. If we want to be more granular we need to start tracking.