### PR TITLE
fedora is now py310

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           - {IMAGE: "ubuntu-focal", TOXENV: "py38"}
           - {IMAGE: "ubuntu-rolling", TOXENV: "py39"}
           - {IMAGE: "ubuntu-rolling", TOXENV: "py39-randomorder"}
-          - {IMAGE: "fedora", TOXENV: "py39"}
+          - {IMAGE: "fedora", TOXENV: "py310"}
           - {IMAGE: "alpine", TOXENV: "py39"}
     name: "${{ matrix.IMAGE.TOXENV }} on ${{ matrix.IMAGE.IMAGE }}"
     timeout-minutes: 15


### PR DESCRIPTION
#6536 (and really every other PR) is blocked on this merging.