### PR TITLE
add TLSv1.3 PSKs function bindings

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -255,6 +255,26 @@ void SSL_CTX_set_psk_client_callback(SSL_CTX *,
                                          unsigned char *,
                                          unsigned int
                                      ));
+void SSL_CTX_set_psk_find_session_callback(SSL_CTX *,
+                                           int (*)(
+                                               SSL *,
+                                               const unsigned char *,
+                                               size_t,
+                                               SSL_SESSION **
+                                           ));
+void SSL_CTX_set_psk_use_session_callback(SSL_CTX *,
+                                          int (*)(
+                                              SSL *,
+                                              const EVP_MD *,
+                                              const unsigned char **,
+                                              size_t *,
+                                              SSL_SESSION **
+                                          ));
+const SSL_CIPHER *SSL_CIPHER_find(SSL *, const unsigned char *);
+SSL_SESSION *SSL_SESSION_new(void);
+int SSL_SESSION_set1_master_key(SSL_SESSION *, const unsigned char *,
+int SSL_SESSION_set_cipher(SSL_SESSION *, const SSL_CIPHER *);
+int SSL_SESSION_set_protocol_version(SSL_SESSION *, int);
 
 int SSL_CTX_set_session_id_context(SSL_CTX *, const unsigned char *,
                                    unsigned int);
@@ -662,6 +682,21 @@ void (*SSL_CTX_set_psk_client_callback)(SSL_CTX *,
                                             unsigned char *,
                                             unsigned int
                                         )) = NULL;
+void (*SSL_CTX_set_psk_find_session_callback)(SSL_CTX *,
+                                           int (*)(
+                                               SSL *,
+                                               const unsigned char *,
+                                               size_t,
+                                               SSL_SESSION **
+                                           )) = NULL;
+void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
+                                          int (*)(
+                                              SSL *,
+                                              const EVP_MD *,
+                                              const unsigned char **,
+                                              size_t *,
+                                              SSL_SESSION **
+                                          )) = NULL;
 #else
 static const long Cryptography_HAS_PSK = 1;
 #endif

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -811,9 +811,6 @@ int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
 #endif
-#if CRYPTOGRAPHY_IS_BORINGSSL
-    SSL_SESSION *(*SSL_SESSION_new)(const SSL_CTX *) = NULL;
-#endif
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;
 #endif

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -811,6 +811,9 @@ int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
 #endif
+#if CRYPTOGRAPHY_IS_BORINGSSL
+    SSL_SESSION *(*SSL_SESSION_new)(const SSL_CTX *) = NULL;
+#endif
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;
 #endif

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -802,12 +802,17 @@ void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
                                               size_t *,
                                               SSL_SESSION **
                                           )) = NULL;
-const SSL_CIPHER *(*SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
-SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
+                                          
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111 || CRYPTOGRAPHY_IS_BORINGSSL || \
+    CRYPTOGRAPHY_LIBRESSL_LESS_THAN_340
+    const SSL_CIPHER *(*SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
+#endif
 int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
                                    size_t) = NULL;
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
-int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
+#if !CRYPTOGRAPHY_IS_BORINGSSL
+    int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
+#endif
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;
 #endif

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -809,7 +809,7 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
-    if !CRYPTOGRAPHY_IS_LIBRESSL || !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+    #if !CRYPTOGRAPHY_IS_LIBRESSL || !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
         SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
     #endif
 #endif

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -272,7 +272,6 @@ void SSL_CTX_set_psk_use_session_callback(SSL_CTX *,
                                               SSL_SESSION **
                                           ));
 const SSL_CIPHER *SSL_CIPHER_find(SSL *, const unsigned char *);
-SSL_SESSION *SSL_SESSION_new(void);
 int SSL_SESSION_set1_master_key(SSL_SESSION *, const unsigned char *,
                                  size_t);
 int SSL_SESSION_set_cipher(SSL_SESSION *, const SSL_CIPHER *);
@@ -810,6 +809,9 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
+    SSL_SESSION *(*SSL_SESSION_new)(void);
+#else
+    SSL_SESSION *(*SSL_SESSION_new)(const SSL_CTX *) = NULL;
 #endif
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -809,9 +809,7 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
-    SSL_SESSION *(*SSL_SESSION_new)(void);
-#else
-    SSL_SESSION *(*SSL_SESSION_new)(const SSL_CTX *) = NULL;
+    SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
 #endif
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -802,7 +802,7 @@ void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
                                               size_t *,
                                               SSL_SESSION **
                                           )) = NULL;
-#if CRYPTOGRAPHY_LIBRESSL_LESS_THAN_340
+#if CRYPTOGRAPHY_LIBRESSL_LESS_THAN_340 || CRYPTOGRAPHY_IS_BORINGSSL
     const SSL_CIPHER *(*SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
 #endif
 int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -273,6 +273,7 @@ void SSL_CTX_set_psk_use_session_callback(SSL_CTX *,
 const SSL_CIPHER *SSL_CIPHER_find(SSL *, const unsigned char *);
 SSL_SESSION *SSL_SESSION_new(void);
 int SSL_SESSION_set1_master_key(SSL_SESSION *, const unsigned char *,
+                                 size_t);
 int SSL_SESSION_set_cipher(SSL_SESSION *, const SSL_CIPHER *);
 int SSL_SESSION_set_protocol_version(SSL_SESSION *, int);
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -809,7 +809,7 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
-    #if !CRYPTOGRAPHY_IS_LIBRESSL || !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+    #if !CRYPTOGRAPHY_IS_LIBRESSL
         SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
     #endif
 #endif

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -803,8 +803,7 @@ void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
                                               SSL_SESSION **
                                           )) = NULL;
                                           
-#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111 || CRYPTOGRAPHY_IS_BORINGSSL || \
-    CRYPTOGRAPHY_LIBRESSL_LESS_THAN_340
+#if CRYPTOGRAPHY_LIBRESSL_LESS_THAN_340
     const SSL_CIPHER *(*SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
 #endif
 int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
@@ -812,6 +811,7 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
+    SSL_SESSION *(*SSL_SESSION_new)(const SSL_CTX *) = NULL;
 #endif
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -802,8 +802,8 @@ void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
                                               size_t *,
                                               SSL_SESSION **
                                           )) = NULL;
-const SSL_CIPHER (**SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
-SSL_SESSION (**SSL_SESSION_new)(void) = NULL;
+const SSL_CIPHER *(*SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
+SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
 int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
                                    size_t) = NULL;
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -806,7 +806,7 @@ const SSL_CIPHER (**SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
 SSL_SESSION (**SSL_SESSION_new)(void) = NULL;
 int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
                                    size_t) = NULL;
-int (*SSL_SESSION_set_cipher*)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
+int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -809,7 +809,7 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
-    #if !CRYPTOGRAPHY_IS_LIBRESSL
+    #if !CRYPTOGRAPHY_IS_LIBRESSL && !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
         SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
     #endif
 #endif

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -21,6 +21,7 @@ static const long Cryptography_HAS_SECURE_RENEGOTIATION;
 static const long Cryptography_HAS_SSL_CTX_CLEAR_OPTIONS;
 static const long Cryptography_HAS_DTLS;
 static const long Cryptography_HAS_PSK;
+static const long Cryptography_HAS_PSK_TLSv1_3;
 static const long Cryptography_HAS_VERIFIED_CHAIN;
 static const long Cryptography_HAS_KEYLOG;
 static const long Cryptography_HAS_GET_PROTO_VERSION;
@@ -683,21 +684,6 @@ void (*SSL_CTX_set_psk_client_callback)(SSL_CTX *,
                                             unsigned char *,
                                             unsigned int
                                         )) = NULL;
-void (*SSL_CTX_set_psk_find_session_callback)(SSL_CTX *,
-                                           int (*)(
-                                               SSL *,
-                                               const unsigned char *,
-                                               size_t,
-                                               SSL_SESSION **
-                                           )) = NULL;
-void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
-                                          int (*)(
-                                              SSL *,
-                                              const EVP_MD *,
-                                              const unsigned char **,
-                                              size_t *,
-                                              SSL_SESSION **
-                                          )) = NULL;
 #else
 static const long Cryptography_HAS_PSK = 1;
 #endif
@@ -796,5 +782,33 @@ void (*SSL_CTX_set_cookie_verify_cb)(SSL_CTX *,
                                        )) = NULL;
 #else
 static const long Cryptography_HAS_SSL_COOKIE = 1;
+#endif
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111 || \
+    CRYPTOGRAPHY_IS_LIBRESSL || CRYPTOGRAPHY_IS_BORINGSSL || \
+    defined(OPENSSL_NO_PSK)
+static const long Cryptography_HAS_PSK_TLSv1_3 = 0;
+void (*SSL_CTX_set_psk_find_session_callback)(SSL_CTX *,
+                                           int (*)(
+                                               SSL *,
+                                               const unsigned char *,
+                                               size_t,
+                                               SSL_SESSION **
+                                           )) = NULL;
+void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
+                                          int (*)(
+                                              SSL *,
+                                              const EVP_MD *,
+                                              const unsigned char **,
+                                              size_t *,
+                                              SSL_SESSION **
+                                          )) = NULL;
+const SSL_CIPHER (**SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
+SSL_SESSION (**SSL_SESSION_new)(void) = NULL;
+int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
+                                   size_t) = NULL;
+int (*SSL_SESSION_set_cipher*)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
+int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
+#else
+static const long Cryptography_HAS_PSK_TLSv1_3 = 1;
 #endif
 """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -802,7 +802,6 @@ void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
                                               size_t *,
                                               SSL_SESSION **
                                           )) = NULL;
-                                          
 #if CRYPTOGRAPHY_LIBRESSL_LESS_THAN_340
     const SSL_CIPHER *(*SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
 #endif
@@ -811,7 +810,6 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
-    SSL_SESSION *(*SSL_SESSION_new)(const SSL_CTX *) = NULL;
 #endif
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -809,7 +809,9 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
-    SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
+    if !CRYPTOGRAPHY_IS_LIBRESSL || !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+        SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
+    #endif
 #endif
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -133,6 +133,7 @@ def cryptography_has_psk_tlsv13() -> typing.List[str]:
         "SSL_CTX_set_psk_use_session_callback",
     ]
 
+
 def cryptography_has_custom_ext() -> typing.List[str]:
     return [
         "SSL_CTX_add_client_custom_ext",

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -124,6 +124,8 @@ def cryptography_has_psk() -> typing.List[str]:
         "SSL_CTX_use_psk_identity_hint",
         "SSL_CTX_set_psk_server_callback",
         "SSL_CTX_set_psk_client_callback",
+        "SSL_CTX_set_psk_find_session_callback",
+        "SSL_CTX_set_psk_use_session_callback",
     ]
 
 

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -124,10 +124,14 @@ def cryptography_has_psk() -> typing.List[str]:
         "SSL_CTX_use_psk_identity_hint",
         "SSL_CTX_set_psk_server_callback",
         "SSL_CTX_set_psk_client_callback",
+    ]
+
+
+def cryptography_has_psk_tlsv13() -> typing.List[str]:
+    return [
         "SSL_CTX_set_psk_find_session_callback",
         "SSL_CTX_set_psk_use_session_callback",
     ]
-
 
 def cryptography_has_custom_ext() -> typing.List[str]:
     return [
@@ -318,6 +322,7 @@ CONDITIONAL_NAMES = {
     ),
     "Cryptography_HAS_FIPS": cryptography_has_fips,
     "Cryptography_HAS_PSK": cryptography_has_psk,
+    "Cryptography_HAS_PSK_TLSv1_3": cryptography_has_psk_tlsv13,
     "Cryptography_HAS_CUSTOM_EXT": cryptography_has_custom_ext,
     "Cryptography_HAS_OPENSSL_CLEANUP": cryptography_has_openssl_cleanup,
     "Cryptography_HAS_TLSv1_3": cryptography_has_tlsv13,

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -131,6 +131,7 @@ def cryptography_has_psk_tlsv13() -> typing.List[str]:
     return [
         "SSL_CTX_set_psk_find_session_callback",
         "SSL_CTX_set_psk_use_session_callback",
+        "SSL_SESSION_new",
     ]
 
 


### PR DESCRIPTION
Accord to document of openssl use TLSv1.3 PSKs should use [SSL_CTX_set_psk_find_session_callback](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_psk_find_session_callback.html) 
[SSL_CTX_set_psk_use_session_callback](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_psk_use_session_callback.html)

also other functions needed.