### PR TITLE
refactor cipher to reduce indirection and add typing

### DIFF
--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -6,12 +6,6 @@
 import abc
 import typing
 
-from cryptography import utils
-from cryptography.exceptions import (
-    AlreadyFinalized,
-    AlreadyUpdated,
-    NotYetFinalized,
-)
 from cryptography.hazmat.primitives._cipheralgorithm import CipherAlgorithm
 from cryptography.hazmat.primitives.ciphers import modes
 
@@ -37,31 +31,38 @@ class CipherContext(metaclass=abc.ABCMeta):
         Returns the results of processing the final block as bytes.
         """
 
-
-class AEADCipherContext(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def authenticate_additional_data(self, data: bytes) -> None:
         """
-        Authenticates the provided bytes.
+        Authenticates the provided bytes. This method is only relevant for
+        AEAD cipher/mode combinations.
         """
 
-
-class AEADDecryptionContext(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def finalize_with_tag(self, tag: bytes) -> bytes:
         """
         Returns the results of processing the final block as bytes and allows
-        delayed passing of the authentication tag.
+        delayed passing of the authentication tag. This method is only
+        relevant for AEAD cipher/mode combinations.
         """
 
-
-class AEADEncryptionContext(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def tag(self) -> bytes:
         """
         Returns tag bytes. This is only available after encryption is
-        finalized.
+        finalized. This property is only relevant for AEAD cipher/mode
+        combinations.
         """
+
+
+# Prior to 36.0 cryptography returned different interfaces based on the
+# cipher/mode combination returned. This resulted in a significant amount
+# of (slow) indirection and made typing very difficult. All methods have
+# now been added to the CipherContext itself and the previous context names
+# are just aliases for compatibility.
+AEADCipherContext = CipherContext
+AEADDecryptionContext = CipherContext
+AEADEncryptionContext = CipherContext
 
 
 class Cipher(object):
@@ -81,7 +82,7 @@ class Cipher(object):
         self.algorithm = algorithm
         self.mode = mode
 
-    def encryptor(self):
+    def encryptor(self) -> CipherContext:
         if isinstance(self.mode, modes.ModeWithAuthenticationTag):
             if self.mode.tag is not None:
                 raise ValueError(
@@ -89,123 +90,13 @@ class Cipher(object):
                 )
         from cryptography.hazmat.backends.openssl.backend import backend
 
-        ctx = backend.create_symmetric_encryption_ctx(
+        return backend.create_symmetric_encryption_ctx(
             self.algorithm, self.mode
         )
-        return self._wrap_ctx(ctx, encrypt=True)
 
-    def decryptor(self):
+    def decryptor(self) -> CipherContext:
         from cryptography.hazmat.backends.openssl.backend import backend
 
-        ctx = backend.create_symmetric_decryption_ctx(
+        return backend.create_symmetric_decryption_ctx(
             self.algorithm, self.mode
         )
-        return self._wrap_ctx(ctx, encrypt=False)
-
-    def _wrap_ctx(self, ctx, encrypt):
-        if isinstance(self.mode, modes.ModeWithAuthenticationTag):
-            if encrypt:
-                return _AEADEncryptionContext(ctx)
-            else:
-                return _AEADCipherContext(ctx)
-        else:
-            return _CipherContext(ctx)
-
-
-@utils.register_interface(CipherContext)
-class _CipherContext(object):
-    def __init__(self, ctx):
-        self._ctx = ctx
-
-    def update(self, data: bytes) -> bytes:
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        return self._ctx.update(data)
-
-    def update_into(self, data: bytes, buf) -> int:
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        return self._ctx.update_into(data, buf)
-
-    def finalize(self) -> bytes:
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        data = self._ctx.finalize()
-        self._ctx = None
-        return data
-
-
-@utils.register_interface(AEADCipherContext)
-@utils.register_interface(CipherContext)
-@utils.register_interface(AEADDecryptionContext)
-class _AEADCipherContext(object):
-    def __init__(self, ctx):
-        self._ctx = ctx
-        self._bytes_processed = 0
-        self._aad_bytes_processed = 0
-        self._tag = None
-        self._updated = False
-
-    def _check_limit(self, data_size: int) -> None:
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        self._updated = True
-        self._bytes_processed += data_size
-        if self._bytes_processed > self._ctx._mode._MAX_ENCRYPTED_BYTES:
-            raise ValueError(
-                "{} has a maximum encrypted byte limit of {}".format(
-                    self._ctx._mode.name, self._ctx._mode._MAX_ENCRYPTED_BYTES
-                )
-            )
-
-    def update(self, data: bytes) -> bytes:
-        self._check_limit(len(data))
-        return self._ctx.update(data)
-
-    def update_into(self, data: bytes, buf) -> int:
-        self._check_limit(len(data))
-        return self._ctx.update_into(data, buf)
-
-    def finalize(self) -> bytes:
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        data = self._ctx.finalize()
-        self._tag = self._ctx.tag
-        self._ctx = None
-        return data
-
-    def finalize_with_tag(self, tag: bytes) -> bytes:
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        data = self._ctx.finalize_with_tag(tag)
-        self._tag = self._ctx.tag
-        self._ctx = None
-        return data
-
-    def authenticate_additional_data(self, data: bytes) -> None:
-        if self._ctx is None:
-            raise AlreadyFinalized("Context was already finalized.")
-        if self._updated:
-            raise AlreadyUpdated("Update has been called on this context.")
-
-        self._aad_bytes_processed += len(data)
-        if self._aad_bytes_processed > self._ctx._mode._MAX_AAD_BYTES:
-            raise ValueError(
-                "{} has a maximum AAD byte limit of {}".format(
-                    self._ctx._mode.name, self._ctx._mode._MAX_AAD_BYTES
-                )
-            )
-
-        self._ctx.authenticate_additional_data(data)
-
-
-@utils.register_interface(AEADEncryptionContext)
-class _AEADEncryptionContext(_AEADCipherContext):
-    @property
-    def tag(self) -> bytes:
-        if self._ctx is not None:
-            raise NotYetFinalized(
-                "You must finalize encryption before " "getting the tag."
-            )
-        assert self._tag is not None
-        return self._tag

--- a/src/cryptography/hazmat/primitives/keywrap.py
+++ b/src/cryptography/hazmat/primitives/keywrap.py
@@ -120,10 +120,10 @@ def aes_key_unwrap_with_padding(
     if len(wrapped_key) == 16:
         # RFC 5649 - 4.2 - exactly two 64-bit blocks
         decryptor = Cipher(AES(wrapping_key), ECB()).decryptor()
-        b = decryptor.update(wrapped_key)
+        bb = decryptor.update(wrapped_key)
         assert decryptor.finalize() == b""
-        a = b[:8]
-        data = b[8:]
+        a = bb[:8]
+        data = bb[8:]
         n = 1
     else:
         r = [wrapped_key[i : i + 8] for i in range(0, len(wrapped_key), 8)]

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -71,9 +71,13 @@ class TestAESModeGCM(object):
             modes.GCM(b"\x01" * 16),
             backend=backend,
         ).encryptor()
-        encryptor._bytes_processed = modes.GCM._MAX_ENCRYPTED_BYTES - 16
+        new_val = modes.GCM._MAX_ENCRYPTED_BYTES - 16
+        encryptor._bytes_processed = new_val  # type: ignore[attr-defined]
         encryptor.update(b"0" * 16)
-        assert encryptor._bytes_processed == modes.GCM._MAX_ENCRYPTED_BYTES
+        assert (
+            encryptor._bytes_processed  # type: ignore[attr-defined]
+            == modes.GCM._MAX_ENCRYPTED_BYTES
+        )
         with pytest.raises(ValueError):
             encryptor.update(b"0")
 
@@ -83,9 +87,13 @@ class TestAESModeGCM(object):
             modes.GCM(b"\x01" * 16),
             backend=backend,
         ).encryptor()
-        encryptor._aad_bytes_processed = modes.GCM._MAX_AAD_BYTES - 16
+        new_val = modes.GCM._MAX_AAD_BYTES - 16
+        encryptor._aad_bytes_processed = new_val  # type: ignore[attr-defined]
         encryptor.authenticate_additional_data(b"0" * 16)
-        assert encryptor._aad_bytes_processed == modes.GCM._MAX_AAD_BYTES
+        assert (
+            encryptor._aad_bytes_processed  # type: ignore[attr-defined]
+            == modes.GCM._MAX_AAD_BYTES
+        )
         with pytest.raises(ValueError):
             encryptor.authenticate_additional_data(b"0")
 
@@ -96,11 +104,11 @@ class TestAESModeGCM(object):
             backend=backend,
         ).encryptor()
         encryptor.update(b"0" * 8)
-        assert encryptor._bytes_processed == 8
+        assert encryptor._bytes_processed == 8  # type: ignore[attr-defined]
         encryptor.update(b"0" * 7)
-        assert encryptor._bytes_processed == 15
+        assert encryptor._bytes_processed == 15  # type: ignore[attr-defined]
         encryptor.update(b"0" * 18)
-        assert encryptor._bytes_processed == 33
+        assert encryptor._bytes_processed == 33  # type: ignore[attr-defined]
 
     def test_gcm_aad_increments(self, backend):
         encryptor = base.Cipher(
@@ -109,9 +117,13 @@ class TestAESModeGCM(object):
             backend=backend,
         ).encryptor()
         encryptor.authenticate_additional_data(b"0" * 8)
-        assert encryptor._aad_bytes_processed == 8
+        assert (
+            encryptor._aad_bytes_processed == 8  # type: ignore[attr-defined]
+        )
         encryptor.authenticate_additional_data(b"0" * 18)
-        assert encryptor._aad_bytes_processed == 26
+        assert (
+            encryptor._aad_bytes_processed == 26  # type: ignore[attr-defined]
+        )
 
     def test_gcm_tag_decrypt_none(self, backend):
         key = binascii.unhexlify(b"5211242698bed4774a090620a6ca56f3")

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -325,14 +325,14 @@ class TestCipherUpdateInto(object):
         c = ciphers.Cipher(AES(key), modes.ECB(), backend)
         encryptor = c.encryptor()
         # Lower max chunk size so we can test chunking
-        monkeypatch.setattr(encryptor._ctx, "_MAX_CHUNK_SIZE", 40)
+        monkeypatch.setattr(encryptor, "_MAX_CHUNK_SIZE", 40)
         buf = bytearray(527)
         pt = b"abcdefghijklmnopqrstuvwxyz012345" * 16  # 512 bytes
         processed = encryptor.update_into(pt, buf)
         assert processed == 512
         decryptor = c.decryptor()
         # Change max chunk size to verify alternate boundaries don't matter
-        monkeypatch.setattr(decryptor._ctx, "_MAX_CHUNK_SIZE", 73)
+        monkeypatch.setattr(decryptor, "_MAX_CHUNK_SIZE", 73)
         decbuf = bytearray(527)
         decprocessed = decryptor.update_into(buf[:processed], decbuf)
         assert decbuf[:decprocessed] == pt
@@ -344,4 +344,6 @@ class TestCipherUpdateInto(object):
         key = b"\x00" * 16
         c = ciphers.Cipher(AES(key), modes.ECB(), backend)
         encryptor = c.encryptor()
-        backend._ffi.new("int *", encryptor._ctx._MAX_CHUNK_SIZE)
+        backend._ffi.new(
+            "int *", encryptor._MAX_CHUNK_SIZE  # type: ignore[attr-defined]
+        )


### PR DESCRIPTION
In draft to discuss the approach.

This PR attempts to significantly change our approach to CipherContexts and reduce indirection while doing it. Our public API has been documented to return different interfaces depending on the cipher/mode combination as well as whether you're encrypting/decrypting. This has made typing exceedingly difficult. Rather than attempt to conform to those choices this PR instead collapses all interfaces into `CipherContext` and returns the underlying `_CipherContext` object in the OpenSSL backend rather than wrap it. This lowers function call overhead, but exposes methods that have no meaning (e.g. `authenticate_additional_data` on non-AEAD, etc). To exactly mimic the previous behavior these methods/properties raise `AttributeError` if called when they shouldn't be accessible.

If we decide we want to move forward this PR is incomplete and still needs:

- [ ] Tests for accessing methods with no meaning for the current cipher/mode combo
- [ ] Documentation updates for changes to CipherContext interfaces

I'm not sure this is really a win, although being able to return type information is good.