### PR TITLE
_ModuleWithDeprecations should inherit from types.ModuleType (#6267)

### DIFF
--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -7,6 +7,7 @@ import abc
 import enum
 import inspect
 import sys
+import types
 import typing
 import warnings
 
@@ -113,8 +114,9 @@ class _DeprecatedValue(object):
         self.warning_class = warning_class
 
 
-class _ModuleWithDeprecations(object):
+class _ModuleWithDeprecations(types.ModuleType):
     def __init__(self, module):
+        super().__init__(module.__name__)
         self.__dict__["_module"] = module
 
     def __getattr__(self, attr):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@
 
 
 import binascii
+import inspect
 import os
 import textwrap
 
@@ -12,6 +13,7 @@ import pretend
 import pytest
 
 import cryptography
+import cryptography.utils
 from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 
 import cryptography_vectors
@@ -4444,3 +4446,8 @@ def test_raises_unsupported_algorithm():
             "An error.", _Reasons.BACKEND_MISSING_INTERFACE
         )
     assert exc_info.type is UnsupportedAlgorithm
+
+
+def test_inspect_deprecated_module():
+    # Check if inspection is supported by _ModuleWithDeprecations
+    assert inspect.getsourcefile(cryptography.utils).endswith('utils.py')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4449,5 +4449,5 @@ def test_raises_unsupported_algorithm():
 
 
 def test_inspect_deprecated_module():
-    # Check if inspection is supported by _ModuleWithDeprecations
-    assert inspect.getsourcefile(cryptography.utils).endswith('utils.py')
+    # Check if inspection is supported by _ModuleWithDeprecations.
+    assert inspect.getsourcefile(cryptography.utils).endswith("utils.py")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4450,6 +4450,9 @@ def test_raises_unsupported_algorithm():
 
 def test_inspect_deprecated_module():
     # Check if inspection is supported by _ModuleWithDeprecations.
+    assert isinstance(
+        cryptography.utils, cryptography.utils._ModuleWithDeprecations
+    )
     source_file = inspect.getsourcefile(cryptography.utils)
     assert isinstance(source_file, str)
     assert source_file.endswith("utils.py")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4450,4 +4450,6 @@ def test_raises_unsupported_algorithm():
 
 def test_inspect_deprecated_module():
     # Check if inspection is supported by _ModuleWithDeprecations.
-    assert inspect.getsourcefile(cryptography.utils).endswith("utils.py")
+    source_file = inspect.getsourcefile(cryptography.utils)
+    assert isinstance(source_file, str)
+    assert source_file.endswith("utils.py")


### PR DESCRIPTION
Update utils.py

I created a unit test for this simple change, but sadly I could not run the tests, because I could not install all dependencies (e.g. Rust as I am behind a corporate firewall). Someone please run the unit tests if they are not run automatically.