### PR TITLE
switch to .tar.xz for the vectors

### DIFF
--- a/vectors/setup.cfg
+++ b/vectors/setup.cfg
@@ -16,3 +16,6 @@ packages = find:
 
 [bdist_wheel]
 universal = 1
+
+[sdist]
+formats = xztar


### PR DESCRIPTION
This only saves 6MB, but why not. No change for cryptography itself