### PR TITLE
boring changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,10 @@ Changelog
   not support signing.
 * Extension values can now be serialized to a DER byte string by calling
   :func:`~cryptography.x509.ExtensionType.public_bytes`.
+* Added experimental support for compiling against BoringSSL. As BoringSSL
+  does not commit to a stable API, ``cryptography`` tests against the
+  latest commit only. Please note that several features are not available
+  when building against BoringSSL.
 
 .. _v35-0-0:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -10,6 +10,7 @@ bcrypt
 Bleichenbacher
 Blowfish
 boolean
+BoringSSL
 Botan
 Brainpool
 Bullseye


### PR DESCRIPTION
some proposed verbiage. Do we want to consider this experimental or is it fully supported? I argue for experimental because if you try to call the APIs we're skipping in tests you'll get ugly errors, which isn't really the user experience I want.

fixes #6576 