### PR TITLE
Vendor crates in sdist

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -43,7 +43,7 @@ jobs:
         run: .venv/bin/pip install -U pip wheel cffi setuptools-rust
       - name: Make sdist
         run: .venv/bin/python setup.py sdist
-      - run: tar zxvf dist/cryptography*.tar.gz && mkdir tmpwheelhouse
+      - run: tar zxvf dist/cryptography*.tar.bz2 && mkdir tmpwheelhouse
       - name: Build the wheel
         run: |
           if [ -n "${{ matrix.PYTHON.ABI_VERSION }}" ]; then
@@ -52,6 +52,7 @@ jobs:
           cd cryptography*
           LDFLAGS="-L/opt/pyca/cryptography/openssl/lib" \
               CFLAGS="-I/opt/pyca/cryptography/openssl/include -Wl,--exclude-libs,ALL" \
+              CARGO_NET_OFFLINE=true \
               ../.venv/bin/python setup.py bdist_wheel $PY_LIMITED_API && mv dist/cryptography*.whl ../tmpwheelhouse
         env:
           RUSTUP_HOME: /root/.rustup
@@ -122,13 +123,14 @@ jobs:
       - run: ${{ matrix.PYTHON.BIN_PATH }} -m venv venv
       - run: venv/bin/pip install -U pip wheel cffi setuptools-rust
       - run: venv/bin/python setup.py sdist
-      - run: tar zxvf dist/cryptography*.tar.gz && mkdir wheelhouse
+      - run: tar zxvf dist/cryptography*.tar.bz2 && mkdir wheelhouse
       - name: Build the wheel
         run: |
           cd cryptography*
           CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS="1" \
               LDFLAGS="${HOME}/openssl-macos-x86-64/lib/libcrypto.a ${HOME}/openssl-macos-x86-64/lib/libssl.a" \
               CFLAGS="-I${HOME}/openssl-macos-x86-64/include -mmacosx-version-min=10.10 -march=core2" \
+              CARGO_NET_OFFLINE=true \
               ../venv/bin/python setup.py bdist_wheel --py-limited-api=${{ matrix.PYTHON.ABI_VERSION }} && mv dist/cryptography*.whl ../wheelhouse
         env:
           MACOSX_DEPLOYMENT_TARGET:  "10.10"
@@ -190,9 +192,12 @@ jobs:
 
       - run: python -m pip install -U pip wheel cffi setuptools-rust
       - run: python setup.py sdist
-      - run: tar zxvf dist/cryptography*.tar.gz && mkdir wheelhouse
+      - run: tar zxvf dist/cryptography*.tar.bz && mkdir wheelhouse
         shell: bash
-      - run: cd cryptography* && python setup.py bdist_wheel --py-limited-api=${{ matrix.PYTHON.ABI_VERSION }} && mv dist/cryptography*.whl ../wheelhouse
+      - run: |
+            cd cryptography*
+            CARGO_NET_OFFLINE=true \
+                python setup.py bdist_wheel --py-limited-api=${{ matrix.PYTHON.ABI_VERSION }} && mv dist/cryptography*.whl ../wheelhouse
       - run: pip install -f wheelhouse --no-index cryptography
       - name: Print the OpenSSL we built and linked against
         run: |

--- a/.zuul.playbooks/playbooks/wheel/roles/build-wheel-manylinux/files/build-wheels.sh
+++ b/.zuul.playbooks/playbooks/wheel/roles/build-wheel-manylinux/files/build-wheels.sh
@@ -22,6 +22,7 @@ for P in ${PYTHONS}; do
 
     LDFLAGS="-L/opt/pyca/cryptography/openssl/lib" \
            CFLAGS="-I/opt/pyca/cryptography/openssl/include -Wl,--exclude-libs,ALL" \
+           CARGO_NET_OFFLINE=true \
            .venv/bin/python setup.py bdist_wheel $PY_LIMITED_API
 
     auditwheel repair --plat ${PLAT} -w wheelhouse/ dist/cryptography*.whl

--- a/.zuul.playbooks/playbooks/wheel/roles/build-wheel-manylinux/tasks/main.yaml
+++ b/.zuul.playbooks/playbooks/wheel/roles/build-wheel-manylinux/tasks/main.yaml
@@ -42,7 +42,7 @@
   find:
     paths: '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/dist'
     file_type: file
-    patterns: "*.tar.gz"
+    patterns: "*.tar.bz2"
   register: _sdist
 
 - assert:
@@ -62,7 +62,7 @@
 
 - name: Find cryptography subdir from sdist build dir
   set_fact:
-    _build_dir: "{{ ansible_user_dir }}/build/{{ _sdist.files[0].path | basename | replace('.tar.gz', '') }}"
+    _build_dir: "{{ ansible_user_dir }}/build/{{ _sdist.files[0].path | basename | replace('.tar.bz2', '') }}"
 
 - name: Show _build_dir
   debug:

--- a/.zuul.playbooks/playbooks/wheel/roles/build-wheel-manylinux/tasks/main.yaml
+++ b/.zuul.playbooks/playbooks/wheel/roles/build-wheel-manylinux/tasks/main.yaml
@@ -11,6 +11,10 @@
   include_role:
     name: ensure-pip
 
+- name: Install rust
+  include_role:
+    name: ensure-rust
+
 # We build an sdist of the checkout, and then build wheels from the
 # sdist.  This ensures that nothing is left out of the sdist.
 - name: Install sdist required packages

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Changelog
   :func:`~cryptography.hazmat.primitives.serialization.pkcs12.load_pkcs12`,
   which will return an object of type
   :class:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12KeyAndCertificates`.
+* The source distribution (sdist) now contains vendored Rust crates. Users
+  can perform offline installation from sdist without additional downloads.
+  We also switched to ``tar.bz2`` format in order to reduce size.
 
 .. _v35-0-0:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -104,6 +104,7 @@ responder
 runtime
 Schneier
 scrypt
+sdist
 serializer
 Serializers
 SHA
@@ -121,6 +122,7 @@ unencrypted
 unicode
 unpadded
 unpadding
+vendored
 verifier
 Verifier
 Verisign

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ build-backend = "setuptools.build_meta"
 line-length = 79
 target-version = ["py36"]
 
+[tool.check-manifest]
+ignore = [".cargo/**"]
+
 [tool.pytest.ini_options]
 addopts = "-r s"
 markers = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     cffi >=1.12
 setup_requires =
     cffi >=1.12
-    setuptools_rust >= 0.11.4
+    setuptools_rust >= 0.12.1
 
 [options.packages.find]
 where = src
@@ -77,7 +77,7 @@ docstest =
     twine >= 1.12.0
     sphinxcontrib-spelling >= 4.0.1
 sdist =
-    setuptools_rust >= 0.11.4
+    setuptools_rust >= 0.12.1
 pep8test =
     black
     flake8
@@ -87,3 +87,7 @@ pep8test =
 # Versions: v3.1.3 - ignore_few_rounds, v3.1.5 - abi3
 ssh =
     bcrypt >= 3.1.5
+
+[sdist]
+formats = bztar
+vendor_crates = True

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands =
 
 [flake8]
 ignore = E203,E211,W503,W504,N818
-exclude = .tox,*.egg,.git,_build,.hypothesis
+exclude = .tox,*.egg,.git,_build,.hypothesis,.cargo
 select = E,W,F,N,I
 application-import-names = cryptography,cryptography_vectors,tests
 


### PR DESCRIPTION
Use setuptools_rust 0.12 feature to vendor and bundle all Rust crates in
the source distribution. Vendoring enables offline installation. The
build process no longer has to fetch crates from crates.io.

Also switch sdist format from tar.gz bundle to tar.bz2 bundle to reduce
the size of the sdist file. Vendoring increases the size of the gztar
bundle size from 560 kB to 11 MB. The bz2tar format shrinks the sdist
to 7.2 MB.

Signed-off-by: Christian Heimes <christian@python.org>