### PR TITLE
Add `SSL_set_verify` binding for pyca/pyopenssl#255

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -181,6 +181,8 @@ int SSL_peek(SSL *, void *, int);
 X509 *SSL_get_certificate(const SSL *);
 X509 *SSL_get_peer_certificate(const SSL *);
 int SSL_get_ex_data_X509_STORE_CTX_idx(void);
+void SSL_set_verify(SSL *, int, int (*)(int, X509_STORE_CTX *));
+int SSL_get_verify_mode(const SSL *);
 
 /* Added in 1.0.2 */
 X509_VERIFY_PARAM *SSL_get0_param(SSL *);


### PR DESCRIPTION
Both `SSL_set_verify` and `SSL_get_verify_mode` have been around forever, so no compatibility issues here. 
The callback definition is exactly the same as for the `SSL_CTX_` variants (minus the CTX).