### PR TITLE
docs: upgrade image to latest 20.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,8 @@ sphinx:
   builder: dirhtml
 
 build:
-  # First RTD build env which includes a rust toolchain
-  image: "7.0"
+  # readdocs master now includes a rust toolchain
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
 


### PR DESCRIPTION
openssl version is messed in `image 7', which causes error e.g.
https://readthedocs.org/projects/cryptography/builds/14446988/

Signed-off-by: Match Man <ppucoder@gmail.com>