### PR TITLE
Fix version in changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,9 @@
 Changelog
 =========
 
-.. _v35-0-0:
+.. _v3-5-0:
 
-35.0.0 - `main`_
+3.5.0 - `main`_
 ~~~~~~~~~~~~~~~~
 
  .. note:: This version is not yet released and is under active development.


### PR DESCRIPTION
Minor edit but I noticed the changelog was mentioning 35.0.0 instead of (I guess 3.5.0)