### PR TITLE
Added init defaults to classes in x509.extensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Changelog
   and ``x86_64`` architectures. Users on macOS should upgrade to the latest
   ``pip`` to ensure they can use this wheel, although we will continue to
   ship ``x86_64`` specific wheels for now to ease the transition.
+* Added defaults to several class __init__ to make code more succinct.
 
 .. _v36-0-0:
 

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -183,9 +183,9 @@ class AuthorityKeyIdentifier(ExtensionType):
 
     def __init__(
         self,
-        key_identifier: typing.Optional[bytes],
-        authority_cert_issuer: typing.Optional[typing.Iterable[GeneralName]],
-        authority_cert_serial_number: typing.Optional[int],
+        key_identifier: typing.Optional[bytes] = None,
+        authority_cert_issuer: typing.Optional[typing.Iterable[GeneralName]] = None,
+        authority_cert_serial_number: typing.Optional[int] = None,
     ) -> None:
         if (authority_cert_issuer is None) != (
             authority_cert_serial_number is None
@@ -446,7 +446,7 @@ class AccessDescription(object):
 class BasicConstraints(ExtensionType):
     oid = ExtensionOID.BASIC_CONSTRAINTS
 
-    def __init__(self, ca: bool, path_length: typing.Optional[int]) -> None:
+    def __init__(self, ca: bool, path_length: typing.Optional[int] = None) -> None:
         if not isinstance(ca, bool):
             raise TypeError("ca must be a boolean value")
 
@@ -1179,15 +1179,15 @@ class KeyUsage(ExtensionType):
 
     def __init__(
         self,
-        digital_signature: bool,
-        content_commitment: bool,
-        key_encipherment: bool,
-        data_encipherment: bool,
-        key_agreement: bool,
-        key_cert_sign: bool,
-        crl_sign: bool,
-        encipher_only: bool,
-        decipher_only: bool,
+        digital_signature: bool = False,
+        content_commitment: bool = False,
+        key_encipherment: bool = False,
+        data_encipherment: bool = False,
+        key_agreement: bool = False,
+        key_cert_sign: bool = False,
+        crl_sign: bool = False,
+        encipher_only: bool = False,
+        decipher_only: bool = False,
     ) -> None:
         if not key_agreement and (encipher_only or decipher_only):
             raise ValueError(
@@ -2003,13 +2003,13 @@ class IssuingDistributionPoint(ExtensionType):
 
     def __init__(
         self,
-        full_name: typing.Optional[typing.Iterable[GeneralName]],
-        relative_name: typing.Optional[RelativeDistinguishedName],
-        only_contains_user_certs: bool,
-        only_contains_ca_certs: bool,
-        only_some_reasons: typing.Optional[typing.FrozenSet[ReasonFlags]],
-        indirect_crl: bool,
-        only_contains_attribute_certs: bool,
+        full_name: typing.Optional[typing.Iterable[GeneralName]] = None,
+        relative_name: typing.Optional[RelativeDistinguishedName] = None,
+        only_contains_user_certs: bool = False,
+        only_contains_ca_certs: bool = False,
+        only_some_reasons: typing.Optional[typing.FrozenSet[ReasonFlags]] = None,
+        indirect_crl: bool = False,
+        only_contains_attribute_certs: bool = False,
     ) -> None:
         if full_name is not None:
             full_name = list(full_name)


### PR DESCRIPTION
I added several defaults to class initialization methods for parameters which were already considered to be optional, but were created as positional (required) arguments.  With this change, users creating instances of these classes do not have to add several `None` or `False` arguments for the sake of satisfying the initialization, which only makes the code more confusing.  Instead, by changing them to keyword arguments, with defaults, code can be more succinct. 

Example Before:
```python
from cryptography import x509
x509.KeyUsage(True, False, False, False, False, True, True, False, False)  # Unclear what these mean
```

Example After:
```python
from cryptography import x509
x509.KeyUsage(digital_signature=True, key_cert_sign=True, crl_sign=True)  # Clear what usage is being configured
```

Because python allows keyword arguments to be set using positional arguments, this should be a non-breaking change.