### PR TITLE
raise a ValueError if the AEAD tag is too long

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -238,10 +238,17 @@ class _CipherContext(object):
         return self._backend._ffi.buffer(buf)[: outlen[0]]
 
     def finalize_with_tag(self, tag: bytes) -> bytes:
-        if len(tag) < self._mode._min_tag_length:
+        tag_len = len(tag)
+        if tag_len < self._mode._min_tag_length:
             raise ValueError(
                 "Authentication tag must be {} bytes or longer.".format(
                     self._mode._min_tag_length
+                )
+            )
+        elif tag_len > self._block_size_bytes:
+            raise ValueError(
+                "Authentication tag cannot be more than {} bytes.".format(
+                    self._block_size_bytes
                 )
             )
         res = self._backend._lib.EVP_CIPHER_CTX_ctrl(

--- a/src/cryptography/hazmat/primitives/ciphers/__init__.py
+++ b/src/cryptography/hazmat/primitives/ciphers/__init__.py
@@ -3,16 +3,16 @@
 # for complete details.
 
 
+from cryptography.hazmat.primitives._cipheralgorithm import (
+    BlockCipherAlgorithm,
+    CipherAlgorithm,
+)
 from cryptography.hazmat.primitives.ciphers.base import (
     AEADCipherContext,
     AEADDecryptionContext,
     AEADEncryptionContext,
     Cipher,
     CipherContext,
-)
-from cryptography.hazmat.primitives._cipheralgorithm import (
-    BlockCipherAlgorithm,
-    CipherAlgorithm,
 )
 
 

--- a/src/cryptography/hazmat/primitives/ciphers/__init__.py
+++ b/src/cryptography/hazmat/primitives/ciphers/__init__.py
@@ -7,10 +7,12 @@ from cryptography.hazmat.primitives.ciphers.base import (
     AEADCipherContext,
     AEADDecryptionContext,
     AEADEncryptionContext,
-    BlockCipherAlgorithm,
     Cipher,
-    CipherAlgorithm,
     CipherContext,
+)
+from cryptography.hazmat.primitives._cipheralgorithm import (
+    BlockCipherAlgorithm,
+    CipherAlgorithm,
 )
 
 

--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -22,14 +22,6 @@ from cryptography.hazmat.primitives._cipheralgorithm import (
 from cryptography.hazmat.primitives.ciphers import modes
 
 
-class BlockCipherAlgorithm(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
-    def block_size(self) -> int:
-        """
-        The size of a block as an integer in bits (e.g. 64, 128).
-        """
-
-
 class CipherContext(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def update(self, data: bytes) -> bytes:

--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -16,9 +16,7 @@ from cryptography.exceptions import (
 )
 from cryptography.hazmat.backends import _get_backend
 from cryptography.hazmat.backends.interfaces import Backend, CipherBackend
-from cryptography.hazmat.primitives._cipheralgorithm import (
-    CipherAlgorithm as CipherAlgorithm,
-)
+from cryptography.hazmat.primitives._cipheralgorithm import CipherAlgorithm
 from cryptography.hazmat.primitives.ciphers import modes
 
 

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -229,3 +229,10 @@ class GCM(Mode, ModeWithInitializationVector, ModeWithAuthenticationTag):
 
     def validate_for_algorithm(self, algorithm: CipherAlgorithm) -> None:
         _check_aes_key_length(self, algorithm)
+        block_size_bytes = algorithm.block_size // 8
+        if self._tag is not None and len(self._tag) > block_size_bytes:
+            raise ValueError(
+                "Authentication tag cannot be more than {} bytes.".format(
+                    block_size_bytes
+                )
+            )

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -7,7 +7,11 @@ import abc
 import typing
 
 from cryptography import utils
-from cryptography.hazmat.primitives._cipheralgorithm import CipherAlgorithm
+from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
+from cryptography.hazmat.primitives._cipheralgorithm import (
+    BlockCipherAlgorithm,
+    CipherAlgorithm,
+)
 
 
 class Mode(metaclass=abc.ABCMeta):
@@ -229,6 +233,11 @@ class GCM(Mode, ModeWithInitializationVector, ModeWithAuthenticationTag):
 
     def validate_for_algorithm(self, algorithm: CipherAlgorithm) -> None:
         _check_aes_key_length(self, algorithm)
+        if not isinstance(algorithm, BlockCipherAlgorithm):
+            raise UnsupportedAlgorithm(
+                "GCM requires a block cipher algorithm",
+                _Reasons.UNSUPPORTED_CIPHER,
+            )
         block_size_bytes = algorithm.block_size // 8
         if self._tag is not None and len(self._tag) > block_size_bytes:
             raise ValueError(

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -168,12 +168,13 @@ class TestAESModeGCM(object):
 
         decryptor.finalize_with_tag(tag)
 
-    def test_gcm_tag_decrypt_finalize_tag_length(self, backend):
+    @pytest.mark.parametrize("tag", [b"tagtooshort", b"toolong" * 12])
+    def test_gcm_tag_decrypt_finalize_tag_length(self, tag, backend):
         decryptor = base.Cipher(
             algorithms.AES(b"0" * 16), modes.GCM(b"0" * 12), backend=backend
         ).decryptor()
         with pytest.raises(ValueError):
-            decryptor.finalize_with_tag(b"tagtooshort")
+            decryptor.finalize_with_tag(tag)
 
     def test_buffer_protocol(self, backend):
         data = bytearray(b"helloworld")

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -211,11 +211,10 @@ def test_invalid_backend():
 
 def test_invalid_gcm_algorithm():
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
-        cipher = ciphers.Cipher(
+        ciphers.Cipher(
             ARC4(b"\x00" * 16),
             modes.GCM(b"\x00" * 12),
         )
-        cipher.encryptor()
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -209,6 +209,15 @@ def test_invalid_backend():
         )
 
 
+def test_invalid_gcm_algorithm():
+    with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
+        cipher = ciphers.Cipher(
+            ARC4(b"\x00" * 16),
+            modes.GCM(b"\x00" * 12),
+        )
+        cipher.encryptor()
+
+
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
         AES(b"\x00" * 16), modes.ECB()

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -333,6 +333,13 @@ def aead_tag_exception_test(backend, cipher_factory, mode_factory):
         mode_factory(binascii.unhexlify(b"0" * 24), b"000")
 
     with pytest.raises(ValueError):
+        Cipher(
+            cipher_factory(binascii.unhexlify(b"0" * 32)),
+            mode_factory(binascii.unhexlify(b"0" * 24), b"toolong" * 12),
+            backend,
+        )
+
+    with pytest.raises(ValueError):
         mode_factory(binascii.unhexlify(b"0" * 24), b"000000", 2)
 
     cipher = Cipher(


### PR DESCRIPTION
this is checked in both the GCM mode constructor as well as finalize_with_tag

The logic assumes a 128-bit block cipher, which all our AEADs require (and all our non-GCM AEADs run through the separate one-shot AEAD APIs anyway).

fixes #6244 