### PR TITLE
Set `dirhtml` builder explicitly in the RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+sphinx:
+  # The config file overrides the UI settings:
+  # https://github.com/pyca/cryptography/issues/5863#issuecomment-817828152
+  builder: dirhtml
+
 build:
   # First RTD build env which includes a rust toolchain
   image: "7.0"


### PR DESCRIPTION
After introducing the `.readthedocs.yml` config in the repo, it
started overriding all of the settings set via the RTD UI
unintentionally switching the URL scheme.

This change reverts that switch resurrecting the old one.

Fixes #5863

Refs:
* https://github.com/pyca/cryptography/issues/5863#issuecomment-817828152