### PR TITLE
more typing in the tests

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -15,7 +15,10 @@ from cryptography.hazmat.bindings._rust import x509 as rust_x509
 from cryptography.hazmat.primitives import constant_time, serialization
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from cryptography.hazmat.primitives.asymmetric.types import PUBLIC_KEY_TYPES
+from cryptography.hazmat.primitives.asymmetric.types import (
+    CERTIFICATE_PUBLIC_KEY_TYPES,
+    PUBLIC_KEY_TYPES,
+)
 from cryptography.x509.certificate_transparency import (
     SignedCertificateTimestamp,
 )
@@ -41,7 +44,9 @@ from cryptography.x509.oid import (
 ExtensionTypeVar = typing.TypeVar("ExtensionTypeVar", bound="ExtensionType")
 
 
-def _key_identifier_from_public_key(public_key: PUBLIC_KEY_TYPES) -> bytes:
+def _key_identifier_from_public_key(
+    public_key: CERTIFICATE_PUBLIC_KEY_TYPES,
+) -> bytes:
     if isinstance(public_key, RSAPublicKey):
         data = public_key.public_bytes(
             serialization.Encoding.DER,
@@ -209,6 +214,11 @@ class AuthorityKeyIdentifier(ExtensionType):
         self._authority_cert_issuer = authority_cert_issuer
         self._authority_cert_serial_number = authority_cert_serial_number
 
+    # This takes PUBLIC_KEY_TYPES and not CERTIFICATE_PUBLIC_KEY_TYPES
+    # because an issuer cannot have an X25519/X448 key. This introduces
+    # some unfortunate asymmetry that requires typing users to explicitly
+    # narrow their type, but we should make this accurate and not just
+    # convenient.
     @classmethod
     def from_issuer_public_key(
         cls, public_key: PUBLIC_KEY_TYPES
@@ -287,7 +297,7 @@ class SubjectKeyIdentifier(ExtensionType):
 
     @classmethod
     def from_public_key(
-        cls, public_key: PUBLIC_KEY_TYPES
+        cls, public_key: CERTIFICATE_PUBLIC_KEY_TYPES
     ) -> "SubjectKeyIdentifier":
         return cls(_key_identifier_from_public_key(public_key))
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -632,7 +632,7 @@ def test_pyopenssl_cert_fallback():
     )
     x509_ossl = None
     with pytest.warns(utils.CryptographyDeprecationWarning):
-        x509_ossl = cert._x509
+        x509_ossl = cert._x509  # type:ignore[attr-defined]
     assert x509_ossl is not None
 
     from cryptography.hazmat.backends.openssl.x509 import _Certificate
@@ -648,7 +648,7 @@ def test_pyopenssl_csr_fallback():
     )
     req_ossl = None
     with pytest.warns(utils.CryptographyDeprecationWarning):
-        req_ossl = cert._x509_req
+        req_ossl = cert._x509_req  # type:ignore[attr-defined]
     assert req_ossl is not None
 
     from cryptography.hazmat.backends.openssl.x509 import (
@@ -666,7 +666,7 @@ def test_pyopenssl_crl_fallback():
     )
     req_crl = None
     with pytest.warns(utils.CryptographyDeprecationWarning):
-        req_crl = cert._x509_crl
+        req_crl = cert._x509_crl  # type:ignore[attr-defined]
     assert req_crl is not None
 
     from cryptography.hazmat.backends.openssl.x509 import (

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -12,7 +12,7 @@ import pytest
 from cryptography import x509
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec, ed25519, ed448
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, ed448, rsa
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.x509 import ocsp
 
@@ -1009,7 +1009,9 @@ class TestOCSPResponse(object):
             b"mMEfd265tE5t6ZFZe/zqOyhAhIDHHh6fckClQB7xfIiCztSevCAABgPMjAxODA4"
             b"MzAxMTAwMDBaoBEYDzIwMTgwOTA2MTEwMDAwWg=="
         )
-        issuer.public_key().verify(
+        public_key = issuer.public_key()
+        assert isinstance(public_key, rsa.RSAPublicKey)
+        public_key.verify(
             resp.signature,
             resp.tbs_response_bytes,
             PKCS1v15(),

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -17,7 +17,7 @@ from cryptography import x509
 from cryptography.hazmat._oid import _OID_NAMES
 from cryptography.hazmat.bindings._rust import x509 as rust_x509
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509 import (
     DNSName,
     NameConstraints,
@@ -1486,8 +1486,7 @@ class TestExtensions(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        extensions = cert.extensions
-        ext = extensions.get_extension_for_oid(ExtensionOID.BASIC_CONSTRAINTS)
+        ext = cert.extensions.get_extension_for_class(x509.BasicConstraints)
         assert ext is not None
         assert ext.value.ca is False
 
@@ -1513,6 +1512,7 @@ class TestExtensions(object):
         ext = cert.extensions.get_extension_for_oid(
             x509.ObjectIdentifier("1.2.3.4")
         )
+        assert isinstance(ext.value, x509.UnrecognizedExtension)
         assert ext.value.value == b"value"
 
     def test_unsupported_extension(self, backend):
@@ -1575,7 +1575,6 @@ class TestExtensions(object):
         )
         ext = cert.extensions.get_extension_for_class(x509.BasicConstraints)
         assert ext is not None
-        assert isinstance(ext.value, x509.BasicConstraints)
 
     def test_repr(self, backend):
         cert = _load_cert(
@@ -1601,9 +1600,7 @@ class TestBasicConstraintsExtension(object):
             x509.load_der_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.BASIC_CONSTRAINTS
-        )
+        ext = cert.extensions.get_extension_for_class(x509.BasicConstraints)
         assert ext is not None
         assert ext.critical is True
         assert ext.value.ca is True
@@ -1615,9 +1612,7 @@ class TestBasicConstraintsExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.BASIC_CONSTRAINTS
-        )
+        ext = cert.extensions.get_extension_for_class(x509.BasicConstraints)
         assert ext is not None
         assert ext.critical is True
         assert ext.value.ca is True
@@ -1629,9 +1624,7 @@ class TestBasicConstraintsExtension(object):
             x509.load_der_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.BASIC_CONSTRAINTS
-        )
+        ext = cert.extensions.get_extension_for_class(x509.BasicConstraints)
         assert ext is not None
         assert ext.critical is True
         assert ext.value.ca is True
@@ -1643,9 +1636,7 @@ class TestBasicConstraintsExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.BASIC_CONSTRAINTS
-        )
+        ext = cert.extensions.get_extension_for_class(x509.BasicConstraints)
         assert ext is not None
         assert ext.critical is True
         assert ext.value.ca is False
@@ -1675,9 +1666,7 @@ class TestBasicConstraintsExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.BASIC_CONSTRAINTS
-        )
+        ext = cert.extensions.get_extension_for_class(x509.BasicConstraints)
         assert ext is not None
         assert ext.critical is False
         assert ext.value.ca is False
@@ -1690,8 +1679,8 @@ class TestSubjectKeyIdentifierExtension(object):
             x509.load_der_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_KEY_IDENTIFIER
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier
         )
         ski = ext.value
         assert ext is not None
@@ -1845,8 +1834,7 @@ class TestKeyUsageExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        extensions = cert.extensions
-        ext = extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE)
+        ext = cert.extensions.get_extension_for_class(x509.KeyUsage)
         assert ext is not None
 
         ku = ext.value
@@ -1868,7 +1856,7 @@ class TestKeyUsageExtension(object):
             x509.load_der_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE)
+        ext = cert.extensions.get_extension_for_class(x509.KeyUsage)
         assert ext is not None
         assert ext.critical is True
 
@@ -2324,8 +2312,8 @@ class TestRSAIssuerAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.ISSUER_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.IssuerAlternativeName
         )
         assert list(ext.value) == [
             x509.UniformResourceIdentifier("http://path.to.root/root.crt"),
@@ -2441,8 +2429,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         assert ext.critical is False
@@ -2458,8 +2446,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
 
         dns = ext.value.get_values_for_type(x509.DNSName)
@@ -2480,6 +2468,7 @@ class TestRSASubjectAlternativeNameExtension(object):
             ExtensionOID.SUBJECT_ALTERNATIVE_NAME
         )
 
+        assert isinstance(san.value, x509.SubjectAlternativeName)
         dns = san.value.get_values_for_type(x509.DNSName)
         assert dns == [""]
 
@@ -2489,8 +2478,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
 
         dns = ext.value.get_values_for_type(x509.DNSName)
@@ -2511,8 +2500,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         assert ext.critical is False
@@ -2527,8 +2516,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         uri = ext.value.get_values_for_type(x509.UniformResourceIdentifier)
@@ -2543,8 +2532,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         assert ext.critical is False
@@ -2563,8 +2552,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         assert ext.critical is False
@@ -2590,8 +2579,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         assert ext.critical is False
@@ -2621,8 +2610,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         rfc822_name = ext.value.get_values_for_type(x509.RFC822Name)
@@ -2638,8 +2627,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         assert ext.critical is False
@@ -2694,8 +2683,8 @@ class TestRSASubjectAlternativeNameExtension(object):
             backend,
         )
 
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
         )
         assert ext is not None
         assert ext.critical is False
@@ -2738,9 +2727,7 @@ class TestExtendedKeyUsageExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.EXTENDED_KEY_USAGE
-        )
+        ext = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
         assert ext is not None
         assert ext.critical is False
 
@@ -3509,8 +3496,8 @@ class TestAuthorityKeyIdentifierExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+        ext = cert.extensions.get_extension_for_class(
+            x509.AuthorityKeyIdentifier
         )
         assert ext is not None
         assert ext.critical is False
@@ -3527,8 +3514,8 @@ class TestAuthorityKeyIdentifierExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+        ext = cert.extensions.get_extension_for_class(
+            x509.AuthorityKeyIdentifier
         )
         assert ext is not None
         assert ext.critical is False
@@ -3558,8 +3545,8 @@ class TestAuthorityKeyIdentifierExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        ext = cert.extensions.get_extension_for_oid(
-            ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+        ext = cert.extensions.get_extension_for_class(
+            x509.AuthorityKeyIdentifier
         )
         assert ext is not None
         assert ext.critical is False
@@ -3593,9 +3580,9 @@ class TestAuthorityKeyIdentifierExtension(object):
         ext = cert.extensions.get_extension_for_oid(
             ExtensionOID.AUTHORITY_KEY_IDENTIFIER
         )
-        aki = x509.AuthorityKeyIdentifier.from_issuer_public_key(
-            issuer_cert.public_key()
-        )
+        public_key = issuer_cert.public_key()
+        assert isinstance(public_key, rsa.RSAPublicKey)
+        aki = x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key)
         assert ext.value == aki
 
     def test_from_issuer_subject_key_identifier(self, backend):
@@ -5165,8 +5152,8 @@ class TestInhibitAnyPolicyExtension(object):
             x509.load_pem_x509_certificate,
             backend,
         )
-        iap = cert.extensions.get_extension_for_oid(
-            ExtensionOID.INHIBIT_ANY_POLICY
+        iap = cert.extensions.get_extension_for_class(
+            x509.InhibitAnyPolicy
         ).value
         assert iap.skip_certs == 5
 


### PR DESCRIPTION
This adds typing to `_load_cert` and now that it returns a real type we can improve our tests (and switch to using our better APIs that do more effective type narrowing in many cases).

One nuance here is that now that we allow x25519/x448 as public key types we have an odd asymmetry where it's sane to encode that in SKI but nonsensical to have it in AKI. I've left the mypy types such that this is the case (although you can defeat the typing by generating an SKI and then create the AKI from SKI. Sorry, Python typing isn't expressive enough to prevent that).