### PR TITLE
Docs: clarify min pip version which understands abi3

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -155,7 +155,7 @@ Why are there no wheels for my Python3.x version?
 Our Python3 wheels are ``abi3`` wheels. This means they support multiple
 versions of Python. The ``abi3`` wheel can be used with any version of Python
 greater than or equal to the version it specifies. Recent versions of ``pip``
-will automatically install ``abi3`` wheels.
+(20.0.1+) will automatically install ``abi3`` wheels.
 
 Why can't I import my PEM file?
 -------------------------------


### PR DESCRIPTION
Be more specific than just "recent versions of pip" regarding which versions support selecting 'cp3X-abi3' wheels on python 3.Y where Y > X.

Aside from 'recent' not aging well, this should also help people who may have pip itself pinned & need to know how far they have to upgrade to benefit from this.

Having found #5669 when searching for the issue at hand, I ended up on the linked https://cryptography.io/en/latest/faq/#why-are-there-no-wheels-for-my-python3-x-version and had to figure out by trial and error which pip version is sufficient to get this behaviour.