### PR TITLE
add TLSv1.3 PSKs function bindings

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -21,6 +21,7 @@ static const long Cryptography_HAS_SECURE_RENEGOTIATION;
 static const long Cryptography_HAS_SSL_CTX_CLEAR_OPTIONS;
 static const long Cryptography_HAS_DTLS;
 static const long Cryptography_HAS_PSK;
+static const long Cryptography_HAS_PSK_TLSv1_3;
 static const long Cryptography_HAS_VERIFIED_CHAIN;
 static const long Cryptography_HAS_KEYLOG;
 static const long Cryptography_HAS_GET_PROTO_VERSION;
@@ -255,6 +256,26 @@ void SSL_CTX_set_psk_client_callback(SSL_CTX *,
                                          unsigned char *,
                                          unsigned int
                                      ));
+void SSL_CTX_set_psk_find_session_callback(SSL_CTX *,
+                                           int (*)(
+                                               SSL *,
+                                               const unsigned char *,
+                                               size_t,
+                                               SSL_SESSION **
+                                           ));
+void SSL_CTX_set_psk_use_session_callback(SSL_CTX *,
+                                          int (*)(
+                                              SSL *,
+                                              const EVP_MD *,
+                                              const unsigned char **,
+                                              size_t *,
+                                              SSL_SESSION **
+                                          ));
+const SSL_CIPHER *SSL_CIPHER_find(SSL *, const unsigned char *);
+int SSL_SESSION_set1_master_key(SSL_SESSION *, const unsigned char *,
+                                 size_t);
+int SSL_SESSION_set_cipher(SSL_SESSION *, const SSL_CIPHER *);
+int SSL_SESSION_set_protocol_version(SSL_SESSION *, int);
 
 int SSL_CTX_set_session_id_context(SSL_CTX *, const unsigned char *,
                                    unsigned int);
@@ -760,5 +781,39 @@ void (*SSL_CTX_set_cookie_verify_cb)(SSL_CTX *,
                                        )) = NULL;
 #else
 static const long Cryptography_HAS_SSL_COOKIE = 1;
+#endif
+#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111 || \
+    CRYPTOGRAPHY_IS_LIBRESSL || CRYPTOGRAPHY_IS_BORINGSSL || \
+    defined(OPENSSL_NO_PSK)
+static const long Cryptography_HAS_PSK_TLSv1_3 = 0;
+void (*SSL_CTX_set_psk_find_session_callback)(SSL_CTX *,
+                                           int (*)(
+                                               SSL *,
+                                               const unsigned char *,
+                                               size_t,
+                                               SSL_SESSION **
+                                           )) = NULL;
+void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
+                                          int (*)(
+                                              SSL *,
+                                              const EVP_MD *,
+                                              const unsigned char **,
+                                              size_t *,
+                                              SSL_SESSION **
+                                          )) = NULL;
+#if CRYPTOGRAPHY_LIBRESSL_LESS_THAN_340 || CRYPTOGRAPHY_IS_BORINGSSL
+    const SSL_CIPHER *(*SSL_CIPHER_find)(SSL *, const unsigned char *) = NULL;
+#endif
+int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
+                                   size_t) = NULL;
+int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
+#if !CRYPTOGRAPHY_IS_BORINGSSL
+    int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
+    #if !CRYPTOGRAPHY_IS_LIBRESSL && !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
+        SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
+    #endif
+#endif
+#else
+static const long Cryptography_HAS_PSK_TLSv1_3 = 1;
 #endif
 """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -272,7 +272,8 @@ void SSL_CTX_set_psk_use_session_callback(SSL_CTX *,
                                               SSL_SESSION **
                                           ));
 const SSL_CIPHER *SSL_CIPHER_find(SSL *, const unsigned char *);
-SSL_SESSION *SSL_SESSION_new(void);
+/* Wrap SSL_SESSION_new to avoid namespace collision. */
+SSL_SESSION *Cryptography_SSL_SESSION_new(void);
 int SSL_SESSION_set1_master_key(SSL_SESSION *, const unsigned char *,
                                  size_t);
 int SSL_SESSION_set_cipher(SSL_SESSION *, const SSL_CIPHER *);
@@ -810,11 +811,12 @@ int (*SSL_SESSION_set1_master_key)(SSL_SESSION *, const unsigned char *,
 int (*SSL_SESSION_set_cipher)(SSL_SESSION *, const SSL_CIPHER *) = NULL;
 #if !CRYPTOGRAPHY_IS_BORINGSSL
     int (*SSL_SESSION_set_protocol_version)(SSL_SESSION *, int) = NULL;
-    #if !CRYPTOGRAPHY_IS_LIBRESSL && !CRYPTOGRAPHY_OPENSSL_LESS_THAN_111
-        SSL_SESSION *(*SSL_SESSION_new)(void) = NULL;
-    #endif
 #endif
+SSL_SESSION *(*Cryptography_SSL_SESSION_new)(void) = NULL;
 #else
 static const long Cryptography_HAS_PSK_TLSv1_3 = 1;
+SSL_SESSION *Cryptography_SSL_SESSION_new(void) {
+    return SSL_SESSION_new();
+}
 #endif
 """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -272,6 +272,7 @@ void SSL_CTX_set_psk_use_session_callback(SSL_CTX *,
                                               SSL_SESSION **
                                           ));
 const SSL_CIPHER *SSL_CIPHER_find(SSL *, const unsigned char *);
+SSL_SESSION *SSL_SESSION_new(void);
 int SSL_SESSION_set1_master_key(SSL_SESSION *, const unsigned char *,
                                  size_t);
 int SSL_SESSION_set_cipher(SSL_SESSION *, const SSL_CIPHER *);

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -131,8 +131,8 @@ def cryptography_has_psk_tlsv13() -> typing.List[str]:
     return [
         "SSL_CTX_set_psk_find_session_callback",
         "SSL_CTX_set_psk_use_session_callback",
+        "Cryptography_SSL_SESSION_new",
         "SSL_CIPHER_find",
-        "SSL_SESSION_new",
         "SSL_SESSION_set1_master_key",
         "SSL_SESSION_set_cipher",
         "SSL_SESSION_set_protocol_version",

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -127,6 +127,13 @@ def cryptography_has_psk() -> typing.List[str]:
     ]
 
 
+def cryptography_has_psk_tlsv13() -> typing.List[str]:
+    return [
+        "SSL_CTX_set_psk_find_session_callback",
+        "SSL_CTX_set_psk_use_session_callback",
+    ]
+
+
 def cryptography_has_custom_ext() -> typing.List[str]:
     return [
         "SSL_CTX_add_client_custom_ext",
@@ -316,6 +323,7 @@ CONDITIONAL_NAMES = {
     ),
     "Cryptography_HAS_FIPS": cryptography_has_fips,
     "Cryptography_HAS_PSK": cryptography_has_psk,
+    "Cryptography_HAS_PSK_TLSv1_3": cryptography_has_psk_tlsv13,
     "Cryptography_HAS_CUSTOM_EXT": cryptography_has_custom_ext,
     "Cryptography_HAS_OPENSSL_CLEANUP": cryptography_has_openssl_cleanup,
     "Cryptography_HAS_TLSv1_3": cryptography_has_tlsv13,

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -131,6 +131,11 @@ def cryptography_has_psk_tlsv13() -> typing.List[str]:
     return [
         "SSL_CTX_set_psk_find_session_callback",
         "SSL_CTX_set_psk_use_session_callback",
+        "SSL_CIPHER_find",
+        "SSL_SESSION_new",
+        "SSL_SESSION_set1_master_key",
+        "SSL_SESSION_set_cipher",
+        "SSL_SESSION_set_protocol_version",
     ]
 
 


### PR DESCRIPTION
Accord to document of openssl use TLSv1.3 PSKs should use
 [SSL_CTX_set_psk_find_session_callback](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_psk_find_session_callback.html)
[SSL_CTX_set_psk_use_session_callback](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_psk_use_session_callback.html)

also other functions needed.