### PR TITLE
Corrected test parsing of certificates

### DIFF
--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -110,9 +110,9 @@ def _parse_cert(der):
         # Skip subjectPublicKeyInfo
         _ = tbs_cert.read_element(SEQUENCE)
         # Skip issuerUniqueID
-        _ = tbs_cert.read_optional_element(CONTEXT_SPECIFIC | CONSTRUCTED | 1)
+        _ = tbs_cert.read_optional_element(CONTEXT_SPECIFIC | 1)
         # Skip subjectUniqueID
-        _ = tbs_cert.read_optional_element(CONTEXT_SPECIFIC | CONSTRUCTED | 2)
+        _ = tbs_cert.read_optional_element(CONTEXT_SPECIFIC | 2)
         # Skip extensions
         _ = tbs_cert.read_optional_element(CONTEXT_SPECIFIC | CONSTRUCTED | 3)
 


### PR DESCRIPTION
RFC 5280 says these fields are both `IMPLICIT` tagging, and `IMPLICIT` tagging is only `CONSTRUCTED` if the inner type is, and the inner type is `BIT STRING` here, which is not `CONSTRUCTED`.

In practice this is irrelevant since _no one_ ever uses these fields