### PR TITLE
preparations for musllinux

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -22,6 +22,12 @@ jobs:
           - { NAME: "manylinux2014_x86_64", CONTAINER: "cryptography-manylinux2014:x86_64" }
           - { name: "manylinux_2_24_x86_64", CONTAINER: "cryptography-manylinux_2_24:x86_64"}
           - { name: "musllinux_1_1_x86_64", CONTAINER: "cryptography-musllinux_1_1:x86_64"}
+        exclude:
+          # There are no readily available musllinux PyPy distributions
+          - PYTHON: { VERSION: "pypy3.6", PATH: "/opt/pypy3.6/bin/pypy" }
+            MANYLINUX: { name: "musllinux_1_1_x86_64", CONTAINER: "cryptography-musllinux_1_1:x86_64" }
+          - PYTHON: { VERSION: "pypy3.7", PATH: "/opt/pypy3.7/bin/pypy" }
+            MANYLINUX: { name: "musllinux_1_1_x86_64", CONTAINER: "cryptography-musllinux_1_1:x86_64"}
     name: "${{ matrix.PYTHON.VERSION }} for ${{ matrix.MANYLINUX.NAME }}"
     steps:
       - run: ${{ matrix.PYTHON.PATH }} -m venv .venv

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -21,6 +21,7 @@ jobs:
           - { NAME: "manylinux2010_x86_64", CONTAINER: "cryptography-manylinux2010:x86_64" }
           - { NAME: "manylinux2014_x86_64", CONTAINER: "cryptography-manylinux2014:x86_64" }
           - { name: "manylinux_2_24_x86_64", CONTAINER: "cryptography-manylinux_2_24:x86_64"}
+          - { name: "musllinux_1_1_x86_64", CONTAINER: "cryptography-musllinux_1_1:x86_64"}
     name: "${{ matrix.PYTHON.VERSION }} for ${{ matrix.MANYLINUX.NAME }}"
     steps:
       - run: ${{ matrix.PYTHON.PATH }} -m venv .venv
@@ -41,8 +42,8 @@ jobs:
       - run: auditwheel repair --plat ${{ matrix.MANYLINUX.NAME }} tmpwheelhouse/cryptograph*.whl -w wheelhouse/
       - run: unzip wheelhouse/*.whl -d execstack.check
       - run: |
-          results=$(execstack execstack.check/cryptography/hazmat/bindings/*.so)
-          count=$(echo "$results" | grep -c '^X' || true)
+          results=$(readelf -lW execstack.check/cryptography/hazmat/bindings/*.so)
+          count=$(echo "$results" | grep -c 'GNU_STACK.*[R ][W ]E' || true)
           if [ "$count" -ne 0 ]; then
             exit 1
           else


### PR DESCRIPTION
Just added musllinux to the wheel builder and tweaked the execstack call to readelf which happens to be present in both pypa manylinux and musllinux images.

This should just work once the following are resolved:
- [x] https://github.com/pypa/manylinux/pull/1135
- [x] https://github.com/pypa/auditwheel/issues/327
- [x] https://github.com/pyca/infra/pull/367
- [x] https://github.com/pypa/warehouse/pull/9982

If you'd like to test that whole chain out, there's instructions in the last PR https://github.com/pyca/infra/pull/367
