### PR TITLE
fixes #6404 -- attempt to treat OCSP Nonce as being an octet string

### DIFF
--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -367,7 +367,7 @@ pub(crate) fn encode_extension(
         Ok(Some(asn1::write_single(&idp)))
     } else if oid == &*oid::NONCE_OID {
         let nonce = ext.getattr("nonce")?.extract::<&[u8]>()?;
-        Ok(Some(nonce.to_vec()))
+        Ok(Some(asn1::write_single(&nonce)))
     } else {
         Ok(None)
     }

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -111,9 +111,10 @@ impl OCSPRequest {
                     // just the raw extension value. This is nonsense, since they're always
                     // supposed to be ASN.1 TLVs. RFC 6960 correctly specifies that the
                     // nonce is an OCTET STRING, and so you should unwrap the TLV to get
-                    // the nonce. For now we just implement the old behavior, even though
-                    // it's deranged.
-                    Ok(Some(x509_module.call_method1("OCSPNonce", (value,))?))
+                    // the nonce. So we try parsing as a TLV and fall back to just using
+                    // the raw value.
+                    let nonce = asn1::parse_single::<&[u8]>(value).unwrap_or(value);
+                    Ok(Some(x509_module.call_method1("OCSPNonce", (nonce,))?))
                 } else {
                     Ok(None)
                 }

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -351,9 +351,10 @@ impl OCSPResponse {
                     // just the raw extension value. This is nonsense, since they're always
                     // supposed to be ASN.1 TLVs. RFC 6960 correctly specifies that the
                     // nonce is an OCTET STRING, and so you should unwrap the TLV to get
-                    // the nonce. For now we just implement the old behavior, even though
-                    // it's deranged.
-                    Ok(Some(x509_module.call_method1("OCSPNonce", (ext_data,))?))
+                    // the nonce. So we try parsing as a TLV and fall back to just using
+                    // the raw value.
+                    let nonce = asn1::parse_single::<&[u8]>(ext_data).unwrap_or(ext_data);
+                    Ok(Some(x509_module.call_method1("OCSPNonce", (nonce,))?))
                 } else {
                     Ok(None)
                 }

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -103,7 +103,7 @@ class TestOCSPRequest(object):
         ext = req.extensions[0]
         assert ext.critical is False
         assert ext.value == x509.OCSPNonce(
-            b"\x04\x10{\x80Z\x1d7&\xb8\xb8OH\xd2\xf8\xbf\xd7-\xfd"
+            b"{\x80Z\x1d7&\xb8\xb8OH\xd2\xf8\xbf\xd7-\xfd"
         )
 
     def test_load_request_with_unknown_extension(self):
@@ -1159,7 +1159,7 @@ class TestOCSPResponse(object):
         ext = resp.extensions[0]
         assert ext.critical is False
         assert ext.value == x509.OCSPNonce(
-            b'\x04\x105\x957\x9fa\x03\x83\x87\x89rW\x8f\xae\x99\xf7"'
+            b'5\x957\x9fa\x03\x83\x87\x89rW\x8f\xae\x99\xf7"'
         )
 
     def test_response_unknown_extension(self):

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -6121,7 +6121,7 @@ class TestOCSPNonce(object):
 
     def test_public_bytes(self):
         ext = x509.OCSPNonce(b"0" * 5)
-        assert ext.public_bytes() == b"00000"
+        assert ext.public_bytes() == b"\x04\x0500000"
 
 
 def test_all_extension_oid_members_have_names_defined():


### PR DESCRIPTION
This is an awful hybrid, but hopefully puts us on a path to removing this nonsense