### PR TITLE
add macos arm64 self-hosted CI

### DIFF
--- a/.github/workflows/macarm64.yml
+++ b/.github/workflows/macarm64.yml
@@ -1,0 +1,69 @@
+name: macOS arm64 CI
+on:
+  push:
+    branches:
+      - main
+      - '*.*.x'
+    tags:
+      - '*.*'
+      - '*.*.*'
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  macos-arm64:
+    if: github.repository_owner == 'pyca'
+    runs-on: [self-hosted, macos, ARM64]
+    name: "macOS arm64"
+    strategy:
+      fail-fast: false
+      matrix:
+        PYTHON:
+          - {TOXENV: "py310", BIN_PATH: '/Library/Frameworks/Python.framework/Versions/3.10/bin/python3'}
+    timeout-minutes: 10
+    steps:
+      - name: "Delete workspace" # self-hosted runners need this, sigh
+        run: gfind ! -name '.' ! -name '..' -delete
+      - uses: actions/checkout@v2.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/cache@v2.1.7
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src/rust/target/
+          key: ${{ runner.os }}-${{ matrix.PYTHON.TOXENV }}-cargo-macarm64-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: actions/checkout@v2.4.0
+        with:
+          repository: "google/wycheproof"
+          path: "wycheproof"
+          ref: "master"
+      - name: Setup venv and install deps
+        run: |
+          arch -arm64 $BIN_PATH -m venv venv
+          arch -arm64 venv/bin/python -m pip install tox requests
+        env:
+          BIN_PATH: ${{ matrix.PYTHON.BIN_PATH }}
+      - name: Download OpenSSL
+        run: |
+          arch -arm64 venv/bin/python .github/workflows/download_openssl.py macos openssl-macos-universal2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tests
+        run: |
+          CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1 \
+            LDFLAGS="${HOME}/openssl-macos-universal2/lib/libcrypto.a ${HOME}/openssl-macos-universal2/lib/libssl.a" \
+            CFLAGS="-I${HOME}/openssl-macos-universal2/include -Werror -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=unused-function -Wno-error=unused-command-line-argument $EXTRA_CFLAGS" \
+            arch -arm64 venv/bin/tox -r --  --color=yes --wycheproof-root=wycheproof
+        env:
+          TOXENV: ${{ matrix.PYTHON.TOXENV }}
+          ARCHFLAGS: '-arch arm64'
+          CARGO_TARGET_DIR: ${{ format('{0}/src/rust/target/', github.workspace) }}

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,14 @@ commands =
     pip list
     pytest -n auto --durations=10 {posargs} tests/
 
+# Temp coverage disable for macOS arm64 because CTracer isn't compiling
+# probably due to the crazy rosetta arch -arm64 shenanigans
+[testenv:macos-nocoverage]
+basepython = python3
+commands =
+    pip list
+    pytest -n auto --durations=10 {posargs} tests/
+
 [testenv:docs]
 extras =
     docs


### PR DESCRIPTION
Sample run here: https://github.com/pyca/cryptography/actions/runs/1530356575

Doesn't run on PRs just like our arm64 linux runners. Coverage disabled because I didn't feel like figuring out why CTracer wasn't building (incidentally it takes ~4.5 min to run the test suite even with pure Python coverage on an M1).

All the `arch -arm64` prefixes are because the GHA runner is running under rosetta2 so we need to explicitly invoke the binaries as arm64 instead.