### PR TITLE
remove some unused functions and add some docs about use

### DIFF
--- a/src/_cffi_src/openssl/ecdh.py
+++ b/src/_cffi_src/openssl/ecdh.py
@@ -11,6 +11,7 @@ TYPES = """
 """
 
 FUNCTIONS = """
+/* This function is no longer used by pyOpenSSL >= 21.1 */
 long SSL_CTX_set_ecdh_auto(SSL_CTX *, int);
 """
 

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -47,12 +47,10 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *, const EVP_CIPHER *, ENGINE *,
 int EVP_CipherUpdate(EVP_CIPHER_CTX *, unsigned char *, int *,
                      const unsigned char *, int);
 int EVP_CipherFinal_ex(EVP_CIPHER_CTX *, unsigned char *, int *);
-int EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *);
 int EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *);
 EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void);
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *);
 int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *, int);
-const EVP_CIPHER *EVP_CIPHER_CTX_cipher(const EVP_CIPHER_CTX *);
 
 int EVP_MD_CTX_copy_ex(EVP_MD_CTX *, const EVP_MD_CTX *);
 int EVP_DigestInit_ex(EVP_MD_CTX *, const EVP_MD *, ENGINE *);
@@ -94,7 +92,6 @@ int EVP_DigestVerifyInit(EVP_MD_CTX *, EVP_PKEY_CTX **, const EVP_MD *,
 
 EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *, ENGINE *);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int, ENGINE *);
-EVP_PKEY_CTX *EVP_PKEY_CTX_dup(EVP_PKEY_CTX *);
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *);
 int EVP_PKEY_sign_init(EVP_PKEY_CTX *);
 int EVP_PKEY_sign(EVP_PKEY_CTX *, unsigned char *, size_t *,
@@ -122,12 +119,12 @@ int EVP_PKEY_derive(EVP_PKEY_CTX *, unsigned char *, size_t *);
 int EVP_PKEY_set_type(EVP_PKEY *, int);
 
 int EVP_PKEY_id(const EVP_PKEY *);
-int Cryptography_EVP_PKEY_id(const EVP_PKEY *);
 
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 void EVP_MD_CTX_free(EVP_MD_CTX *);
-/* Backwards compat aliases for pyOpenSSL */
+/* This function is no longer used by pyOpenSSL >= 21.1 */
 EVP_MD_CTX *Cryptography_EVP_MD_CTX_new(void);
+/* This function is no longer used by pyOpenSSL >= 21.1 */
 void Cryptography_EVP_MD_CTX_free(EVP_MD_CTX *);
 
 /* Added in 1.1.1 */
@@ -179,9 +176,6 @@ const long Cryptography_HAS_EVP_PKEY_DHX = 0;
 const long EVP_PKEY_DHX = -1;
 #endif
 
-int Cryptography_EVP_PKEY_id(const EVP_PKEY *key) {
-    return EVP_PKEY_id(key);
-}
 EVP_MD_CTX *Cryptography_EVP_MD_CTX_new(void) {
     return EVP_MD_CTX_new();
 }

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -175,18 +175,15 @@ int X509_REVOKED_get_ext_count(X509_REVOKED *);
 X509_EXTENSION *X509_REVOKED_get_ext(X509_REVOKED *, int);
 
 X509_REVOKED *X509_REVOKED_dup(X509_REVOKED *);
+/* This function is no longer used by pyOpenSSL >= 21.1 */
 X509_REVOKED *Cryptography_X509_REVOKED_dup(X509_REVOKED *);
 
 const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *);
 
 long X509_get_version(X509 *);
 
-ASN1_TIME *X509_get_notBefore(X509 *);
-ASN1_TIME *X509_get_notAfter(X509 *);
 ASN1_TIME *X509_getm_notBefore(const X509 *);
 ASN1_TIME *X509_getm_notAfter(const X509 *);
-const ASN1_TIME *X509_get0_notBefore(const X509 *);
-const ASN1_TIME *X509_get0_notAfter(const X509 *);
 
 long X509_REQ_get_version(X509_REQ *);
 X509_NAME *X509_REQ_get_subject_name(X509_REQ *);
@@ -217,16 +214,13 @@ const ASN1_TIME *X509_CRL_get0_nextUpdate(const X509_CRL *);
 X509_NAME *X509_CRL_get_issuer(X509_CRL *);
 Cryptography_STACK_OF_X509_REVOKED *X509_CRL_get_REVOKED(X509_CRL *);
 
-/* These aren't macros these arguments are all const X on openssl > 1.0.x */
+/* This function is no longer used by pyOpenSSL >= 21.1 */
 int X509_CRL_set_lastUpdate(X509_CRL *, ASN1_TIME *);
+/* This function is no longer used by pyOpenSSL >= 21.1 */
 int X509_CRL_set_nextUpdate(X509_CRL *, ASN1_TIME *);
-int X509_set_notBefore(X509 *, ASN1_TIME *);
-int X509_set_notAfter(X509 *, ASN1_TIME *);
 
 int X509_CRL_set1_lastUpdate(X509_CRL *, const ASN1_TIME *);
 int X509_CRL_set1_nextUpdate(X509_CRL *, const ASN1_TIME *);
-int X509_set1_notBefore(X509 *, const ASN1_TIME *);
-int X509_set1_notAfter(X509 *, const ASN1_TIME *);
 
 EC_KEY *d2i_EC_PUBKEY_bio(BIO *, EC_KEY **);
 int i2d_EC_PUBKEY_bio(BIO *, EC_KEY *);


### PR DESCRIPTION
The functions being removed are unused by both cryptography and
pyopenssl and the existing functions (x509_getm_notBefore/notAfter) are
not deprecated.