### PR TITLE
Increased minimum macOS version to 10.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
         run: |
           CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1 \
             LDFLAGS="${HOME}/openssl-macos-x86-64/lib/libcrypto.a ${HOME}/openssl-macos-x86-64/lib/libssl.a" \
-            CFLAGS="-I${HOME}/openssl-macos-x86-64/include -Werror -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=unused-function -Wno-error=unused-command-line-argument -mmacosx-version-min=10.10 -march=core2 $EXTRA_CFLAGS" \
+            CFLAGS="-I${HOME}/openssl-macos-x86-64/include -Werror -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=unused-function -Wno-error=unused-command-line-argument -mmacosx-version-min=10.11 -march=core2 $EXTRA_CFLAGS" \
             tox -r --  --color=yes --wycheproof-root=wycheproof
         env:
           TOXENV: ${{ matrix.PYTHON.TOXENV }}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -88,7 +88,7 @@ jobs:
             # Despite the name, this is built for the macOS 11 SDK on arm64 and 10.9+ on intel
             DOWNLOAD_URL: 'https://www.python.org/ftp/python/3.10.0/python-3.10.0post2-macos11.pkg'
             BIN_PATH: '/Library/Frameworks/Python.framework/Versions/3.10/bin/python3'
-            DEPLOYMENT_TARGET: '10.10'
+            DEPLOYMENT_TARGET: '10.11'
             # This archflags is default, but let's be explicit
             ARCHFLAGS: '-arch x86_64 -arch arm64'
             # See https://github.com/pypa/cibuildwheel/blob/c8876b5c54a6c6b08de5d4b1586906b56203bd9e/cibuildwheel/macos.py#L257-L269
@@ -99,7 +99,7 @@ jobs:
             ABI_VERSION: 'cp36'
             DOWNLOAD_URL: 'https://www.python.org/ftp/python/3.10.0/python-3.10.0post2-macos11.pkg'
             BIN_PATH: '/Library/Frameworks/Python.framework/Versions/3.10/bin/python3'
-            DEPLOYMENT_TARGET: '10.10'
+            DEPLOYMENT_TARGET: '10.11'
             # We continue to build a non-universal2 for a bit to see metrics on
             # download counts (this is a proxy for pip version since universal2
             # requires a 21.x pip)
@@ -107,7 +107,7 @@ jobs:
             _PYTHON_HOST_PLATFORM: 'macosx-10.9-x86_64'
           - VERSION: 'pypy-3.8'
             BIN_PATH: 'pypy3'
-            DEPLOYMENT_TARGET: '10.10'
+            DEPLOYMENT_TARGET: '10.11'
             _PYTHON_HOST_PLATFORM: 'macosx-10.9-x86_64'
             ARCHFLAGS: '-arch x86_64'
     name: "${{ matrix.PYTHON.VERSION }} ABI ${{ matrix.PYTHON.ABI_VERSION }} macOS ${{ matrix.PYTHON.ARCHFLAGS }}"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Changelog
   from the public key and private key classes. These methods were originally
   deprecated in version 2.0, but had an extended deprecation timeline due
   to usage. Any remaining users should transition to ``sign`` and ``verify``.
+* **BACKWARDS INCOMPATIBLE:** Dropped support for macOS 10.10, macOS users must
+  upgrade to 10.11 or newer.
 * Deprecated OpenSSL 1.1.0 support. OpenSSL 1.1.0 is no longer supported by
   the OpenSSL project. Support for compiling with OpenSSL 1.1.0 will be
   removed in a future release.


### PR DESCRIPTION
Both Firefox and Chrome have dropped support for 10.10, and apple hasn't supported it in 4 years. Dropbox however, does still seem to support it.