### PR TITLE
Expose a few more OpenSSL functions that are useful for DTLS support

### DIFF
--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -39,9 +39,11 @@ int BIO_reset(BIO *);
 void BIO_set_retry_read(BIO *);
 void BIO_clear_retry_flags(BIO *);
 
-BIO_ADDR *BIO_ADDR_new(void);
-void BIO_ADDR_free(BIO_ADDR *);
 """
 
 CUSTOMIZATIONS = """
+#if !CRYPTOGRAPHY_IS_LIBRESSL
+BIO_ADDR *BIO_ADDR_new(void);
+void BIO_ADDR_free(BIO_ADDR *);
+#endif
 """

--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -50,7 +50,7 @@ CUSTOMIZATIONS = """
 typedef struct sockaddr BIO_ADDR;
 
 BIO_ADDR *BIO_ADDR_new(void) {
-    return malloc(sizeof(sockaddr_storage));
+    return malloc(sizeof(struct sockaddr_storage));
 }
 
 void BIO_ADDR_free(BIO_ADDR *ptr) {

--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -39,11 +39,22 @@ int BIO_reset(BIO *);
 void BIO_set_retry_read(BIO *);
 void BIO_clear_retry_flags(BIO *);
 
+BIO_ADDR *BIO_ADDR_new(void);
+void BIO_ADDR_free(BIO_ADDR *);
 """
 
 CUSTOMIZATIONS = """
-#if !CRYPTOGRAPHY_IS_LIBRESSL
-BIO_ADDR *BIO_ADDR_new(void);
-void BIO_ADDR_free(BIO_ADDR *);
+#if CRYPTOGRAPHY_IS_LIBRESSL
+#include <sys/socket.h>
+#include <stdlib.h>
+typedef struct sockaddr BIO_ADDR;
+
+BIO_ADDR *BIO_ADDR_new(void) {
+    return malloc(sizeof(sockaddr_storage));
+}
+
+void BIO_ADDR_free(BIO_ADDR *ptr) {
+    free(ptr);
+}
 #endif
 """

--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -10,6 +10,7 @@ INCLUDES = """
 TYPES = """
 typedef ... BIO;
 typedef ... BIO_METHOD;
+typedef ... BIO_ADDR;
 """
 
 FUNCTIONS = """
@@ -37,6 +38,9 @@ int BIO_should_retry(BIO *);
 int BIO_reset(BIO *);
 void BIO_set_retry_read(BIO *);
 void BIO_clear_retry_flags(BIO *);
+
+BIO_ADDR *BIO_ADDR_new(void);
+void BIO_ADDR_free(BIO_ADDR *);
 """
 
 CUSTOMIZATIONS = """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -90,6 +90,7 @@ static const long SSL_OP_ALL;
 static const long SSL_OP_SINGLE_ECDH_USE;
 static const long SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
 static const long SSL_OP_LEGACY_SERVER_CONNECT;
+static const long SSL_OP_NO_RENEGOTIATION;
 static const long SSL_VERIFY_PEER;
 static const long SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 static const long SSL_VERIFY_CLIENT_ONCE;
@@ -225,6 +226,13 @@ void SSL_CTX_set_cookie_generate_cb(SSL_CTX *,
                                         unsigned char *,
                                         unsigned int *
                                     ));
+void SSL_CTX_set_cookie_verify_cb(SSL_CTX *,
+                                    int (*)(
+                                        SSL *,
+                                        unsigned char *,
+                                        unsigned int
+                                    ));
+
 long SSL_CTX_get_read_ahead(SSL_CTX *);
 long SSL_CTX_set_read_ahead(SSL_CTX *, long);
 
@@ -468,6 +476,13 @@ long Cryptography_DTLSv1_get_timeout(SSL *, time_t *, long *);
 long DTLSv1_handle_timeout(SSL *);
 long DTLS_set_link_mtu(SSL *, long);
 long DTLS_get_link_min_mtu(SSL *);
+size_t DTLS_get_data_mtu(SSL *);
+long SSL_set_mtu(SSL *, long);
+typedef ... BIO_ADDR;
+BIO_ADDR *BIO_ADDR_new(void);
+void BIO_ADDR_free(BIO_ADDR *);
+int DTLSv1_listen(SSL *, BIO_ADDR *);
+
 
 /* Custom extensions. */
 typedef int (*custom_ext_add_cb)(SSL *, unsigned int,

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -90,7 +90,6 @@ static const long SSL_OP_ALL;
 static const long SSL_OP_SINGLE_ECDH_USE;
 static const long SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
 static const long SSL_OP_LEGACY_SERVER_CONNECT;
-static const long SSL_OP_NO_RENEGOTIATION;
 static const long SSL_VERIFY_PEER;
 static const long SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 static const long SSL_VERIFY_CLIENT_ONCE;
@@ -223,7 +222,7 @@ void SSL_CTX_set_cert_verify_callback(SSL_CTX *,
 void SSL_CTX_set_cookie_generate_cb(SSL_CTX *,
                                     int (*)(
                                         SSL *,
-                                        const unsigned char *,
+                                        unsigned char *,
                                         unsigned int *
                                     ));
 void SSL_CTX_set_cookie_verify_cb(SSL_CTX *,
@@ -476,7 +475,6 @@ long Cryptography_DTLSv1_get_timeout(SSL *, time_t *, long *);
 long DTLSv1_handle_timeout(SSL *);
 long DTLS_set_link_mtu(SSL *, long);
 long DTLS_get_link_min_mtu(SSL *);
-size_t DTLS_get_data_mtu(SSL *);
 long SSL_set_mtu(SSL *, long);
 int DTLSv1_listen(SSL *, BIO_ADDR *);
 
@@ -721,5 +719,14 @@ long (*SSL_get_min_proto_version)(SSL *) = NULL;
 long (*SSL_get_max_proto_version)(SSL *) = NULL;
 #else
 static const long Cryptography_HAS_GET_PROTO_VERSION = 1;
+#endif
+
+#if !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+size_t DTLS_get_data_mtu(SSL *);
+static const long SSL_OP_NO_RENEGOTIATION;
+#endif
+
+#if !CRYPTOGRAPHY_IS_LIBRESSL
+int DTLSv1_listen(SSL *, BIO_ADDR *);
 #endif
 """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -35,6 +35,7 @@ static const long Cryptography_HAS_RELEASE_BUFFERS;
  * supported
  */
 static const long Cryptography_HAS_OP_NO_COMPRESSION;
+static const long Cryptography_HAS_OP_NO_RENEGOTIATION;
 static const long Cryptography_HAS_SSL_OP_MSIE_SSLV2_RSA_PADDING;
 static const long Cryptography_HAS_SSL_SET_SSL_CTX;
 static const long Cryptography_HAS_SSL_OP_NO_TICKET;
@@ -64,6 +65,7 @@ static const long SSL_OP_NO_TLSv1_2;
 static const long SSL_OP_NO_TLSv1_3;
 static const long SSL_OP_NO_DTLSv1;
 static const long SSL_OP_NO_DTLSv1_2;
+static const long SSL_OP_NO_RENEGOTIATION;
 static const long SSL_OP_NO_COMPRESSION;
 static const long SSL_OP_SINGLE_DH_USE;
 static const long SSL_OP_EPHEMERAL_RSA;
@@ -477,6 +479,7 @@ long DTLS_set_link_mtu(SSL *, long);
 long DTLS_get_link_min_mtu(SSL *);
 long SSL_set_mtu(SSL *, long);
 int DTLSv1_listen(SSL *, BIO_ADDR *);
+size_t DTLS_get_data_mtu(SSL *);
 
 
 /* Custom extensions. */
@@ -566,6 +569,12 @@ static const long Cryptography_HAS_SSL_SET_SSL_CTX = 1;
 static const long Cryptography_HAS_NEXTPROTONEG = 0;
 static const long Cryptography_HAS_ALPN = 1;
 
+#ifdef SSL_OP_NO_RENEGOTIATION
+static const long Cryptography_HAS_OP_NO_RENEGOTIATION = 1;
+#else
+static const long Cryptography_HAS_OP_NO_RENEGOTIATION = 0;
+#endif
+
 #if CRYPTOGRAPHY_IS_LIBRESSL
 void (*SSL_CTX_set_cert_cb)(SSL_CTX *, int (*)(SSL *, void *), void *) = NULL;
 void (*SSL_set_cert_cb)(SSL *, int (*)(SSL *, void *), void *) = NULL;
@@ -602,6 +611,10 @@ static const long SSL_OP_NO_DTLSv1_2 = 0;
 #endif
 long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
 long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
+#endif
+
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+size_t (*DTLS_get_data_mtu)(SSL *) = NULL;
 #endif
 
 static const long Cryptography_HAS_DTLS = 1;
@@ -719,14 +732,5 @@ long (*SSL_get_min_proto_version)(SSL *) = NULL;
 long (*SSL_get_max_proto_version)(SSL *) = NULL;
 #else
 static const long Cryptography_HAS_GET_PROTO_VERSION = 1;
-#endif
-
-#if !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
-size_t DTLS_get_data_mtu(SSL *);
-static const long SSL_OP_NO_RENEGOTIATION;
-#endif
-
-#if !CRYPTOGRAPHY_IS_LIBRESSL
-int DTLSv1_listen(SSL *, BIO_ADDR *);
 #endif
 """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -478,9 +478,6 @@ long DTLS_set_link_mtu(SSL *, long);
 long DTLS_get_link_min_mtu(SSL *);
 size_t DTLS_get_data_mtu(SSL *);
 long SSL_set_mtu(SSL *, long);
-typedef ... BIO_ADDR;
-BIO_ADDR *BIO_ADDR_new(void);
-void BIO_ADDR_free(BIO_ADDR *);
 int DTLSv1_listen(SSL *, BIO_ADDR *);
 
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -223,13 +223,13 @@ void SSL_CTX_set_cert_verify_callback(SSL_CTX *,
 void SSL_CTX_set_cookie_generate_cb(SSL_CTX *,
                                     int (*)(
                                         SSL *,
-                                        unsigned char *,
+                                        const unsigned char *,
                                         unsigned int *
                                     ));
 void SSL_CTX_set_cookie_verify_cb(SSL_CTX *,
                                     int (*)(
                                         SSL *,
-                                        unsigned char *,
+                                        const unsigned char *,
                                         unsigned int
                                     ));
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -44,6 +44,7 @@ static const long Cryptography_HAS_NEXTPROTONEG;
 static const long Cryptography_HAS_SET_CERT_CB;
 static const long Cryptography_HAS_CUSTOM_EXT;
 static const long Cryptography_HAS_SRTP;
+static const long Cryptography_HAS_DTLS_GET_DATA_MTU;
 
 static const long SSL_FILETYPE_PEM;
 static const long SSL_FILETYPE_ASN1;
@@ -615,7 +616,10 @@ long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
 #endif
 
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+static const long Cryptography_HAS_DTLS_GET_DATA_MTU = 0;
 size_t (*DTLS_get_data_mtu)(SSL *) = NULL;
+#else
+static const long Cryptography_HAS_DTLS_GET_DATA_MTU = 1;
 #endif
 
 static const long Cryptography_HAS_DTLS = 1;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -573,6 +573,7 @@ static const long Cryptography_HAS_ALPN = 1;
 static const long Cryptography_HAS_OP_NO_RENEGOTIATION = 1;
 #else
 static const long Cryptography_HAS_OP_NO_RENEGOTIATION = 0;
+static const long SSL_OP_NO_RENEGOTIATION = 0;
 #endif
 
 #if CRYPTOGRAPHY_IS_LIBRESSL

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -244,6 +244,18 @@ def cryptography_has_providers():
     ]
 
 
+def cryptography_has_op_no_renegotiation():
+    return [
+        "SSL_OP_NO_RENEGOTIATION",
+    ]
+
+
+def DTLS_get_data_mtu():
+    return [
+        "DTLS_get_data_mtu",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -291,4 +303,6 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_SRTP": cryptography_has_srtp,
     "Cryptography_HAS_GET_PROTO_VERSION": cryptography_has_get_proto_version,
     "Cryptography_HAS_PROVIDERS": cryptography_has_providers,
+    "Cryptography_HAS_OP_NO_RENEGOTIATION": cryptography_has_op_no_renegotiation,
+    "DTLS_get_data_mtu": DTLS_get_data_mtu,
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -250,7 +250,7 @@ def cryptography_has_op_no_renegotiation():
     ]
 
 
-def DTLS_get_data_mtu():
+def dtls_get_data_mtu():
     return [
         "DTLS_get_data_mtu",
     ]
@@ -303,6 +303,8 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_SRTP": cryptography_has_srtp,
     "Cryptography_HAS_GET_PROTO_VERSION": cryptography_has_get_proto_version,
     "Cryptography_HAS_PROVIDERS": cryptography_has_providers,
-    "Cryptography_HAS_OP_NO_RENEGOTIATION": cryptography_has_op_no_renegotiation,
-    "DTLS_get_data_mtu": DTLS_get_data_mtu,
+    "Cryptography_HAS_OP_NO_RENEGOTIATION": (
+        cryptography_has_op_no_renegotiation
+    ),
+    "DTLS_get_data_mtu": dtls_get_data_mtu,
 }

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -250,7 +250,7 @@ def cryptography_has_op_no_renegotiation():
     ]
 
 
-def dtls_get_data_mtu():
+def cryptography_has_dtls_get_data_mtu():
     return [
         "DTLS_get_data_mtu",
     ]
@@ -306,5 +306,5 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_OP_NO_RENEGOTIATION": (
         cryptography_has_op_no_renegotiation
     ),
-    "DTLS_get_data_mtu": dtls_get_data_mtu,
+    "Cryptography_HAS_DTLS_GET_DATA_MTU": cryptography_has_dtls_get_data_mtu,
 }


### PR DESCRIPTION
Also `OP_NO_RENEGOTIATION` I guess, which is useful because renegotiation is the worst.