### PR TITLE
deprecate backend part 7 of n

### DIFF
--- a/src/cryptography/hazmat/backends/interfaces.py
+++ b/src/cryptography/hazmat/backends/interfaces.py
@@ -4,14 +4,6 @@
 
 
 import abc
-import typing
-
-
-if typing.TYPE_CHECKING:
-    from cryptography.x509.base import (
-        RevokedCertificate,
-        RevokedCertificateBuilder,
-    )
 
 
 class CipherBackend(metaclass=abc.ABCMeta):
@@ -268,17 +260,6 @@ class DERSerializationBackend(metaclass=abc.ABCMeta):
         """
 
 
-class X509Backend(metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    def create_x509_revoked_certificate(
-        self, builder: "RevokedCertificateBuilder"
-    ) -> "RevokedCertificate":
-        """
-        Create a RevokedCertificate object from a RevokedCertificateBuilder
-        object.
-        """
-
-
 class DHBackend(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def generate_dh_parameters(self, generator, key_size):
@@ -362,7 +343,6 @@ class Backend(
     RSABackend,
     PEMSerializationBackend,
     ScryptBackend,
-    X509Backend,
     metaclass=abc.ABCMeta,
 ):
     @abc.abstractmethod

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -58,9 +58,6 @@ from cryptography.hazmat.backends.openssl.x448 import (
     _X448PrivateKey,
     _X448PublicKey,
 )
-from cryptography.hazmat.backends.openssl.x509 import (
-    _RawRevokedCertificate,
-)
 from cryptography.hazmat.bindings._rust import (
     x509 as rust_x509,
 )
@@ -821,21 +818,6 @@ class Backend(BackendInterface):
 
     def create_cmac_ctx(self, algorithm):
         return _CMACContext(self, algorithm)
-
-    def create_x509_revoked_certificate(
-        self, builder: x509.RevokedCertificateBuilder
-    ) -> x509.RevokedCertificate:
-        if not isinstance(builder, x509.RevokedCertificateBuilder):
-            raise TypeError("Builder type mismatch.")
-        serial_number = builder._serial_number
-        revocation_date = builder._revocation_date
-        assert serial_number is not None
-        assert revocation_date is not None
-        return _RawRevokedCertificate(
-            serial_number,
-            revocation_date,
-            x509.Extensions(builder._extensions),
-        )
 
     def load_pem_private_key(self, data, password):
         return self._load_key(

--- a/src/cryptography/hazmat/backends/openssl/x509.py
+++ b/src/cryptography/hazmat/backends/openssl/x509.py
@@ -3,7 +3,6 @@
 # for complete details.
 
 
-import datetime
 import warnings
 
 from cryptography import utils, x509
@@ -44,27 +43,3 @@ def _CertificateRevocationList(  # noqa: N802
         utils.DeprecatedIn35,
     )
     return backend._ossl2crl(x509_crl)
-
-
-class _RawRevokedCertificate(x509.RevokedCertificate):
-    def __init__(
-        self,
-        serial_number: int,
-        revocation_date: datetime.datetime,
-        extensions: x509.Extensions,
-    ):
-        self._serial_number = serial_number
-        self._revocation_date = revocation_date
-        self._extensions = extensions
-
-    @property
-    def serial_number(self) -> int:
-        return self._serial_number
-
-    @property
-    def revocation_date(self) -> datetime.datetime:
-        return self._revocation_date
-
-    @property
-    def extensions(self) -> x509.Extensions:
-        return self._extensions

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -472,14 +472,6 @@ class TestOpenSSLCMAC(object):
             backend.create_cmac_ctx(DummyCipherAlgorithm())
 
 
-class TestOpenSSLCreateRevokedCertificate(object):
-    def test_invalid_builder(self):
-        with pytest.raises(TypeError):
-            backend.create_x509_revoked_certificate(
-                object()  # type: ignore[arg-type]
-            )
-
-
 class TestOpenSSLSerializationWithOpenSSL(object):
     def test_pem_password_cb(self):
         userdata = backend._ffi.new("CRYPTOGRAPHY_PASSWORD_DATA *")


### PR DESCRIPTION
* Move around some code to kill the need for a backend method
* Type the backend arg to typing.Any since we just don't care now

refs #6499 