### PR TITLE
Speed up RSA tests in 3.0.0

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -182,6 +182,7 @@ class Backend(BackendInterface):
         self._binding = binding.Binding()
         self._ffi = self._binding.ffi
         self._lib = self._binding.lib
+        self._rsa_check_key = True
         self._fips_enabled = self._is_fips_enabled()
 
         self._cipher_registry = {}
@@ -507,7 +508,7 @@ class Backend(BackendInterface):
         self.openssl_assert(res == 1)
         evp_pkey = self._rsa_cdata_to_evp_pkey(rsa_cdata)
 
-        return _RSAPrivateKey(self, rsa_cdata, evp_pkey)
+        return _RSAPrivateKey(self, rsa_cdata, evp_pkey, self._rsa_check_key)
 
     def generate_rsa_parameters_supported(self, public_exponent, key_size):
         return (
@@ -546,7 +547,7 @@ class Backend(BackendInterface):
         self.openssl_assert(res == 1)
         evp_pkey = self._rsa_cdata_to_evp_pkey(rsa_cdata)
 
-        return _RSAPrivateKey(self, rsa_cdata, evp_pkey)
+        return _RSAPrivateKey(self, rsa_cdata, evp_pkey, self._rsa_check_key)
 
     def load_rsa_public_numbers(self, numbers):
         rsa._check_public_key_components(numbers.e, numbers.n)
@@ -620,7 +621,9 @@ class Backend(BackendInterface):
             rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
             self.openssl_assert(rsa_cdata != self._ffi.NULL)
             rsa_cdata = self._ffi.gc(rsa_cdata, self._lib.RSA_free)
-            return _RSAPrivateKey(self, rsa_cdata, evp_pkey)
+            return _RSAPrivateKey(
+                self, rsa_cdata, evp_pkey, self._rsa_check_key
+            )
         elif key_type == self._lib.EVP_PKEY_DSA:
             dsa_cdata = self._lib.EVP_PKEY_get1_DSA(evp_pkey)
             self.openssl_assert(dsa_cdata != self._ffi.NULL)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -182,7 +182,7 @@ class Backend(BackendInterface):
         self._binding = binding.Binding()
         self._ffi = self._binding.ffi
         self._lib = self._binding.lib
-        self._rsa_check_key = True
+        self._rsa_skip_check_key = False
         self._fips_enabled = self._is_fips_enabled()
 
         self._cipher_registry = {}
@@ -508,7 +508,9 @@ class Backend(BackendInterface):
         self.openssl_assert(res == 1)
         evp_pkey = self._rsa_cdata_to_evp_pkey(rsa_cdata)
 
-        return _RSAPrivateKey(self, rsa_cdata, evp_pkey, self._rsa_check_key)
+        return _RSAPrivateKey(
+            self, rsa_cdata, evp_pkey, self._rsa_skip_check_key
+        )
 
     def generate_rsa_parameters_supported(self, public_exponent, key_size):
         return (
@@ -547,7 +549,9 @@ class Backend(BackendInterface):
         self.openssl_assert(res == 1)
         evp_pkey = self._rsa_cdata_to_evp_pkey(rsa_cdata)
 
-        return _RSAPrivateKey(self, rsa_cdata, evp_pkey, self._rsa_check_key)
+        return _RSAPrivateKey(
+            self, rsa_cdata, evp_pkey, self._rsa_skip_check_key
+        )
 
     def load_rsa_public_numbers(self, numbers):
         rsa._check_public_key_components(numbers.e, numbers.n)
@@ -622,7 +626,7 @@ class Backend(BackendInterface):
             self.openssl_assert(rsa_cdata != self._ffi.NULL)
             rsa_cdata = self._ffi.gc(rsa_cdata, self._lib.RSA_free)
             return _RSAPrivateKey(
-                self, rsa_cdata, evp_pkey, self._rsa_check_key
+                self, rsa_cdata, evp_pkey, self._rsa_skip_check_key
             )
         elif key_type == self._lib.EVP_PKEY_DSA:
             dsa_cdata = self._lib.EVP_PKEY_get1_DSA(evp_pkey)

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -382,11 +382,19 @@ class _RSAVerificationContext(AsymmetricVerificationContext):
 
 
 class _RSAPrivateKey(RSAPrivateKey):
-    def __init__(self, backend, rsa_cdata, evp_pkey):
-        res = backend._lib.RSA_check_key(rsa_cdata)
-        if res != 1:
-            errors = backend._consume_errors_with_text()
-            raise ValueError("Invalid private key", errors)
+    def __init__(self, backend, rsa_cdata, evp_pkey, _check_key):
+        # RSA_check_key is slower in OpenSSL 3.0.0 due to improved
+        # primality checking. In normal use this is unlikely to be a problem
+        # since users don't load new keys constantly, but for TESTING we've
+        # added an init arg that allows skipping the checks. You should not
+        # use this in production code unless you understand the consequences.
+        # This uses "not False" instead of if True to default to checking in
+        # cases where someone passes the wrong type.
+        if _check_key is not False:
+            res = backend._lib.RSA_check_key(rsa_cdata)
+            if res != 1:
+                errors = backend._consume_errors_with_text()
+                raise ValueError("Invalid private key", errors)
 
         # Blinding is on by default in many versions of OpenSSL, but let's
         # just be conservative here.

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -382,15 +382,13 @@ class _RSAVerificationContext(AsymmetricVerificationContext):
 
 
 class _RSAPrivateKey(RSAPrivateKey):
-    def __init__(self, backend, rsa_cdata, evp_pkey, _check_key):
+    def __init__(self, backend, rsa_cdata, evp_pkey, _skip_check_key):
         # RSA_check_key is slower in OpenSSL 3.0.0 due to improved
         # primality checking. In normal use this is unlikely to be a problem
         # since users don't load new keys constantly, but for TESTING we've
         # added an init arg that allows skipping the checks. You should not
         # use this in production code unless you understand the consequences.
-        # This uses "not False" instead of if True to default to checking in
-        # cases where someone passes the wrong type.
-        if _check_key is not False:
+        if not _skip_check_key:
             res = backend._lib.RSA_check_key(rsa_cdata)
             if res != 1:
                 errors = backend._consume_errors_with_text()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,11 @@ def pytest_runtest_setup(item):
 def backend(request):
     check_backend_support(openssl_backend, request)
     return openssl_backend
+
+
+# This fixture is used to disable key checking before tests start. It is
+# briefly re-enabled in test_rsa_check_key_paths to ensure we get full
+# coverage. This entirely a performance optimization for OpenSSL 3.0.0.
+@pytest.fixture(autouse=True, scope="session")
+def _disable_rsa_key_checks():
+    openssl_backend._rsa_check_key = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,11 +33,3 @@ def pytest_runtest_setup(item):
 def backend(request):
     check_backend_support(openssl_backend, request)
     return openssl_backend
-
-
-# This fixture is used to disable key checking before tests start. It is
-# briefly re-enabled in test_rsa_check_key_paths to ensure we get full
-# coverage. This entirely a performance optimization for OpenSSL 3.0.0.
-@pytest.fixture(autouse=True, scope="session")
-def _disable_rsa_key_checks():
-    openssl_backend._rsa_check_key = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,12 @@ def pytest_runtest_setup(item):
 def backend(request):
     check_backend_support(openssl_backend, request)
     return openssl_backend
+
+
+@pytest.fixture
+def disable_rsa_checks(backend):
+    # Use this fixture to skip RSA key checks in tests that need the
+    # performance.
+    backend._rsa_skip_check_key = True
+    yield
+    backend._rsa_skip_check_key = False

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -67,15 +67,6 @@ class DummyMGF(object):
     _salt_length = 0
 
 
-@pytest.fixture
-def disable_rsa_checks(backend):
-    # Use this fixture to skip RSA key checks in tests that need the
-    # performance.
-    backend._rsa_skip_check_key = True
-    yield
-    backend._rsa_skip_check_key = False
-
-
 def _check_fips_key_length(backend, private_key):
     if (
         backend._fips_enabled

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -186,7 +186,9 @@ def test_rsa_check_key_paths(backend):
             lambda pemfile: pemfile.read(),
             mode="rb",
         )
-        key = serialization.load_pem_private_key(data, password=None, backend=backend)
+        key = serialization.load_pem_private_key(
+            data, password=None, backend=backend
+        )
         assert key
     finally:
         backend._rsa_check_key = False

--- a/tests/wycheproof/utils.py
+++ b/tests/wycheproof/utils.py
@@ -3,7 +3,9 @@ from ..utils import load_wycheproof_tests
 
 def wycheproof_tests(*paths):
     def wrapper(func):
-        def run_wycheproof(backend, subtests, pytestconfig):
+        def run_wycheproof(
+            backend, disable_rsa_checks, subtests, pytestconfig
+        ):
             wycheproof_root = pytestconfig.getoption(
                 "--wycheproof-root", skip=True
             )


### PR DESCRIPTION
`RSA_check_key` is slower in OpenSSL 3.0.0 due to improved primality checking. In normal use this is unlikely to be a problem since users don't load new keys constantly, but we do in our tests. This adds some private flags to allow skipping those checks for performance reasons.

On my laptop with this patch it takes 16s to run test_rsa.py. The previous commit takes 72s.