### PR TITLE
Informative error on incompatible Fernet key

### DIFF
--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -34,8 +34,7 @@ class Fernet(object):
             key = base64.urlsafe_b64decode(key)
         except binascii.Error as exc:
             raise ValueError(
-                f"Fernet key must be 32 url-safe base64-encoded bytes, "
-                f"not {key!r}."
+                f"Fernet key must be 32 url-safe base64-encoded bytes."
                 ) from exc
         if len(key) != 32:
             raise ValueError(

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -35,7 +35,7 @@ class Fernet(object):
         except binascii.Error as exc:
             raise ValueError(
                 f"Fernet key must be 32 url-safe base64-encoded bytes."
-                ) from exc
+            ) from exc
         if len(key) != 32:
             raise ValueError(
                 "Fernet key must be 32 url-safe base64-encoded bytes."

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -34,7 +34,7 @@ class Fernet(object):
             key = base64.urlsafe_b64decode(key)
         except binascii.Error as exc:
             raise ValueError(
-                f"Fernet key must be 32 url-safe base64-encoded bytes."
+                "Fernet key must be 32 url-safe base64-encoded bytes."
             ) from exc
         if len(key) != 32:
             raise ValueError(

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -30,7 +30,13 @@ class Fernet(object):
         key: typing.Union[bytes, str],
         backend: typing.Any = None,
     ):
-        key = base64.urlsafe_b64decode(key)
+        try:
+            key = base64.urlsafe_b64decode(key)
+        except binascii.Error as exc:
+            raise ValueError(
+                f"Fernet key must be 32 url-safe base64-encoded bytes, "
+                f"not {key!r}."
+                ) from exc
         if len(key) != 32:
             raise ValueError(
                 "Fernet key must be 32 url-safe base64-encoded bytes."

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -130,9 +130,10 @@ class TestFernet(object):
         f = Fernet(Fernet.generate_key(), backend=backend)
         assert f.decrypt(f.encrypt(message)) == message
 
-    def test_bad_key(self, backend):
+    @pytest.mark.parametrize("key", [base64.urlsafe_b64encode(b"abc"), b"abc"])
+    def test_bad_key(self, backend, key):
         with pytest.raises(ValueError):
-            Fernet(base64.urlsafe_b64encode(b"abc"), backend=backend)
+            Fernet(key, backend=backend)
 
     def test_extract_timestamp(self, monkeypatch, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)


### PR DESCRIPTION
Current error throws a random `binascii.Error` which [causes confusion](https://stackoverflow.com/questions/70499901/binascii-error-incorrect-padding-when-making-an-encrypted-password). I've changed it to be a `ValueError`, same as thrown by an incorrect length.

Don't think there's any backwards compatibility concern in here. A different error will be thrown but it's an erroneous input and the wrong error.