### PR TITLE
Make OAEP test vector generating works on python3

### DIFF
--- a/docs/development/custom-vectors/rsa-oaep-sha2/generate_rsa_oaep_sha2.py
+++ b/docs/development/custom-vectors/rsa-oaep-sha2/generate_rsa_oaep_sha2.py
@@ -27,29 +27,29 @@ def build_vectors(mgf1alg, hashalg, filename):
         skey = rsa.generate_private_key(65537, 2048, backend)
         pn = skey.private_numbers()
         examples = private["examples"]
-        output.append(b"# =============================================")
-        output.append(b"# Example")
-        output.append(b"# Public key")
-        output.append(b"# Modulus:")
+        output.append("# =============================================")
+        output.append("# Example")
+        output.append("# Public key")
+        output.append("# Modulus:")
         output.append(format(pn.public_numbers.n, "x"))
-        output.append(b"# Exponent:")
+        output.append("# Exponent:")
         output.append(format(pn.public_numbers.e, "x"))
-        output.append(b"# Private key")
-        output.append(b"# Modulus:")
+        output.append("# Private key")
+        output.append("# Modulus:")
         output.append(format(pn.public_numbers.n, "x"))
-        output.append(b"# Public exponent:")
+        output.append("# Public exponent:")
         output.append(format(pn.public_numbers.e, "x"))
-        output.append(b"# Exponent:")
+        output.append("# Exponent:")
         output.append(format(pn.d, "x"))
-        output.append(b"# Prime 1:")
+        output.append("# Prime 1:")
         output.append(format(pn.p, "x"))
-        output.append(b"# Prime 2:")
+        output.append("# Prime 2:")
         output.append(format(pn.q, "x"))
-        output.append(b"# Prime exponent 1:")
+        output.append("# Prime exponent 1:")
         output.append(format(pn.dmp1, "x"))
-        output.append(b"# Prime exponent 2:")
+        output.append("# Prime exponent 2:")
         output.append(format(pn.dmq1, "x"))
-        output.append(b"# Coefficient:")
+        output.append("# Coefficient:")
         output.append(format(pn.iqmp, "x"))
         pkey = skey.public_key()
         vectorkey = rsa.RSAPrivateNumbers(
@@ -84,17 +84,17 @@ def build_vectors(mgf1alg, hashalg, filename):
                 ),
             )
             output.append(
-                b"# OAEP Example {0} alg={1} mgf1={2}".format(
+                "# OAEP Example {0} alg={1} mgf1={2}".format(
                     count, hashalg.name, mgf1alg.name
                 )
             )
             count += 1
-            output.append(b"# Message:")
-            output.append(example["message"])
-            output.append(b"# Encryption:")
-            output.append(binascii.hexlify(ct))
+            output.append("# Message:")
+            output.append(example["message"].decode("utf-8"))
+            output.append("# Encryption:")
+            output.append(binascii.hexlify(ct).decode("utf-8"))
 
-    return b"\n".join(output)
+    return "\n".join(output)
 
 
 def write_file(data, filename):


### PR DESCRIPTION
The script seems to be run with Python 2 originally some time ago and it is not compatible to Python 3 since its mixed usage of bytes and string. This change does a minimum change to make it work on python3.

TL;DR:
I was originally trying to make the script to work on both 2 and 3, so all changes are made in the way to do so.
But when testing with Python 2 I met backend importing error, then I found that "latest" pyca/cryptography already dropped the support to python2:
 >3.4 - 2021-02-07
 > BACKWARDS INCOMPATIBLE: Support for Python 2 has been removed.

 Anyways, if someone really wants to run _this_ script on Python 2 with an old version of pyca/cryptography, it should be doable.

I agree that RSA OAEP encrypt and decrypt are really rare use cases if compared to RSA sign/verify. But from a cryptographic worker's aspect, it is *as* important as others. So I listed some open topics to this script:
1. If consider _functionality_ of this script, it doesn't generate test vector for 1K, 3K and 4K key size. Ofc it can be easily added. 
2. Also, my test to use truncated SHA512 as `mgf1( )` and digest algorithm was rejected by openssl backend. Though they are legitimate at least by definition of https://datatracker.ietf.org/doc/html/rfc8017#page-19. But this is more like a case for openssl after checking its support to OAEP...