### PR TITLE
Add x509.Name.rfc4514_attribute_name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Changelog
 * We now ship ``manylinux_2_24`` wheels, in addition to our ``manylinux2010``
   and ``manylinux2014`` wheels.
 * Added ``rfc4514_attribute_name`` attribute to
-  :attr:`x509.Name <cryptography.x509.Name.rfc4514_attribute_name>`,
+  :attr:`x509.NameAttribute <cryptography.x509.NameAttribute.rfc4514_attribute_name>`,
 
 .. _v3-4-7:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Changelog
   in regions where they may be required, and are not generally recommended.
 * We now ship ``manylinux_2_24`` wheels, in addition to our ``manylinux2010``
   and ``manylinux2014`` wheels.
+* Added ``rfc4514_attribute_name`` attribute to
+  :attr:`x509.Name <cryptography.x509.Name.rfc4514_attribute_name>`,
 
 .. _v3-4-7:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1333,6 +1333,15 @@ X.509 CSR (Certificate Signing Request) Builder Object
 
         The value of the attribute.
 
+    .. attribute:: rfc4514_attribute_name
+
+        .. versionadded:: 35.0
+
+        :type: :term:`text`
+
+        The :rfc:`4514` short attribute name (for example "CN"),
+        or the OID dotted string if a short name is unavailable.
+
     .. method:: rfc4514_string()
 
         .. versionadded:: 2.5

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -118,6 +118,13 @@ class NameAttribute(object):
     def value(self) -> str:
         return self._value
 
+    @property
+    def rfc4514_attribute_name(self) -> str:
+        """
+        The short attribute name (for example "CN") if available, otherwise the OID dotted string.
+        """
+        return _NAMEOID_TO_NAME.get(self.oid, self.oid.dotted_string)
+
     def rfc4514_string(self) -> str:
         """
         Format as RFC4514 Distinguished Name string.
@@ -125,8 +132,7 @@ class NameAttribute(object):
         Use short attribute name if available, otherwise fall back to OID
         dotted string.
         """
-        key = _NAMEOID_TO_NAME.get(self.oid, self.oid.dotted_string)
-        return "%s=%s" % (key, _escape_dn_value(self.value))
+        return "%s=%s" % (self.rfc4514_attribute_name, _escape_dn_value(self.value))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, NameAttribute):

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -121,7 +121,8 @@ class NameAttribute(object):
     @property
     def rfc4514_attribute_name(self) -> str:
         """
-        The short attribute name (for example "CN") if available, otherwise the OID dotted string.
+        The short attribute name (for example "CN") if available,
+        otherwise the OID dotted string.
         """
         return _NAMEOID_TO_NAME.get(self.oid, self.oid.dotted_string)
 
@@ -132,7 +133,10 @@ class NameAttribute(object):
         Use short attribute name if available, otherwise fall back to OID
         dotted string.
         """
-        return "%s=%s" % (self.rfc4514_attribute_name, _escape_dn_value(self.value))
+        return "%s=%s" % (
+            self.rfc4514_attribute_name,
+            _escape_dn_value(self.value),
+        )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, NameAttribute):

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -4991,6 +4991,12 @@ class TestName(object):
 
         assert repr(name) == expected_repr
 
+    def test_rfc4514_attribute_name(self):
+        a = x509.NameAttribute(NameOID.COMMON_NAME, "cryptography.io")
+        assert a.rfc4514_attribute_name == "CN"
+        b = x509.NameAttribute(NameOID.PSEUDONYM, "cryptography.io")
+        assert b.rfc4514_attribute_name == "2.5.4.65"
+
     def test_rfc4514_string(self):
         n = x509.Name(
             [


### PR DESCRIPTION
Follow up to #5959, which for some reason decided to self-close when I force-pushed. 🤷😃 

In short, this PR adds `x509.Name.rfc4514_attribute_name` to expose a (short-form) textual OID representation. I'm happy to change things around, let me know what you think.