### PR TITLE
deprecate backend part 1 of n

### DIFF
--- a/docs/development/custom-vectors/arc4/generate_arc4.py
+++ b/docs/development/custom-vectors/arc4/generate_arc4.py
@@ -4,7 +4,6 @@
 
 import binascii
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import ciphers
 from cryptography.hazmat.primitives.ciphers import algorithms
 
@@ -65,7 +64,6 @@ def _build_vectors():
             cipher = ciphers.Cipher(
                 algorithms.ARC4(binascii.unhexlify(key)),
                 None,
-                default_backend(),
             )
             encryptor = cipher.encryptor()
             current_offset = 0

--- a/docs/development/custom-vectors/cast5/generate_cast5.py
+++ b/docs/development/custom-vectors/cast5/generate_cast5.py
@@ -4,7 +4,6 @@
 
 import binascii
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, base, modes
 
 
@@ -12,7 +11,6 @@ def encrypt(mode, key, iv, plaintext):
     cipher = base.Cipher(
         algorithms.CAST5(binascii.unhexlify(key)),
         mode(binascii.unhexlify(iv)),
-        default_backend(),
     )
     encryptor = cipher.encryptor()
     ct = encryptor.update(binascii.unhexlify(plaintext))

--- a/docs/development/custom-vectors/hkdf/generate_hkdf.py
+++ b/docs/development/custom-vectors/hkdf/generate_hkdf.py
@@ -4,7 +4,6 @@
 
 import binascii
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
@@ -15,7 +14,6 @@ OKM = HKDF(
     length=L,
     salt=None,
     info=None,
-    backend=default_backend(),
 ).derive(IKM)
 
 

--- a/docs/development/custom-vectors/idea/generate_idea.py
+++ b/docs/development/custom-vectors/idea/generate_idea.py
@@ -1,6 +1,5 @@
 import binascii
 
-from cryptography.hazmat.backends.openssl.backend import backend
 from cryptography.hazmat.primitives.ciphers import algorithms, base, modes
 
 
@@ -8,7 +7,6 @@ def encrypt(mode, key, iv, plaintext):
     cipher = base.Cipher(
         algorithms.IDEA(binascii.unhexlify(key)),
         mode(binascii.unhexlify(iv)),
-        backend,
     )
     encryptor = cipher.encryptor()
     ct = encryptor.update(binascii.unhexlify(plaintext))

--- a/docs/development/custom-vectors/rsa-oaep-sha2/generate_rsa_oaep_sha2.py
+++ b/docs/development/custom-vectors/rsa-oaep-sha2/generate_rsa_oaep_sha2.py
@@ -6,7 +6,6 @@ import binascii
 import itertools
 import os
 
-from cryptography.hazmat.backends.openssl.backend import backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
@@ -24,7 +23,7 @@ def build_vectors(mgf1alg, hashalg, filename):
         # small. Instead we parse the vectors for the test cases, then
         # generate our own 2048-bit keys for each.
         private, _ = vector
-        skey = rsa.generate_private_key(65537, 2048, backend)
+        skey = rsa.generate_private_key(65537, 2048)
         pn = skey.private_numbers()
         examples = private["examples"]
         output.append("# =============================================")
@@ -62,7 +61,7 @@ def build_vectors(mgf1alg, hashalg, filename):
             public_numbers=rsa.RSAPublicNumbers(
                 e=private["public_exponent"], n=private["modulus"]
             ),
-        ).private_key(backend)
+        ).private_key()
         count = 1
 
         for example in examples:

--- a/docs/development/custom-vectors/secp256k1/verify_secp256k1.py
+++ b/docs/development/custom-vectors/secp256k1/verify_secp256k1.py
@@ -1,6 +1,5 @@
 import os
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import (
@@ -27,7 +26,7 @@ def verify_one_vector(vector):
 
     numbers = ec.EllipticCurvePublicNumbers(x, y, ec.SECP256K1())
 
-    key = numbers.public_key(default_backend())
+    key = numbers.public_key()
 
     verifier = key.verifier(
         signature, ec.ECDSA(CRYPTOGRAPHY_HASH_TYPES[digest_algorithm]())

--- a/docs/development/custom-vectors/seed/generate_seed.py
+++ b/docs/development/custom-vectors/seed/generate_seed.py
@@ -1,6 +1,5 @@
 import binascii
 
-from cryptography.hazmat.backends.openssl.backend import backend
 from cryptography.hazmat.primitives.ciphers import algorithms, base, modes
 
 
@@ -8,7 +7,6 @@ def encrypt(mode, key, iv, plaintext):
     cipher = base.Cipher(
         algorithms.SEED(binascii.unhexlify(key)),
         mode(binascii.unhexlify(iv)),
-        backend,
     )
     encryptor = cipher.encryptor()
     ct = encryptor.update(binascii.unhexlify(plaintext))

--- a/docs/development/test-vectors.rst
+++ b/docs/development/test-vectors.rst
@@ -1,12 +1,11 @@
 Test vectors
 ============
 
-Testing the correctness of the primitives implemented in each ``cryptography``
-backend requires trusted test vectors. Where possible these vectors are
+Testing the correctness of the primitives implemented in ``cryptography``
+requires trusted test vectors. Where possible these vectors are
 obtained from official sources such as `NIST`_ or `IETF`_ RFCs. When this is
 not possible ``cryptography`` has chosen to create a set of custom vectors
-using an official vector file as input to verify consistency between
-implemented backends.
+using an official vector file as input.
 
 Vectors are kept in the ``cryptography_vectors`` package rather than within our
 main test suite.


### PR DESCRIPTION
* update all custom vector generation scripts to not use backends
* remove references to backends in test-vectors.rst
refs #6499