### PR TITLE
Try removing the SSL_library_init call in initialization

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -163,8 +163,6 @@ class Binding:
             if not cls._lib_loaded:
                 cls.lib = build_conditional_library(lib, CONDITIONAL_NAMES)
                 cls._lib_loaded = True
-                # initialize the SSL library
-                cls.lib.SSL_library_init()
                 cls._register_osrandom_engine()
                 # As of OpenSSL 3.0.0 we must register a legacy cipher provider
                 # to get RC2 (needed for junk asymmetric private key


### PR DESCRIPTION
I'm reasonably certain it's not required in recent OpenSSLs