### PR TITLE
Dedicated check for signature hash algorithms

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -326,6 +326,15 @@ class Backend:
         evp_md = self._evp_md_from_algorithm(algorithm)
         return evp_md != self._ffi.NULL
 
+    def signature_hash_supported(
+        self, algorithm: hashes.HashAlgorithm
+    ) -> bool:
+        # Dedicated check for hashing algorithm use in message digest for
+        # signatures, e.g. RSA PKCS#1 v1.5 SHA1 (sha1WithRSAEncryption).
+        if self._fips_enabled and isinstance(algorithm, hashes.SHA1):
+            return False
+        return self.hash_supported(algorithm)
+
     def scrypt_supported(self) -> bool:
         if self._fips_enabled:
             return False
@@ -723,7 +732,8 @@ class Backend:
         if isinstance(padding, PKCS1v15):
             return True
         elif isinstance(padding, PSS) and isinstance(padding._mgf, MGF1):
-            # SHA1 is permissible in MGF1 in FIPS
+            # SHA1 is permissible in MGF1 in FIPS and when SHA1 is blocked
+            # as signature algorithm.
             if self._fips_enabled and isinstance(
                 padding._mgf._algorithm, hashes.SHA1
             ):
@@ -854,7 +864,7 @@ class Backend:
     def dsa_hash_supported(self, algorithm: hashes.HashAlgorithm) -> bool:
         if not self.dsa_supported():
             return False
-        return self.hash_supported(algorithm)
+        return self.signature_hash_supported(algorithm)
 
     def cmac_algorithm_supported(self, algorithm) -> bool:
         return self.cipher_supported(

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -732,7 +732,7 @@ class Backend:
         if isinstance(padding, PKCS1v15):
             return True
         elif isinstance(padding, PSS) and isinstance(padding._mgf, MGF1):
-            # SHA1 is permissible in MGF1 in FIPS and when SHA1 is blocked
+            # SHA1 is permissible in MGF1 in FIPS even when SHA1 is blocked
             # as signature algorithm.
             if self._fips_enabled and isinstance(
                 padding._mgf._algorithm, hashes.SHA1

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -14,8 +14,8 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
 from cryptography.hazmat.primitives.serialization import pkcs7
 
-from ...utils import load_vectors_from_file, raises_unsupported_algorithm
 from .utils import skip_signature_hash
+from ...utils import load_vectors_from_file, raises_unsupported_algorithm
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -15,6 +15,7 @@ from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
 from cryptography.hazmat.primitives.serialization import pkcs7
 
 from ...utils import load_vectors_from_file, raises_unsupported_algorithm
+from .utils import skip_signature_hash
 
 
 @pytest.mark.supported(
@@ -346,8 +347,7 @@ class TestPKCS7Builder:
     def test_sign_alternate_digests_der(
         self, hash_alg, expected_value, backend
     ):
-        if isinstance(hash_alg, hashes.SHA1) and backend._fips_enabled:
-            pytest.skip("SHA1 not supported in FIPS mode")
+        skip_signature_hash(backend, hash_alg)
 
         data = b"hello world"
         cert, key = _load_cert_key()
@@ -375,8 +375,7 @@ class TestPKCS7Builder:
     def test_sign_alternate_digests_detached(
         self, hash_alg, expected_value, backend
     ):
-        if isinstance(hash_alg, hashes.SHA1) and backend._fips_enabled:
-            pytest.skip("SHA1 not supported in FIPS mode")
+        skip_signature_hash(backend, hash_alg)
 
         data = b"hello world"
         cert, key = _load_cert_key()

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1163,7 +1163,9 @@ class TestRSAPSSMGF1Verification:
             )
         )
         and backend.signature_hash_supported(hashes.SHA1()),
-        skip_message="Does not support PSS using MGF1 with SHA1 or SHA1 signature.",
+        skip_message=(
+            "Does not support PSS using MGF1 with SHA1 or SHA1 signature."
+        ),
     )(
         generate_rsa_verification_test(
             load_rsa_nist_vectors,

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -579,3 +579,8 @@ def skip_fips_traditional_openssl(backend, fmt):
         pytest.skip(
             "Traditional OpenSSL key format is not supported in FIPS mode."
         )
+
+
+def skip_signature_hash(backend, hash_alg: hashes.HashAlgorithm):
+    if not backend.signature_hash_supported(hash_alg):
+        pytest.skip(f"{hash_alg} is not a supported signature hash algorithm.")

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -830,6 +830,12 @@ class TestRSACertificate:
         assert isinstance(public_key, rsa.RSAPublicKey)
         assert len(cert.signature) == public_key.key_size // 8
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.signature_hash_supported(
+            hashes.SHA1()
+        ),
+        skip_message="Does not support SHA-1 signature.",
+    )
     def test_tbs_certificate_bytes(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
@@ -1616,6 +1622,12 @@ class TestRSACertificateRequest:
             b"e36181e8c4c270c354b7f52c128db1b70639823324c7ea24791b7bc3d7005f3b"
         )
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.signature_hash_supported(
+            hashes.SHA1()
+        ),
+        skip_message="Does not support SHA-1 signature.",
+    )
     def test_tbs_certrequest_bytes(self, backend):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
@@ -1776,8 +1788,8 @@ class TestRSACertificateRequest:
         ],
     )
     def test_build_cert(self, hashalg, hashalg_oid, backend):
-        if not backend.hash_supported(hashalg()):
-            pytest.skip(f"{hashalg} not supported in FIPS mode")
+        if not backend.signature_hash_supported(hashalg()):
+            pytest.skip(f"{hashalg} signature not supported")
 
         issuer_private_key = RSA_KEY_2048.private_key(backend)
         subject_private_key = RSA_KEY_2048.private_key(backend)
@@ -2714,8 +2726,8 @@ class TestCertificateBuilder:
         self, hashalg, hashalg_oid, backend
     ):
         _skip_curve_unsupported(backend, ec.SECP256R1())
-        if not backend.hash_supported(hashalg()):
-            pytest.skip(f"{hashalg} not supported in FIPS mode")
+        if not backend.signature_hash_supported(hashalg()):
+            pytest.skip(f"{hashalg} signature not supported")
 
         issuer_private_key = ec.generate_private_key(ec.SECP256R1(), backend)
         subject_private_key = ec.generate_private_key(ec.SECP256R1(), backend)
@@ -4389,6 +4401,12 @@ class TestCertificateSigningRequestBuilder:
     skip_message="Does not support DSA.",
 )
 class TestDSACertificate:
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.signature_hash_supported(
+            hashes.SHA1()
+        ),
+        skip_message="Does not support SHA-1 signature.",
+    )
     def test_load_dsa_cert(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "dsa_selfsigned_ca.pem"),
@@ -4516,6 +4534,10 @@ class TestDSACertificate:
 @pytest.mark.supported(
     only_if=lambda backend: backend.dsa_supported(),
     skip_message="Does not support DSA.",
+)
+@pytest.mark.supported(
+    only_if=lambda backend: backend.signature_hash_supported(hashes.SHA1()),
+    skip_message="Does not support SHA-1 signature.",
 )
 class TestDSACertificateRequest:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Move the check for FIPS mode and blocked SHA1 signature algorithm
into the backend code. Some distros will block SHA1 for RSA signatures
in the near future. The new ``signature_hash_supported()`` method will
allow us to flip the switch in one place.

Note: The ban of SHA1 signatures does not affect MGF1's inner hash algorithm.

Signed-off-by: Christian Heimes <christian@python.org>