### PR TITLE
make PRIVATE/PUBLIC_KEY_TYPES a public API

### DIFF
--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -8,7 +8,9 @@ import typing
 
 
 if typing.TYPE_CHECKING:
-    from cryptography.hazmat._types import _PRIVATE_KEY_TYPES
+    from cryptography.hazmat.primitives.asymmetric.types import (
+        PRIVATE_KEY_TYPES,
+    )
     from cryptography.hazmat.primitives import hashes
     from cryptography.x509.base import (
         Certificate,
@@ -306,7 +308,7 @@ class X509Backend(metaclass=abc.ABCMeta):
     def create_x509_csr(
         self,
         builder: "CertificateSigningRequestBuilder",
-        private_key: "_PRIVATE_KEY_TYPES",
+        private_key: "PRIVATE_KEY_TYPES",
         algorithm: typing.Optional["hashes.HashAlgorithm"],
     ) -> "CertificateSigningRequest":
         """
@@ -317,7 +319,7 @@ class X509Backend(metaclass=abc.ABCMeta):
     def create_x509_certificate(
         self,
         builder: "CertificateBuilder",
-        private_key: "_PRIVATE_KEY_TYPES",
+        private_key: "PRIVATE_KEY_TYPES",
         algorithm: typing.Optional["hashes.HashAlgorithm"],
     ) -> "Certificate":
         """
@@ -328,7 +330,7 @@ class X509Backend(metaclass=abc.ABCMeta):
     def create_x509_crl(
         self,
         builder: "CertificateRevocationListBuilder",
-        private_key: "_PRIVATE_KEY_TYPES",
+        private_key: "PRIVATE_KEY_TYPES",
         algorithm: typing.Optional["hashes.HashAlgorithm"],
     ) -> "CertificateRevocationList":
         """

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -12,7 +12,6 @@ from contextlib import contextmanager
 
 from cryptography import utils, x509
 from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
-from cryptography.hazmat._types import _PRIVATE_KEY_TYPES
 from cryptography.hazmat.backends.interfaces import Backend as BackendInterface
 from cryptography.hazmat.backends.openssl import aead
 from cryptography.hazmat.backends.openssl.ciphers import _CipherContext
@@ -108,6 +107,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import (
     PKCS1v15,
     PSS,
 )
+from cryptography.hazmat.primitives.asymmetric.types import PRIVATE_KEY_TYPES
 from cryptography.hazmat.primitives.ciphers.algorithms import (
     AES,
     ARC4,
@@ -895,7 +895,7 @@ class Backend(BackendInterface):
     def create_x509_csr(
         self,
         builder: x509.CertificateSigningRequestBuilder,
-        private_key: _PRIVATE_KEY_TYPES,
+        private_key: PRIVATE_KEY_TYPES,
         algorithm: typing.Optional[hashes.HashAlgorithm],
     ) -> _CertificateSigningRequest:
         if not isinstance(builder, x509.CertificateSigningRequestBuilder):
@@ -976,7 +976,7 @@ class Backend(BackendInterface):
     def create_x509_certificate(
         self,
         builder: x509.CertificateBuilder,
-        private_key: _PRIVATE_KEY_TYPES,
+        private_key: PRIVATE_KEY_TYPES,
         algorithm: typing.Optional[hashes.HashAlgorithm],
     ) -> _Certificate:
         if not isinstance(builder, x509.CertificateBuilder):
@@ -1078,7 +1078,7 @@ class Backend(BackendInterface):
     def create_x509_crl(
         self,
         builder: x509.CertificateRevocationListBuilder,
-        private_key: _PRIVATE_KEY_TYPES,
+        private_key: PRIVATE_KEY_TYPES,
         algorithm: typing.Optional[hashes.HashAlgorithm],
     ) -> _CertificateRevocationList:
         if not isinstance(builder, x509.CertificateRevocationListBuilder):

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -22,7 +22,7 @@ from cryptography.hazmat.backends.openssl.encode_asn1 import (
     _txt2obj_gc,
 )
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.x509.base import _PUBLIC_KEY_TYPES
+from cryptography.x509.base import PUBLIC_KEY_TYPES
 from cryptography.x509.name import _ASN1Type
 
 
@@ -76,7 +76,7 @@ class _Certificate(x509.Certificate):
         self._backend.openssl_assert(asn1_int != self._backend._ffi.NULL)
         return _asn1_integer_to_int(self._backend, asn1_int)
 
-    def public_key(self) -> _PUBLIC_KEY_TYPES:
+    def public_key(self) -> PUBLIC_KEY_TYPES:
         pkey = self._backend._lib.X509_get_pubkey(self._x509)
         if pkey == self._backend._ffi.NULL:
             # Remove errors from the stack.
@@ -360,7 +360,7 @@ class _CertificateRevocationList(x509.CertificateRevocationList):
     def extensions(self) -> x509.Extensions:
         return self._backend._crl_extension_parser.parse(self._x509_crl)
 
-    def is_signature_valid(self, public_key: _PUBLIC_KEY_TYPES) -> bool:
+    def is_signature_valid(self, public_key: PUBLIC_KEY_TYPES) -> bool:
         if not isinstance(
             public_key,
             (
@@ -403,7 +403,7 @@ class _CertificateSigningRequest(x509.CertificateSigningRequest):
     def __hash__(self) -> int:
         return hash(self.public_bytes(serialization.Encoding.DER))
 
-    def public_key(self) -> _PUBLIC_KEY_TYPES:
+    def public_key(self) -> PUBLIC_KEY_TYPES:
         pkey = self._backend._lib.X509_REQ_get_pubkey(self._x509_req)
         self._backend.openssl_assert(pkey != self._backend._ffi.NULL)
         pkey = self._backend._ffi.gc(pkey, self._backend._lib.EVP_PKEY_free)

--- a/src/cryptography/hazmat/primitives/asymmetric/types.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/types.py
@@ -13,14 +13,14 @@ from cryptography.hazmat.primitives.asymmetric import (
 )
 
 
-_PUBLIC_KEY_TYPES = typing.Union[
+PUBLIC_KEY_TYPES = typing.Union[
     dsa.DSAPublicKey,
     rsa.RSAPublicKey,
     ec.EllipticCurvePublicKey,
     ed25519.Ed25519PublicKey,
     ed448.Ed448PublicKey,
 ]
-_PRIVATE_KEY_TYPES = typing.Union[
+PRIVATE_KEY_TYPES = typing.Union[
     ed25519.Ed25519PrivateKey,
     ed448.Ed448PrivateKey,
     rsa.RSAPrivateKey,

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -5,27 +5,27 @@
 
 import typing
 
-from cryptography.hazmat._types import (
-    _PRIVATE_KEY_TYPES,
-    _PUBLIC_KEY_TYPES,
-)
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives.asymmetric import dh
+from cryptography.hazmat.primitives.asymmetric.types import (
+    PRIVATE_KEY_TYPES,
+    PUBLIC_KEY_TYPES,
+)
 
 
 def load_pem_private_key(
     data: bytes,
     password: typing.Optional[bytes],
     backend: typing.Optional[Backend] = None,
-) -> _PRIVATE_KEY_TYPES:
+) -> PRIVATE_KEY_TYPES:
     backend = _get_backend(backend)
     return backend.load_pem_private_key(data, password)
 
 
 def load_pem_public_key(
     data: bytes, backend: typing.Optional[Backend] = None
-) -> _PUBLIC_KEY_TYPES:
+) -> PUBLIC_KEY_TYPES:
     backend = _get_backend(backend)
     return backend.load_pem_public_key(data)
 
@@ -41,14 +41,14 @@ def load_der_private_key(
     data: bytes,
     password: typing.Optional[bytes],
     backend: typing.Optional[Backend] = None,
-) -> _PRIVATE_KEY_TYPES:
+) -> PRIVATE_KEY_TYPES:
     backend = _get_backend(backend)
     return backend.load_der_private_key(data, password)
 
 
 def load_der_public_key(
     data: bytes, backend: typing.Optional[Backend] = None
-) -> _PUBLIC_KEY_TYPES:
+) -> PUBLIC_KEY_TYPES:
     backend = _get_backend(backend)
     return backend.load_der_public_key(data)
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -9,7 +9,6 @@ import os
 import typing
 from enum import Enum
 
-from cryptography.hazmat._types import _PRIVATE_KEY_TYPES, _PUBLIC_KEY_TYPES
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import hashes, serialization
@@ -19,6 +18,10 @@ from cryptography.hazmat.primitives.asymmetric import (
     ed25519,
     ed448,
     rsa,
+)
+from cryptography.hazmat.primitives.asymmetric.types import (
+    PRIVATE_KEY_TYPES,
+    PUBLIC_KEY_TYPES,
 )
 from cryptography.x509.extensions import Extension, ExtensionType, Extensions
 from cryptography.x509.name import Name
@@ -99,7 +102,7 @@ class Certificate(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def public_key(self) -> _PUBLIC_KEY_TYPES:
+    def public_key(self) -> PUBLIC_KEY_TYPES:
         """
         Returns the public key
         """
@@ -320,7 +323,7 @@ class CertificateRevocationList(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def is_signature_valid(self, public_key: _PUBLIC_KEY_TYPES) -> bool:
+    def is_signature_valid(self, public_key: PUBLIC_KEY_TYPES) -> bool:
         """
         Verifies signature of revocation list against given public key.
         """
@@ -346,7 +349,7 @@ class CertificateSigningRequest(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def public_key(self) -> _PUBLIC_KEY_TYPES:
+    def public_key(self) -> PUBLIC_KEY_TYPES:
         """
         Returns the public key
         """
@@ -518,7 +521,7 @@ class CertificateSigningRequestBuilder(object):
 
     def sign(
         self,
-        private_key: _PRIVATE_KEY_TYPES,
+        private_key: PRIVATE_KEY_TYPES,
         algorithm: typing.Optional[hashes.HashAlgorithm],
         backend: typing.Optional[Backend] = None,
     ) -> CertificateSigningRequest:
@@ -538,7 +541,7 @@ class CertificateBuilder(object):
         self,
         issuer_name: typing.Optional[Name] = None,
         subject_name: typing.Optional[Name] = None,
-        public_key: typing.Optional[_PUBLIC_KEY_TYPES] = None,
+        public_key: typing.Optional[PUBLIC_KEY_TYPES] = None,
         serial_number: typing.Optional[int] = None,
         not_valid_before: typing.Optional[datetime.datetime] = None,
         not_valid_after: typing.Optional[datetime.datetime] = None,
@@ -591,7 +594,7 @@ class CertificateBuilder(object):
 
     def public_key(
         self,
-        key: _PUBLIC_KEY_TYPES,
+        key: PUBLIC_KEY_TYPES,
     ) -> "CertificateBuilder":
         """
         Sets the requestor's public key (as found in the signing request).
@@ -737,7 +740,7 @@ class CertificateBuilder(object):
 
     def sign(
         self,
-        private_key: _PRIVATE_KEY_TYPES,
+        private_key: PRIVATE_KEY_TYPES,
         algorithm: typing.Optional[hashes.HashAlgorithm],
         backend: typing.Optional[Backend] = None,
     ) -> Certificate:
@@ -885,7 +888,7 @@ class CertificateRevocationListBuilder(object):
 
     def sign(
         self,
-        private_key: _PRIVATE_KEY_TYPES,
+        private_key: PRIVATE_KEY_TYPES,
         algorithm: typing.Optional[hashes.HashAlgorithm],
         backend: typing.Optional[Backend] = None,
     ) -> CertificateRevocationList:

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -10,11 +10,11 @@ import ipaddress
 import typing
 from enum import Enum
 
-from cryptography.hazmat._types import _PUBLIC_KEY_TYPES
 from cryptography.hazmat.bindings._rust import asn1
 from cryptography.hazmat.primitives import constant_time, serialization
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.hazmat.primitives.asymmetric.types import PUBLIC_KEY_TYPES
 from cryptography.x509.certificate_transparency import (
     SignedCertificateTimestamp,
 )
@@ -40,7 +40,7 @@ from cryptography.x509.oid import (
 ExtensionTypeVar = typing.TypeVar("ExtensionTypeVar", bound="ExtensionType")
 
 
-def _key_identifier_from_public_key(public_key: _PUBLIC_KEY_TYPES) -> bytes:
+def _key_identifier_from_public_key(public_key: PUBLIC_KEY_TYPES) -> bytes:
     if isinstance(public_key, RSAPublicKey):
         data = public_key.public_bytes(
             serialization.Encoding.DER,
@@ -197,7 +197,7 @@ class AuthorityKeyIdentifier(ExtensionType):
 
     @classmethod
     def from_issuer_public_key(
-        cls, public_key: _PUBLIC_KEY_TYPES
+        cls, public_key: PUBLIC_KEY_TYPES
     ) -> "AuthorityKeyIdentifier":
         digest = _key_identifier_from_public_key(public_key)
         return cls(
@@ -270,7 +270,7 @@ class SubjectKeyIdentifier(ExtensionType):
 
     @classmethod
     def from_public_key(
-        cls, public_key: _PUBLIC_KEY_TYPES
+        cls, public_key: PUBLIC_KEY_TYPES
     ) -> "SubjectKeyIdentifier":
         return cls(_key_identifier_from_public_key(public_key))
 

--- a/src/cryptography/x509/ocsp.py
+++ b/src/cryptography/x509/ocsp.py
@@ -11,8 +11,8 @@ from enum import Enum
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509.base import (
+    PRIVATE_KEY_TYPES,
     _EARLIEST_UTC_TIME,
-    _PRIVATE_KEY_TYPES,
     _convert_to_naive_utc_time,
     _reject_duplicate_extension,
 )
@@ -457,7 +457,7 @@ class OCSPResponseBuilder(object):
 
     def sign(
         self,
-        private_key: _PRIVATE_KEY_TYPES,
+        private_key: PRIVATE_KEY_TYPES,
         algorithm: typing.Optional[hashes.HashAlgorithm],
     ) -> OCSPResponse:
         from cryptography.hazmat.backends.openssl.backend import backend


### PR DESCRIPTION
With this PR I propose to move  the type aliases in `hazmat._types` to `hazmat.primitives.asymmetric.types` and make them public (= remove the `_` at the start).

Rationale: Without public access, it becomes impossible to typehint functions that use cryptography without either duplicating the type aliases or accessing internal members. Making them public does not hurt maintainability of the code base, as the `Union` would have to updated with any new key types anyway to make mypy happy.

Consider this (not too outlandish) code example in a downstream project:

```python
# Either that import or create your own type alias that is just a duplicate
from cryptography.hazmat._types import _PRIVATE_KEY_TYPES
from cryptography.hazmat.primitives.asymmetric import rsa
# This would be much better:
#from cryptography.hazmat.primitives.asymmetric import types

def read_private_key(path) -> _PRIVATE_KEY_TYPES:
    """Reads a private key but throw an error if it is an RSA key with key_size < 2048."""
    with open("path/to/key.pem", "rb") as key_file:
        key = serialization.load_pem_private_key(key_file.read(), password=None)
    
    if isinstance(key, rsa.RSAPrivateKey) and key.key_size < 2048:
        raise ValueError("Sorry, RSA keys must be at least 2048 bytes")
    return key
```