### PR TITLE
oxidize SubjectAltName

### DIFF
--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -32,9 +32,7 @@ _IPADDRESS_TYPES = typing.Union[
 
 
 class UnsupportedGeneralNameType(Exception):
-    def __init__(self, msg: str, type: int) -> None:
-        super(UnsupportedGeneralNameType, self).__init__(msg)
-        self.type = type
+    pass
 
 
 class GeneralName(metaclass=abc.ABCMeta):

--- a/src/rust/src/asn1.rs
+++ b/src/rust/src/asn1.rs
@@ -173,12 +173,12 @@ struct TbsCertificate<'a> {
     _extensions: Option<asn1::Sequence<'a>>,
 }
 
-type Name<'a> = asn1::SequenceOf<'a, asn1::SetOf<'a, AttributeTypeValue<'a>>>;
+pub(crate) type Name<'a> = asn1::SequenceOf<'a, asn1::SetOf<'a, AttributeTypeValue<'a>>>;
 
 #[derive(asn1::Asn1Read)]
-struct AttributeTypeValue<'a> {
-    _type: asn1::ObjectIdentifier<'a>,
-    value: asn1::Tlv<'a>,
+pub(crate) struct AttributeTypeValue<'a> {
+    pub(crate) type_id: asn1::ObjectIdentifier<'a>,
+    pub(crate) value: asn1::Tlv<'a>,
 }
 
 #[derive(asn1::Asn1Read)]

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -2296,10 +2296,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_der_x509_certificate,
             backend,
         )
-        with pytest.raises(x509.UnsupportedGeneralNameType) as exc:
+        with pytest.raises(x509.UnsupportedGeneralNameType):
             cert.extensions
-
-        assert exc.value.type == 3
 
     def test_registered_id(self, backend):
         cert = _load_cert(


### PR DESCRIPTION
This encompasses oxidizing parsing of GeneralName, which most of the remaining extensions need.