### PR TITLE
Expand typing coverage to exceptions

### DIFF
--- a/src/cryptography/exceptions.py
+++ b/src/cryptography/exceptions.py
@@ -3,7 +3,14 @@
 # for complete details.
 
 
+import typing
+
 from cryptography import utils
+
+if typing.TYPE_CHECKING:
+    from cryptography.hazmat.bindings.openssl.binding import (
+        _OpenSSLErrorWithText,
+    )
 
 
 class _Reasons(utils.Enum):
@@ -22,7 +29,9 @@ class _Reasons(utils.Enum):
 
 
 class UnsupportedAlgorithm(Exception):
-    def __init__(self, message, reason=None):
+    def __init__(
+        self, message: str, reason: typing.Optional[_Reasons] = None
+    ) -> None:
         super(UnsupportedAlgorithm, self).__init__(message)
         self._reason = reason
 
@@ -48,7 +57,9 @@ class InvalidSignature(Exception):
 
 
 class InternalError(Exception):
-    def __init__(self, msg, err_code):
+    def __init__(
+        self, msg: str, err_code: typing.List["_OpenSSLErrorWithText"]
+    ) -> None:
         super(InternalError, self).__init__(msg)
         self.err_code = err_code
 

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -3,7 +3,6 @@
 # for complete details.
 
 
-import collections
 import threading
 import types
 import typing
@@ -15,8 +14,9 @@ from cryptography.exceptions import InternalError
 from cryptography.hazmat.bindings._openssl import ffi, lib
 from cryptography.hazmat.bindings.openssl._conditional import CONDITIONAL_NAMES
 
-_OpenSSLErrorWithText = collections.namedtuple(
-    "_OpenSSLErrorWithText", ["code", "lib", "reason", "reason_text"]
+_OpenSSLErrorWithText = typing.NamedTuple(
+    "_OpenSSLErrorWithText",
+    [("code", int), ("lib", int), ("reason", int), ("reason_text", bytes)],
 )
 
 


### PR DESCRIPTION
Involves making _OpenSSLErrorWithText a typing.NamedTuple