### PR TITLE
fix nightly clippy warnings

### DIFF
--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -281,7 +281,7 @@ impl Certificate {
                     "UnsupportedAlgorithm",
                     (format!(
                         "Signature algorithm OID: {} not recognized",
-                        self.raw.borrow_value().signature_alg.oid.to_string()
+                        self.raw.borrow_value().signature_alg.oid
                     ),),
                 )?,
             ))),

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -157,7 +157,7 @@ impl CertificateSigningRequest {
                     "UnsupportedAlgorithm",
                     (format!(
                         "Signature algorithm OID: {} not recognized",
-                        self.raw.borrow_value().signature_alg.oid.to_string()
+                        self.raw.borrow_value().signature_alg.oid
                     ),),
                 )?,
             ))),

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -177,10 +177,7 @@ impl OCSPResponse {
             Err(_) => {
                 let exc_messsage = format!(
                     "Signature algorithm OID: {} not recognized",
-                    self.requires_successful_response()?
-                        .signature_algorithm
-                        .oid
-                        .to_string()
+                    self.requires_successful_response()?.signature_algorithm.oid
                 );
                 Err(PyAsn1Error::from(pyo3::PyErr::from_instance(
                     py.import("cryptography.exceptions")?


### PR DESCRIPTION
oid implements the Display trait so to_string is redundant when passing to format!