### PR TITLE
type encryptor/decryptor

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -415,10 +415,14 @@ class Backend(BackendInterface):
                 SM4, mode_cls, GetCipherByName("sm4-{mode.name}")
             )
 
-    def create_symmetric_encryption_ctx(self, cipher, mode):
+    def create_symmetric_encryption_ctx(
+        self, cipher: CipherAlgorithm, mode: Mode
+    ) -> _CipherContext:
         return _CipherContext(self, cipher, mode, _CipherContext._ENCRYPT)
 
-    def create_symmetric_decryption_ctx(self, cipher, mode):
+    def create_symmetric_decryption_ctx(
+        self, cipher: CipherAlgorithm, mode: Mode
+    ) -> _CipherContext:
         return _CipherContext(self, cipher, mode, _CipherContext._DECRYPT)
 
     def pbkdf2_hmac_supported(self, algorithm: hashes.HashAlgorithm) -> bool:

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -4,7 +4,6 @@
 
 import typing
 
-from cryptography import utils
 from cryptography.exceptions import InvalidTag, UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.primitives import ciphers
 from cryptography.hazmat.primitives.ciphers import algorithms, modes
@@ -14,10 +13,6 @@ if typing.TYPE_CHECKING:
     from cryptography.hazmat.backends.openssl.backend import Backend
 
 
-@utils.register_interface(ciphers.CipherContext)
-@utils.register_interface(ciphers.AEADCipherContext)
-@utils.register_interface(ciphers.AEADEncryptionContext)
-@utils.register_interface(ciphers.AEADDecryptionContext)
 class _CipherContext(object):
     _ENCRYPT = 1
     _DECRYPT = 0

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -7,7 +7,7 @@ import typing
 from cryptography import utils
 from cryptography.exceptions import InvalidTag, UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.primitives import ciphers
-from cryptography.hazmat.primitives.ciphers import modes
+from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 
 if typing.TYPE_CHECKING:
@@ -71,7 +71,7 @@ class _CipherContext(object):
             iv_nonce = self._backend._ffi.from_buffer(mode.tweak)
         elif isinstance(mode, modes.ModeWithNonce):
             iv_nonce = self._backend._ffi.from_buffer(mode.nonce)
-        elif isinstance(cipher, modes.ModeWithNonce):
+        elif isinstance(cipher, algorithms.ChaCha20):
             iv_nonce = self._backend._ffi.from_buffer(cipher.nonce)
         else:
             iv_nonce = self._backend._ffi.NULL

--- a/src/cryptography/hazmat/primitives/ciphers/algorithms.py
+++ b/src/cryptography/hazmat/primitives/ciphers/algorithms.py
@@ -8,7 +8,6 @@ from cryptography.hazmat.primitives.ciphers import (
     BlockCipherAlgorithm,
     CipherAlgorithm,
 )
-from cryptography.hazmat.primitives.ciphers.modes import ModeWithNonce
 
 
 def _verify_key_size(algorithm: CipherAlgorithm, key: bytes) -> bytes:
@@ -133,7 +132,7 @@ class SEED(CipherAlgorithm, BlockCipherAlgorithm):
         return len(self.key) * 8
 
 
-class ChaCha20(CipherAlgorithm, ModeWithNonce):
+class ChaCha20(CipherAlgorithm):
     name = "ChaCha20"
     key_sizes = frozenset([256])
 

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -29,7 +29,7 @@ class Mode(metaclass=abc.ABCMeta):
         """
 
 
-class ModeWithInitializationVector(metaclass=abc.ABCMeta):
+class ModeWithInitializationVector(Mode, metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def initialization_vector(self) -> bytes:
         """
@@ -37,7 +37,7 @@ class ModeWithInitializationVector(metaclass=abc.ABCMeta):
         """
 
 
-class ModeWithTweak(metaclass=abc.ABCMeta):
+class ModeWithTweak(Mode, metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def tweak(self) -> bytes:
         """
@@ -45,7 +45,7 @@ class ModeWithTweak(metaclass=abc.ABCMeta):
         """
 
 
-class ModeWithNonce(metaclass=abc.ABCMeta):
+class ModeWithNonce(Mode, metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def nonce(self) -> bytes:
         """
@@ -53,7 +53,7 @@ class ModeWithNonce(metaclass=abc.ABCMeta):
         """
 
 
-class ModeWithAuthenticationTag(metaclass=abc.ABCMeta):
+class ModeWithAuthenticationTag(Mode, metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def tag(self) -> typing.Optional[bytes]:
         """
@@ -89,7 +89,7 @@ def _check_iv_and_key_length(self, algorithm):
     _check_iv_length(self, algorithm)
 
 
-class CBC(Mode, ModeWithInitializationVector):
+class CBC(ModeWithInitializationVector):
     name = "CBC"
 
     def __init__(self, initialization_vector: bytes):
@@ -103,7 +103,7 @@ class CBC(Mode, ModeWithInitializationVector):
     validate_for_algorithm = _check_iv_and_key_length
 
 
-class XTS(Mode, ModeWithTweak):
+class XTS(ModeWithTweak):
     name = "XTS"
 
     def __init__(self, tweak: bytes):
@@ -132,7 +132,7 @@ class ECB(Mode):
     validate_for_algorithm = _check_aes_key_length
 
 
-class OFB(Mode, ModeWithInitializationVector):
+class OFB(ModeWithInitializationVector):
     name = "OFB"
 
     def __init__(self, initialization_vector: bytes):
@@ -146,7 +146,7 @@ class OFB(Mode, ModeWithInitializationVector):
     validate_for_algorithm = _check_iv_and_key_length
 
 
-class CFB(Mode, ModeWithInitializationVector):
+class CFB(ModeWithInitializationVector):
     name = "CFB"
 
     def __init__(self, initialization_vector: bytes):
@@ -160,7 +160,7 @@ class CFB(Mode, ModeWithInitializationVector):
     validate_for_algorithm = _check_iv_and_key_length
 
 
-class CFB8(Mode, ModeWithInitializationVector):
+class CFB8(ModeWithInitializationVector):
     name = "CFB8"
 
     def __init__(self, initialization_vector: bytes):
@@ -174,7 +174,7 @@ class CFB8(Mode, ModeWithInitializationVector):
     validate_for_algorithm = _check_iv_and_key_length
 
 
-class CTR(Mode, ModeWithNonce):
+class CTR(ModeWithNonce):
     name = "CTR"
 
     def __init__(self, nonce: bytes):
@@ -190,7 +190,7 @@ class CTR(Mode, ModeWithNonce):
         _check_nonce_length(self.nonce, self.name, algorithm)
 
 
-class GCM(Mode, ModeWithInitializationVector, ModeWithAuthenticationTag):
+class GCM(ModeWithInitializationVector, ModeWithAuthenticationTag):
     name = "GCM"
     _MAX_ENCRYPTED_BYTES = (2 ** 39 - 256) // 8
     _MAX_AAD_BYTES = (2 ** 64) // 8

--- a/src/cryptography/hazmat/primitives/keywrap.py
+++ b/src/cryptography/hazmat/primitives/keywrap.py
@@ -120,10 +120,10 @@ def aes_key_unwrap_with_padding(
     if len(wrapped_key) == 16:
         # RFC 5649 - 4.2 - exactly two 64-bit blocks
         decryptor = Cipher(AES(wrapping_key), ECB()).decryptor()
-        b = decryptor.update(wrapped_key)
+        out = decryptor.update(wrapped_key)
         assert decryptor.finalize() == b""
-        a = b[:8]
-        data = b[8:]
+        a = out[:8]
+        data = out[8:]
         n = 1
     else:
         r = [wrapped_key[i : i + 8] for i in range(0, len(wrapped_key), 8)]

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -71,9 +71,11 @@ class TestAESModeGCM(object):
             modes.GCM(b"\x01" * 16),
             backend=backend,
         ).encryptor()
-        encryptor._bytes_processed = modes.GCM._MAX_ENCRYPTED_BYTES - 16
+        new_max = modes.GCM._MAX_ENCRYPTED_BYTES - 16
+        encryptor._bytes_processed = new_max  # type: ignore[attr-defined]
         encryptor.update(b"0" * 16)
-        assert encryptor._bytes_processed == modes.GCM._MAX_ENCRYPTED_BYTES
+        max = modes.GCM._MAX_ENCRYPTED_BYTES
+        assert encryptor._bytes_processed == max  # type: ignore[attr-defined]
         with pytest.raises(ValueError):
             encryptor.update(b"0")
 
@@ -83,9 +85,13 @@ class TestAESModeGCM(object):
             modes.GCM(b"\x01" * 16),
             backend=backend,
         ).encryptor()
-        encryptor._aad_bytes_processed = modes.GCM._MAX_AAD_BYTES - 16
+        new_max = modes.GCM._MAX_AAD_BYTES - 16
+        encryptor._aad_bytes_processed = new_max  # type: ignore[attr-defined]
         encryptor.authenticate_additional_data(b"0" * 16)
-        assert encryptor._aad_bytes_processed == modes.GCM._MAX_AAD_BYTES
+        max = modes.GCM._MAX_AAD_BYTES
+        assert (
+            encryptor._aad_bytes_processed == max  # type: ignore[attr-defined]
+        )
         with pytest.raises(ValueError):
             encryptor.authenticate_additional_data(b"0")
 
@@ -96,11 +102,11 @@ class TestAESModeGCM(object):
             backend=backend,
         ).encryptor()
         encryptor.update(b"0" * 8)
-        assert encryptor._bytes_processed == 8
+        assert encryptor._bytes_processed == 8  # type: ignore[attr-defined]
         encryptor.update(b"0" * 7)
-        assert encryptor._bytes_processed == 15
+        assert encryptor._bytes_processed == 15  # type: ignore[attr-defined]
         encryptor.update(b"0" * 18)
-        assert encryptor._bytes_processed == 33
+        assert encryptor._bytes_processed == 33  # type: ignore[attr-defined]
 
     def test_gcm_aad_increments(self, backend):
         encryptor = base.Cipher(
@@ -109,9 +115,13 @@ class TestAESModeGCM(object):
             backend=backend,
         ).encryptor()
         encryptor.authenticate_additional_data(b"0" * 8)
-        assert encryptor._aad_bytes_processed == 8
+        assert (
+            encryptor._aad_bytes_processed == 8  # type: ignore[attr-defined]
+        )
         encryptor.authenticate_additional_data(b"0" * 18)
-        assert encryptor._aad_bytes_processed == 26
+        assert (
+            encryptor._aad_bytes_processed == 26  # type: ignore[attr-defined]
+        )
 
     def test_gcm_tag_decrypt_none(self, backend):
         key = binascii.unhexlify(b"5211242698bed4774a090620a6ca56f3")

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -325,14 +325,18 @@ class TestCipherUpdateInto(object):
         c = ciphers.Cipher(AES(key), modes.ECB(), backend)
         encryptor = c.encryptor()
         # Lower max chunk size so we can test chunking
-        monkeypatch.setattr(encryptor._ctx, "_MAX_CHUNK_SIZE", 40)
+        monkeypatch.setattr(
+            encryptor._ctx, "_MAX_CHUNK_SIZE", 40  # type: ignore[attr-defined]
+        )
         buf = bytearray(527)
         pt = b"abcdefghijklmnopqrstuvwxyz012345" * 16  # 512 bytes
         processed = encryptor.update_into(pt, buf)
         assert processed == 512
         decryptor = c.decryptor()
         # Change max chunk size to verify alternate boundaries don't matter
-        monkeypatch.setattr(decryptor._ctx, "_MAX_CHUNK_SIZE", 73)
+        monkeypatch.setattr(
+            decryptor._ctx, "_MAX_CHUNK_SIZE", 73  # type: ignore[attr-defined]
+        )
         decbuf = bytearray(527)
         decprocessed = decryptor.update_into(buf[:processed], decbuf)
         assert decbuf[:decprocessed] == pt
@@ -344,4 +348,7 @@ class TestCipherUpdateInto(object):
         key = b"\x00" * 16
         c = ciphers.Cipher(AES(key), modes.ECB(), backend)
         encryptor = c.encryptor()
-        backend._ffi.new("int *", encryptor._ctx._MAX_CHUNK_SIZE)
+        backend._ffi.new(
+            "int *",
+            encryptor._ctx._MAX_CHUNK_SIZE,  # type: ignore[attr-defined]
+        )


### PR DESCRIPTION
This makes Cipher generic over mode and then uses that generic type to determine the return type of encryptor/decryptor. This makes the type signature look weird for the constructor with tools like pylance, but mypy itself enforces the typing properly and pylance correctly shows the resulting encryptor/decryptor return type. All hail abusing generics.

replaces #6740 

fixes #6083 

refs #6531