### PR TITLE
Add more demonstrative code to examples

### DIFF
--- a/docs/hazmat/primitives/mac/hmac.rst
+++ b/docs/hazmat/primitives/mac/hmac.rst
@@ -28,10 +28,12 @@ of a message.
     .. doctest::
 
         >>> from cryptography.hazmat.primitives import hashes, hmac
+        >>> key = b'test key. Beware! A real key should use os.urandom or TRNG to generate'
         >>> h = hmac.HMAC(key, hashes.SHA256())
         >>> h.update(b"message to hash")
-        >>> h.finalize()
-        b'#F\xdaI\x8b"e\xc4\xf1\xbb\x9a\x8fc\xff\xf5\xdex.\xbc\xcd/+\x8a\x86\x1d\x84\'\xc3\xa6\x1d\xd8J'
+        >>> signature = h.finalize()
+        >>> signature
+        b'k\xd9\xb29\xefS\xf8\xcf\xec\xed\xbf\x95\xe6\x97X\x18\x9e%\x11DU1\x9fq}\x9a\x9c\xe0)y`='
 
     If the backend doesn't support the requested ``algorithm`` an
     :class:`~cryptography.exceptions.UnsupportedAlgorithm` exception will be
@@ -48,7 +50,10 @@ of a message.
 
         >>> h = hmac.HMAC(key, hashes.SHA256())
         >>> h.update(b"message to hash")
-        >>> h.verify(b"an incorrect signature")
+        >>> h_copy = h.copy() # get a copy of `h' to be reused
+        >>> h.verify(signature)
+        >>>
+        >>> h_copy.verify(b"an incorrect signature")
         Traceback (most recent call last):
         ...
         cryptography.exceptions.InvalidSignature: Signature did not match digest.


### PR DESCRIPTION
1. In signature generation code example, add a preferred way to create 1key'. Also enables this code example to be run solely.
2. In verify( ) code example, add a positive case before the negative one. Also add usage of copy( ) which is mandatory to do self authentication.

Tested with `Python 3.8.1 (tags/v3.8.1:1b293b6, Dec 18 2019, 22:39:24) [MSC v.1916 32 bit (Intel)] on win32'