### PR TITLE
Add types for padding.PSS class.

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -23,6 +23,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import (
     OAEP,
     PKCS1v15,
     PSS,
+    _MaxLength,
     calculate_max_pss_salt_length,
 )
 from cryptography.hazmat.primitives.asymmetric.rsa import (
@@ -41,10 +42,10 @@ def _get_rsa_pss_salt_length(
     pss: PSS,
     key: typing.Union[RSAPrivateKey, RSAPublicKey],
     hash_algorithm: hashes.HashAlgorithm,
-) -> int:
+) -> typing.Union[int, _MaxLength]:
     salt = pss._salt_length
 
-    if salt is MGF1.MAX_LENGTH or salt is PSS.MAX_LENGTH:
+    if isinstance(salt, _MaxLength):
         return calculate_max_pss_salt_length(key, hash_algorithm)
     else:
         return salt

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -52,8 +52,9 @@ class TestLibreSkip:
             skip_if_libre_ssl("LibreSSL 2.1.6")
 
 
-class DummyMGF:
+class DummyMGF(padding.MGF):
     _salt_length = 0
+    _algorithm = hashes.SHA1()
 
 
 class TestOpenSSL:
@@ -410,7 +411,7 @@ class TestOpenSSLRSA:
         assert (
             backend.rsa_padding_supported(
                 padding.OAEP(
-                    mgf=DummyMGF(),  # type: ignore[arg-type]
+                    mgf=DummyMGF(),
                     algorithm=hashes.SHA1(),
                     label=None,
                 ),

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -61,8 +61,9 @@ from ...utils import (
 )
 
 
-class DummyMGF:
+class DummyMGF(padding.MGF):
     _salt_length = 0
+    _algorithm = hashes.SHA1()
 
 
 def _check_fips_key_length(backend, private_key):
@@ -1350,7 +1351,8 @@ class TestPSS:
     def test_invalid_salt_length_not_integer(self):
         with pytest.raises(TypeError):
             padding.PSS(
-                mgf=padding.MGF1(hashes.SHA1()), salt_length=b"not_a_length"
+                mgf=padding.MGF1(hashes.SHA1()),
+                salt_length=b"not_a_length",  # type:ignore[arg-type]
             )
 
     def test_invalid_salt_length_negative_integer(self):
@@ -1630,7 +1632,7 @@ class TestRSADecryption:
             private_key.decrypt(
                 b"0" * 256,
                 padding.OAEP(
-                    mgf=DummyMGF(),  # type: ignore[arg-type]
+                    mgf=DummyMGF(),
                     algorithm=hashes.SHA1(),
                     label=None,
                 ),
@@ -1829,7 +1831,7 @@ class TestRSAEncryption:
             public_key.encrypt(
                 b"ciphertext",
                 padding.OAEP(
-                    mgf=DummyMGF(),  # type: ignore[arg-type]
+                    mgf=DummyMGF(),
                     algorithm=hashes.SHA1(),
                     label=None,
                 ),


### PR DESCRIPTION
This adds types to the ``PSS`` class, similar to the types that are present in typeshed:

https://github.com/python/typeshed/blob/04100b9cec9a5a25217e5e5d45e77560ef3ced48/stubs/cryptography/cryptography/hazmat/primitives/asymmetric/padding.pyi#L25