### PR TITLE
We don't pass the cffi buffer from any other method like this

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/x448.py
+++ b/src/cryptography/hazmat/backends/openssl/x448.py
@@ -69,7 +69,8 @@ class _X448PrivateKey(X448PrivateKey):
         )
         self._backend.openssl_assert(res == 1)
         self._backend.openssl_assert(buflen[0] == _X448_KEY_SIZE)
-        return self._backend.x448_load_public_bytes(buf)
+        public_bytes = self._backend._ffi.buffer(buf)[:]
+        return self._backend.x448_load_public_bytes(public_bytes)
 
     def exchange(self, peer_public_key: X448PublicKey) -> bytes:
         if not isinstance(peer_public_key, X448PublicKey):


### PR DESCRIPTION
We could optimize this in the future to allow passing buffers more directly and avoid a copy, but for now let's just be consistent with the rest of our methods.