### PR TITLE
Update annotation for key

### DIFF
--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -27,7 +27,7 @@ _MAX_CLOCK_SKEW = 60
 
 
 class Fernet(object):
-    def __init__(self, key: bytes, backend: typing.Optional[Backend] = None):
+    def __init__(self, key: typing.Union[bytes, str], backend: typing.Optional[Backend] = None):
         backend = _get_backend(backend)
 
         key = base64.urlsafe_b64decode(key)

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -27,7 +27,11 @@ _MAX_CLOCK_SKEW = 60
 
 
 class Fernet(object):
-    def __init__(self, key: typing.Union[bytes, str], backend: typing.Optional[Backend] = None):
+    def __init__(
+        self,
+        key: typing.Union[bytes, str],
+        backend: typing.Optional[Backend] = None
+    ):
         backend = _get_backend(backend)
 
         key = base64.urlsafe_b64decode(key)

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -30,7 +30,7 @@ class Fernet(object):
     def __init__(
         self,
         key: typing.Union[bytes, str],
-        backend: typing.Optional[Backend] = None
+        backend: typing.Optional[Backend] = None,
     ):
         backend = _get_backend(backend)
 


### PR DESCRIPTION
The key argument is passed immediately into `urlsafe_b64decode()`, which accepts `str` or `bytes`.

> Decode bytes-like object or ASCII string s...
https://docs.python.org/3/library/base64.html#base64.urlsafe_b64decode