### PR TITLE
Allow custom attribute shortnames in rfc4514_string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,15 @@ Changelog
   :func:`~cryptography.hazmat.primitives.serialization.pkcs12.load_pkcs12`,
   which will return an object of type
   :class:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12KeyAndCertificates`.
+* :meth:`~cryptography.x509.Name.rfc4514_string` and related methods now have
+  an optional ``attr_name_overrides`` parameter to supply custom OID to name
+  mappings, which can be used to match vendor-specific extensions.
+* **BACKWARDS INCOMPATIBLE:** Reverted the nonstandard formatting of
+  email address fields as ``E`` in
+  :meth:`~cryptography.x509.Name.rfc4514_string` methods from version 35.0.
+
+  The previous behavior can be restored with:
+  ``name.rfc4514_string({NameOID.EMAIL_ADDRESS: "E"})``
 
 .. _v35-0-0:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1292,12 +1292,42 @@ X.509 CSR (Certificate Signing Request) Builder Object
 
         :return bytes: The DER encoded name.
 
-    .. method:: rfc4514_string()
+    .. method:: rfc4514_string(attr_name_overrides=None)
 
         .. versionadded:: 2.5
+        .. versionchanged:: 36.0
 
-        :return str: Format the given name as a :rfc:`4514` Distinguished Name
-            string, for example ``CN=mydomain.com,O=My Org,C=US``.
+            Added ``attr_name_overrides`` parameter.
+
+        Format the given name as a :rfc:`4514` Distinguished Name
+        string, for example ``CN=mydomain.com,O=My Org,C=US``.
+
+        By default, attributes ``CN``, ``L``, ``ST``, ``O``, ``OU``, ``C``,
+        ``STREET``, ``DC``, ``UID`` are represented by their short name.
+        Unrecognized attributes are formatted as dotted OID strings.
+
+        Example:
+
+        .. doctest::
+
+            >>> name = x509.Name([
+            ...     x509.NameAttribute(NameOID.EMAIL_ADDRESS, "santa@north.pole"),
+            ...     x509.NameAttribute(NameOID.COMMON_NAME, "Santa Claus"),
+            ... ])
+            >>> name.rfc4514_string()
+            'CN=Santa Claus,1.2.840.113549.1.9.1=santa@north.pole'
+            >>> name.rfc4514_string({NameOID.EMAIL_ADDRESS: "E"})
+            'CN=Santa Claus,E=santa@north.pole'
+
+        :type attr_name_overrides:
+            Dict-like mapping from :class:`~cryptography.x509.ObjectIdentifier`
+            to ``str``
+        :param attr_name_overrides: Specify custom OID to name mappings, which
+            can be used to match vendor-specific extensions. See
+            :class:`~cryptography.x509.oid.NameOID` for common attribute
+            OIDs.
+
+        :rtype: str
 
 
 .. class:: Version
@@ -1342,12 +1372,21 @@ X.509 CSR (Certificate Signing Request) Builder Object
         The :rfc:`4514` short attribute name (for example "CN"),
         or the OID dotted string if a short name is unavailable.
 
-    .. method:: rfc4514_string()
+    .. method:: rfc4514_string(attr_name_overrides=None)
 
         .. versionadded:: 2.5
+        .. versionchanged:: 36.0
+
+            Added ``attr_name_overrides`` parameter.
 
         :return str: Format the given attribute as a :rfc:`4514` Distinguished
             Name string.
+
+        :type attr_name_overrides:
+            Dict-like mapping from :class:`~cryptography.x509.ObjectIdentifier`
+            to ``str``
+        :param attr_name_overrides: Specify custom OID to name mappings, which
+            can be used to match vendor-specific extensions.
 
 
 .. class:: RelativeDistinguishedName(attributes)
@@ -1365,12 +1404,21 @@ X.509 CSR (Certificate Signing Request) Builder Object
         :returns: A list of :class:`NameAttribute` instances that match the OID
             provided.  The list should contain zero or one values.
 
-    .. method:: rfc4514_string()
+    .. method:: rfc4514_string(attr_name_overrides=None)
 
         .. versionadded:: 2.5
+        .. versionchanged:: 36.0
+
+            Added ``attr_name_overrides`` parameter.
 
         :return str: Format the given RDN set as a :rfc:`4514` Distinguished
             Name string.
+
+        :type attr_name_overrides:
+            Dict-like mapping from :class:`~cryptography.x509.ObjectIdentifier`
+            to ``str``
+        :param attr_name_overrides: Specify custom OID to name mappings, which
+            can be used to match vendor-specific extensions.
 
 
 .. class:: ObjectIdentifier

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -4728,6 +4728,23 @@ class TestNameAttribute(object):
         na = x509.NameAttribute(NameOID.BUSINESS_CATEGORY, "banking")
         assert na.rfc4514_string() == "2.5.4.15=banking"
 
+    def test_distinguished_name_custom_attrs(self):
+        name = x509.Name(
+            [
+                x509.NameAttribute(NameOID.EMAIL_ADDRESS, "santa@north.pole"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "Santa Claus"),
+            ]
+        )
+        assert name.rfc4514_string({}) == (
+            "CN=Santa Claus,1.2.840.113549.1.9.1=santa@north.pole"
+        )
+        assert name.rfc4514_string({NameOID.EMAIL_ADDRESS: "E"}) == (
+            "CN=Santa Claus,E=santa@north.pole"
+        )
+        assert name.rfc4514_string(
+            {NameOID.COMMON_NAME: "CommonName", NameOID.EMAIL_ADDRESS: "E"}
+        ) == ("CommonName=Santa Claus,E=santa@north.pole")
+
     def test_empty_value(self):
         na = x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "")
         assert na.rfc4514_string() == r"ST="


### PR DESCRIPTION
`rfc4514_string()` and related methods now have an optional
`attr_name_overrides` parameter to supply custom OID to name mappings,
which can be used to match vendor-specific extensions.

**BACKWARDS INCOMPATIBLE:** Reverted the nonstandard formatting of email
address fields as `E` in `rfc4514_string()` methods from version 35.0.0.

The previous behavior can be restored with:
`name.rfc4514_string({NameOID.EMAIL_ADDRESS: "E"})`

Expanded documentation of `Name.rfc4514_string`.