### PR TITLE
Block TripleDES in FIPS mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Changelog
   :class:`~cryptography.x509.ocsp.OCSPResponse`. 
 * Restored support for signing certificates and other structures in
   :doc:`/x509/index` with SHA3 hash algorithms.
+* :class:`~cryptography.hazmat.primitives.ciphers.algorithms.TripleDES` is
+  disabled in FIPS mode.
 
 .. _v36-0-1:
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -147,7 +147,9 @@ class Backend:
         b"aes-192-gcm",
         b"aes-256-gcm",
     }
-    _fips_ciphers = (AES, TripleDES)
+    # TripleDES encryption is disallowed/deprecated throughout 2023 in
+    # FIPS 140-3. To keep it simple we denylist any use of TripleDES (TDEA).
+    _fips_ciphers = (AES,)
     # Sometimes SHA1 is still permissible. That logic is contained
     # within the various *_supported methods.
     _fips_hashes = (
@@ -344,12 +346,9 @@ class Backend:
 
     def cipher_supported(self, cipher: CipherAlgorithm, mode: Mode) -> bool:
         if self._fips_enabled:
-            # FIPS mode requires AES or TripleDES, but only CBC/ECB allowed
-            # in TripleDES mode.
-            if not isinstance(cipher, self._fips_ciphers) or (
-                isinstance(cipher, TripleDES)
-                and not isinstance(mode, (CBC, ECB))
-            ):
+            # FIPS mode requires AES. TripleDES is disallowed/deprecated in
+            # FIPS 140-3.
+            if not isinstance(cipher, self._fips_ciphers):
                 return False
 
         try:

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -482,9 +482,7 @@ def _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, params):
 
     # TripleDES is disallowed in FIPS mode.
     if backend._fips_enabled and algorithm is algorithms.TripleDES:
-        pytest.skip(
-            f"TripleDES is not supported in FIPS mode."
-        )
+        pytest.skip("TripleDES is not supported in FIPS mode.")
 
     ctrkdf = KBKDFCMAC(
         algorithm,

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -480,6 +480,12 @@ def _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, params):
     algorithm = supported_cipher_algorithms.get(prf)
     assert algorithm is not None
 
+    # TripleDES is disallowed in FIPS mode.
+    if backend._fips_enabled and algorithm is algorithms.TripleDES:
+        pytest.skip(
+            f"TripleDES is not supported in FIPS mode."
+        )
+
     ctrkdf = KBKDFCMAC(
         algorithm,
         Mode.CounterMode,


### PR DESCRIPTION
NIST SP-800-131A rev 2 lists TripleDES Encryption as disallowed in FIPS 140-3
decryption as legacy use. Three-key TDEA is listed as deprecated
throughout 2023 and disallowed after 2023.

For simplicity we block all use of TripleDES in FIPS mode.

Fixes: #6875
Signed-off-by: Christian Heimes <christian@python.org>