### PR TITLE
Add Encryption2021 serialization encryption type

### DIFF
--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -978,6 +978,17 @@ Serialization Encryption Types
 
     :param bytes password: The password to use for encryption.
 
+.. class:: Encryption2021(password)
+
+    Encrypt using the best available encryption for a given key in year 2021.
+    The algorithm will never change. In the future, encryption may fail or the
+    class may be removed if the encryption algorithm is considered too weak.
+
+    As of now it uses the same algorithms as
+    :class:`~cryptography.hazmat.primitives.serialization.BestAvailableEncryption`.
+
+    :param bytes password: The password to use for encryption.
+
 .. class:: NoEncryption
 
     Do not encrypt.

--- a/src/cryptography/hazmat/primitives/_serialization.py
+++ b/src/cryptography/hazmat/primitives/_serialization.py
@@ -51,5 +51,9 @@ class BestAvailableEncryption(KeySerializationEncryption):
         self.password = password
 
 
+class Encryption2021(BestAvailableEncryption):
+    pass
+
+
 class NoEncryption(KeySerializationEncryption):
     pass

--- a/src/cryptography/hazmat/primitives/serialization/__init__.py
+++ b/src/cryptography/hazmat/primitives/serialization/__init__.py
@@ -6,6 +6,7 @@
 from cryptography.hazmat.primitives._serialization import (
     BestAvailableEncryption,
     Encoding,
+    Encryption2021,
     KeySerializationEncryption,
     NoEncryption,
     ParameterFormat,
@@ -41,5 +42,6 @@ __all__ = [
     "ParameterFormat",
     "KeySerializationEncryption",
     "BestAvailableEncryption",
+    "Encryption2021",
     "NoEncryption",
 ]

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -550,6 +550,8 @@ def load_ssh_private_key(
 def serialize_ssh_private_key(
     private_key: _SSH_PRIVATE_KEY_TYPES,
     password: typing.Optional[bytes] = None,
+    *,
+    ciphername: typing.Optional[bytes] = None,
 ) -> bytes:
     """Serialize private key with OpenSSH custom encoding."""
     if password is not None:
@@ -575,7 +577,8 @@ def serialize_ssh_private_key(
     # setup parameters
     f_kdfoptions = _FragList()
     if password:
-        ciphername = _DEFAULT_CIPHER
+        if ciphername is None:
+            ciphername = _DEFAULT_CIPHER
         blklen = _SSH_CIPHERS[ciphername][3]
         kdfname = _BCRYPT
         rounds = _DEFAULT_ROUNDS

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2180,7 +2180,7 @@ class TestRSAPrimeFactorRecovery(object):
 
 class TestRSAPrivateKeySerialization(object):
     @pytest.mark.parametrize(
-        ("fmt", "password"),
+        ("fmt", "password", "encryption"),
         itertools.product(
             [
                 serialization.PrivateFormat.TraditionalOpenSSL,
@@ -2192,15 +2192,21 @@ class TestRSAPrivateKeySerialization(object):
                 b"!*$&(@#$*&($T@%_somesymbols",
                 b"\x01" * 1000,
             ],
+            [
+                serialization.BestAvailableEncryption,
+                serialization.Encryption2021,
+            ],
         ),
     )
-    def test_private_bytes_encrypted_pem(self, backend, fmt, password):
+    def test_private_bytes_encrypted_pem(
+        self, backend, fmt, password, encryption
+    ):
         skip_fips_traditional_openssl(backend, fmt)
         key = RSA_KEY_2048.private_key(backend)
         serialized = key.private_bytes(
             serialization.Encoding.PEM,
             fmt,
-            serialization.BestAvailableEncryption(password),
+            encryption(password),
         )
         loaded_key = serialization.load_pem_private_key(
             serialized, password, backend
@@ -2225,20 +2231,29 @@ class TestRSAPrivateKeySerialization(object):
             key.private_bytes(encoding, fmt, serialization.NoEncryption())
 
     @pytest.mark.parametrize(
-        ("fmt", "password"),
-        [
-            [serialization.PrivateFormat.PKCS8, b"s"],
-            [serialization.PrivateFormat.PKCS8, b"longerpassword"],
-            [serialization.PrivateFormat.PKCS8, b"!*$&(@#$*&($T@%_somesymbol"],
-            [serialization.PrivateFormat.PKCS8, b"\x01" * 1000],
-        ],
+        ("fmt", "password", "encryption"),
+        itertools.product(
+            [serialization.PrivateFormat.PKCS8],
+            [
+                b"s",
+                b"longerpassword",
+                b"!*$&(@#$*&($T@%_somesymbols",
+                b"\x01" * 1000,
+            ],
+            [
+                serialization.BestAvailableEncryption,
+                serialization.Encryption2021,
+            ],
+        ),
     )
-    def test_private_bytes_encrypted_der(self, backend, fmt, password):
+    def test_private_bytes_encrypted_der(
+        self, backend, fmt, password, encryption
+    ):
         key = RSA_KEY_2048.private_key(backend)
         serialized = key.private_bytes(
             serialization.Encoding.DER,
             fmt,
-            serialization.BestAvailableEncryption(password),
+            encryption(password),
         )
         loaded_key = serialization.load_der_private_key(
             serialized, password, backend


### PR DESCRIPTION
``BestAvailableEncryption`` provides a curated selection of encryption
algorithms that can change over time. While a curated selection is best
for majority of users, some users in a LTS/Enterprise environment need
more stability.

I propose the addition of a curated and versioned selection of
encryption types. Every time the algorithm selection of
``BestAvailableEncryption``, a new ``Encryption$VERSION`` is added. Once
the algorithms of an old ``Encryption$VERSION`` are considered too weak
(for some definition of "weak"), the type is deprecated. When the
algorithm is broken, it is dropped.

In practice this will happen very rarely. The current selection uses
AES-256.

Signed-off-by: Christian Heimes <christian@python.org>