### PR TITLE
add concurrency to cancel in-progress jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This creates a concurrency group that uses the workflow name and PR number (if available) or commit ref as a key. If a new build is triggered under that concurrency group while a previous build is running it will be canceled.

This means repeated pushes to a PR will cancel all previous builds, while multiple merges to main will not cancel (as they are under a separate concurrency group).