### PR TITLE
remove twisted from downstream testing for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,6 @@ jobs:
         DOWNSTREAM:
           - paramiko
           - pyopenssl
-          - twisted
           - aws-encryption-sdk
           - dynamodb-encryption-sdk
           - certbot


### PR DESCRIPTION
spurious failures and no resolution at this time.