### PR TITLE
make ExtensionTypeVar covariant

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -41,7 +41,9 @@ from cryptography.x509.oid import (
     ObjectIdentifier,
 )
 
-ExtensionTypeVar = typing.TypeVar("ExtensionTypeVar", bound="ExtensionType")
+ExtensionTypeVar = typing.TypeVar(
+    "ExtensionTypeVar", bound="ExtensionType", covariant=True
+)
 
 
 def _key_identifier_from_public_key(


### PR DESCRIPTION
Make `ExtensionTypeVar` generic covariant. This tells mypy that any concrete class for ExtensionType in `x509.Extension[x509.ExtensionType]` (e.g. a `x509.Extension[x509.SubjectAlternativeName]`) is a subclass of ExtensionType... as is actually the case. For some reason, generic types are invariant by default, see https://mypy.readthedocs.io/en/stable/generics.html#variance-of-generic-types for more information.

This fixes typing issues for example in this (somewhat contrived, of course) script:

```python
from cryptography import x509
from cryptography.x509.oid import ExtensionOID


def send(ext: x509.Extension[x509.ExtensionType]) -> None:
    print(ext.oid)


no_check = x509.Extension(
    oid=ExtensionOID.OCSP_NO_CHECK, critical=False, value=x509.OCSPNoCheck()
)   

# Without the patch, mypy says:
#   Argument 1 to "send" has incompatible type "Extension[OCSPNoCheck]"; expected "Extension[ExtensionType]"  [arg-type]
send(no_check)
```

With my PR, mypy show the line as clean.