### PR TITLE
Add X509_alias_set1 to the ffi

### DIFF
--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -58,6 +58,7 @@ EVP_PKEY *X509_get_pubkey(X509 *);
 int X509_set_pubkey(X509 *, EVP_PKEY *);
 
 unsigned char *X509_alias_get0(X509 *, int *);
+int X509_alias_set1(X509 *, const unsigned char *, int);
 int X509_sign(X509 *, EVP_PKEY *, const EVP_MD *);
 
 int X509_digest(const X509 *, const EVP_MD *, unsigned char *, unsigned int *);


### PR DESCRIPTION
Add `X509_alias_set1` to the ffi (not sure about the wording) as a first step to allow serialization of CA friendlyNames in the PKCS12 format. See Issue #6135, in particular [this post](https://github.com/pyca/cryptography/issues/6135#issuecomment-868449674) for more information.
