### PR TITLE
add two additional DSA signature algorithm oids & test dsa_with_sha224

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -2964,6 +2964,20 @@ instances. The following common OIDs are available as constants.
         Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.2"``. This is
         a SHA256 digest signed by a DSA key.
 
+    .. attribute:: DSA_WITH_SHA384
+
+        .. versionadded:: 36.0
+
+        Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.3"``. This is
+        a SHA384 digest signed by a DSA key.
+
+    .. attribute:: DSA_WITH_SHA512
+
+        .. versionadded:: 36.0
+
+        Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.4"``. This is
+        a SHA512 digest signed by a DSA key.
+
     .. attribute:: ED25519
 
         .. versionadded:: 2.8

--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -167,6 +167,8 @@ class SignatureAlgorithmOID(object):
     DSA_WITH_SHA1 = ObjectIdentifier("1.2.840.10040.4.3")
     DSA_WITH_SHA224 = ObjectIdentifier("2.16.840.1.101.3.4.3.1")
     DSA_WITH_SHA256 = ObjectIdentifier("2.16.840.1.101.3.4.3.2")
+    DSA_WITH_SHA384 = ObjectIdentifier("2.16.840.1.101.3.4.3.3")
+    DSA_WITH_SHA512 = ObjectIdentifier("2.16.840.1.101.3.4.3.4")
     ED25519 = ObjectIdentifier("1.3.101.112")
     ED448 = ObjectIdentifier("1.3.101.113")
     GOSTR3411_94_WITH_3410_2001 = ObjectIdentifier("1.2.643.2.2.3")

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -2586,6 +2586,7 @@ class TestCertificateBuilder(object):
         ("hashalg", "hashalg_oid"),
         [
             (hashes.SHA1, x509.SignatureAlgorithmOID.DSA_WITH_SHA1),
+            (hashes.SHA224, x509.SignatureAlgorithmOID.DSA_WITH_SHA224),
             (hashes.SHA256, x509.SignatureAlgorithmOID.DSA_WITH_SHA256),
         ],
     )


### PR DESCRIPTION
Can't add sha384 and sha512 tests because OpenSSL doesn't support this.