### PR TITLE
Use well-defined enum representation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - {VERSION: "3.9", TOXENV: "py39", OPENSSL: {TYPE: "libressl", VERSION: "3.1.5"}}
           - {VERSION: "3.9", TOXENV: "py39", OPENSSL: {TYPE: "libressl", VERSION: "3.2.5"}}
           - {VERSION: "3.9", TOXENV: "py39", OPENSSL: {TYPE: "libressl", VERSION: "3.3.2"}}
+          - {VERSION: "3.10-dev", TOXENV: "py310"}
         RUST:
           - stable
     name: "${{ matrix.PYTHON.TOXENV }} ${{ matrix.PYTHON.OPENSSL.TYPE }} ${{ matrix.PYTHON.OPENSSL.VERSION }} ${{ matrix.PYTHON.OPENSSL.CONFIG_FLAGS }}"

--- a/src/cryptography/exceptions.py
+++ b/src/cryptography/exceptions.py
@@ -3,10 +3,10 @@
 # for complete details.
 
 
-from enum import Enum
+from cryptography import utils
 
 
-class _Reasons(Enum):
+class _Reasons(utils.Enum):
     BACKEND_MISSING_INTERFACE = 0
     UNSUPPORTED_HASH = 1
     UNSUPPORTED_CIPHER = 2

--- a/src/cryptography/hazmat/primitives/_serialization.py
+++ b/src/cryptography/hazmat/primitives/_serialization.py
@@ -3,13 +3,14 @@
 # for complete details.
 
 import abc
-from enum import Enum
+
+from cryptography import utils
 
 # This exists to break an import cycle. These classes are normally accessible
 # from the serialization module.
 
 
-class Encoding(Enum):
+class Encoding(utils.Enum):
     PEM = "PEM"
     DER = "DER"
     OpenSSH = "OpenSSH"
@@ -18,14 +19,14 @@ class Encoding(Enum):
     SMIME = "S/MIME"
 
 
-class PrivateFormat(Enum):
+class PrivateFormat(utils.Enum):
     PKCS8 = "PKCS8"
     TraditionalOpenSSL = "TraditionalOpenSSL"
     Raw = "Raw"
     OpenSSH = "OpenSSH"
 
 
-class PublicFormat(Enum):
+class PublicFormat(utils.Enum):
     SubjectPublicKeyInfo = "X.509 subjectPublicKeyInfo with PKCS#1"
     PKCS1 = "Raw PKCS#1"
     OpenSSH = "OpenSSH"
@@ -34,7 +35,7 @@ class PublicFormat(Enum):
     UncompressedPoint = "X9.62 Uncompressed Point"
 
 
-class ParameterFormat(Enum):
+class ParameterFormat(utils.Enum):
     PKCS3 = "PKCS3"
 
 

--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
@@ -4,7 +4,6 @@
 
 
 import typing
-from enum import Enum
 
 from cryptography import utils
 from cryptography.exceptions import (
@@ -19,11 +18,11 @@ from cryptography.hazmat.primitives import constant_time, hashes, hmac
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
 
-class Mode(Enum):
+class Mode(utils.Enum):
     CounterMode = "ctr"
 
 
-class CounterLocation(Enum):
+class CounterLocation(utils.Enum):
     BeforeFixed = "before_fixed"
     AfterFixed = "after_fixed"
 

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -3,8 +3,8 @@
 # for complete details.
 
 import typing
-from enum import Enum
 
+from cryptography import utils
 from cryptography import x509
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
@@ -36,7 +36,7 @@ _ALLOWED_PRIVATE_KEY_TYPES = typing.Union[
 ]
 
 
-class PKCS7Options(Enum):
+class PKCS7Options(utils.Enum):
     Text = "Add text/plain MIME type"
     Binary = "Don't translate input data into canonical MIME format"
     DetachedSignature = "Don't embed data in the PKCS7 structure"

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -4,6 +4,7 @@
 
 
 import abc
+import enum
 import inspect
 import sys
 import typing
@@ -152,3 +153,13 @@ int_from_bytes = deprecated(
     "int_from_bytes is deprecated, use int.from_bytes instead",
     DeprecatedIn34,
 )
+
+
+# Python 3.10 changed representation of enums. We use well-defined object
+# representation and string representation from Python 3.9.
+class Enum(enum.Enum):
+    def __repr__(self):
+        return f"<{self.__class__.__name__}.{self._name_}: {self._value_!r}>"
+
+    def __str__(self):
+        return f"{self.__class__.__name__}.{self._name_}"

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -7,8 +7,8 @@ import abc
 import datetime
 import os
 import typing
-from enum import Enum
 
+from cryptography import utils
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.hazmat.primitives import hashes, serialization
@@ -71,7 +71,7 @@ def _convert_to_naive_utc_time(time: datetime.datetime) -> datetime.datetime:
         return time
 
 
-class Version(Enum):
+class Version(utils.Enum):
     v1 = 0
     v3 = 2
 

--- a/src/cryptography/x509/certificate_transparency.py
+++ b/src/cryptography/x509/certificate_transparency.py
@@ -5,15 +5,16 @@
 
 import abc
 import datetime
-from enum import Enum
+
+from cryptography import utils
 
 
-class LogEntryType(Enum):
+class LogEntryType(utils.Enum):
     X509_CERTIFICATE = 0
     PRE_CERTIFICATE = 1
 
 
-class Version(Enum):
+class Version(utils.Enum):
     v1 = 0
 
 

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -8,8 +8,8 @@ import datetime
 import hashlib
 import ipaddress
 import typing
-from enum import Enum
 
+from cryptography import utils
 from cryptography.hazmat.bindings._rust import asn1
 from cryptography.hazmat.primitives import constant_time, serialization
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
@@ -671,7 +671,7 @@ class DistributionPoint(object):
         return self._crl_issuer
 
 
-class ReasonFlags(Enum):
+class ReasonFlags(utils.Enum):
     unspecified = "unspecified"
     key_compromise = "keyCompromise"
     ca_compromise = "cACompromise"
@@ -1035,7 +1035,7 @@ class TLSFeature(ExtensionType):
         return hash(tuple(self._features))
 
 
-class TLSFeatureType(Enum):
+class TLSFeatureType(utils.Enum):
     # status_request is defined in RFC 6066 and is used for what is commonly
     # called OCSP Must-Staple when present in the TLS Feature extension in an
     # X.509 certificate.

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -3,14 +3,14 @@
 # for complete details.
 
 import typing
-from enum import Enum
 
+from cryptography import utils
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend
 from cryptography.x509.oid import NameOID, ObjectIdentifier
 
 
-class _ASN1Type(Enum):
+class _ASN1Type(utils.Enum):
     UTF8String = 12
     NumericString = 18
     PrintableString = 19

--- a/src/cryptography/x509/ocsp.py
+++ b/src/cryptography/x509/ocsp.py
@@ -6,8 +6,8 @@
 import abc
 import datetime
 import typing
-from enum import Enum
 
+from cryptography import utils
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509.base import (
@@ -27,12 +27,12 @@ _OIDS_TO_HASH = {
 }
 
 
-class OCSPResponderEncoding(Enum):
+class OCSPResponderEncoding(utils.Enum):
     HASH = "By Hash"
     NAME = "By Name"
 
 
-class OCSPResponseStatus(Enum):
+class OCSPResponseStatus(utils.Enum):
     SUCCESSFUL = 0
     MALFORMED_REQUEST = 1
     INTERNAL_ERROR = 2
@@ -58,7 +58,7 @@ def _verify_algorithm(algorithm):
         )
 
 
-class OCSPCertStatus(Enum):
+class OCSPCertStatus(utils.Enum):
     GOOD = 0
     REVOKED = 1
     UNKNOWN = 2

--- a/tests/test_cryptography_utils.py
+++ b/tests/test_cryptography_utils.py
@@ -2,6 +2,7 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+import enum
 import typing
 
 import pytest
@@ -51,3 +52,13 @@ class TestCachedProperty(object):
         assert len(accesses) == 1
         assert t.t == 14
         assert len(accesses) == 1
+
+
+def test_enum():
+    class TestEnum(utils.Enum):
+        value = "something"
+
+    assert issubclass(TestEnum, enum.Enum)
+    assert isinstance(TestEnum.value, enum.Enum)
+    assert repr(TestEnum.value) == "<TestEnum.value: 'something'>"
+    assert str(TestEnum.value) == "TestEnum.value"


### PR DESCRIPTION
Python 3.10 changed enum's object and string representation. PyCA
cryptography now uses a custom subclass of enum.Enum() will well-defined
``__repr__`` and ``__str__`` from Python 3.9.

Related: https://bugs.python.org/issue40066
Fixes: https://github.com/pyca/cryptography/issues/5995
Signed-off-by: Christian Heimes <cheimes@redhat.com>