### PR TITLE
Expose X509_verify for X.509 certificate signature verification

### DIFF
--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -59,6 +59,7 @@ int X509_set_pubkey(X509 *, EVP_PKEY *);
 
 unsigned char *X509_alias_get0(X509 *, int *);
 int X509_sign(X509 *, EVP_PKEY *, const EVP_MD *);
+int X509_verify(X509 *, EVP_PKEY *);
 
 int X509_digest(const X509 *, const EVP_MD *, unsigned char *, unsigned int *);
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -189,6 +189,12 @@ class Certificate(metaclass=abc.ABCMeta):
         Serializes the certificate to PEM or DER format.
         """
 
+    @abc.abstractmethod
+    def is_signature_valid(self, public_key: PUBLIC_KEY_TYPES) -> bool:
+        """
+        Verifies signature of certificate against given public key.
+        """
+
 
 # Runtime isinstance checks need this since the rust class is not a subclass.
 Certificate.register(rust_x509.Certificate)

--- a/src/rust/src/x509.rs
+++ b/src/rust/src/x509.rs
@@ -482,6 +482,18 @@ impl Certificate {
             },
         )
     }
+
+    fn is_signature_valid<'p>(
+        slf: pyo3::pycell::PyRef<'_, Self>,
+        py: pyo3::Python<'p>,
+        public_key: &'p pyo3::PyAny,
+    ) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let backend = py
+            .import("cryptography.hazmat.backends.openssl.backend")?
+            .getattr("backend")?;
+        backend.call_method1("_cert_is_signature_valid", (slf, public_key))
+    }
+
     // This getter exists for compatibility with pyOpenSSL and will be removed.
     // DO NOT RELY ON IT. WE WILL BREAK YOU WHEN WE FEEL LIKE IT.
     #[getter]


### PR DESCRIPTION
Currently, certificate signature verification involves verifying the signature on the cert tbs data. This is already more involved than it should be as users will have to handle the possible values of `Certificate.signature_algorithm_oid` for the different algorithm and hash pairings.
The `Certificate` class only exposes the `ObjectIdentifier` of the signature's ASN.1 `AlgorithmIdentifier` field, which isn't so bad if we're dealing with RSA PKCS#1 v1.5 signatures, but is an issue if we're dealing with RSA PSS signatures, where the `AlgorithmIdentifier` may store other parameters. Handling these signatures isn't currently easy.

To solve this, we can ~~shamelessly copy~~ adapt the existing code used for verifying CRL signatures. We simply serialise the certificate and let OpenSSL check.