### PR TITLE
type encryptor/decryptor

### DIFF
--- a/src/cryptography/hazmat/primitives/keywrap.py
+++ b/src/cryptography/hazmat/primitives/keywrap.py
@@ -120,10 +120,10 @@ def aes_key_unwrap_with_padding(
     if len(wrapped_key) == 16:
         # RFC 5649 - 4.2 - exactly two 64-bit blocks
         decryptor = Cipher(AES(wrapping_key), ECB()).decryptor()
-        b = decryptor.update(wrapped_key)
+        out = decryptor.update(wrapped_key)
         assert decryptor.finalize() == b""
-        a = b[:8]
-        data = b[8:]
+        a = out[:8]
+        data = out[8:]
         n = 1
     else:
         r = [wrapped_key[i : i + 8] for i in range(0, len(wrapped_key), 8)]

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -46,6 +46,7 @@ class TestAESModeGCM(object):
             algorithms.AES(key), modes.GCM(iv), backend=backend
         )
         encryptor = cipher.encryptor()
+        assert isinstance(encryptor, base.AEADEncryptionContext)
         encryptor.authenticate_additional_data(aad)
         encryptor.finalize()
         assert encryptor.tag == tag
@@ -61,6 +62,7 @@ class TestAESModeGCM(object):
             algorithms.AES(key), modes.GCM(iv), backend=backend
         )
         encryptor = cipher.encryptor()
+        assert isinstance(encryptor, base.AEADEncryptionContext)
         computed_ct = encryptor.update(pt) + encryptor.finalize()
         assert computed_ct == ct
         assert encryptor.tag == tag
@@ -71,9 +73,12 @@ class TestAESModeGCM(object):
             modes.GCM(b"\x01" * 16),
             backend=backend,
         ).encryptor()
-        encryptor._bytes_processed = modes.GCM._MAX_ENCRYPTED_BYTES - 16
+        assert isinstance(encryptor, base.AEADEncryptionContext)
+        new_max = modes.GCM._MAX_ENCRYPTED_BYTES - 16
+        encryptor._bytes_processed = new_max  # type: ignore[attr-defined]
         encryptor.update(b"0" * 16)
-        assert encryptor._bytes_processed == modes.GCM._MAX_ENCRYPTED_BYTES
+        max = modes.GCM._MAX_ENCRYPTED_BYTES
+        assert encryptor._bytes_processed == max  # type: ignore[attr-defined]
         with pytest.raises(ValueError):
             encryptor.update(b"0")
 
@@ -83,9 +88,14 @@ class TestAESModeGCM(object):
             modes.GCM(b"\x01" * 16),
             backend=backend,
         ).encryptor()
-        encryptor._aad_bytes_processed = modes.GCM._MAX_AAD_BYTES - 16
+        assert isinstance(encryptor, base.AEADEncryptionContext)
+        new_max = modes.GCM._MAX_AAD_BYTES - 16
+        encryptor._aad_bytes_processed = new_max  # type: ignore[attr-defined]
         encryptor.authenticate_additional_data(b"0" * 16)
-        assert encryptor._aad_bytes_processed == modes.GCM._MAX_AAD_BYTES
+        max = modes.GCM._MAX_AAD_BYTES
+        assert (
+            encryptor._aad_bytes_processed == max  # type: ignore[attr-defined]
+        )
         with pytest.raises(ValueError):
             encryptor.authenticate_additional_data(b"0")
 
@@ -95,12 +105,13 @@ class TestAESModeGCM(object):
             modes.GCM(b"\x01" * 16),
             backend=backend,
         ).encryptor()
+        assert isinstance(encryptor, base.AEADEncryptionContext)
         encryptor.update(b"0" * 8)
-        assert encryptor._bytes_processed == 8
+        assert encryptor._bytes_processed == 8  # type: ignore[attr-defined]
         encryptor.update(b"0" * 7)
-        assert encryptor._bytes_processed == 15
+        assert encryptor._bytes_processed == 15  # type: ignore[attr-defined]
         encryptor.update(b"0" * 18)
-        assert encryptor._bytes_processed == 33
+        assert encryptor._bytes_processed == 33  # type: ignore[attr-defined]
 
     def test_gcm_aad_increments(self, backend):
         encryptor = base.Cipher(
@@ -108,10 +119,15 @@ class TestAESModeGCM(object):
             modes.GCM(b"\x01" * 16),
             backend=backend,
         ).encryptor()
+        assert isinstance(encryptor, base.AEADEncryptionContext)
         encryptor.authenticate_additional_data(b"0" * 8)
-        assert encryptor._aad_bytes_processed == 8
+        assert (
+            encryptor._aad_bytes_processed == 8  # type: ignore[attr-defined]
+        )
         encryptor.authenticate_additional_data(b"0" * 18)
-        assert encryptor._aad_bytes_processed == 26
+        assert (
+            encryptor._aad_bytes_processed == 26  # type: ignore[attr-defined]
+        )
 
     def test_gcm_tag_decrypt_none(self, backend):
         key = binascii.unhexlify(b"5211242698bed4774a090620a6ca56f3")
@@ -121,12 +137,14 @@ class TestAESModeGCM(object):
         encryptor = base.Cipher(
             algorithms.AES(key), modes.GCM(iv), backend=backend
         ).encryptor()
+        assert isinstance(encryptor, base.AEADEncryptionContext)
         encryptor.authenticate_additional_data(aad)
         encryptor.finalize()
 
         decryptor = base.Cipher(
             algorithms.AES(key), modes.GCM(iv), backend=backend
         ).decryptor()
+        assert isinstance(decryptor, base.AEADDecryptionContext)
         decryptor.authenticate_additional_data(aad)
         with pytest.raises(ValueError):
             decryptor.finalize()
@@ -139,6 +157,7 @@ class TestAESModeGCM(object):
         encryptor = base.Cipher(
             algorithms.AES(key), modes.GCM(iv), backend=backend
         ).encryptor()
+        assert isinstance(encryptor, base.AEADEncryptionContext)
         encryptor.authenticate_additional_data(aad)
         encryptor.finalize()
         tag = encryptor.tag
@@ -146,6 +165,7 @@ class TestAESModeGCM(object):
         decryptor = base.Cipher(
             algorithms.AES(key), modes.GCM(iv, tag), backend=backend
         ).decryptor()
+        assert isinstance(decryptor, base.AEADDecryptionContext)
         decryptor.authenticate_additional_data(aad)
         decryptor.finalize()
 
@@ -157,6 +177,7 @@ class TestAESModeGCM(object):
         encryptor = base.Cipher(
             algorithms.AES(key), modes.GCM(iv), backend=backend
         ).encryptor()
+        assert isinstance(encryptor, base.AEADEncryptionContext)
         encryptor.authenticate_additional_data(aad)
         encryptor.finalize()
         tag = encryptor.tag
@@ -164,6 +185,7 @@ class TestAESModeGCM(object):
         decryptor = base.Cipher(
             algorithms.AES(key), modes.GCM(iv), backend=backend
         ).decryptor()
+        assert isinstance(decryptor, base.AEADDecryptionContext)
         decryptor.authenticate_additional_data(aad)
 
         decryptor.finalize_with_tag(tag)
@@ -173,6 +195,7 @@ class TestAESModeGCM(object):
         decryptor = base.Cipher(
             algorithms.AES(b"0" * 16), modes.GCM(b"0" * 12), backend=backend
         ).decryptor()
+        assert isinstance(decryptor, base.AEADDecryptionContext)
         with pytest.raises(ValueError):
             decryptor.finalize_with_tag(tag)
 
@@ -183,6 +206,7 @@ class TestAESModeGCM(object):
             modes.GCM(bytearray(b"\x00" * 12)),
             backend,
         ).encryptor()
+        assert isinstance(enc, base.AEADEncryptionContext)
         enc.authenticate_additional_data(bytearray(b"foo"))
         ct = enc.update(data) + enc.finalize()
         dec = base.Cipher(
@@ -190,6 +214,7 @@ class TestAESModeGCM(object):
             modes.GCM(bytearray(b"\x00" * 12), enc.tag),
             backend,
         ).decryptor()
+        assert isinstance(dec, base.AEADDecryptionContext)
         dec.authenticate_additional_data(bytearray(b"foo"))
         pt = dec.update(ct) + dec.finalize()
         assert pt == data
@@ -206,11 +231,13 @@ class TestAESModeGCM(object):
 
         payload = b"data"
         encryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).encryptor()
+        assert isinstance(encryptor, base.AEADEncryptionContext)
         ct = encryptor.update(payload)
         encryptor.finalize()
         tag = encryptor.tag
 
         decryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).decryptor()
+        assert isinstance(decryptor, base.AEADDecryptionContext)
         pt = decryptor.update(ct)
 
         decryptor.finalize_with_tag(tag)

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -19,6 +19,8 @@ from cryptography.exceptions import (
 from cryptography.hazmat.primitives import hashes, hmac, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.ciphers import (
+    AEADDecryptionContext,
+    AEADEncryptionContext,
     BlockCipherAlgorithm,
     Cipher,
     algorithms,
@@ -121,6 +123,7 @@ def aead_test(backend, cipher_factory, mode_factory, params):
             backend,
         )
         decryptor = cipher.decryptor()
+        assert isinstance(decryptor, AEADDecryptionContext)
         decryptor.authenticate_additional_data(aad)
         actual_plaintext = decryptor.update(ciphertext)
         with pytest.raises(InvalidTag):
@@ -132,6 +135,7 @@ def aead_test(backend, cipher_factory, mode_factory, params):
             backend,
         )
         encryptor = cipher.encryptor()
+        assert isinstance(encryptor, AEADEncryptionContext)
         encryptor.authenticate_additional_data(aad)
         actual_ciphertext = encryptor.update(plaintext)
         actual_ciphertext += encryptor.finalize()
@@ -147,6 +151,7 @@ def aead_test(backend, cipher_factory, mode_factory, params):
             backend,
         )
         decryptor = cipher.decryptor()
+        assert isinstance(decryptor, AEADDecryptionContext)
         decryptor.authenticate_additional_data(aad)
         actual_plaintext = decryptor.update(ciphertext)
         actual_plaintext += decryptor.finalize()
@@ -297,6 +302,7 @@ def aead_exception_test(backend, cipher_factory, mode_factory):
         backend,
     )
     encryptor = cipher.encryptor()
+    assert isinstance(encryptor, AEADEncryptionContext)
     encryptor.update(b"a" * 16)
     with pytest.raises(NotYetFinalized):
         encryptor.tag
@@ -315,9 +321,10 @@ def aead_exception_test(backend, cipher_factory, mode_factory):
         backend,
     )
     decryptor = cipher.decryptor()
+    assert isinstance(decryptor, AEADDecryptionContext)
     decryptor.update(b"a" * 16)
     with pytest.raises(AttributeError):
-        decryptor.tag
+        decryptor.tag  # type: ignore[attr-defined]
 
 
 def generate_aead_tag_exception_test(cipher_factory, mode_factory):

--- a/tests/wycheproof/test_aes.py
+++ b/tests/wycheproof/test_aes.py
@@ -9,7 +9,13 @@ import pytest
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.ciphers import (
+    AEADDecryptionContext,
+    AEADEncryptionContext,
+    Cipher,
+    algorithms,
+    modes,
+)
 from cryptography.hazmat.primitives.ciphers.aead import AESCCM, AESGCM
 
 from .utils import wycheproof_tests
@@ -62,6 +68,7 @@ def test_aes_gcm(backend, wycheproof):
         pytest.skip("Non-96-bit IVs unsupported in FIPS mode.")
     if wycheproof.valid or wycheproof.acceptable:
         enc = Cipher(algorithms.AES(key), modes.GCM(iv), backend).encryptor()
+        assert isinstance(enc, AEADEncryptionContext)
         enc.authenticate_additional_data(aad)
         computed_ct = enc.update(msg) + enc.finalize()
         computed_tag = enc.tag
@@ -72,6 +79,7 @@ def test_aes_gcm(backend, wycheproof):
             modes.GCM(iv, tag, min_tag_length=len(tag)),
             backend,
         ).decryptor()
+        assert isinstance(dec, AEADDecryptionContext)
         dec.authenticate_additional_data(aad)
         computed_msg = dec.update(ct) + dec.finalize()
         assert computed_msg == msg
@@ -81,6 +89,7 @@ def test_aes_gcm(backend, wycheproof):
             modes.GCM(iv, tag, min_tag_length=len(tag)),
             backend,
         ).decryptor()
+        assert isinstance(dec, AEADDecryptionContext)
         dec.authenticate_additional_data(aad)
         dec.update(ct)
         with pytest.raises(InvalidTag):


### PR DESCRIPTION
These methods are dynamic so the type of return you get depends on the
cipher/mode you passed. Users should type narrow to CipherContext,
AEADEncryptionContext, or AEADDecryptionContext as needed.

This commit significantly modifies the way we declare these interfaces
and duplicates the methods between AEADCipherContext and CipherContext.

If we didn't do that then type narrowing like
isinstance(encryptor, CipherContext) would be ambiguous since both
AEADEncryptionContext and AEADDecryptionContext would be descendents of
CipherContext.

Removing the indirection (as in #6642) doesn't provide much performance benefit and this approach allows a reasonable path forward on typing.