### PR TITLE
fix: fixed confusing typo on DSA docs

### DIFF
--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -49,7 +49,7 @@ Generation
 
     Generate DSA parameters.
 
-    :param int key_size: The length of :attr:`~DSAParameterNumbers.q`. It
+    :param int key_size: The length of :attr:`~DSAParameterNumbers.p`. It
         should be either 1024, 2048, 3072, or 4096. For keys generated in 2015
         this should be `at least 2048`_ (See page 41).
 


### PR DESCRIPTION
From the looks of it, this is just a typo but it was a bit confusing when reading it since the bit length of `q` is not any of the numbers listed, but the bit length of `p` is supposed to be