### PR TITLE
remove bionic and centos 8 arm64 jobs

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -13,20 +13,6 @@
       tox_envlist: py38
 
 - job:
-    name: pyca-cryptography-ubuntu-bionic-py36-arm64
-    parent: pyca-cryptography-base
-    nodeset: ubuntu-bionic-arm64
-    vars:
-      tox_envlist: py36
-
-- job:
-    name: pyca-cryptography-centos-8-py36-arm64
-    parent: pyca-cryptography-base
-    nodeset: centos-8-arm64
-    vars:
-      tox_envlist: py36
-
-- job:
     name: pyca-cryptography-build-wheel
     abstract: true
     pre-run: .zuul.playbooks/playbooks/wheel/pre.yaml

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -4,8 +4,6 @@
         - pyca-cryptography-build-wheel-arm64
         - pyca-cryptography-build-wheel-x86_64
         - pyca-cryptography-ubuntu-focal-py38-arm64
-        - pyca-cryptography-ubuntu-bionic-py36-arm64
-        - pyca-cryptography-centos-8-py36-arm64
     release:
       jobs:
         - pyca-cryptography-build-wheel-arm64


### PR DESCRIPTION
Reliability and speed is insufficient and we get almost the same CI
bug finding value with just one arm64 job for now.