### PR TITLE
Remove explicit subclassing of object now that all classes are new-style

### DIFF
--- a/docs/development/custom-vectors/secp256k1/generate_secp256k1.py
+++ b/docs/development/custom-vectors/secp256k1/generate_secp256k1.py
@@ -19,7 +19,7 @@ HASHLIB_HASH_TYPES = {
 }
 
 
-class TruncatedHash(object):
+class TruncatedHash:
     def __init__(self, hasher):
         self.hasher = hasher
 

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -23,7 +23,7 @@ class InvalidToken(Exception):
 _MAX_CLOCK_SKEW = 60
 
 
-class Fernet(object):
+class Fernet:
     def __init__(
         self,
         key: typing.Union[bytes, str],
@@ -164,7 +164,7 @@ class Fernet(object):
         return unpadded
 
 
-class MultiFernet(object):
+class MultiFernet:
     def __init__(self, fernets: typing.Iterable[Fernet]):
         fernets = list(fernets)
         if not fernets:

--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -7,7 +7,7 @@ import typing
 from cryptography.hazmat.primitives import hashes
 
 
-class ObjectIdentifier(object):
+class ObjectIdentifier:
     def __init__(self, dotted_string: str) -> None:
         self._dotted_string = dotted_string
 
@@ -76,7 +76,7 @@ class ObjectIdentifier(object):
         return self._dotted_string
 
 
-class ExtensionOID(object):
+class ExtensionOID:
     SUBJECT_DIRECTORY_ATTRIBUTES = ObjectIdentifier("2.5.29.9")
     SUBJECT_KEY_IDENTIFIER = ObjectIdentifier("2.5.29.14")
     KEY_USAGE = ObjectIdentifier("2.5.29.15")
@@ -106,17 +106,17 @@ class ExtensionOID(object):
     SIGNED_CERTIFICATE_TIMESTAMPS = ObjectIdentifier("1.3.6.1.4.1.11129.2.4.5")
 
 
-class OCSPExtensionOID(object):
+class OCSPExtensionOID:
     NONCE = ObjectIdentifier("1.3.6.1.5.5.7.48.1.2")
 
 
-class CRLEntryExtensionOID(object):
+class CRLEntryExtensionOID:
     CERTIFICATE_ISSUER = ObjectIdentifier("2.5.29.29")
     CRL_REASON = ObjectIdentifier("2.5.29.21")
     INVALIDITY_DATE = ObjectIdentifier("2.5.29.24")
 
 
-class NameOID(object):
+class NameOID:
     COMMON_NAME = ObjectIdentifier("2.5.4.3")
     COUNTRY_NAME = ObjectIdentifier("2.5.4.6")
     LOCALITY_NAME = ObjectIdentifier("2.5.4.7")
@@ -149,7 +149,7 @@ class NameOID(object):
     UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2")
 
 
-class SignatureAlgorithmOID(object):
+class SignatureAlgorithmOID:
     RSA_WITH_MD5 = ObjectIdentifier("1.2.840.113549.1.1.4")
     RSA_WITH_SHA1 = ObjectIdentifier("1.2.840.113549.1.1.5")
     # This is an alternate OID for RSA with SHA1 that is occasionally seen
@@ -202,7 +202,7 @@ _SIG_OIDS_TO_HASH: typing.Dict[
 }
 
 
-class ExtendedKeyUsageOID(object):
+class ExtendedKeyUsageOID:
     SERVER_AUTH = ObjectIdentifier("1.3.6.1.5.5.7.3.1")
     CLIENT_AUTH = ObjectIdentifier("1.3.6.1.5.5.7.3.2")
     CODE_SIGNING = ObjectIdentifier("1.3.6.1.5.5.7.3.3")
@@ -214,22 +214,22 @@ class ExtendedKeyUsageOID(object):
     KERBEROS_PKINIT_KDC = ObjectIdentifier("1.3.6.1.5.2.3.5")
 
 
-class AuthorityInformationAccessOID(object):
+class AuthorityInformationAccessOID:
     CA_ISSUERS = ObjectIdentifier("1.3.6.1.5.5.7.48.2")
     OCSP = ObjectIdentifier("1.3.6.1.5.5.7.48.1")
 
 
-class SubjectInformationAccessOID(object):
+class SubjectInformationAccessOID:
     CA_REPOSITORY = ObjectIdentifier("1.3.6.1.5.5.7.48.5")
 
 
-class CertificatePoliciesOID(object):
+class CertificatePoliciesOID:
     CPS_QUALIFIER = ObjectIdentifier("1.3.6.1.5.5.7.2.1")
     CPS_USER_NOTICE = ObjectIdentifier("1.3.6.1.5.5.7.2.2")
     ANY_POLICY = ObjectIdentifier("2.5.29.32.0")
 
 
-class AttributeOID(object):
+class AttributeOID:
     CHALLENGE_PASSWORD = ObjectIdentifier("1.2.840.113549.1.9.7")
     UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2")
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -124,7 +124,7 @@ _MemoryBIO = collections.namedtuple("_MemoryBIO", ["bio", "char_ptr"])
 
 
 # Not actually supported, just used as a marker for some serialization tests.
-class _RC2(object):
+class _RC2:
     pass
 
 
@@ -2402,7 +2402,7 @@ class Backend:
         return self._read_mem_bio(bio_out)
 
 
-class GetCipherByName(object):
+class GetCipherByName:
     def __init__(self, fmt: str):
         self._fmt = fmt
 

--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -13,7 +13,7 @@ if typing.TYPE_CHECKING:
     from cryptography.hazmat.backends.openssl.backend import Backend
 
 
-class _CipherContext(object):
+class _CipherContext:
     _ENCRYPT = 1
     _DECRYPT = 0
     _MAX_CHUNK_SIZE = 2**30 - 1

--- a/src/cryptography/hazmat/backends/openssl/cmac.py
+++ b/src/cryptography/hazmat/backends/openssl/cmac.py
@@ -17,7 +17,7 @@ if typing.TYPE_CHECKING:
     from cryptography.hazmat.backends.openssl.backend import Backend
 
 
-class _CMACContext(object):
+class _CMACContext:
     def __init__(
         self,
         backend: "Backend",

--- a/src/cryptography/hazmat/backends/openssl/poly1305.py
+++ b/src/cryptography/hazmat/backends/openssl/poly1305.py
@@ -16,7 +16,7 @@ if typing.TYPE_CHECKING:
     from cryptography.hazmat.backends.openssl.backend import Backend
 
 
-class _Poly1305Context(object):
+class _Poly1305Context:
     def __init__(self, backend: "Backend", key: bytes) -> None:
         self._backend = backend
 

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -20,7 +20,7 @@ _OpenSSLErrorWithText = typing.NamedTuple(
 )
 
 
-class _OpenSSLError(object):
+class _OpenSSLError:
     def __init__(self, code: int, lib: int, reason: int):
         self._code = code
         self._lib = lib
@@ -114,7 +114,7 @@ def build_conditional_library(lib, conditional_names):
     return conditional_lib
 
 
-class Binding(object):
+class Binding:
     """
     OpenSSL API wrapper.
     """

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -20,7 +20,7 @@ def generate_parameters(
     return ossl.generate_dh_parameters(generator, key_size)
 
 
-class DHParameterNumbers(object):
+class DHParameterNumbers:
     def __init__(self, p: int, g: int, q: typing.Optional[int] = None) -> None:
         if not isinstance(p, int) or not isinstance(g, int):
             raise TypeError("p and g must be integers")
@@ -70,7 +70,7 @@ class DHParameterNumbers(object):
         return self._q
 
 
-class DHPublicNumbers(object):
+class DHPublicNumbers:
     def __init__(self, y: int, parameter_numbers: DHParameterNumbers) -> None:
         if not isinstance(y, int):
             raise TypeError("y must be an integer.")
@@ -111,7 +111,7 @@ class DHPublicNumbers(object):
         return self._parameter_numbers
 
 
-class DHPrivateNumbers(object):
+class DHPrivateNumbers:
     def __init__(self, x: int, public_numbers: DHPublicNumbers) -> None:
         if not isinstance(x, int):
             raise TypeError("x must be an integer.")

--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -123,7 +123,7 @@ class DSAPublicKey(metaclass=abc.ABCMeta):
 DSAPublicKeyWithSerialization = DSAPublicKey
 
 
-class DSAParameterNumbers(object):
+class DSAParameterNumbers:
     def __init__(self, p: int, q: int, g: int):
         if (
             not isinstance(p, int)
@@ -173,7 +173,7 @@ class DSAParameterNumbers(object):
         )
 
 
-class DSAPublicNumbers(object):
+class DSAPublicNumbers:
     def __init__(self, y: int, parameter_numbers: DSAParameterNumbers):
         if not isinstance(y, int):
             raise TypeError("DSAPublicNumbers y argument must be an integer.")
@@ -220,7 +220,7 @@ class DSAPublicNumbers(object):
         )
 
 
-class DSAPrivateNumbers(object):
+class DSAPrivateNumbers:
     def __init__(self, x: int, public_numbers: DSAPublicNumbers):
         if not isinstance(x, int):
             raise TypeError("DSAPrivateNumbers x argument must be an integer.")

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.asymmetric import (
 )
 
 
-class EllipticCurveOID(object):
+class EllipticCurveOID:
     SECP192R1 = ObjectIdentifier("1.2.840.10045.3.1.1")
     SECP224R1 = ObjectIdentifier("1.3.132.0.33")
     SECP256K1 = ObjectIdentifier("1.3.132.0.10")
@@ -344,7 +344,7 @@ def derive_private_key(
     return ossl.derive_elliptic_curve_private_key(private_value, curve)
 
 
-class EllipticCurvePublicNumbers(object):
+class EllipticCurvePublicNumbers:
     def __init__(self, x: int, y: int, curve: EllipticCurve):
         if not isinstance(x, int) or not isinstance(y, int):
             raise TypeError("x and y must be integers.")
@@ -443,7 +443,7 @@ class EllipticCurvePublicNumbers(object):
         )
 
 
-class EllipticCurvePrivateNumbers(object):
+class EllipticCurvePrivateNumbers:
     def __init__(
         self, private_value: int, public_numbers: EllipticCurvePublicNumbers
     ):
@@ -492,7 +492,7 @@ class EllipticCurvePrivateNumbers(object):
         return hash((self.private_value, self.public_numbers))
 
 
-class ECDH(object):
+class ECDH:
     pass
 
 

--- a/src/cryptography/hazmat/primitives/asymmetric/padding.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/padding.py
@@ -53,7 +53,7 @@ class OAEP(AsymmetricPadding):
         self._label = label
 
 
-class MGF1(object):
+class MGF1:
     MAX_LENGTH = object()
 
     def __init__(self, algorithm: hashes.HashAlgorithm):

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -288,7 +288,7 @@ def rsa_recover_prime_factors(
     return (p, q)
 
 
-class RSAPrivateNumbers(object):
+class RSAPrivateNumbers:
     def __init__(
         self,
         p: int,
@@ -392,7 +392,7 @@ class RSAPrivateNumbers(object):
         )
 
 
-class RSAPublicNumbers(object):
+class RSAPublicNumbers:
     def __init__(self, e: int, n: int):
         if not isinstance(e, int) or not isinstance(n, int):
             raise TypeError("RSAPublicNumbers arguments must be integers.")

--- a/src/cryptography/hazmat/primitives/asymmetric/utils.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/utils.py
@@ -11,7 +11,7 @@ decode_dss_signature = asn1.decode_dss_signature
 encode_dss_signature = asn1.encode_dss_signature
 
 
-class Prehashed(object):
+class Prehashed:
     def __init__(self, algorithm: hashes.HashAlgorithm):
         if not isinstance(algorithm, hashes.HashAlgorithm):
             raise TypeError("Expected instance of HashAlgorithm.")

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.backends.openssl import aead
 from cryptography.hazmat.backends.openssl.backend import backend
 
 
-class ChaCha20Poly1305(object):
+class ChaCha20Poly1305:
     _MAX_SIZE = 2**32
 
     def __init__(self, key: bytes):
@@ -74,7 +74,7 @@ class ChaCha20Poly1305(object):
             raise ValueError("Nonce must be 12 bytes")
 
 
-class AESCCM(object):
+class AESCCM:
     _MAX_SIZE = 2**32
 
     def __init__(self, key: bytes, tag_length: int = 16):
@@ -159,7 +159,7 @@ class AESCCM(object):
             raise ValueError("Nonce must be between 7 and 13 bytes")
 
 
-class AESGCM(object):
+class AESGCM:
     _MAX_SIZE = 2**32
 
     def __init__(self, key: bytes):
@@ -222,7 +222,7 @@ class AESGCM(object):
             raise ValueError("Nonce must be between 8 and 128 bytes")
 
 
-class AESOCB3(object):
+class AESOCB3:
     _MAX_SIZE = 2**32
 
     def __init__(self, key: bytes):

--- a/src/cryptography/hazmat/primitives/cmac.py
+++ b/src/cryptography/hazmat/primitives/cmac.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
     from cryptography.hazmat.backends.openssl.cmac import _CMACContext
 
 
-class CMAC(object):
+class CMAC:
     _ctx: typing.Optional["_CMACContext"]
     _algorithm: ciphers.BlockCipherAlgorithm
 

--- a/src/cryptography/hazmat/primitives/padding.py
+++ b/src/cryptography/hazmat/primitives/padding.py
@@ -104,7 +104,7 @@ def _byte_unpadding_check(
     return buffer_[:-pad_size]
 
 
-class PKCS7(object):
+class PKCS7:
     def __init__(self, block_size: int):
         _byte_padding_check(block_size)
         self.block_size = block_size
@@ -163,7 +163,7 @@ class _PKCS7UnpaddingContext(PaddingContext):
         return result
 
 
-class ANSIX923(object):
+class ANSIX923:
     def __init__(self, block_size: int):
         _byte_padding_check(block_size)
         self.block_size = block_size

--- a/src/cryptography/hazmat/primitives/poly1305.py
+++ b/src/cryptography/hazmat/primitives/poly1305.py
@@ -13,7 +13,7 @@ from cryptography.exceptions import (
 from cryptography.hazmat.backends.openssl.poly1305 import _Poly1305Context
 
 
-class Poly1305(object):
+class Poly1305:
     _ctx: typing.Optional[_Poly1305Context]
 
     def __init__(self, key: bytes):

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -45,7 +45,7 @@ class PKCS7Options(utils.Enum):
     NoCerts = "Don't embed signer certificate"
 
 
-class PKCS7SignatureBuilder(object):
+class PKCS7SignatureBuilder:
     def __init__(
         self,
         data: typing.Optional[bytes] = None,

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -168,7 +168,7 @@ def _to_mpint(val: int) -> bytes:
     return utils.int_to_bytes(val, nbytes)
 
 
-class _FragList(object):
+class _FragList:
     """Build recursive structure without data copy."""
 
     flist: typing.List[bytes]
@@ -218,7 +218,7 @@ class _FragList(object):
         return buf.tobytes()
 
 
-class _SSHFormatRSA(object):
+class _SSHFormatRSA:
     """Format for RSA keys.
 
     Public:
@@ -288,7 +288,7 @@ class _SSHFormatRSA(object):
         f_priv.put_mpint(private_numbers.q)
 
 
-class _SSHFormatDSA(object):
+class _SSHFormatDSA:
     """Format for DSA keys.
 
     Public:
@@ -360,7 +360,7 @@ class _SSHFormatDSA(object):
             raise ValueError("SSH supports only 1024 bit DSA keys")
 
 
-class _SSHFormatECDSA(object):
+class _SSHFormatECDSA:
     """Format for ECDSA keys.
 
     Public:
@@ -431,7 +431,7 @@ class _SSHFormatECDSA(object):
         f_priv.put_mpint(private_numbers.private_value)
 
 
-class _SSHFormatEd25519(object):
+class _SSHFormatEd25519:
     """Format for Ed25519 keys.
 
     Public:

--- a/src/cryptography/hazmat/primitives/twofactor/hotp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/hotp.py
@@ -41,7 +41,7 @@ def _generate_uri(
     return f"otpauth://{type_name}/{label}?{urlencode(parameters)}"
 
 
-class HOTP(object):
+class HOTP:
     def __init__(
         self,
         key: bytes,

--- a/src/cryptography/hazmat/primitives/twofactor/totp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/totp.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.twofactor.hotp import (
 )
 
 
-class TOTP(object):
+class TOTP:
     def __init__(
         self,
         key: bytes,

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -105,7 +105,7 @@ def verify_interface(
             )
 
 
-class _DeprecatedValue(object):
+class _DeprecatedValue:
     def __init__(self, value: object, message: str, warning_class):
         self.value = value
         self.message = message

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -568,7 +568,7 @@ def load_der_x509_crl(
     return rust_x509.load_der_x509_crl(data)
 
 
-class CertificateSigningRequestBuilder(object):
+class CertificateSigningRequestBuilder:
     def __init__(
         self,
         subject_name: typing.Optional[Name] = None,
@@ -646,7 +646,7 @@ class CertificateSigningRequestBuilder(object):
         return rust_x509.create_x509_csr(self, private_key, algorithm)
 
 
-class CertificateBuilder(object):
+class CertificateBuilder:
     _extensions: typing.List[Extension[ExtensionType]]
 
     def __init__(
@@ -883,7 +883,7 @@ class CertificateBuilder(object):
         return rust_x509.create_x509_certificate(self, private_key, algorithm)
 
 
-class CertificateRevocationListBuilder(object):
+class CertificateRevocationListBuilder:
     _extensions: typing.List[Extension[ExtensionType]]
     _revoked_certificates: typing.List[RevokedCertificate]
 
@@ -1018,7 +1018,7 @@ class CertificateRevocationListBuilder(object):
         return rust_x509.create_x509_crl(self, private_key, algorithm)
 
 
-class RevokedCertificateBuilder(object):
+class RevokedCertificateBuilder:
     def __init__(
         self,
         serial_number: typing.Optional[int] = None,

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -107,7 +107,7 @@ class ExtensionType(metaclass=abc.ABCMeta):
         )
 
 
-class Extensions(object):
+class Extensions:
     def __init__(
         self, extensions: typing.Iterable["Extension[ExtensionType]"]
     ) -> None:
@@ -400,7 +400,7 @@ class SubjectInformationAccess(ExtensionType):
         return rust_x509.encode_extension_value(self)
 
 
-class AccessDescription(object):
+class AccessDescription:
     def __init__(
         self, access_method: ObjectIdentifier, access_location: GeneralName
     ) -> None:
@@ -604,7 +604,7 @@ class FreshestCRL(ExtensionType):
         return rust_x509.encode_extension_value(self)
 
 
-class DistributionPoint(object):
+class DistributionPoint:
     def __init__(
         self,
         full_name: typing.Optional[typing.Iterable[GeneralName]],
@@ -858,7 +858,7 @@ class CertificatePolicies(ExtensionType):
         return rust_x509.encode_extension_value(self)
 
 
-class PolicyInformation(object):
+class PolicyInformation:
     def __init__(
         self,
         policy_identifier: ObjectIdentifier,
@@ -922,7 +922,7 @@ class PolicyInformation(object):
         return self._policy_qualifiers
 
 
-class UserNotice(object):
+class UserNotice:
     def __init__(
         self,
         notice_reference: typing.Optional["NoticeReference"],
@@ -968,7 +968,7 @@ class UserNotice(object):
         return self._explicit_text
 
 
-class NoticeReference(object):
+class NoticeReference:
     def __init__(
         self,
         organization: typing.Optional[str],
@@ -1462,7 +1462,7 @@ class Extension(typing.Generic[ExtensionTypeVar]):
         return hash((self.oid, self.critical, self.value))
 
 
-class GeneralNames(object):
+class GeneralNames:
     def __init__(self, general_names: typing.Iterable[GeneralName]) -> None:
         general_names = list(general_names)
         if not all(isinstance(x, GeneralName) for x in general_names):

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -84,7 +84,7 @@ def _escape_dn_value(val: typing.Union[str, bytes]) -> str:
     return val
 
 
-class NameAttribute(object):
+class NameAttribute:
     def __init__(
         self,
         oid: ObjectIdentifier,
@@ -190,7 +190,7 @@ class NameAttribute(object):
         return "<NameAttribute(oid={0.oid}, value={0.value!r})>".format(self)
 
 
-class RelativeDistinguishedName(object):
+class RelativeDistinguishedName:
     def __init__(self, attributes: typing.Iterable[NameAttribute]):
         attributes = list(attributes)
         if not attributes:
@@ -246,7 +246,7 @@ class RelativeDistinguishedName(object):
         return "<RelativeDistinguishedName({})>".format(self.rfc4514_string())
 
 
-class Name(object):
+class Name:
     @typing.overload
     def __init__(self, attributes: typing.Iterable[NameAttribute]) -> None:
         ...

--- a/src/cryptography/x509/ocsp.py
+++ b/src/cryptography/x509/ocsp.py
@@ -57,7 +57,7 @@ class OCSPCertStatus(utils.Enum):
     UNKNOWN = 2
 
 
-class _SingleResponse(object):
+class _SingleResponse:
     def __init__(
         self,
         cert: x509.Certificate,
@@ -367,7 +367,7 @@ class OCSPResponse(metaclass=abc.ABCMeta):
         """
 
 
-class OCSPRequestBuilder(object):
+class OCSPRequestBuilder:
     def __init__(
         self,
         request: typing.Optional[
@@ -417,7 +417,7 @@ class OCSPRequestBuilder(object):
         return ocsp.create_ocsp_request(self)
 
 
-class OCSPResponseBuilder(object):
+class OCSPResponseBuilder:
     def __init__(
         self,
         response: typing.Optional[_SingleResponse] = None,

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -43,7 +43,7 @@ def skip_if_libre_ssl(openssl_version):
         pytest.skip("LibreSSL hard-codes RAND_bytes to use arc4random.")
 
 
-class TestLibreSkip(object):
+class TestLibreSkip:
     def test_skip_no(self):
         assert skip_if_libre_ssl("OpenSSL 1.0.2h  3 May 2016") is None
 
@@ -52,11 +52,11 @@ class TestLibreSkip(object):
             skip_if_libre_ssl("LibreSSL 2.1.6")
 
 
-class DummyMGF(object):
+class DummyMGF:
     _salt_length = 0
 
 
-class TestOpenSSL(object):
+class TestOpenSSL:
     def test_backend_exists(self):
         assert backend
 
@@ -178,7 +178,7 @@ class TestOpenSSL(object):
     reason="Requires OpenSSL with ENGINE support and OpenSSL < 1.1.1d",
 )
 @pytest.mark.skip_fips(reason="osrandom engine disabled for FIPS")
-class TestOpenSSLRandomEngine(object):
+class TestOpenSSLRandomEngine:
     def setup(self):
         # The default RAND engine is global and shared between
         # tests. We make sure that the default engine is osrandom
@@ -307,7 +307,7 @@ class TestOpenSSLRandomEngine(object):
     backend._lib.CRYPTOGRAPHY_NEEDS_OSRANDOM_ENGINE,
     reason="Requires OpenSSL without ENGINE support or OpenSSL >=1.1.1d",
 )
-class TestOpenSSLNoEngine(object):
+class TestOpenSSLNoEngine:
     def test_no_engine_support(self):
         assert (
             backend._ffi.string(backend._lib.Cryptography_osrandom_engine_id)
@@ -325,7 +325,7 @@ class TestOpenSSLNoEngine(object):
         backend.activate_osrandom_engine()
 
 
-class TestOpenSSLRSA(object):
+class TestOpenSSLRSA:
     def test_generate_rsa_parameters_supported(self):
         assert backend.generate_rsa_parameters_supported(1, 1024) is False
         assert backend.generate_rsa_parameters_supported(4, 1024) is False
@@ -438,13 +438,13 @@ class TestOpenSSLRSA(object):
             )
 
 
-class TestOpenSSLCMAC(object):
+class TestOpenSSLCMAC:
     def test_unsupported_cipher(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
             backend.create_cmac_ctx(DummyBlockCipherAlgorithm(b"bad"))
 
 
-class TestOpenSSLSerializationWithOpenSSL(object):
+class TestOpenSSLSerializationWithOpenSSL:
     def test_pem_password_cb(self):
         userdata = backend._ffi.new("CRYPTOGRAPHY_PASSWORD_DATA *")
         pw = b"abcdefg"
@@ -497,13 +497,13 @@ class TestOpenSSLSerializationWithOpenSSL(object):
             )
 
 
-class TestOpenSSLEllipticCurve(object):
+class TestOpenSSLEllipticCurve:
     def test_sn_to_elliptic_curve_not_supported(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_ELLIPTIC_CURVE):
             _sn_to_elliptic_curve(backend, "fake")
 
 
-class TestRSAPEMSerialization(object):
+class TestRSAPEMSerialization:
     def test_password_length_limit(self):
         password = b"x" * 1024
         key = RSA_KEY_2048.private_key(backend)
@@ -523,7 +523,7 @@ class TestRSAPEMSerialization(object):
     only_if=lambda backend: backend.dh_supported(),
     skip_message="Requires DH support",
 )
-class TestOpenSSLDHSerialization(object):
+class TestOpenSSLDHSerialization:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -179,7 +179,7 @@ def skip_if_memtesting_not_supported():
 
 @pytest.mark.skip_fips(reason="FIPS self-test sets allow_customize = 0")
 @skip_if_memtesting_not_supported()
-class TestAssertNoMemoryLeaks(object):
+class TestAssertNoMemoryLeaks:
     def test_no_leak_no_malloc(self):
         assert_no_memory_leaks(
             textwrap.dedent(
@@ -245,7 +245,7 @@ class TestAssertNoMemoryLeaks(object):
 
 @pytest.mark.skip_fips(reason="FIPS self-test sets allow_customize = 0")
 @skip_if_memtesting_not_supported()
-class TestOpenSSLMemoryLeaks(object):
+class TestOpenSSLMemoryLeaks:
     @pytest.mark.parametrize(
         "path", ["x509/PKITS_data/certs/ValidcRLIssuerTest28EE.crt"]
     )

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.bindings.openssl.binding import (
 )
 
 
-class TestOpenSSL(object):
+class TestOpenSSL:
     def test_binding_loads(self):
         binding = Binding()
         assert binding

--- a/tests/hazmat/primitives/test_3des.py
+++ b/tests/hazmat/primitives/test_3des.py
@@ -24,7 +24,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support TripleDES CBC",
 )
-class TestTripleDESModeCBC(object):
+class TestTripleDESModeCBC:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "CBC"),
@@ -56,7 +56,7 @@ class TestTripleDESModeCBC(object):
     ),
     skip_message="Does not support TripleDES OFB",
 )
-class TestTripleDESModeOFB(object):
+class TestTripleDESModeOFB:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "OFB"),
@@ -88,7 +88,7 @@ class TestTripleDESModeOFB(object):
     ),
     skip_message="Does not support TripleDES CFB",
 )
-class TestTripleDESModeCFB(object):
+class TestTripleDESModeCFB:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "CFB"),
@@ -120,7 +120,7 @@ class TestTripleDESModeCFB(object):
     ),
     skip_message="Does not support TripleDES CFB8",
 )
-class TestTripleDESModeCFB8(object):
+class TestTripleDESModeCFB8:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "CFB"),
@@ -152,7 +152,7 @@ class TestTripleDESModeCFB8(object):
     ),
     skip_message="Does not support TripleDES ECB",
 )
-class TestTripleDESModeECB(object):
+class TestTripleDESModeECB:
     test_kat = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "3DES", "ECB"),

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -51,7 +51,7 @@ def test_chacha20poly1305_unsupported_on_older_openssl(backend):
     not _aead_supported(ChaCha20Poly1305),
     reason="Does not support ChaCha20Poly1305",
 )
-class TestChaCha20Poly1305(object):
+class TestChaCha20Poly1305:
     def test_data_too_large(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
@@ -187,7 +187,7 @@ class TestChaCha20Poly1305(object):
     not _aead_supported(AESCCM),
     reason="Does not support AESCCM",
 )
-class TestAESCCM(object):
+class TestAESCCM:
     def test_data_too_large(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
@@ -360,7 +360,7 @@ def _load_gcm_vectors():
     return [x for x in vectors if len(x["tag"]) == 32 and len(x["iv"]) >= 16]
 
 
-class TestAESGCM(object):
+class TestAESGCM:
     def test_data_too_large(self):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
@@ -482,7 +482,7 @@ def test_aesocb3_unsupported_on_older_openssl(backend):
     not _aead_supported(AESOCB3),
     reason="Does not support AESOCB3",
 )
-class TestAESOCB3(object):
+class TestAESOCB3:
     def test_data_too_large(self):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -21,7 +21,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support AES XTS",
 )
-class TestAESModeXTS(object):
+class TestAESModeXTS:
     def test_xts_vectors(self, backend, subtests):
         # This list comprehension excludes any vector that does not have a
         # data unit length that is divisible by 8. The NIST vectors include
@@ -80,7 +80,7 @@ class TestAESModeXTS(object):
     ),
     skip_message="Does not support AES CBC",
 )
-class TestAESModeCBC(object):
+class TestAESModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "CBC"),
@@ -112,7 +112,7 @@ class TestAESModeCBC(object):
     ),
     skip_message="Does not support AES ECB",
 )
-class TestAESModeECB(object):
+class TestAESModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "ECB"),
@@ -144,7 +144,7 @@ class TestAESModeECB(object):
     ),
     skip_message="Does not support AES OFB",
 )
-class TestAESModeOFB(object):
+class TestAESModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "OFB"),
@@ -176,7 +176,7 @@ class TestAESModeOFB(object):
     ),
     skip_message="Does not support AES CFB",
 )
-class TestAESModeCFB(object):
+class TestAESModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "CFB"),
@@ -208,7 +208,7 @@ class TestAESModeCFB(object):
     ),
     skip_message="Does not support AES CFB8",
 )
-class TestAESModeCFB8(object):
+class TestAESModeCFB8:
     test_cfb8 = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "CFB"),
@@ -240,7 +240,7 @@ class TestAESModeCFB8(object):
     ),
     skip_message="Does not support AES CTR",
 )
-class TestAESModeCTR(object):
+class TestAESModeCTR:
     test_ctr = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "CTR"),

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -20,7 +20,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support AES GCM",
 )
-class TestAESModeGCM(object):
+class TestAESModeGCM:
     test_gcm = generate_aead_test(
         load_nist_vectors,
         os.path.join("ciphers", "AES", "GCM"),

--- a/tests/hazmat/primitives/test_arc4.py
+++ b/tests/hazmat/primitives/test_arc4.py
@@ -20,7 +20,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support ARC4",
 )
-class TestARC4(object):
+class TestARC4:
     test_rfc = generate_stream_encryption_test(
         load_nist_vectors,
         os.path.join("ciphers", "ARC4"),

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -23,7 +23,7 @@ from ...doubles import DummyCipherAlgorithm, DummyMode
 from ...utils import raises_unsupported_algorithm
 
 
-class TestCipher(object):
+class TestCipher:
     def test_creates_encryptor(self, backend):
         cipher = Cipher(
             algorithms.AES(binascii.unhexlify(b"0" * 32)),
@@ -48,7 +48,7 @@ class TestCipher(object):
             )
 
 
-class TestCipherContext(object):
+class TestCipherContext:
     def test_use_after_finalize(self, backend):
         cipher = Cipher(
             algorithms.AES(binascii.unhexlify(b"0" * 32)),
@@ -131,7 +131,7 @@ class TestCipherContext(object):
     ),
     skip_message="Does not support AES GCM",
 )
-class TestAEADCipherContext(object):
+class TestAEADCipherContext:
     test_aead_exceptions = generate_aead_exception_test(
         algorithms.AES,
         modes.GCM,
@@ -142,7 +142,7 @@ class TestAEADCipherContext(object):
     )
 
 
-class TestModeValidation(object):
+class TestModeValidation:
     def test_cbc(self, backend):
         with pytest.raises(ValueError):
             Cipher(
@@ -188,7 +188,7 @@ class TestModeValidation(object):
             modes.GCM(b"")
 
 
-class TestModesRequireBytes(object):
+class TestModesRequireBytes:
     def test_cbc(self):
         with pytest.raises(TypeError):
             modes.CBC([1] * 16)  # type:ignore[arg-type]

--- a/tests/hazmat/primitives/test_blowfish.py
+++ b/tests/hazmat/primitives/test_blowfish.py
@@ -20,7 +20,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support Blowfish ECB",
 )
-class TestBlowfishModeECB(object):
+class TestBlowfishModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
@@ -36,7 +36,7 @@ class TestBlowfishModeECB(object):
     ),
     skip_message="Does not support Blowfish CBC",
 )
-class TestBlowfishModeCBC(object):
+class TestBlowfishModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
@@ -52,7 +52,7 @@ class TestBlowfishModeCBC(object):
     ),
     skip_message="Does not support Blowfish OFB",
 )
-class TestBlowfishModeOFB(object):
+class TestBlowfishModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),
@@ -68,7 +68,7 @@ class TestBlowfishModeOFB(object):
     ),
     skip_message="Does not support Blowfish CFB",
 )
-class TestBlowfishModeCFB(object):
+class TestBlowfishModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Blowfish"),

--- a/tests/hazmat/primitives/test_camellia.py
+++ b/tests/hazmat/primitives/test_camellia.py
@@ -20,7 +20,7 @@ from ...utils import load_cryptrec_vectors, load_nist_vectors
     ),
     skip_message="Does not support Camellia ECB",
 )
-class TestCamelliaModeECB(object):
+class TestCamelliaModeECB:
     test_ecb = generate_encrypt_test(
         load_cryptrec_vectors,
         os.path.join("ciphers", "Camellia"),
@@ -40,7 +40,7 @@ class TestCamelliaModeECB(object):
     ),
     skip_message="Does not support Camellia CBC",
 )
-class TestCamelliaModeCBC(object):
+class TestCamelliaModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Camellia"),
@@ -56,7 +56,7 @@ class TestCamelliaModeCBC(object):
     ),
     skip_message="Does not support Camellia OFB",
 )
-class TestCamelliaModeOFB(object):
+class TestCamelliaModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Camellia"),
@@ -72,7 +72,7 @@ class TestCamelliaModeOFB(object):
     ),
     skip_message="Does not support Camellia CFB",
 )
-class TestCamelliaModeCFB(object):
+class TestCamelliaModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "Camellia"),

--- a/tests/hazmat/primitives/test_cast5.py
+++ b/tests/hazmat/primitives/test_cast5.py
@@ -20,7 +20,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support CAST5 ECB",
 )
-class TestCAST5ModeECB(object):
+class TestCAST5ModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "CAST5"),
@@ -36,7 +36,7 @@ class TestCAST5ModeECB(object):
     ),
     skip_message="Does not support CAST5 CBC",
 )
-class TestCAST5ModeCBC(object):
+class TestCAST5ModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "CAST5"),
@@ -52,7 +52,7 @@ class TestCAST5ModeCBC(object):
     ),
     skip_message="Does not support CAST5 OFB",
 )
-class TestCAST5ModeOFB(object):
+class TestCAST5ModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "CAST5"),
@@ -68,7 +68,7 @@ class TestCAST5ModeOFB(object):
     ),
     skip_message="Does not support CAST5 CFB",
 )
-class TestCAST5ModeCFB(object):
+class TestCAST5ModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "CAST5"),

--- a/tests/hazmat/primitives/test_chacha20.py
+++ b/tests/hazmat/primitives/test_chacha20.py
@@ -21,7 +21,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support ChaCha20",
 )
-class TestChaCha20(object):
+class TestChaCha20:
     @pytest.mark.parametrize(
         "vector",
         _load_all_params(

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -29,7 +29,7 @@ from ...utils import (
 )
 
 
-class TestAES(object):
+class TestAES:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [(b"0" * 32, 128), (b"0" * 48, 192), (b"0" * 64, 256)],
@@ -47,7 +47,7 @@ class TestAES(object):
             AES("0" * 32)  # type: ignore[arg-type]
 
 
-class TestAESXTS(object):
+class TestAESXTS:
     @pytest.mark.parametrize(
         "mode", (modes.CBC, modes.CTR, modes.CFB, modes.CFB8, modes.OFB)
     )
@@ -68,14 +68,14 @@ class TestAESXTS(object):
             ciphers.Cipher(AES(b"0" * 16), modes.XTS(b"0" * 16), backend)
 
 
-class TestGCM(object):
+class TestGCM:
     @pytest.mark.parametrize("size", [7, 129])
     def test_gcm_min_max(self, size):
         with pytest.raises(ValueError):
             modes.GCM(b"0" * size)
 
 
-class TestCamellia(object):
+class TestCamellia:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [(b"0" * 32, 128), (b"0" * 48, 192), (b"0" * 64, 256)],
@@ -93,7 +93,7 @@ class TestCamellia(object):
             Camellia("0" * 32)  # type: ignore[arg-type]
 
 
-class TestTripleDES(object):
+class TestTripleDES:
     @pytest.mark.parametrize("key", [b"0" * 16, b"0" * 32, b"0" * 48])
     def test_key_size(self, key):
         cipher = TripleDES(binascii.unhexlify(key))
@@ -108,7 +108,7 @@ class TestTripleDES(object):
             TripleDES("0" * 16)  # type: ignore[arg-type]
 
 
-class TestBlowfish(object):
+class TestBlowfish:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [(b"0" * (keysize // 4), keysize) for keysize in range(32, 449, 8)],
@@ -126,7 +126,7 @@ class TestBlowfish(object):
             Blowfish("0" * 8)  # type: ignore[arg-type]
 
 
-class TestCAST5(object):
+class TestCAST5:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [(b"0" * (keysize // 4), keysize) for keysize in range(40, 129, 8)],
@@ -144,7 +144,7 @@ class TestCAST5(object):
             CAST5("0" * 10)  # type: ignore[arg-type]
 
 
-class TestARC4(object):
+class TestARC4:
     @pytest.mark.parametrize(
         ("key", "keysize"),
         [
@@ -170,7 +170,7 @@ class TestARC4(object):
             ARC4("0" * 10)  # type: ignore[arg-type]
 
 
-class TestIDEA(object):
+class TestIDEA:
     def test_key_size(self):
         cipher = IDEA(b"\x00" * 16)
         assert cipher.key_size == 128
@@ -184,7 +184,7 @@ class TestIDEA(object):
             IDEA("0" * 16)  # type: ignore[arg-type]
 
 
-class TestSEED(object):
+class TestSEED:
     def test_key_size(self):
         cipher = SEED(b"\x00" * 16)
         assert cipher.key_size == 128
@@ -224,7 +224,7 @@ def test_invalid_mode_algorithm():
     ),
     skip_message="Does not support AES ECB",
 )
-class TestCipherUpdateInto(object):
+class TestCipherUpdateInto:
     @pytest.mark.parametrize(
         "params",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_cmac.py
+++ b/tests/hazmat/primitives/test_cmac.py
@@ -45,7 +45,7 @@ vectors_3des = load_vectors_from_file(
 fake_key = b"\x00" * 16
 
 
-class TestCMAC(object):
+class TestCMAC:
     @pytest.mark.supported(
         only_if=lambda backend: backend.cmac_algorithm_supported(
             AES(fake_key)

--- a/tests/hazmat/primitives/test_concatkdf.py
+++ b/tests/hazmat/primitives/test_concatkdf.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.kdf.concatkdf import ConcatKDFHMAC
 from cryptography.hazmat.primitives.kdf.concatkdf import ConcatKDFHash
 
 
-class TestConcatKDFHash(object):
+class TestConcatKDFHash:
     def test_length_limit(self, backend):
         big_length = hashes.SHA256().digest_size * (2**32 - 1) + 1
 
@@ -122,7 +122,7 @@ class TestConcatKDFHash(object):
             ckdf.verify(b"foo", "bar")  # type: ignore[arg-type]
 
 
-class TestConcatKDFHMAC(object):
+class TestConcatKDFHMAC:
     def test_length_limit(self, backend):
         big_length = hashes.SHA256().digest_size * (2**32 - 1) + 1
 

--- a/tests/hazmat/primitives/test_constant_time.py
+++ b/tests/hazmat/primitives/test_constant_time.py
@@ -8,7 +8,7 @@ import pytest
 from cryptography.hazmat.primitives import constant_time
 
 
-class TestConstantTimeBytesEq(object):
+class TestConstantTimeBytesEq:
     def test_reject_unicode(self):
         with pytest.raises(TypeError):
             constant_time.bytes_eq(b"foo", "foo")  # type: ignore[arg-type]

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -139,7 +139,7 @@ def test_dh_public_numbers_equality():
     only_if=lambda backend: backend.dh_supported(),
     skip_message="DH not supported",
 )
-class TestDH(object):
+class TestDH:
     def test_small_key_generate_dh(self, backend):
         with pytest.raises(ValueError):
             dh.generate_parameters(2, 511, backend)
@@ -465,7 +465,7 @@ class TestDH(object):
     only_if=lambda backend: backend.dh_supported(),
     skip_message="DH not supported",
 )
-class TestDHPrivateKeySerialization(object):
+class TestDHPrivateKeySerialization:
     @pytest.mark.parametrize(
         ("encoding", "loader_func"),
         [
@@ -656,7 +656,7 @@ class TestDHPrivateKeySerialization(object):
     only_if=lambda backend: backend.dh_supported(),
     skip_message="DH not supported",
 )
-class TestDHPublicKeySerialization(object):
+class TestDHPublicKeySerialization:
     @pytest.mark.parametrize(
         ("encoding", "loader_func"),
         [
@@ -789,7 +789,7 @@ class TestDHPublicKeySerialization(object):
     only_if=lambda backend: backend.dh_supported(),
     skip_message="DH not supported",
 )
-class TestDHParameterSerialization(object):
+class TestDHParameterSerialization:
     @pytest.mark.parametrize(
         ("encoding", "loader_func"),
         [

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -55,7 +55,7 @@ def test_skip_if_dsa_not_supported(backend):
         _skip_if_dsa_not_supported(backend, DummyHashAlgorithm(), 1, 1, 1)
 
 
-class TestDSA(object):
+class TestDSA:
     def test_generate_dsa_parameters(self, backend):
         parameters = dsa.generate_parameters(2048, backend)
         assert isinstance(parameters, dsa.DSAParameters)
@@ -385,7 +385,7 @@ class TestDSA(object):
         ).private_key(backend)
 
 
-class TestDSAVerification(object):
+class TestDSAVerification:
     def test_dsa_verification(self, backend, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "DSA", "FIPS_186-3", "SigVer.rsp"),
@@ -450,7 +450,7 @@ class TestDSAVerification(object):
             public_key.verify(b"\x00" * 128, digest, prehashed_alg)
 
 
-class TestDSASignature(object):
+class TestDSASignature:
     def test_dsa_signing(self, backend, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "DSA", "FIPS_186-3", "SigGen.txt"),
@@ -511,7 +511,7 @@ class TestDSASignature(object):
             private_key.sign(digest, prehashed_alg)
 
 
-class TestDSANumbers(object):
+class TestDSANumbers:
     def test_dsa_parameter_numbers(self):
         parameter_numbers = dsa.DSAParameterNumbers(p=1, q=2, g=3)
         assert parameter_numbers.p == 1
@@ -591,7 +591,7 @@ class TestDSANumbers(object):
         )
 
 
-class TestDSANumberEquality(object):
+class TestDSANumberEquality:
     def test_parameter_numbers_eq(self):
         param = dsa.DSAParameterNumbers(1, 2, 3)
         assert param == dsa.DSAParameterNumbers(1, 2, 3)
@@ -643,7 +643,7 @@ class TestDSANumberEquality(object):
         assert priv != object()
 
 
-class TestDSASerialization(object):
+class TestDSASerialization:
     @pytest.mark.parametrize(
         ("fmt", "password"),
         itertools.product(
@@ -864,7 +864,7 @@ class TestDSASerialization(object):
             )
 
 
-class TestDSAPEMPublicKeySerialization(object):
+class TestDSAPEMPublicKeySerialization:
     @pytest.mark.parametrize(
         ("key_path", "loader_func", "encoding"),
         [

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -274,7 +274,7 @@ def test_ec_key_key_size(backend):
     assert key.public_key().key_size == 256
 
 
-class TestECWithNumbers(object):
+class TestECWithNumbers:
     def test_with_numbers(self, backend, subtests):
         vectors = itertools.product(
             load_vectors_from_file(
@@ -308,7 +308,7 @@ class TestECWithNumbers(object):
                 assert curve_type().name == priv_num.public_numbers.curve.name
 
 
-class TestECDSAVectors(object):
+class TestECDSAVectors:
     def test_signing_with_example_keys(self, backend, subtests):
         vectors = itertools.product(
             load_vectors_from_file(
@@ -597,7 +597,7 @@ class TestECDSAVectors(object):
             )
 
 
-class TestECNumbersEquality(object):
+class TestECNumbersEquality:
     def test_public_numbers_eq(self):
         pub = ec.EllipticCurvePublicNumbers(1, 2, ec.SECP192R1())
         assert pub == ec.EllipticCurvePublicNumbers(1, 2, ec.SECP192R1())
@@ -634,7 +634,7 @@ class TestECNumbersEquality(object):
         assert priv != object()
 
 
-class TestECSerialization(object):
+class TestECSerialization:
     @pytest.mark.parametrize(
         ("fmt", "password"),
         itertools.product(
@@ -890,7 +890,7 @@ class TestECSerialization(object):
         assert parsed_public
 
 
-class TestEllipticCurvePEMPublicKeySerialization(object):
+class TestEllipticCurvePEMPublicKeySerialization:
     @pytest.mark.parametrize(
         ("key_path", "loader_func", "encoding"),
         [
@@ -1146,7 +1146,7 @@ class TestEllipticCurvePEMPublicKeySerialization(object):
         )
 
 
-class TestECDH(object):
+class TestECDH:
     def test_key_exchange_with_vectors(self, backend, subtests):
         vectors = load_vectors_from_file(
             os.path.join(

--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -67,7 +67,7 @@ def test_ed25519_unsupported(backend):
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support",
 )
-class TestEd25519Signing(object):
+class TestEd25519Signing:
     def test_sign_verify_input(self, backend, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "Ed25519", "sign.input"),

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -47,7 +47,7 @@ def test_ed448_unsupported(backend):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-class TestEd448Signing(object):
+class TestEd448Signing:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_hash_vectors.py
+++ b/tests/hazmat/primitives/test_hash_vectors.py
@@ -18,7 +18,7 @@ from ...utils import load_hash_vectors, load_nist_vectors
     only_if=lambda backend: backend.hash_supported(hashes.SHA1()),
     skip_message="Does not support SHA1",
 )
-class TestSHA1(object):
+class TestSHA1:
     test_sha1 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA1"),
@@ -31,7 +31,7 @@ class TestSHA1(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA224()),
     skip_message="Does not support SHA224",
 )
-class TestSHA224(object):
+class TestSHA224:
     test_sha224 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -44,7 +44,7 @@ class TestSHA224(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA256()),
     skip_message="Does not support SHA256",
 )
-class TestSHA256(object):
+class TestSHA256:
     test_sha256 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -57,7 +57,7 @@ class TestSHA256(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA384()),
     skip_message="Does not support SHA384",
 )
-class TestSHA384(object):
+class TestSHA384:
     test_sha384 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -70,7 +70,7 @@ class TestSHA384(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA512()),
     skip_message="Does not support SHA512",
 )
-class TestSHA512(object):
+class TestSHA512:
     test_sha512 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -83,7 +83,7 @@ class TestSHA512(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA512_224()),
     skip_message="Does not support SHA512/224",
 )
-class TestSHA512224(object):
+class TestSHA512224:
     test_sha512_224 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -96,7 +96,7 @@ class TestSHA512224(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA512_256()),
     skip_message="Does not support SHA512/256",
 )
-class TestSHA512256(object):
+class TestSHA512256:
     test_sha512_256 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA2"),
@@ -109,7 +109,7 @@ class TestSHA512256(object):
     only_if=lambda backend: backend.hash_supported(hashes.MD5()),
     skip_message="Does not support MD5",
 )
-class TestMD5(object):
+class TestMD5:
     test_md5 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "MD5"),
@@ -124,7 +124,7 @@ class TestMD5(object):
     ),
     skip_message="Does not support BLAKE2b",
 )
-class TestBLAKE2b(object):
+class TestBLAKE2b:
     test_b2b = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "blake2"),
@@ -139,7 +139,7 @@ class TestBLAKE2b(object):
     ),
     skip_message="Does not support BLAKE2s",
 )
-class TestBLAKE2s256(object):
+class TestBLAKE2s256:
     test_b2s = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "blake2"),
@@ -152,7 +152,7 @@ class TestBLAKE2s256(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA3_224()),
     skip_message="Does not support SHA3_224",
 )
-class TestSHA3224(object):
+class TestSHA3224:
     test_sha3_224 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA3"),
@@ -165,7 +165,7 @@ class TestSHA3224(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA3_256()),
     skip_message="Does not support SHA3_256",
 )
-class TestSHA3256(object):
+class TestSHA3256:
     test_sha3_256 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA3"),
@@ -178,7 +178,7 @@ class TestSHA3256(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA3_384()),
     skip_message="Does not support SHA3_384",
 )
-class TestSHA3384(object):
+class TestSHA3384:
     test_sha3_384 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA3"),
@@ -191,7 +191,7 @@ class TestSHA3384(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA3_512()),
     skip_message="Does not support SHA3_512",
 )
-class TestSHA3512(object):
+class TestSHA3512:
     test_sha3_512 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHA3"),
@@ -206,7 +206,7 @@ class TestSHA3512(object):
     ),
     skip_message="Does not support SHAKE128",
 )
-class TestSHAKE128(object):
+class TestSHAKE128:
     test_shake128 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHAKE"),
@@ -236,7 +236,7 @@ class TestSHAKE128(object):
     ),
     skip_message="Does not support SHAKE256",
 )
-class TestSHAKE256(object):
+class TestSHAKE256:
     test_shake256 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SHAKE"),
@@ -264,7 +264,7 @@ class TestSHAKE256(object):
     only_if=lambda backend: backend.hash_supported(hashes.SM3()),
     skip_message="Does not support SM3",
 )
-class TestSM3(object):
+class TestSM3:
     test_sm3 = generate_hash_test(
         load_hash_vectors,
         os.path.join("hashes", "SM3"),

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -15,7 +15,7 @@ from ...doubles import DummyHashAlgorithm
 from ...utils import raises_unsupported_algorithm
 
 
-class TestHashContext(object):
+class TestHashContext:
     def test_hash_reject_unicode(self, backend):
         m = hashes.Hash(hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):
@@ -47,7 +47,7 @@ class TestHashContext(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA1()),
     skip_message="Does not support SHA1",
 )
-class TestSHA1(object):
+class TestSHA1:
     test_sha1 = generate_base_hash_test(
         hashes.SHA1(),
         digest_size=20,
@@ -58,7 +58,7 @@ class TestSHA1(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA224()),
     skip_message="Does not support SHA224",
 )
-class TestSHA224(object):
+class TestSHA224:
     test_sha224 = generate_base_hash_test(
         hashes.SHA224(),
         digest_size=28,
@@ -69,7 +69,7 @@ class TestSHA224(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA256()),
     skip_message="Does not support SHA256",
 )
-class TestSHA256(object):
+class TestSHA256:
     test_sha256 = generate_base_hash_test(
         hashes.SHA256(),
         digest_size=32,
@@ -80,7 +80,7 @@ class TestSHA256(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA384()),
     skip_message="Does not support SHA384",
 )
-class TestSHA384(object):
+class TestSHA384:
     test_sha384 = generate_base_hash_test(
         hashes.SHA384(),
         digest_size=48,
@@ -91,7 +91,7 @@ class TestSHA384(object):
     only_if=lambda backend: backend.hash_supported(hashes.SHA512()),
     skip_message="Does not support SHA512",
 )
-class TestSHA512(object):
+class TestSHA512:
     test_sha512 = generate_base_hash_test(
         hashes.SHA512(),
         digest_size=64,
@@ -102,7 +102,7 @@ class TestSHA512(object):
     only_if=lambda backend: backend.hash_supported(hashes.MD5()),
     skip_message="Does not support MD5",
 )
-class TestMD5(object):
+class TestMD5:
     test_md5 = generate_base_hash_test(
         hashes.MD5(),
         digest_size=16,
@@ -115,7 +115,7 @@ class TestMD5(object):
     ),
     skip_message="Does not support BLAKE2b",
 )
-class TestBLAKE2b(object):
+class TestBLAKE2b:
     test_blake2b = generate_base_hash_test(
         hashes.BLAKE2b(digest_size=64),
         digest_size=64,
@@ -138,7 +138,7 @@ class TestBLAKE2b(object):
     ),
     skip_message="Does not support BLAKE2s",
 )
-class TestBLAKE2s(object):
+class TestBLAKE2s:
     test_blake2s = generate_base_hash_test(
         hashes.BLAKE2s(digest_size=32),
         digest_size=32,
@@ -164,7 +164,7 @@ def test_buffer_protocol_hash(backend):
     )
 
 
-class TestSHAKE(object):
+class TestSHAKE:
     @pytest.mark.parametrize("xof", [hashes.SHAKE128, hashes.SHAKE256])
     def test_invalid_digest_type(self, xof):
         with pytest.raises(TypeError):
@@ -183,7 +183,7 @@ class TestSHAKE(object):
     only_if=lambda backend: backend.hash_supported(hashes.SM3()),
     skip_message="Does not support SM3",
 )
-class TestSM3(object):
+class TestSM3:
     test_sm3 = generate_base_hash_test(
         hashes.SM3(),
         digest_size=32,

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -18,7 +18,7 @@ from ...utils import (
 )
 
 
-class TestHKDF(object):
+class TestHKDF:
     def test_length_limit(self, backend):
         big_length = 255 * hashes.SHA256().digest_size + 1
 
@@ -135,7 +135,7 @@ class TestHKDF(object):
         assert hkdf.derive(ikm) == binascii.unhexlify(vector["okm"])
 
 
-class TestHKDFExpand(object):
+class TestHKDFExpand:
     def test_derive(self, backend):
         prk = binascii.unhexlify(
             b"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"

--- a/tests/hazmat/primitives/test_hkdf_vectors.py
+++ b/tests/hazmat/primitives/test_hkdf_vectors.py
@@ -17,7 +17,7 @@ from ...utils import load_nist_vectors
     only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
     skip_message="Does not support SHA1.",
 )
-class TestHKDFSHA1(object):
+class TestHKDFSHA1:
     test_hkdfsha1 = generate_hkdf_test(
         load_nist_vectors,
         os.path.join("KDF"),
@@ -30,7 +30,7 @@ class TestHKDFSHA1(object):
     only_if=lambda backend: backend.hmac_supported(hashes.SHA256()),
     skip_message="Does not support SHA256.",
 )
-class TestHKDFSHA256(object):
+class TestHKDFSHA256:
     test_hkdfsha256 = generate_hkdf_test(
         load_nist_vectors,
         os.path.join("KDF"),

--- a/tests/hazmat/primitives/test_hmac.py
+++ b/tests/hazmat/primitives/test_hmac.py
@@ -23,13 +23,13 @@ from ...utils import raises_unsupported_algorithm
     only_if=lambda backend: backend.hmac_supported(hashes.MD5()),
     skip_message="Does not support MD5",
 )
-class TestHMACCopy(object):
+class TestHMACCopy:
     test_copy = generate_base_hmac_test(
         hashes.MD5(),
     )
 
 
-class TestHMAC(object):
+class TestHMAC:
     def test_hmac_reject_unicode(self, backend):
         h = hmac.HMAC(b"mykey", hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):

--- a/tests/hazmat/primitives/test_hmac_vectors.py
+++ b/tests/hazmat/primitives/test_hmac_vectors.py
@@ -17,7 +17,7 @@ from ...utils import load_hash_vectors
     only_if=lambda backend: backend.hmac_supported(hashes.MD5()),
     skip_message="Does not support MD5",
 )
-class TestHMACMD5(object):
+class TestHMACMD5:
     test_hmac_md5 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -30,7 +30,7 @@ class TestHMACMD5(object):
     only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
     skip_message="Does not support SHA1",
 )
-class TestHMACSHA1(object):
+class TestHMACSHA1:
     test_hmac_sha1 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -43,7 +43,7 @@ class TestHMACSHA1(object):
     only_if=lambda backend: backend.hmac_supported(hashes.SHA224()),
     skip_message="Does not support SHA224",
 )
-class TestHMACSHA224(object):
+class TestHMACSHA224:
     test_hmac_sha224 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -56,7 +56,7 @@ class TestHMACSHA224(object):
     only_if=lambda backend: backend.hmac_supported(hashes.SHA256()),
     skip_message="Does not support SHA256",
 )
-class TestHMACSHA256(object):
+class TestHMACSHA256:
     test_hmac_sha256 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -69,7 +69,7 @@ class TestHMACSHA256(object):
     only_if=lambda backend: backend.hmac_supported(hashes.SHA384()),
     skip_message="Does not support SHA384",
 )
-class TestHMACSHA384(object):
+class TestHMACSHA384:
     test_hmac_sha384 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -82,7 +82,7 @@ class TestHMACSHA384(object):
     only_if=lambda backend: backend.hmac_supported(hashes.SHA512()),
     skip_message="Does not support SHA512",
 )
-class TestHMACSHA512(object):
+class TestHMACSHA512:
     test_hmac_sha512 = generate_hmac_test(
         load_hash_vectors,
         "HMAC",
@@ -97,7 +97,7 @@ class TestHMACSHA512(object):
     ),
     skip_message="Does not support BLAKE2",
 )
-class TestHMACBLAKE2(object):
+class TestHMACBLAKE2:
     def test_blake2b(self, backend):
         h = hmac.HMAC(b"0" * 64, hashes.BLAKE2b(digest_size=64), backend)
         h.update(b"test")

--- a/tests/hazmat/primitives/test_idea.py
+++ b/tests/hazmat/primitives/test_idea.py
@@ -20,7 +20,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support IDEA ECB",
 )
-class TestIDEAModeECB(object):
+class TestIDEAModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "IDEA"),
@@ -36,7 +36,7 @@ class TestIDEAModeECB(object):
     ),
     skip_message="Does not support IDEA CBC",
 )
-class TestIDEAModeCBC(object):
+class TestIDEAModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "IDEA"),
@@ -52,7 +52,7 @@ class TestIDEAModeCBC(object):
     ),
     skip_message="Does not support IDEA OFB",
 )
-class TestIDEAModeOFB(object):
+class TestIDEAModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "IDEA"),
@@ -68,7 +68,7 @@ class TestIDEAModeOFB(object):
     ),
     skip_message="Does not support IDEA CFB",
 )
-class TestIDEAModeCFB(object):
+class TestIDEAModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "IDEA"),

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -23,7 +23,7 @@ from ...doubles import (
 from ...utils import raises_unsupported_algorithm
 
 
-class TestKBKDFHMAC(object):
+class TestKBKDFHMAC:
     def test_invalid_key(self, backend):
         kdf = KBKDFHMAC(
             hashes.SHA256(),
@@ -326,7 +326,7 @@ class TestKBKDFHMAC(object):
         assert key == b"\xb7\x01\x05\x98\xf5\x1a\x12L\xc7."
 
 
-class TestKBKDFCMAC(object):
+class TestKBKDFCMAC:
     _KEY_MATERIAL = bytes(32)
     _KEY_MATERIAL2 = _KEY_MATERIAL.replace(b"\x00", b"\x01", 1)
 

--- a/tests/hazmat/primitives/test_kbkdf_vectors.py
+++ b/tests/hazmat/primitives/test_kbkdf_vectors.py
@@ -9,7 +9,7 @@ from .utils import generate_kbkdf_counter_mode_test
 from ...utils import load_nist_kbkdf_vectors
 
 
-class TestCounterKDFCounterMode(object):
+class TestCounterKDFCounterMode:
     test_kbkdfctr = generate_kbkdf_counter_mode_test(
         load_nist_kbkdf_vectors,
         os.path.join("KDF"),

--- a/tests/hazmat/primitives/test_keywrap.py
+++ b/tests/hazmat/primitives/test_keywrap.py
@@ -15,7 +15,7 @@ from .utils import _load_all_params
 from ...utils import load_nist_vectors
 
 
-class TestAESKeyWrap(object):
+class TestAESKeyWrap:
     @pytest.mark.supported(
         only_if=lambda backend: backend.cipher_supported(
             algorithms.AES(b"\x00" * 16), modes.ECB()
@@ -122,7 +122,7 @@ class TestAESKeyWrap(object):
     skip_message="Does not support AES key wrap (RFC 5649) because AES-ECB"
     " is unsupported",
 )
-class TestAESKeyWrapWithPadding(object):
+class TestAESKeyWrapWithPadding:
     def test_wrap(self, backend, subtests):
         params = _load_all_params(
             os.path.join("keywrap", "kwtestvectors"),

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -9,7 +9,7 @@ from cryptography.exceptions import AlreadyFinalized
 from cryptography.hazmat.primitives import padding
 
 
-class TestPKCS7(object):
+class TestPKCS7:
     @pytest.mark.parametrize("size", [127, 4096, -2])
     def test_invalid_block_size(self, size):
         with pytest.raises(ValueError):
@@ -131,7 +131,7 @@ class TestPKCS7(object):
         assert final == unpadded + unpadded
 
 
-class TestANSIX923(object):
+class TestANSIX923:
     @pytest.mark.parametrize("size", [127, 4096, -2])
     def test_invalid_block_size(self, size):
         with pytest.raises(ValueError):

--- a/tests/hazmat/primitives/test_pbkdf2hmac.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac.py
@@ -13,7 +13,7 @@ from ...doubles import DummyHashAlgorithm
 from ...utils import raises_unsupported_algorithm
 
 
-class TestPBKDF2HMAC(object):
+class TestPBKDF2HMAC:
     def test_already_finalized(self, backend):
         kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
         kdf.derive(b"password")

--- a/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
@@ -15,7 +15,7 @@ from ...utils import load_nist_vectors
     only_if=lambda backend: backend.pbkdf2_hmac_supported(hashes.SHA1()),
     skip_message="Does not support SHA1 for PBKDF2HMAC",
 )
-class TestPBKDF2HMACSHA1(object):
+class TestPBKDF2HMACSHA1:
     test_pbkdf2_sha1 = generate_pbkdf2_test(
         load_nist_vectors,
         "KDF",

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -28,7 +28,7 @@ from ...utils import load_vectors_from_file
 @pytest.mark.skip_fips(
     reason="PKCS12 unsupported in FIPS mode. So much bad crypto in it."
 )
-class TestPKCS12Loading(object):
+class TestPKCS12Loading:
     def _test_load_pkcs12_ec_keys(self, filename, password, backend):
         cert = load_vectors_from_file(
             os.path.join("x509", "custom", "ca", "ca.pem"),
@@ -281,7 +281,7 @@ def _load_ca(backend):
 @pytest.mark.skip_fips(
     reason="PKCS12 unsupported in FIPS mode. So much bad crypto in it."
 )
-class TestPKCS12Creation(object):
+class TestPKCS12Creation:
     @pytest.mark.parametrize("name", [None, b"name"])
     @pytest.mark.parametrize(
         ("encryption_algorithm", "password"),
@@ -489,7 +489,7 @@ def test_pkcs12_ordering():
     assert a_idx < b_idx < c_idx
 
 
-class TestPKCS12Objects(object):
+class TestPKCS12Objects:
     def test_certificate_constructor(self, backend):
         with pytest.raises(TypeError):
             PKCS12Certificate(None, None)  # type:ignore[arg-type]

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -21,7 +21,7 @@ from ...utils import load_vectors_from_file, raises_unsupported_algorithm
     only_if=lambda backend: backend.pkcs7_supported(),
     skip_message="Requires OpenSSL with PKCS7 support",
 )
-class TestPKCS7Loading(object):
+class TestPKCS7Loading:
     def test_load_invalid_der_pkcs7(self, backend):
         with pytest.raises(ValueError):
             pkcs7.load_der_pkcs7_certificates(b"nonsense")
@@ -155,7 +155,7 @@ def _load_cert_key():
     only_if=lambda backend: backend.pkcs7_supported(),
     skip_message="Requires OpenSSL with PKCS7 support",
 )
-class TestPKCS7Builder(object):
+class TestPKCS7Builder:
     def test_invalid_data(self, backend):
         builder = pkcs7.PKCS7SignatureBuilder()
         with pytest.raises(TypeError):

--- a/tests/hazmat/primitives/test_poly1305.py
+++ b/tests/hazmat/primitives/test_poly1305.py
@@ -35,7 +35,7 @@ def test_poly1305_unsupported(backend):
     only_if=lambda backend: backend.poly1305_supported(),
     skip_message="Requires OpenSSL with poly1305 support",
 )
-class TestPoly1305(object):
+class TestPoly1305:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -61,7 +61,7 @@ from ...utils import (
 )
 
 
-class DummyMGF(object):
+class DummyMGF:
     _salt_length = 0
 
 
@@ -169,7 +169,7 @@ def test_modular_inverse():
     )
 
 
-class TestRSA(object):
+class TestRSA:
     @pytest.mark.parametrize(
         ("public_exponent", "key_size"),
         itertools.product(
@@ -361,7 +361,7 @@ class TestRSA(object):
             )
 
 
-class TestRSASignature(object):
+class TestRSASignature:
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.PKCS1v15()
@@ -678,7 +678,7 @@ class TestRSASignature(object):
             )
 
 
-class TestRSAVerification(object):
+class TestRSAVerification:
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.PKCS1v15()
@@ -1101,7 +1101,7 @@ class TestRSAVerification(object):
             public_key.verify(b"\x00" * 64, data, pkcs, prehashed_alg)
 
 
-class TestRSAPSSMGF1Verification(object):
+class TestRSAPSSMGF1Verification:
     test_rsa_pss_mgf1_sha1 = pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.PSS(
@@ -1238,7 +1238,7 @@ class TestRSAPSSMGF1Verification(object):
     )
 
 
-class TestRSAPKCS1Verification(object):
+class TestRSAPKCS1Verification:
     test_rsa_pkcs1v15_verify_sha1 = pytest.mark.supported(
         only_if=lambda backend: (
             backend.hash_supported(hashes.SHA1())
@@ -1340,7 +1340,7 @@ class TestRSAPKCS1Verification(object):
     )
 
 
-class TestPSS(object):
+class TestPSS:
     def test_calculate_max_pss_salt_length(self):
         with pytest.raises(TypeError):
             padding.calculate_max_pss_salt_length(
@@ -1373,7 +1373,7 @@ class TestPSS(object):
         assert pss._salt_length == padding.PSS.MAX_LENGTH
 
 
-class TestMGF1(object):
+class TestMGF1:
     def test_invalid_hash_algorithm(self):
         with pytest.raises(TypeError):
             padding.MGF1(b"not_a_hash")  # type:ignore[arg-type]
@@ -1384,7 +1384,7 @@ class TestMGF1(object):
         assert mgf._algorithm == algorithm
 
 
-class TestOAEP(object):
+class TestOAEP:
     def test_invalid_algorithm(self):
         mgf = padding.MGF1(hashes.SHA1())
         with pytest.raises(TypeError):
@@ -1393,7 +1393,7 @@ class TestOAEP(object):
             )
 
 
-class TestRSADecryption(object):
+class TestRSADecryption:
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.PKCS1v15()
@@ -1637,7 +1637,7 @@ class TestRSADecryption(object):
             )
 
 
-class TestRSAEncryption(object):
+class TestRSAEncryption:
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
             padding.OAEP(
@@ -1836,7 +1836,7 @@ class TestRSAEncryption(object):
             )
 
 
-class TestRSANumbers(object):
+class TestRSANumbers:
     def test_rsa_public_numbers(self):
         public_numbers = rsa.RSAPublicNumbers(e=1, n=15)
         assert public_numbers.e == 1
@@ -1963,7 +1963,7 @@ class TestRSANumbers(object):
         assert repr(num) == "<RSAPublicNumbers(e=1, n=1)>"
 
 
-class TestRSANumbersEquality(object):
+class TestRSANumbersEquality:
     def test_public_numbers_eq(self):
         num = RSAPublicNumbers(1, 2)
         num2 = RSAPublicNumbers(1, 2)
@@ -2028,7 +2028,7 @@ class TestRSANumbersEquality(object):
         assert hash(priv1) != hash(priv3)
 
 
-class TestRSAPrimeFactorRecovery(object):
+class TestRSAPrimeFactorRecovery:
     def test_recover_prime_factors(self, subtests):
         vectors = _flatten_pkcs1_examples(
             load_vectors_from_file(
@@ -2057,7 +2057,7 @@ class TestRSAPrimeFactorRecovery(object):
             rsa.rsa_recover_prime_factors(34, 3, 7)
 
 
-class TestRSAPrivateKeySerialization(object):
+class TestRSAPrivateKeySerialization:
     @pytest.mark.parametrize(
         ("fmt", "password"),
         itertools.product(
@@ -2246,7 +2246,7 @@ class TestRSAPrivateKeySerialization(object):
             )
 
 
-class TestRSAPEMPublicKeySerialization(object):
+class TestRSAPEMPublicKeySerialization:
     @pytest.mark.parametrize(
         ("key_path", "loader_func", "encoding", "format"),
         [

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -58,7 +58,7 @@ def test_unsupported_backend(backend):
     only_if=lambda backend: backend.scrypt_supported(),
     skip_message="Does not support Scrypt",
 )
-class TestScrypt(object):
+class TestScrypt:
     @pytest.mark.parametrize("params", vectors)
     def test_derive(self, backend, params):
         _skip_if_memory_limited(_MEM_LIMIT, params)

--- a/tests/hazmat/primitives/test_seed.py
+++ b/tests/hazmat/primitives/test_seed.py
@@ -20,7 +20,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support SEED ECB",
 )
-class TestSEEDModeECB(object):
+class TestSEEDModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SEED"),
@@ -36,7 +36,7 @@ class TestSEEDModeECB(object):
     ),
     skip_message="Does not support SEED CBC",
 )
-class TestSEEDModeCBC(object):
+class TestSEEDModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SEED"),
@@ -52,7 +52,7 @@ class TestSEEDModeCBC(object):
     ),
     skip_message="Does not support SEED OFB",
 )
-class TestSEEDModeOFB(object):
+class TestSEEDModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SEED"),
@@ -68,7 +68,7 @@ class TestSEEDModeOFB(object):
     ),
     skip_message="Does not support SEED CFB",
 )
-class TestSEEDModeCFB(object):
+class TestSEEDModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SEED"),

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -67,7 +67,7 @@ def _skip_fips_format(key_path, password, backend):
             )
 
 
-class TestBufferProtocolSerialization(object):
+class TestBufferProtocolSerialization:
     @pytest.mark.parametrize(
         ("key_path", "password"),
         [
@@ -118,7 +118,7 @@ class TestBufferProtocolSerialization(object):
         _check_rsa_private_numbers(key.private_numbers())
 
 
-class TestDERSerialization(object):
+class TestDERSerialization:
     @pytest.mark.parametrize(
         ("key_path", "password"),
         [
@@ -382,7 +382,7 @@ class TestDERSerialization(object):
             load_der_parameters(param_data, backend)
 
 
-class TestPEMSerialization(object):
+class TestPEMSerialization:
     @pytest.mark.parametrize(
         ("key_file", "password"),
         [
@@ -967,7 +967,7 @@ class TestPEMSerialization(object):
             )
 
 
-class TestRSASSHSerialization(object):
+class TestRSASSHSerialization:
     def test_load_ssh_public_key_unsupported(self, backend):
         ssh_key = b"ecdsa-sha2-junk AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY="
 
@@ -1079,7 +1079,7 @@ class TestRSASSHSerialization(object):
         assert numbers == expected
 
 
-class TestDSSSSHSerialization(object):
+class TestDSSSSHSerialization:
     def test_load_ssh_public_key_dss_too_short(self, backend):
         ssh_key = b"ssh-dss"
 
@@ -1192,7 +1192,7 @@ class TestDSSSSHSerialization(object):
         assert numbers == expected
 
 
-class TestECDSASSHSerialization(object):
+class TestECDSASSHSerialization:
     def test_load_ssh_public_key_ecdsa_nist_p256(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
 
@@ -1330,7 +1330,7 @@ class TestECDSASSHSerialization(object):
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support",
 )
-class TestEd25519SSHSerialization(object):
+class TestEd25519SSHSerialization:
     def test_load_ssh_public_key(self, backend):
         ssh_key = (
             b"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG2fgpmpYO61qeAxGd0wgRaN/E4"
@@ -1371,7 +1371,7 @@ class TestEd25519SSHSerialization(object):
             load_ssh_public_key(ssh_key, backend)
 
 
-class TestKeySerializationEncryptionTypes(object):
+class TestKeySerializationEncryptionTypes:
     def test_non_bytes_password(self):
         with pytest.raises(ValueError):
             BestAvailableEncryption(object())  # type:ignore[arg-type]
@@ -1385,7 +1385,7 @@ class TestKeySerializationEncryptionTypes(object):
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support",
 )
-class TestEd25519Serialization(object):
+class TestEd25519Serialization:
     def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8-enc.der"),
@@ -1473,7 +1473,7 @@ class TestEd25519Serialization(object):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-class TestX448Serialization(object):
+class TestX448Serialization:
     def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "X448", "x448-pkcs8-enc.der"),
@@ -1564,7 +1564,7 @@ class TestX448Serialization(object):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-class TestX25519Serialization(object):
+class TestX25519Serialization:
     def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "X25519", "x25519-pkcs8-enc.der"),
@@ -1655,7 +1655,7 @@ class TestX25519Serialization(object):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-class TestEd448Serialization(object):
+class TestEd448Serialization:
     def test_load_der_private_key(self, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "Ed448", "ed448-pkcs8-enc.der"),
@@ -1749,7 +1749,7 @@ class TestEd448Serialization(object):
     only_if=lambda backend: backend.dh_supported(),
     skip_message="DH not supported",
 )
-class TestDHSerialization(object):
+class TestDHSerialization:
     """Test all options with least-supported key type."""
 
     @pytest.mark.skip_fips(reason="non-FIPS parameters")
@@ -1814,7 +1814,7 @@ class TestDHSerialization(object):
                     private_key.private_bytes(enc, fmt, NoEncryption())
 
 
-class TestOpenSSHSerialization(object):
+class TestOpenSSHSerialization:
     @pytest.mark.parametrize(
         ("key_file", "cert_file"),
         [

--- a/tests/hazmat/primitives/test_sm4.py
+++ b/tests/hazmat/primitives/test_sm4.py
@@ -19,7 +19,7 @@ from ...utils import load_nist_vectors
     ),
     skip_message="Does not support SM4 ECB",
 )
-class TestSM4ModeECB(object):
+class TestSM4ModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SM4"),
@@ -35,7 +35,7 @@ class TestSM4ModeECB(object):
     ),
     skip_message="Does not support SM4 CBC",
 )
-class TestSM4ModeCBC(object):
+class TestSM4ModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SM4"),
@@ -51,7 +51,7 @@ class TestSM4ModeCBC(object):
     ),
     skip_message="Does not support SM4 OFB",
 )
-class TestSM4ModeOFB(object):
+class TestSM4ModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SM4"),
@@ -67,7 +67,7 @@ class TestSM4ModeOFB(object):
     ),
     skip_message="Does not support SM4 CFB",
 )
-class TestSM4ModeCFB(object):
+class TestSM4ModeCFB:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SM4"),
@@ -83,7 +83,7 @@ class TestSM4ModeCFB(object):
     ),
     skip_message="Does not support SM4 CTR",
 )
-class TestSM4ModeCTR(object):
+class TestSM4ModeCTR:
     test_cfb = generate_encrypt_test(
         load_nist_vectors,
         os.path.join("ciphers", "SM4"),

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -41,7 +41,7 @@ def test_x25519_unsupported(backend):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-class TestX25519Exchange(object):
+class TestX25519Exchange:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -41,7 +41,7 @@ def test_x448_unsupported(backend):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-class TestX448Exchange(object):
+class TestX448Exchange:
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(

--- a/tests/hazmat/primitives/test_x963_vectors.py
+++ b/tests/hazmat/primitives/test_x963_vectors.py
@@ -25,7 +25,7 @@ def _skip_hashfn_unsupported(backend, hashfn):
         )
 
 
-class TestX963(object):
+class TestX963:
     _algorithms_dict: typing.Dict[str, typing.Type[hashes.HashAlgorithm]] = {
         "SHA-1": hashes.SHA1,
         "SHA-224": hashes.SHA224,

--- a/tests/hazmat/primitives/test_x963kdf.py
+++ b/tests/hazmat/primitives/test_x963kdf.py
@@ -12,7 +12,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.x963kdf import X963KDF
 
 
-class TestX963KDF(object):
+class TestX963KDF:
     def test_length_limit(self, backend):
         big_length = hashes.SHA256().digest_size * (2**32 - 1) + 1
 

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -24,7 +24,7 @@ vectors = load_vectors_from_file("twofactor/rfc-4226.txt", load_nist_vectors)
     only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
     skip_message="Does not support HMAC-SHA1.",
 )
-class TestHOTP(object):
+class TestHOTP:
     def test_invalid_key_length(self, backend):
         secret = os.urandom(10)
 

--- a/tests/hazmat/primitives/twofactor/test_totp.py
+++ b/tests/hazmat/primitives/twofactor/test_totp.py
@@ -17,7 +17,7 @@ from ....utils import (
 vectors = load_vectors_from_file("twofactor/rfc-6238.txt", load_nist_vectors)
 
 
-class TestTOTP(object):
+class TestTOTP:
     @pytest.mark.supported(
         only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
         skip_message="Does not support HMAC-SHA1.",

--- a/tests/test_cryptography_utils.py
+++ b/tests/test_cryptography_utils.py
@@ -10,9 +10,9 @@ import pytest
 from cryptography import utils
 
 
-class TestCachedProperty(object):
+class TestCachedProperty:
     def test_simple(self):
-        class T(object):
+        class T:
             @utils.cached_property
             def t(self):
                 accesses.append(None)
@@ -34,7 +34,7 @@ class TestCachedProperty(object):
         assert len(accesses) == 2
 
     def test_set(self):
-        class T(object):
+        class T:
             @utils.cached_property
             def t(self):
                 accesses.append(None)

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -38,7 +38,7 @@ def json_parametrize(keys, filename):
     ),
     skip_message="Does not support AES CBC",
 )
-class TestFernet(object):
+class TestFernet:
     @json_parametrize(
         ("secret", "now", "iv", "src", "token"),
         "generate.json",
@@ -150,7 +150,7 @@ class TestFernet(object):
     ),
     skip_message="Does not support AES CBC",
 )
-class TestMultiFernet(object):
+class TestMultiFernet:
     def test_encrypt(self, backend):
         f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         f2 = Fernet(base64.urlsafe_b64encode(b"\x01" * 32), backend=backend)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -12,14 +12,14 @@ from cryptography.utils import (
 )
 
 
-class TestVerifyInterface(object):
+class TestVerifyInterface:
     def test_verify_missing_method(self):
         class SimpleInterface(metaclass=abc.ABCMeta):
             @abc.abstractmethod
             def method(self):
                 """A simple method"""
 
-        class NonImplementer(object):
+        class NonImplementer:
             pass
 
         with pytest.raises(InterfaceNotImplemented):
@@ -31,7 +31,7 @@ class TestVerifyInterface(object):
             def method(self, a):
                 """Method with one argument"""
 
-        class NonImplementer(object):
+        class NonImplementer:
             def method(self):
                 """Method with no arguments"""
 
@@ -46,7 +46,7 @@ class TestVerifyInterface(object):
             def property(self):
                 """An abstract property"""
 
-        class NonImplementer(object):
+        class NonImplementer:
             @property
             def property(self):
                 """A concrete property"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4449,7 +4449,7 @@ def test_raises_unsupported_algorithm():
     assert exc_info.type is UnsupportedAlgorithm
 
 
-class TestDeprecated(object):
+class TestDeprecated:
     def test_getattr(self):
         with pytest.warns(DeprecationWarning):
             assert deprecated_module.DEPRECATED == 3

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -13,7 +13,7 @@ import pytest
 from cryptography.utils import deprecated
 
 
-class TestDeprecated(object):
+class TestDeprecated:
     @typing.no_type_check
     def test_deprecated(self, monkeypatch):
         mod = types.ModuleType("TestDeprecated/test_deprecated")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -886,7 +886,7 @@ def load_nist_ccm_vectors(vector_data):
     return data
 
 
-class WycheproofTest(object):
+class WycheproofTest:
     def __init__(self, testfiledata, testgroup, testcase):
         self.testfiledata = testfiledata
         self.testgroup = testgroup

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -72,7 +72,7 @@ def _generate_root(private_key=None, algorithm=hashes.SHA256()):
     return cert, private_key
 
 
-class TestOCSPRequest(object):
+class TestOCSPRequest:
     def test_bad_request(self):
         with pytest.raises(ValueError):
             ocsp.load_der_ocsp_request(b"invalid")
@@ -162,7 +162,7 @@ class TestOCSPRequest(object):
             req.public_bytes(serialization.Encoding.PEM)
 
 
-class TestOCSPRequestBuilder(object):
+class TestOCSPRequestBuilder:
     def test_add_two_certs(self):
         cert, issuer = _cert_and_issuer()
         builder = ocsp.OCSPRequestBuilder()
@@ -253,7 +253,7 @@ class TestOCSPRequestBuilder(object):
         assert req.extensions[0].critical is critical
 
 
-class TestOCSPResponseBuilder(object):
+class TestOCSPResponseBuilder:
     def test_add_response_twice(self):
         cert, issuer = _cert_and_issuer()
         time = datetime.datetime.now()
@@ -879,7 +879,7 @@ class TestOCSPResponseBuilder(object):
             builder.sign(private_key, None)
 
 
-class TestSignedCertificateTimestampsExtension(object):
+class TestSignedCertificateTimestampsExtension:
     def test_init(self):
         with pytest.raises(TypeError):
             x509.SignedCertificateTimestamps(
@@ -971,7 +971,7 @@ class TestSignedCertificateTimestampsExtension(object):
         )
 
 
-class TestOCSPResponse(object):
+class TestOCSPResponse:
     def test_bad_response(self):
         with pytest.raises(ValueError):
             ocsp.load_der_ocsp_response(b"invalid")
@@ -1300,7 +1300,7 @@ class TestOCSPResponse(object):
             )
 
 
-class TestOCSPEdDSA(object):
+class TestOCSPEdDSA:
     @pytest.mark.supported(
         only_if=lambda backend: backend.ed25519_supported(),
         skip_message="Requires OpenSSL with Ed25519 support / OCSP",

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -55,7 +55,7 @@ class DummyExtension(x509.ExtensionType):
 
 
 @utils.register_interface(x509.GeneralName)
-class FakeGeneralName(object):
+class FakeGeneralName:
     def __init__(self, value):
         self._value = value
 
@@ -76,7 +76,7 @@ def _load_cert(filename, loader: typing.Callable[..., T], backend=None) -> T:
     return cert
 
 
-class TestCertificateRevocationList(object):
+class TestCertificateRevocationList:
     def test_load_pem_crl(self, backend):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
@@ -500,7 +500,7 @@ class TestCertificateRevocationList(object):
             crl.is_signature_valid(object)  # type: ignore[arg-type]
 
 
-class TestRevokedCertificate(object):
+class TestRevokedCertificate:
     def test_revoked_basics(self, backend):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
@@ -688,7 +688,7 @@ class TestRevokedCertificate(object):
         assert crl[2].serial_number == 3
 
 
-class TestRSACertificate(object):
+class TestRSACertificate:
     def test_load_pem_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
@@ -1361,7 +1361,7 @@ class TestRSACertificate(object):
         )
 
 
-class TestRSACertificateRequest(object):
+class TestRSACertificateRequest:
     @pytest.mark.parametrize(
         ("path", "loader_func"),
         [
@@ -1941,7 +1941,7 @@ class TestRSACertificateRequest(object):
         assert parsed.subject_value_tags[1] == 0x13
 
 
-class TestCertificateBuilder(object):
+class TestCertificateBuilder:
     def test_checks_for_unsupported_extensions(self, backend):
         private_key = RSA_KEY_2048.private_key(backend)
         builder = (
@@ -3614,7 +3614,7 @@ class TestCertificateBuilder(object):
             builder.sign(private_key, hashes.SHA256(), backend)
 
 
-class TestCertificateSigningRequestBuilder(object):
+class TestCertificateSigningRequestBuilder:
     def test_sign_invalid_hash_algorithm(self, backend):
         private_key = RSA_KEY_2048.private_key(backend)
 
@@ -4342,7 +4342,7 @@ class TestCertificateSigningRequestBuilder(object):
             builder.sign(private_key, hashes.SHA512(), backend)
 
 
-class TestDSACertificate(object):
+class TestDSACertificate:
     def test_load_dsa_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "dsa_selfsigned_ca.pem"),
@@ -4467,7 +4467,7 @@ class TestDSACertificate(object):
         )
 
 
-class TestDSACertificateRequest(object):
+class TestDSACertificateRequest:
     @pytest.mark.parametrize(
         ("path", "loader_func"),
         [
@@ -4542,7 +4542,7 @@ class TestDSACertificateRequest(object):
         )
 
 
-class TestGOSTCertificate(object):
+class TestGOSTCertificate:
     def test_numeric_string_x509_name_entry(self):
         cert = _load_cert(
             os.path.join("x509", "e-trust.ru.der"),
@@ -4556,7 +4556,7 @@ class TestGOSTCertificate(object):
         )
 
 
-class TestECDSACertificate(object):
+class TestECDSACertificate:
     def test_load_ecdsa_cert(self, backend):
         _skip_curve_unsupported(backend, ec.SECP384R1())
         cert = _load_cert(
@@ -4674,7 +4674,7 @@ class TestECDSACertificate(object):
             cert.public_key()
 
 
-class TestECDSACertificateRequest(object):
+class TestECDSACertificateRequest:
     @pytest.mark.parametrize(
         ("path", "loader_func"),
         [
@@ -4744,7 +4744,7 @@ class TestECDSACertificateRequest(object):
         )
 
 
-class TestOtherCertificate(object):
+class TestOtherCertificate:
     def test_unsupported_subject_public_key_info(self, backend):
         cert = _load_cert(
             os.path.join(
@@ -4766,7 +4766,7 @@ class TestOtherCertificate(object):
             )
 
 
-class TestNameAttribute(object):
+class TestNameAttribute:
     EXPECTED_TYPES = [
         (NameOID.COMMON_NAME, _ASN1Type.UTF8String),
         (NameOID.COUNTRY_NAME, _ASN1Type.PrintableString),
@@ -4919,7 +4919,7 @@ class TestNameAttribute(object):
         assert na.rfc4514_string() == r"ST="
 
 
-class TestRelativeDistinguishedName(object):
+class TestRelativeDistinguishedName:
     def test_init_empty(self):
         with pytest.raises(ValueError):
             x509.RelativeDistinguishedName([])
@@ -5015,7 +5015,7 @@ class TestRelativeDistinguishedName(object):
         assert rdn.get_attributes_for_oid(x509.ObjectIdentifier("1.2.3")) == []
 
 
-class TestObjectIdentifier(object):
+class TestObjectIdentifier:
     def test_eq(self):
         oid1 = x509.ObjectIdentifier("2.999.1")
         oid2 = x509.ObjectIdentifier("2.999.1")
@@ -5062,7 +5062,7 @@ class TestObjectIdentifier(object):
         x509.ObjectIdentifier("2.25.305821105408246119474742976030998643995")
 
 
-class TestName(object):
+class TestName:
     def test_eq(self):
         ava1 = x509.NameAttribute(x509.ObjectIdentifier("2.999.1"), "value1")
         ava2 = x509.NameAttribute(x509.ObjectIdentifier("2.999.2"), "value2")
@@ -5263,7 +5263,7 @@ class TestName(object):
     only_if=lambda backend: backend.ed25519_supported(),
     skip_message="Requires OpenSSL with Ed25519 support",
 )
-class TestEd25519Certificate(object):
+class TestEd25519Certificate:
     def test_load_pem_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "ed25519", "root-ed25519.pem"),
@@ -5292,7 +5292,7 @@ class TestEd25519Certificate(object):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-class TestEd448Certificate(object):
+class TestEd448Certificate:
     def test_load_pem_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "ed448", "root-ed448.pem"),
@@ -5313,7 +5313,7 @@ class TestEd448Certificate(object):
     only_if=lambda backend: backend.dh_supported(),
     skip_message="DH not supported",
 )
-class TestSignatureRejection(object):
+class TestSignatureRejection:
     """Test if signing rejects DH keys properly."""
 
     def load_key(self, backend):

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -25,7 +25,7 @@ from ..hazmat.primitives.fixtures_rsa import RSA_KEY_2048, RSA_KEY_512
 from ..hazmat.primitives.test_ec import _skip_curve_unsupported
 
 
-class TestCertificateRevocationListBuilder(object):
+class TestCertificateRevocationListBuilder:
     def test_issuer_name_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
         with pytest.raises(TypeError):

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -56,7 +56,7 @@ def _make_certbuilder(private_key):
     )
 
 
-class TestExtension(object):
+class TestExtension:
     def test_not_an_oid(self):
         bc = x509.BasicConstraints(ca=False, path_length=None)
         with pytest.raises(TypeError):
@@ -139,7 +139,7 @@ class TestExtension(object):
         assert hash(ext1) != hash(ext3)
 
 
-class TestTLSFeature(object):
+class TestTLSFeature:
     def test_not_enum_type(self):
         with pytest.raises(TypeError):
             x509.TLSFeature([3])  # type:ignore[list-item]
@@ -214,7 +214,7 @@ class TestTLSFeature(object):
         assert ext2.public_bytes() == b"\x30\x03\x02\x01\x11"
 
 
-class TestUnrecognizedExtension(object):
+class TestUnrecognizedExtension:
     def test_invalid_oid(self):
         with pytest.raises(TypeError):
             x509.UnrecognizedExtension(
@@ -281,7 +281,7 @@ class TestUnrecognizedExtension(object):
         assert ext2.public_bytes() == b"\x03\x02\x01"
 
 
-class TestCertificateIssuer(object):
+class TestCertificateIssuer:
     def test_iter_names(self):
         ci = x509.CertificateIssuer(
             [x509.DNSName("cryptography.io"), x509.DNSName("crypto.local")]
@@ -342,7 +342,7 @@ class TestCertificateIssuer(object):
         assert ext.public_bytes() == b"0\x11\x82\x0fcryptography.io"
 
 
-class TestCRLReason(object):
+class TestCRLReason:
     def test_invalid_reason_flags(self):
         with pytest.raises(TypeError):
             x509.CRLReason("notareason")  # type:ignore[arg-type]
@@ -375,7 +375,7 @@ class TestCRLReason(object):
         assert ext.public_bytes() == b"\n\x01\x02"
 
 
-class TestDeltaCRLIndicator(object):
+class TestDeltaCRLIndicator:
     def test_not_int(self):
         with pytest.raises(TypeError):
             x509.DeltaCRLIndicator("notanint")  # type:ignore[arg-type]
@@ -407,7 +407,7 @@ class TestDeltaCRLIndicator(object):
         assert ext.public_bytes() == b"\x02\x01\x02"
 
 
-class TestInvalidityDate(object):
+class TestInvalidityDate:
     def test_invalid_invalidity_date(self):
         with pytest.raises(TypeError):
             x509.InvalidityDate("notadate")  # type:ignore[arg-type]
@@ -441,7 +441,7 @@ class TestInvalidityDate(object):
         assert ext.public_bytes() == b"\x18\x0f20150101010100Z"
 
 
-class TestNoticeReference(object):
+class TestNoticeReference:
     def test_notice_numbers_not_all_int(self):
         with pytest.raises(TypeError):
             x509.NoticeReference(
@@ -486,7 +486,7 @@ class TestNoticeReference(object):
         assert hash(nr) != hash(nr3)
 
 
-class TestUserNotice(object):
+class TestUserNotice:
     def test_notice_reference_invalid(self):
         with pytest.raises(TypeError):
             x509.UserNotice("invalid", None)  # type:ignore[arg-type]
@@ -530,7 +530,7 @@ class TestUserNotice(object):
         assert hash(un) != hash(un3)
 
 
-class TestPolicyInformation(object):
+class TestPolicyInformation:
     def test_invalid_policy_identifier(self):
         with pytest.raises(TypeError):
             x509.PolicyInformation("notanoid", None)  # type:ignore[arg-type]
@@ -608,7 +608,7 @@ class TestPolicyInformation(object):
         assert hash(pi) != hash(pi3)
 
 
-class TestCertificatePolicies(object):
+class TestCertificatePolicies:
     def test_invalid_policies(self):
         pq = ["string"]
         pi = x509.PolicyInformation(x509.ObjectIdentifier("1.2.3"), pq)
@@ -703,7 +703,7 @@ class TestCertificatePolicies(object):
         assert hash(cp) != hash(cp3)
 
 
-class TestCertificatePoliciesExtension(object):
+class TestCertificatePoliciesExtension:
     def test_cps_uri_policy_qualifier(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "cp_cps_uri.pem"),
@@ -856,7 +856,7 @@ class TestCertificatePoliciesExtension(object):
         )
 
 
-class TestKeyUsage(object):
+class TestKeyUsage:
     def test_key_agreement_false_encipher_decipher_true(self):
         with pytest.raises(ValueError):
             x509.KeyUsage(
@@ -1143,7 +1143,7 @@ class TestKeyUsage(object):
         assert ext.public_bytes() == serialized
 
 
-class TestSubjectKeyIdentifier(object):
+class TestSubjectKeyIdentifier:
     def test_properties(self):
         value = binascii.unhexlify(b"092384932230498bc980aa8098456f6ff7ff3ac9")
         ski = x509.SubjectKeyIdentifier(value)
@@ -1205,7 +1205,7 @@ class TestSubjectKeyIdentifier(object):
         )
 
 
-class TestAuthorityKeyIdentifier(object):
+class TestAuthorityKeyIdentifier:
     def test_authority_cert_issuer_not_generalname(self):
         with pytest.raises(TypeError):
             x509.AuthorityKeyIdentifier(
@@ -1336,7 +1336,7 @@ class TestAuthorityKeyIdentifier(object):
         )
 
 
-class TestBasicConstraints(object):
+class TestBasicConstraints:
     def test_ca_not_boolean(self):
         with pytest.raises(TypeError):
             x509.BasicConstraints(
@@ -1391,7 +1391,7 @@ class TestBasicConstraints(object):
         assert ext.public_bytes() == b"0\x03\x01\x01\xff"
 
 
-class TestExtendedKeyUsage(object):
+class TestExtendedKeyUsage:
     def test_not_all_oids(self):
         with pytest.raises(TypeError):
             x509.ExtendedKeyUsage(["notoid"])  # type:ignore[list-item]
@@ -1463,7 +1463,7 @@ class TestExtendedKeyUsage(object):
         assert ext.public_bytes() == b"0\x08\x06\x02+\x06\x06\x02+\x07"
 
 
-class TestExtensions(object):
+class TestExtensions:
     def test_no_extensions(self, backend):
         cert = _load_cert(
             os.path.join("x509", "verisign_md2_root.pem"),
@@ -1591,7 +1591,7 @@ class TestExtensions(object):
         )
 
 
-class TestBasicConstraintsExtension(object):
+class TestBasicConstraintsExtension:
     def test_ca_true_pathlen_6(self, backend):
         cert = _load_cert(
             os.path.join(
@@ -1672,7 +1672,7 @@ class TestBasicConstraintsExtension(object):
         assert ext.value.ca is False
 
 
-class TestSubjectKeyIdentifierExtension(object):
+class TestSubjectKeyIdentifierExtension:
     def test_subject_key_identifier(self, backend):
         cert = _load_cert(
             os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
@@ -1815,7 +1815,7 @@ class TestSubjectKeyIdentifierExtension(object):
         assert ext.value == ski
 
 
-class TestKeyUsageExtension(object):
+class TestKeyUsageExtension:
     def test_no_key_usage(self, backend):
         cert = _load_cert(
             os.path.join("x509", "verisign_md2_root.pem"),
@@ -1870,7 +1870,7 @@ class TestKeyUsageExtension(object):
         assert ku.crl_sign is True
 
 
-class TestDNSName(object):
+class TestDNSName:
     def test_non_a_label(self):
         with pytest.raises(ValueError):
             x509.DNSName(".\xf5\xe4\xf6\xfc.example.com")
@@ -1900,7 +1900,7 @@ class TestDNSName(object):
         assert hash(n2) == hash(n3)
 
 
-class TestDirectoryName(object):
+class TestDirectoryName:
     def test_not_name(self):
         with pytest.raises(TypeError):
             x509.DirectoryName(b"notaname")  # type:ignore[arg-type]
@@ -1950,7 +1950,7 @@ class TestDirectoryName(object):
         assert hash(gn) != hash(gn3)
 
 
-class TestRFC822Name(object):
+class TestRFC822Name:
     def test_repr(self):
         gn = x509.RFC822Name("string")
         assert repr(gn) == "<RFC822Name(value='string')>"
@@ -1994,7 +1994,7 @@ class TestRFC822Name(object):
         assert hash(g1) != hash(g3)
 
 
-class TestUniformResourceIdentifier(object):
+class TestUniformResourceIdentifier:
     def test_equality(self):
         gn = x509.UniformResourceIdentifier("string")
         gn2 = x509.UniformResourceIdentifier("string2")
@@ -2038,7 +2038,7 @@ class TestUniformResourceIdentifier(object):
         assert repr(gn) == ("<UniformResourceIdentifier(value='string')>")
 
 
-class TestRegisteredID(object):
+class TestRegisteredID:
     def test_not_oid(self):
         with pytest.raises(TypeError):
             x509.RegisteredID(b"notanoid")  # type:ignore[arg-type]
@@ -2072,7 +2072,7 @@ class TestRegisteredID(object):
         assert hash(gn) != hash(gn3)
 
 
-class TestIPAddress(object):
+class TestIPAddress:
     def test_not_ipaddress(self):
         with pytest.raises(TypeError):
             x509.IPAddress(b"notanipaddress")  # type:ignore[arg-type]
@@ -2112,7 +2112,7 @@ class TestIPAddress(object):
         assert hash(gn) != hash(gn3)
 
 
-class TestOtherName(object):
+class TestOtherName:
     def test_invalid_args(self):
         with pytest.raises(TypeError):
             x509.OtherName(
@@ -2162,7 +2162,7 @@ class TestOtherName(object):
         assert hash(gn) != hash(gn3)
 
 
-class TestGeneralNames(object):
+class TestGeneralNames:
     def test_get_values_for_type(self):
         gns = x509.GeneralNames([x509.DNSName("cryptography.io")])
         names = gns.get_values_for_type(x509.DNSName)
@@ -2233,7 +2233,7 @@ class TestGeneralNames(object):
         assert hash(gns) != hash(gns3)
 
 
-class TestIssuerAlternativeName(object):
+class TestIssuerAlternativeName:
     def test_get_values_for_type(self):
         san = x509.IssuerAlternativeName([x509.DNSName("cryptography.io")])
         names = san.get_values_for_type(x509.DNSName)
@@ -2305,7 +2305,7 @@ class TestIssuerAlternativeName(object):
         assert ext.public_bytes() == b"0\x11\x82\x0fcryptography.io"
 
 
-class TestRSAIssuerAlternativeNameExtension(object):
+class TestRSAIssuerAlternativeNameExtension:
     def test_uri(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "ian_uri.pem"),
@@ -2320,7 +2320,7 @@ class TestRSAIssuerAlternativeNameExtension(object):
         ]
 
 
-class TestCRLNumber(object):
+class TestCRLNumber:
     def test_eq(self):
         crl_number = x509.CRLNumber(15)
         assert crl_number == x509.CRLNumber(15)
@@ -2350,7 +2350,7 @@ class TestCRLNumber(object):
         assert ext.public_bytes() == b"\x02\x01\x0f"
 
 
-class TestSubjectAlternativeName(object):
+class TestSubjectAlternativeName:
     def test_get_values_for_type(self):
         san = x509.SubjectAlternativeName([x509.DNSName("cryptography.io")])
         names = san.get_values_for_type(x509.DNSName)
@@ -2422,7 +2422,7 @@ class TestSubjectAlternativeName(object):
         assert ext.public_bytes() == b"0\x11\x82\x0fcryptography.io"
 
 
-class TestRSASubjectAlternativeNameExtension(object):
+class TestRSASubjectAlternativeNameExtension:
     def test_dns_name(self, backend):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.pem"),
@@ -2720,7 +2720,7 @@ class TestRSASubjectAlternativeNameExtension(object):
         assert result == sans
 
 
-class TestExtendedKeyUsageExtension(object):
+class TestExtendedKeyUsageExtension:
     def test_eku(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "extended_key_usage.pem"),
@@ -2743,7 +2743,7 @@ class TestExtendedKeyUsageExtension(object):
         ] == list(ext.value)
 
 
-class TestAccessDescription(object):
+class TestAccessDescription:
     def test_invalid_access_method(self):
         with pytest.raises(TypeError):
             x509.AccessDescription(
@@ -2820,7 +2820,7 @@ class TestAccessDescription(object):
         assert hash(ad) != hash(ad3)
 
 
-class TestPolicyConstraints(object):
+class TestPolicyConstraints:
     def test_invalid_explicit_policy(self):
         with pytest.raises(TypeError):
             x509.PolicyConstraints("invalid", None)  # type:ignore[arg-type]
@@ -2866,7 +2866,7 @@ class TestPolicyConstraints(object):
         assert ext.public_bytes() == b"0\x06\x80\x01\x02\x81\x01\x01"
 
 
-class TestPolicyConstraintsExtension(object):
+class TestPolicyConstraintsExtension:
     def test_inhibit_policy_mapping(self, backend):
         cert = _load_cert(
             os.path.join("x509", "department-of-state-root.pem"),
@@ -2906,7 +2906,7 @@ class TestPolicyConstraintsExtension(object):
         assert ext.public_bytes() == b"\x30\x03\x81\x01\x00"
 
 
-class TestAuthorityInformationAccess(object):
+class TestAuthorityInformationAccess:
     def test_invalid_descriptions(self):
         with pytest.raises(TypeError):
             x509.AuthorityInformationAccess(
@@ -3112,7 +3112,7 @@ class TestAuthorityInformationAccess(object):
         )
 
 
-class TestSubjectInformationAccess(object):
+class TestSubjectInformationAccess:
     def test_invalid_descriptions(self):
         with pytest.raises(TypeError):
             x509.SubjectInformationAccess(
@@ -3311,7 +3311,7 @@ class TestSubjectInformationAccess(object):
         )
 
 
-class TestSubjectInformationAccessExtension(object):
+class TestSubjectInformationAccessExtension:
     def test_sia(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "sia.pem"),
@@ -3340,7 +3340,7 @@ class TestSubjectInformationAccessExtension(object):
         )
 
 
-class TestAuthorityInformationAccessExtension(object):
+class TestAuthorityInformationAccessExtension:
     def test_aia_ocsp_ca_issuers(self, backend):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.pem"),
@@ -3489,7 +3489,7 @@ class TestAuthorityInformationAccessExtension(object):
         )
 
 
-class TestAuthorityKeyIdentifierExtension(object):
+class TestAuthorityKeyIdentifierExtension:
     def test_aki_keyid(self, backend):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.pem"),
@@ -3608,7 +3608,7 @@ class TestAuthorityKeyIdentifierExtension(object):
         assert ext.value == aki
 
 
-class TestNameConstraints(object):
+class TestNameConstraints:
     def test_ipaddress_wrong_type(self):
         with pytest.raises(TypeError):
             x509.NameConstraints(
@@ -3743,7 +3743,7 @@ class TestNameConstraints(object):
         )
 
 
-class TestNameConstraintsExtension(object):
+class TestNameConstraintsExtension:
     def test_permitted_excluded(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "nc_permitted_excluded_2.pem"),
@@ -3925,7 +3925,7 @@ class TestNameConstraintsExtension(object):
         )
 
 
-class TestDistributionPoint(object):
+class TestDistributionPoint:
     def test_distribution_point_full_name_not_general_names(self):
         with pytest.raises(TypeError):
             x509.DistributionPoint(
@@ -4143,7 +4143,7 @@ class TestDistributionPoint(object):
         assert hash(dp) != hash(dp3)
 
 
-class TestFreshestCRL(object):
+class TestFreshestCRL:
     def test_invalid_distribution_points(self):
         with pytest.raises(TypeError):
             x509.FreshestCRL(
@@ -4394,7 +4394,7 @@ class TestFreshestCRL(object):
         )
 
 
-class TestCRLDistributionPoints(object):
+class TestCRLDistributionPoints:
     def test_invalid_distribution_points(self):
         with pytest.raises(TypeError):
             x509.CRLDistributionPoints(
@@ -4673,7 +4673,7 @@ class TestCRLDistributionPoints(object):
         )
 
 
-class TestCRLDistributionPointsExtension(object):
+class TestCRLDistributionPointsExtension:
     def test_fullname_and_crl_issuer(self, backend):
         cert = _load_cert(
             os.path.join(
@@ -4978,7 +4978,7 @@ class TestCRLDistributionPointsExtension(object):
         )
 
 
-class TestFreshestCRLExtension(object):
+class TestFreshestCRLExtension:
     def test_vector(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "freshestcrl.pem"),
@@ -5069,7 +5069,7 @@ class TestFreshestCRLExtension(object):
         )
 
 
-class TestOCSPNoCheckExtension(object):
+class TestOCSPNoCheckExtension:
     def test_nocheck(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "ocsp_nocheck.pem"),
@@ -5109,7 +5109,7 @@ class TestOCSPNoCheckExtension(object):
         assert ext.public_bytes() == b"\x05\x00"
 
 
-class TestInhibitAnyPolicy(object):
+class TestInhibitAnyPolicy:
     def test_not_int(self):
         with pytest.raises(TypeError):
             x509.InhibitAnyPolicy("notint")  # type:ignore[arg-type]
@@ -5145,7 +5145,7 @@ class TestInhibitAnyPolicy(object):
         assert ext.public_bytes() == b"\x02\x01\x01"
 
 
-class TestInhibitAnyPolicyExtension(object):
+class TestInhibitAnyPolicyExtension:
     def test_inhibit_any_policy(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "inhibit_any_policy_5.pem"),
@@ -5158,7 +5158,7 @@ class TestInhibitAnyPolicyExtension(object):
         assert iap.skip_certs == 5
 
 
-class TestIssuingDistributionPointExtension(object):
+class TestIssuingDistributionPointExtension:
     @pytest.mark.parametrize(
         ("filename", "expected"),
         [
@@ -5686,7 +5686,7 @@ class TestIssuingDistributionPointExtension(object):
         )
 
 
-class TestPrecertPoisonExtension(object):
+class TestPrecertPoisonExtension:
     def test_load(self, backend):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.precert.pem"),
@@ -5744,7 +5744,7 @@ class TestPrecertPoisonExtension(object):
         assert ext.public_bytes() == b"\x05\x00"
 
 
-class TestSignedCertificateTimestamps(object):
+class TestSignedCertificateTimestamps:
     def test_eq(self, backend):
         sct = (
             _load_cert(
@@ -5850,7 +5850,7 @@ class TestSignedCertificateTimestamps(object):
             ext.public_bytes()
 
 
-class TestPrecertificateSignedCertificateTimestampsExtension(object):
+class TestPrecertificateSignedCertificateTimestampsExtension:
     def test_init(self):
         with pytest.raises(TypeError):
             x509.PrecertificateSignedCertificateTimestamps(
@@ -6071,7 +6071,7 @@ class TestPrecertificateSignedCertificateTimestampsExtension(object):
         )
 
 
-class TestInvalidExtension(object):
+class TestInvalidExtension:
     def test_invalid_certificate_policies_data(self, backend):
         # UserNotice OID but CPSURI structure
         cert = _load_cert(
@@ -6092,7 +6092,7 @@ class TestInvalidExtension(object):
             cert.extensions
 
 
-class TestOCSPNonce(object):
+class TestOCSPNonce:
     def test_non_bytes(self):
         with pytest.raises(TypeError):
             x509.OCSPNonce(38)  # type:ignore[arg-type]

--- a/tests/x509/test_x509_revokedcertbuilder.py
+++ b/tests/x509/test_x509_revokedcertbuilder.py
@@ -12,7 +12,7 @@ import pytz
 from cryptography import x509
 
 
-class TestRevokedCertificateBuilder(object):
+class TestRevokedCertificateBuilder:
     def test_serial_number_must_be_integer(self):
         with pytest.raises(TypeError):
             x509.RevokedCertificateBuilder().serial_number(


### PR DESCRIPTION
As someone who first with Python in 2.4 or so, this habit is going to be hard to break.