### PR TITLE
Serialize PKCS12 CA alias/friendlyName 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,8 @@ Changelog
   :doc:`/x509/index` with SHA3 hash algorithms.
 * :class:`~cryptography.hazmat.primitives.ciphers.algorithms.TripleDES` is
   disabled in FIPS mode.
+* Added support for serialization of PKCS#12 CA friendly names/aliases in
+  :func:`~cryptography.hazmat.primitives.serialization.pkcs12.serialize_key_and_certificates`
 
 .. _v36-0-2:
 

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -521,7 +521,14 @@ file suffix.
     :type cert: :class:`~cryptography.x509.Certificate` or ``None``
 
     :param cas: An optional set of certificates to also include in the structure.
-    :type cas: list of :class:`~cryptography.x509.Certificate` or ``None``
+        If a :class:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12Certificate`
+        is given, its friendly name will be serialized.
+    :type cas: list of
+        :class:`~cryptography.x509.Certificate`
+        ,
+        :class:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12Certificate`
+        , or
+        ``None``
 
     :param encryption_algorithm: The encryption algorithm that should be used
         for the key and certificate. An instance of an object conforming to the

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -523,12 +523,10 @@ file suffix.
     :param cas: An optional set of certificates to also include in the structure.
         If a :class:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12Certificate`
         is given, its friendly name will be serialized.
-    :type cas: list of
+    :type cas: ``None``, or list of
         :class:`~cryptography.x509.Certificate`
-        ,
+        or
         :class:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12Certificate`
-        , or
-        ``None``
 
     :param encryption_algorithm: The encryption algorithm that should be used
         for the key and certificate. An instance of an object conforming to the

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2223,7 +2223,6 @@ class Backend:
                         res = self._lib.X509_alias_set1(
                             ossl_ca, ca_name_buf, -1
                         )
-                        print(self._ffi.string(ca_name_buf))
                         if not res:
                             raise RuntimeError(
                                 'Could not set alias "{}" for additional cert'

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -117,6 +117,7 @@ from cryptography.hazmat.primitives.serialization.pkcs12 import (
     PKCS12Certificate,
     PKCS12KeyAndCertificates,
     _ALLOWED_PKCS12_TYPES,
+    _PKCS12_CAS_TYPES,
 )
 
 
@@ -2175,7 +2176,7 @@ class Backend:
         name: typing.Optional[bytes],
         key: typing.Optional[_ALLOWED_PKCS12_TYPES],
         cert: typing.Optional[x509.Certificate],
-        cas: typing.Optional[typing.List[typing.Union[x509.Certificate, PKCS12Certificate]]],
+        cas: typing.Optional[typing.List[_PKCS12_CAS_TYPES]],
         encryption_algorithm: serialization.KeySerializationEncryption,
     ) -> bytes:
         password = None
@@ -2214,13 +2215,17 @@ class Backend:
             ossl_cas = []
             for ca in cas:
                 if isinstance(ca, PKCS12Certificate):
-                    # Copied from Felix's gist https://gist.github.com/felixfontein/f750763fd5773fbf0ab22af87239aab0
+                    # Copied from Felix's gist
+                    # https://gist.github.com/
+                    # felixfontein/f750763fd5773fbf0ab22af87239aab0
                     ca_alias = ca.friendly_name
                     ossl_ca = self._cert2ossl(ca.certificate)
                     if ca_alias is not None:
-                        with self._zeroed_null_terminated_buf(ca_alias) as ca_name_buf:
+                        with self._zeroed_null_terminated_buf(
+                            ca_alias
+                        ) as ca_name_buf:
                             self._lib.X509_alias_set1(
-                                    ossl_ca, ca_name_buf, len(ca_alias)
+                                ossl_ca, ca_name_buf, len(ca_alias)
                             )
                 else:
                     ossl_ca = self._cert2ossl(ca)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2215,17 +2215,19 @@ class Backend:
             ossl_cas = []
             for ca in cas:
                 if isinstance(ca, PKCS12Certificate):
-                    # Copied from Felix's gist
-                    # https://gist.github.com/
-                    # felixfontein/f750763fd5773fbf0ab22af87239aab0
                     ca_alias = ca.friendly_name
                     ossl_ca = self._cert2ossl(ca.certificate)
-                    if ca_alias is not None:
-                        with self._zeroed_null_terminated_buf(
-                            ca_alias
-                        ) as ca_name_buf:
-                            self._lib.X509_alias_set1(
-                                ossl_ca, ca_name_buf, len(ca_alias)
+                    with self._zeroed_null_terminated_buf(
+                        ca_alias
+                    ) as ca_name_buf:
+                        res = self._lib.X509_alias_set1(
+                            ossl_ca, ca_name_buf, -1
+                        )
+                        print(self._ffi.string(ca_name_buf))
+                        if not res:
+                            raise RuntimeError(
+                                'Could not set alias "{}" for additional cert'
+                                "{}".format(ca, ca.friendly_name)
                             )
                 else:
                     ossl_ca = self._cert2ossl(ca)

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2223,11 +2223,7 @@ class Backend:
                         res = self._lib.X509_alias_set1(
                             ossl_ca, ca_name_buf, -1
                         )
-                        if not res:
-                            raise RuntimeError(
-                                'Could not set alias "{}" for additional cert'
-                                "{}".format(ca, ca.friendly_name)
-                            )
+                        self.openssl_assert(res == 1)
                 else:
                     ossl_ca = self._cert2ossl(ca)
                 ossl_cas.append(ossl_ca)

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -183,7 +183,7 @@ def serialize_key_and_certificates(
 
     if cas is not None:
         cas = list(cas)
-        if not all(isinstance(val, x509.Certificate) or isinstance(val, PKCS12Certificate) for val in cas):
+        if not all(isinstance(val, (x509.Certificate, PKCS12Certificate)) for val in cas):
             raise TypeError("all values in cas must be certificates")
 
     if not isinstance(

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -157,11 +157,17 @@ def load_pkcs12(
     return ossl.load_pkcs12(data, password)
 
 
+_PKCS12_CAS_TYPES = typing.Union[
+    x509.Certificate,
+    PKCS12Certificate,
+]
+
+
 def serialize_key_and_certificates(
     name: typing.Optional[bytes],
     key: typing.Optional[_ALLOWED_PKCS12_TYPES],
     cert: typing.Optional[x509.Certificate],
-    cas: typing.Optional[typing.Iterable[typing.Union[x509.Certificate, PKCS12Certificate]]],
+    cas: typing.Optional[typing.Iterable[_PKCS12_CAS_TYPES]],
     encryption_algorithm: serialization.KeySerializationEncryption,
 ) -> bytes:
     if key is not None and not isinstance(
@@ -183,7 +189,13 @@ def serialize_key_and_certificates(
 
     if cas is not None:
         cas = list(cas)
-        if not all(isinstance(val, (x509.Certificate, PKCS12Certificate)) for val in cas):
+        if not all(isinstance(
+            val,
+            (
+                x509.Certificate,
+                PKCS12Certificate,
+            )
+        ) for val in cas):
             raise TypeError("all values in cas must be certificates")
 
     if not isinstance(

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -161,7 +161,7 @@ def serialize_key_and_certificates(
     name: typing.Optional[bytes],
     key: typing.Optional[_ALLOWED_PKCS12_TYPES],
     cert: typing.Optional[x509.Certificate],
-    cas: typing.Optional[typing.Iterable[x509.Certificate]],
+    cas: typing.Optional[typing.Iterable[typing.Union[x509.Certificate, PKCS12Certificate]]],
     encryption_algorithm: serialization.KeySerializationEncryption,
 ) -> bytes:
     if key is not None and not isinstance(
@@ -183,7 +183,7 @@ def serialize_key_and_certificates(
 
     if cas is not None:
         cas = list(cas)
-        if not all(isinstance(val, x509.Certificate) for val in cas):
+        if not all(isinstance(val, x509.Certificate) or isinstance(val, PKCS12Certificate) for val in cas):
             raise TypeError("all values in cas must be certificates")
 
     if not isinstance(

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -189,13 +189,16 @@ def serialize_key_and_certificates(
 
     if cas is not None:
         cas = list(cas)
-        if not all(isinstance(
-            val,
-            (
-                x509.Certificate,
-                PKCS12Certificate,
+        if not all(
+            isinstance(
+                val,
+                (
+                    x509.Certificate,
+                    PKCS12Certificate,
+                ),
             )
-        ) for val in cas):
+            for val in cas
+        ):
             raise TypeError("all values in cas must be certificates")
 
     if not isinstance(

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -408,19 +408,19 @@ class TestPKCS12Creation:
         cert3 = _load_cert(backend, os.path.join("x509", "letsencryptx3.pem"))
         encryption = serialization.NoEncryption()
         p12 = serialize_key_and_certificates(
-            b'test', key, cert,
+            b"test",
+            key,
+            cert,
             [
-                PKCS12Certificate(cert2, b'cert2'),
-                PKCS12Certificate(cert3, None)
+                PKCS12Certificate(cert2, b"cert2"),
+                PKCS12Certificate(cert3, None),
             ],
-            encryption
+            encryption,
         )
 
-        p12_cert = load_pkcs12(
-            p12, None, backend
-        )
+        p12_cert = load_pkcs12(p12, None, backend)
         cas = p12_cert.additional_certs
-        assert cas[0].friendly_name == b'cert2'
+        assert cas[0].friendly_name == b"cert2"
         assert cas[1].friendly_name is None
 
     def test_generate_wrong_types(self, backend):

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -298,12 +298,12 @@ def _load_ca(backend):
 
 
 @pytest.mark.skip_fips(
-        reason="PKCS12 unsupported in FIPS mode. So much bad crypto in it."
+    reason="PKCS12 unsupported in FIPS mode. So much bad crypto in it."
 )
 class TestPKCS12Creation:
     @pytest.mark.parametrize(
-            (
-                    "kgenerator",
+        (
+            "kgenerator",
             "ktype",
             "kparam",
         ),

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -403,20 +403,25 @@ class TestPKCS12Creation:
     def test_generate_cas_friendly_names(self, backend):
         cert, key = _load_ca(backend)
         cert2 = _load_cert(
-                backend, os.path.join("x509", "custom", "dsa_selfsigned_ca.pem")
+            backend, os.path.join("x509", "custom", "dsa_selfsigned_ca.pem")
         )
         cert3 = _load_cert(backend, os.path.join("x509", "letsencryptx3.pem"))
         encryption = serialization.NoEncryption()
         p12 = serialize_key_and_certificates(
-                b'test', key, cert, [PKCS12Certificate(cert2, b'cert2'), PKCS12Certificate(cert3, b'cert3')], encryption
+            b'test', key, cert,
+            [
+                PKCS12Certificate(cert2, b'cert2'),
+                PKCS12Certificate(cert3, None)
+            ],
+            encryption
         )
 
         p12_cert = load_pkcs12(
-                p12, None, backend
+            p12, None, backend
         )
         cas = p12_cert.additional_certs
         assert cas[0].friendly_name == b'cert2'
-        assert cas[1].friendly_name == b'cert3'
+        assert cas[1].friendly_name is None
 
     def test_generate_wrong_types(self, backend):
         cert, key = _load_ca(backend)


### PR DESCRIPTION
See issue #6135 for motivation.

This is one of several ways to implement CA alias/friendlyName serialization, and the one that I think is the least disruptive.

I have manually checked that the CA aliases/friendlyNames are serialized by saving a .p12 file, so the changes work and all old tests pass.
~~However, I cannot figure out a way to test it.~~ Added tests that work, updating PR from draft.