### PR TITLE
less builds on zuul

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -36,22 +36,3 @@
           image: ghcr.io/pyca/cryptography-musllinux_1_1:aarch64
           pythons:
             - cp36-cp36m
-
-- job:
-    name: pyca-cryptography-build-wheel-x86_64
-    parent: pyca-cryptography-build-wheel
-    nodeset: ubuntu-bionic
-    vars:
-      wheel_builds:
-        - platform: manylinux2010_x86_64
-          image: ghcr.io/pyca/cryptography-manylinux2010:x86_64
-          pythons:
-            - cp36-cp36m
-        - platform: manylinux2014_x86_64
-          image: ghcr.io/pyca/cryptography-manylinux2014:x86_64
-          pythons:
-            - cp36-cp36m
-        - platform: manylinux_2_24_x86_64
-          image: ghcr.io/pyca/cryptography-manylinux_2_24:x86_64
-          pythons:
-            - cp36-cp36m


### PR DESCRIPTION
We don't care about x86_64 wheel builds here anyway and they're
periodically slowing down our CI (when zuul is already by 2-3x the
slowest component). Let's remove them.