### PR TITLE
Add more debug assistance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,9 @@ except:  # noqa: E722
     # during PEP517 building and prints this text. setuptools raises SystemExit
     # when compilation fails right now, but it's possible this isn't stable
     # or a public API commitment so we'll remain ultra conservative.
+
+    import pkg_resources
+
     print(
         """
     =============================DEBUG ASSISTANCE=============================
@@ -166,6 +169,18 @@ except:  # noqa: E722
        https://cryptography.io/en/latest/faq.html
     4) Ensure you have a recent Rust toolchain installed:
        https://cryptography.io/en/latest/installation.html#rust
+    """
+    )
+    print(f"    Python: {'.'.join(str(v) for v in sys.version_info[:3])}")
+    print(f"    platform: {platform.platform()}")
+    for dist in ["pip", "setuptools", "setuptools_rust"]:
+        try:
+            version = pkg_resources.get_distribution(dist).version
+        except pkg_resources.DistributionNotFound:
+            version = "n/a"
+        print(f"    {dist}: {version}")
+    print(
+        """\
     =============================DEBUG ASSISTANCE=============================
     """
     )


### PR DESCRIPTION
Print Python version, platform, setuptools, pip, and setuptools_rust
on failed builds.

## Example output

```
    =============================DEBUG ASSISTANCE=============================
    If you are seeing a compilation error please try the following steps to
    successfully install cryptography:
    1) Upgrade to the latest pip and try again. This will fix errors for most
       users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
    2) Read https://cryptography.io/en/latest/installation.html for specific
       instructions for your platform.
    3) Check our frequently asked questions for more information:
       https://cryptography.io/en/latest/faq.html
    4) Ensure you have a recent Rust toolchain installed:
       https://cryptography.io/en/latest/installation.html#rust
    
    Python: 3.9.6
    platform: Linux-5.13.6-200.fc34.x86_64-x86_64-with-glibc2.33
    pip: 21.0.1
    setuptools: 53.0.0
    setuptools_rust: 0.11.6
    =============================DEBUG ASSISTANCE=============================
```

Signed-off-by: Christian Heimes <christian@python.org>