### PR TITLE
Document cross compilation target == host bugfix.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -160,6 +160,18 @@ use ``--no-binary``.
 
     $ pip install cryptography --no-binary cryptography
 
+Cross Compiling
+~~~~~~~~~~~~~~~
+
+If you are cross compiling for a target system that has the same target triple
+as the build host you should add these variables in your environment to prevent
+cargo from linking host build-scripts against the target libraries.
+
+.. code-block:: console
+
+    __CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS="nightly"
+    CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST="true"
+    CARGO_TARGET_APPLIES_TO_HOST="false"
 
 Using your own OpenSSL on Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This fix is needed for example when cross compiling for a `x86_64` target from a `x86_64` build host.