### PR TITLE
continued optimization of zuul builds

### DIFF
--- a/.zuul.playbooks/playbooks/wheel/roles/build-wheel-manylinux/tasks/main.yaml
+++ b/.zuul.playbooks/playbooks/wheel/roles/build-wheel-manylinux/tasks/main.yaml
@@ -13,16 +13,6 @@
 
 # We build an sdist of the checkout, and then build wheels from the
 # sdist.  This ensures that nothing is left out of the sdist.
-- name: Install sdist required packages
-  package:
-    name:
-      - build-essential
-      - libssl-dev
-      - libffi-dev
-      - python3-dev
-  become: yes
-  when: ansible_distribution in ['Debian', 'Ubuntu']
-
 - name: Install setuptools-rust
   pip:
     name: setuptools-rust
@@ -80,22 +70,6 @@
       /io/build-wheels.sh
   become: yes
   loop: '{{ wheel_builds }}'
-
-- name: Copy sdist to output
-  synchronize:
-    src: '{{ _sdist.files[0].path }}'
-    dest: '{{ zuul.executor.log_root }}'
-    mode: pull
-
-- name: Return sdist artifact
-  zuul_return:
-    data:
-      zuul:
-        artifacts:
-          - name: '{{ _sdist.files[0].path | basename }}'
-            url: 'sdist/{{ _sdist.files[0].path }}'
-            metadata:
-              type: sdist
 
 - name: Copy wheels to output
   synchronize:


### PR DESCRIPTION
we don't need to install compilers for building the sdist and python is
already present on the system. we also don't care about copying the
sdist back out, just the binary wheels