### PR TITLE
support attributes on csrs with an iterable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKey`).
 * :ref:`Deprecated the backend argument<faq-missing-backend>` for all
   functions.
+* Added support for iterating over arbitrary request
+  :attr:`~cryptography.x509.CertificateSigningRequest.attributes`.
+* Deprecated the ``get_attribute_for_oid`` method on
+  :class:`~cryptography.x509.CertificateSigningRequest` in favor of
+  :meth:`~cryptography.x509.Attributes.get_attribute_for_oid` on the new
+  :class:`~cryptography.x509.Attributes` object.
 * Fixed handling of PEM files to allow loading when certificate and key are
   in the same file.
 * Fixed parsing of :class:`~cryptography.x509.CertificatePolicies` extensions
@@ -326,7 +332,7 @@ Changelog
 * Added support for parsing
   :class:`~cryptography.x509.SignedCertificateTimestamps` in OCSP responses.
 * Added support for parsing attributes in certificate signing requests via
-  :meth:`~cryptography.x509.CertificateSigningRequest.get_attribute_for_oid`.
+  ``CertificateSigningRequest.get_attribute_for_oid``.
 * Added support for encoding attributes in certificate signing requests via
   :meth:`~cryptography.x509.CertificateSigningRequestBuilder.add_attribute`.
 * On OpenSSL 1.1.1d and higher ``cryptography`` now uses OpenSSL's

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -855,17 +855,13 @@ X.509 CSR (Certificate Signing Request) Object
         :raises cryptography.x509.UnsupportedGeneralNameType: If an extension
             contains a general name that is not supported.
 
-    .. method:: get_attribute_for_oid(oid)
+    .. attribute:: attributes
 
-        .. versionadded:: 3.0
+        .. versionadded:: 36.0
 
-        :param oid: An :class:`ObjectIdentifier` instance.
+        :type: :class:`Attributes`
 
-        :returns: The bytes value of the attribute or an exception if not
-            found.
-
-        :raises cryptography.x509.AttributeNotFound: If the request does
-            not have the attribute requested.
+        The attributes encoded in the certificate signing request.
 
     .. method:: public_bytes(encoding)
 
@@ -2758,6 +2754,47 @@ OCSP Extensions
 
         :type: bytes
 
+X.509 Request Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: Attributes
+
+    .. versionadded:: 36.0
+
+    An Attributes instance is an ordered list of attributes.  The object
+    is iterable to get every attribute. Each returned element is an
+    :class:`Attribute`.
+
+    .. method:: get_attribute_for_oid(oid)
+
+        .. versionadded:: 36.0
+
+        :param oid: An :class:`ObjectIdentifier` instance.
+
+        :returns: The :class:`Attribute` or an exception if not found.
+
+        :raises cryptography.x509.AttributeNotFound: If the request does
+            not have the attribute requested.
+
+
+.. class:: Attribute
+
+    .. versionadded:: 36.0
+
+    An attribute associated with an X.509 request.
+
+    .. attribute:: oid
+
+        :type: :class:`ObjectIdentifier`
+
+        Returns the object identifier for the attribute.
+
+    .. attribute:: value
+
+        :type: bytes
+
+        Returns the value of the attribute.
+
 Object Identifiers
 ~~~~~~~~~~~~~~~~~~
 
@@ -3338,7 +3375,7 @@ Exceptions
 .. class:: AttributeNotFound
 
     This is raised when calling
-    :meth:`CertificateSigningRequest.get_attribute_for_oid` with
+    :meth:`Attributes.get_attribute_for_oid` with
     an attribute OID that is not present in the request.
 
     .. attribute:: oid

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -25,6 +25,7 @@ PersistentlyDeprecated2017 = CryptographyDeprecationWarning
 PersistentlyDeprecated2019 = CryptographyDeprecationWarning
 DeprecatedIn34 = CryptographyDeprecationWarning
 DeprecatedIn35 = CryptographyDeprecationWarning
+DeprecatedIn36 = CryptographyDeprecationWarning
 
 
 def _check_bytes(name: str, value: bytes) -> None:

--- a/src/cryptography/x509/__init__.py
+++ b/src/cryptography/x509/__init__.py
@@ -5,7 +5,9 @@
 
 from cryptography.x509 import certificate_transparency
 from cryptography.x509.base import (
+    Attribute,
     AttributeNotFound,
+    Attributes,
     Certificate,
     CertificateBuilder,
     CertificateRevocationList,
@@ -173,7 +175,9 @@ __all__ = [
     "load_pem_x509_crl",
     "load_der_x509_crl",
     "random_serial_number",
+    "Attribute",
     "AttributeNotFound",
+    "Attributes",
     "InvalidVersion",
     "DeltaCRLIndicator",
     "DuplicateExtension",


### PR DESCRIPTION
fixes #6056 

This PR deprecates `request.get_attribute_for_oid` and replaces it with `request.attributes.get_attribute_for_oid`. It also adds a `request.attributes` iterable that returns `Attribute` objects. `Attribute` objects hold an oid, byte value, and a (private) ASN.1 type tag. This is distinct from `_ASN1Type` we use in other areas, as the type of an extensions attribute is not representable by basic ASN.1 types.