### PR TITLE
Remove FAQ that's no longer relevant

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -111,13 +111,6 @@ earlier the default compiler is extremely old. Use ``pkg_add`` to install a
 newer ``gcc`` and then install ``cryptography`` using
 ``CC=/path/to/newer/gcc pip install cryptography``.
 
-Installing ``cryptography`` fails with ``Invalid environment marker: python_version < '3'``
--------------------------------------------------------------------------------------------
-
-Your ``pip`` and/or ``setuptools`` are outdated. Please upgrade to the latest
-versions with ``pip install -U pip setuptools`` (or on Windows
-``python -m pip install -U pip setuptools``).
-
 Installing cryptography with OpenSSL 0.9.8, 1.0.0, 1.0.1, 1.0.2 fails
 ---------------------------------------------------------------------
 


### PR DESCRIPTION
We don't use environment markers anymore, now if you have a really old setuptools you get some different failure mode