### PR TITLE
type some more things in the tests

### DIFF
--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -371,6 +371,7 @@ class TestDSA(object):
             ),
             mode="rb",
         )
+        assert isinstance(key, dsa.DSAPrivateKey)
         pn = key.private_numbers()
         assert pn.public_numbers.parameter_numbers.p.bit_length() == 4096
         # Turn it back into a key to confirm that values this large pass
@@ -867,7 +868,7 @@ class TestDSASerialization(object):
         )
         with pytest.raises(TypeError):
             key.private_bytes(
-                "notencoding",
+                "notencoding",  # type: ignore[arg-type]
                 serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption(),
             )
@@ -882,7 +883,7 @@ class TestDSASerialization(object):
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",
+                "invalidformat",  # type: ignore[arg-type]
                 serialization.NoEncryption(),
             )
 
@@ -897,7 +898,7 @@ class TestDSASerialization(object):
             key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.TraditionalOpenSSL,
-                "notanencalg",
+                "notanencalg",  # type: ignore[arg-type]
             )
 
     def test_private_bytes_unsupported_encryption_type(self, backend):

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -852,7 +852,7 @@ class TestECSerialization(object):
         )
         with pytest.raises(TypeError):
             key.private_bytes(
-                "notencoding",
+                "notencoding",  # type: ignore[arg-type]
                 serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption(),
             )
@@ -868,7 +868,7 @@ class TestECSerialization(object):
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",
+                "invalidformat",  # type: ignore[arg-type]
                 serialization.NoEncryption(),
             )
 
@@ -884,7 +884,7 @@ class TestECSerialization(object):
             key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.TraditionalOpenSSL,
-                "notanencalg",
+                "notanencalg",  # type: ignore[arg-type]
             )
 
     def test_private_bytes_unsupported_encryption_type(self, backend):
@@ -994,7 +994,8 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
         )
         with pytest.raises(TypeError):
             key.public_bytes(
-                "notencoding", serialization.PublicFormat.SubjectPublicKeyInfo
+                "notencoding",  # type: ignore[arg-type]
+                serialization.PublicFormat.SubjectPublicKeyInfo,
             )
 
     @pytest.mark.parametrize(
@@ -1039,7 +1040,10 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
             ),
         )
         with pytest.raises(TypeError):
-            key.public_bytes(serialization.Encoding.PEM, "invalidformat")
+            key.public_bytes(
+                serialization.Encoding.PEM,
+                "invalidformat",  # type: ignore[arg-type]
+            )
 
     def test_public_bytes_pkcs1_unsupported(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
@@ -1280,11 +1284,12 @@ class TestECDH(object):
                 pemfile.read().encode(), None, backend
             ),
         )
+        assert isinstance(key, ec.EllipticCurvePrivateKey)
 
         with raises_unsupported_algorithm(
             exceptions._Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
         ):
-            key.exchange(None, key.public_key())
+            key.exchange(None, key.public_key())  # type: ignore[arg-type]
 
     def test_exchange_non_matching_curve(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
@@ -1296,6 +1301,7 @@ class TestECDH(object):
                 pemfile.read().encode(), None, backend
             ),
         )
+        assert isinstance(key, ec.EllipticCurvePrivateKey)
         public_key = EC_KEY_SECP384R1.public_numbers.public_key(backend)
 
         with pytest.raises(ValueError):

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -44,6 +44,7 @@ class TestPKCS12Loading(object):
             ),
             mode="rb",
         )
+        assert isinstance(key, ec.EllipticCurvePrivateKey)
         parsed_key, parsed_cert, parsed_more_certs = load_vectors_from_file(
             os.path.join("pkcs12", filename),
             lambda derfile: load_key_and_certificates(
@@ -51,6 +52,7 @@ class TestPKCS12Loading(object):
             ),
             mode="rb",
         )
+        assert isinstance(parsed_key, ec.EllipticCurvePrivateKey)
         assert parsed_cert == cert
         assert parsed_key.private_numbers() == key.private_numbers()
         assert parsed_more_certs == []
@@ -106,6 +108,7 @@ class TestPKCS12Loading(object):
             ),
             mode="rb",
         )
+        assert isinstance(key, ec.EllipticCurvePrivateKey)
         parsed_key, parsed_cert, parsed_more_certs = load_vectors_from_file(
             os.path.join("pkcs12", "no-cert-key-aes256cbc.p12"),
             lambda data: load_key_and_certificates(
@@ -113,6 +116,7 @@ class TestPKCS12Loading(object):
             ),
             mode="rb",
         )
+        assert isinstance(parsed_key, ec.EllipticCurvePrivateKey)
         assert parsed_key.private_numbers() == key.private_numbers()
         assert parsed_cert is None
         assert parsed_more_certs == []
@@ -199,7 +203,7 @@ class TestPKCS12Loading(object):
         assert pkcs12.cert is not None
         assert pkcs12.cert.certificate == cert
         assert pkcs12.cert.friendly_name == name
-        assert pkcs12.key is not None
+        assert isinstance(pkcs12.key, ec.EllipticCurvePrivateKey)
         assert pkcs12.key.private_numbers() == key.private_numbers()
         assert len(pkcs12.additional_certs) == 2
         assert pkcs12.additional_certs[0].certificate == cert2

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -11,7 +11,7 @@ import pytest
 from cryptography import x509
 from cryptography.exceptions import _Reasons
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
 from cryptography.hazmat.primitives.serialization import pkcs7
 
 from ...utils import load_vectors_from_file, raises_unsupported_algorithm
@@ -586,6 +586,7 @@ class TestPKCS7Builder(object):
             ),
             mode="rb",
         )
+        assert isinstance(rsa_key, rsa.RSAPrivateKey)
         rsa_cert = load_vectors_from_file(
             os.path.join("x509", "custom", "ca", "rsa_ca.pem"),
             loader=lambda pemfile: x509.load_pem_x509_certificate(
@@ -629,6 +630,7 @@ class TestPKCS7Builder(object):
             ),
             mode="rb",
         )
+        assert isinstance(rsa_key, rsa.RSAPrivateKey)
         builder = (
             pkcs7.PKCS7SignatureBuilder()
             .set_data(data)

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -536,7 +536,7 @@ class TestPEMSerialization(object):
                 pemfile.read().encode(), b"123456", backend
             ),
         )
-        assert pkey
+        assert isinstance(pkey, rsa.RSAPrivateKey)
 
         numbers = pkey.private_numbers()
         assert numbers.p == int(
@@ -835,7 +835,7 @@ class TestPEMSerialization(object):
                 pemfile.read().encode(), b"foobar", backend
             ),
         )
-        assert pkey
+        assert isinstance(pkey, rsa.RSAPrivateKey)
 
         numbers = pkey.private_numbers()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,7 +38,12 @@ def raises_unsupported_algorithm(reason):
     assert exc_info.value._reason is reason
 
 
-def load_vectors_from_file(filename, loader, mode="r"):
+T = typing.TypeVar("T")
+
+
+def load_vectors_from_file(
+    filename, loader: typing.Callable[..., T], mode="r"
+) -> T:
     with cryptography_vectors.open_vector_file(filename, mode) as vector_file:
         return loader(vector_file)
 


### PR DESCRIPTION
This PR defines a return type for `load_vectors_from_file`, which in turn expands typing significantly through our asymmetric tests. A followup PR extends the return type through `_load_cert`, which significantly expands type information in x509 tests.