### PR TITLE
Require asn1 >= 0.6.4

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 lazy_static = "1"
 pyo3 = { version = "0.14.5" }
-asn1 = { version = "0.6", default-features = false, features = ["derive"] }
+asn1 = { version = "0.6.4", default-features = false, features = ["derive"] }
 pem = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 ouroboros = "0.11"


### PR DESCRIPTION
Cryptography fails to build with asn 0.6.1. Require at least 0.6.4

Closes: https://github.com/pyca/cryptography/issues/6337
Signed-off-by: Christian Heimes <christian@python.org>