### PR TITLE
add downstream tests for mitmproxy

### DIFF
--- a/.github/downstream.d/mitmproxy.sh
+++ b/.github/downstream.d/mitmproxy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/mitmproxy/mitmproxy
+        cd mitmproxy
+        git rev-parse HEAD
+        pip install -e ".[dev]"
+        ;;
+    run)
+        cd mitmproxy
+        pytest test
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,10 +433,11 @@ jobs:
           - dynamodb-encryption-sdk
           - certbot
           - certbot-josepy
+          - mitmproxy
         RUST:
           - stable
         PYTHON:
-          - 3.7
+          - 3.8
     name: "Downstream tests for ${{ matrix.DOWNSTREAM }}"
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
As a late follow-up to #5544, this PR adds downstream CI for @mitmproxy. We've moved most of our OpenSSL API usage to pyOpenSSL, but there are a few places where we continue to rely on bindings. Not having those removed would be fantastic. 😄 

We've recently reduced our test execution time from a few minutes to 20s, so that hopefully should not be a concern. The only change I needed to do is bump the Python version for downstream tests as we don't support 3.7 anymore.