### PR TITLE
Revert "don't use wheels for coverage to work around musllinux perf issues"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ deps =
     pytest-shard>=0.1.2
     randomorder: pytest-randomly
 passenv = ARCHFLAGS LDFLAGS CFLAGS INCLUDE LIB LD_LIBRARY_PATH USERNAME PYTHONIOENCODING RUSTFLAGS CARGO_TARGET_DIR LLVM_PROFILE_FILE OPENSSL_FORCE_FIPS_MODE
-# We can remove install_command when we resolve https://github.com/nedbat/coveragepy/issues/1268
-install_command = python -m pip install --no-binary coverage {opts} {packages}
 commands =
     pip list
     pytest -n auto --cov=cryptography --cov=tests --capture=no --strict-markers --durations=10 {posargs} tests/


### PR DESCRIPTION
Reverts pyca/cryptography#6511