### PR TITLE
Allow to build wheels in Docker containers

### DIFF
--- a/docker_build.py
+++ b/docker_build.py
@@ -1,0 +1,21 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def build(workdir):
+    python_deps = ["wheel", "setuptools_rust", "click", "requests"]
+    debian_deps = ["build-essential", "rustc", "libssl-dev"]
+    subprocess.check_call(["apt-get", "update"])
+    subprocess.check_call(["apt-get", "install", "--yes", ] + debian_deps)
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "--user", ] + python_deps)
+    subprocess.check_call(["python3", "setup.py", "bdist_wheel"], cwd=workdir)
+    subprocess.check_call(["python3", "setup.py", "bdist_wheel"], cwd=workdir / "vectors")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workdir", type=Path)
+    args = parser.parse_args()
+    build(args.workdir)


### PR DESCRIPTION
cryptography currently has wheels for a few Linux architectures: pypy3.6, pypy3.7 and cpython3.6.
Installing cryptography with other Python versions is harder (due to the rust dependency).
This patch allows to build wheels in Docker containers, for easily building wheels in other cpython versions and uploading them to pypi.  For example, if you target 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 and Pypy3.7:

```bash
python release.py 3.4.7 python:3.5-slim-buster python:3.6-slim-buster python:3.7-slim-buster python:3.8-slim-buster python:3.9-slim-buster python:rc-slim-buster pypy:3.7-slim-buster
```