### PR TITLE
make all-green only pass if the tests actually pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,5 +498,8 @@ jobs:
     # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
     runs-on: ubuntu-latest
     needs: [linux, linux-distros, linux-rust, linux-rust-coverage, macos, windows, linux-downstream]
+    if: ${{ always() }}
     steps:
+    - run: echo "😢"; exit 1
+      if: ${{ needs.linux.result != 'success' || needs.linux-distros.result != 'success' || needs.linux-rust.result != 'success' || needs.linux-rust-coverage.result != 'success' || needs.macos.result != 'success' || needs.windows.result != 'success' || needs.linux-downstream.result != 'success' }}
     - run: echo "🎉"


### PR DESCRIPTION
In GitHub Actions if a job needs a previous job (which fails) then the job gets skipped. If a required status is skipped then it's considered passing. This confluence is not good when we want to have an aggregate job we use as a required status to gate for auto-merge queue.

To fix this, we always run the job and then explicitly check the result of every dependent job.