### PR TITLE
3.0.0 deprecated func and it isn't useful to us in general

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -15,15 +15,14 @@ from cryptography.hazmat.bindings._openssl import ffi, lib
 from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
 
 _OpenSSLErrorWithText = collections.namedtuple(
-    "_OpenSSLErrorWithText", ["code", "lib", "func", "reason", "reason_text"]
+    "_OpenSSLErrorWithText", ["code", "lib", "reason", "reason_text"]
 )
 
 
 class _OpenSSLError(object):
-    def __init__(self, code, lib, func, reason):
+    def __init__(self, code, lib, reason):
         self._code = code
         self._lib = lib
-        self._func = func
         self._reason = reason
 
     def _lib_reason_match(self, lib, reason):
@@ -31,7 +30,6 @@ class _OpenSSLError(object):
 
     code = utils.read_only_property("_code")
     lib = utils.read_only_property("_lib")
-    func = utils.read_only_property("_func")
     reason = utils.read_only_property("_reason")
 
 
@@ -43,10 +41,9 @@ def _consume_errors(lib):
             break
 
         err_lib = lib.ERR_GET_LIB(code)
-        err_func = lib.ERR_GET_FUNC(code)
         err_reason = lib.ERR_GET_REASON(code)
 
-        errors.append(_OpenSSLError(code, err_lib, err_func, err_reason))
+        errors.append(_OpenSSLError(code, err_lib, err_reason))
 
     return errors
 
@@ -60,7 +57,7 @@ def _errors_with_text(errors):
 
         errors_with_text.append(
             _OpenSSLErrorWithText(
-                err.code, err.lib, err.func, err.reason, err_text_reason
+                err.code, err.lib, err.reason, err_text_reason
             )
         )
 

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -91,11 +91,10 @@ class TestOpenSSL(object):
             _openssl_assert(b.lib, False)
 
         error = exc_info.value.err_code[0]
-        # As of 3.0.0 OpenSSL sets func codes to 0, so the combined
-        # code is a different value
+        # As of 3.0.0 OpenSSL no longer sets func codes (which we now also
+        # ignore), so the combined code is a different value
         assert error.code in (101183626, 50331786)
         assert error.lib == b.lib.ERR_LIB_EVP
-        assert error.func == b.lib.EVP_F_EVP_ENCRYPTFINAL_EX
         assert error.reason == b.lib.EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH
         assert b"data not multiple of block length" in error.reason_text
 


### PR DESCRIPTION
remove it everywhere and assert on the code/lib/reason

refs https://github.com/openssl/openssl/pull/15955