### PR TITLE
fix two compiler warnings

### DIFF
--- a/src/_cffi_src/openssl/bio.py
+++ b/src/_cffi_src/openssl/bio.py
@@ -25,7 +25,7 @@ int BIO_write(BIO *, const void *, int);
 int BIO_up_ref(BIO *);
 
 BIO *BIO_new(BIO_METHOD *);
-BIO_METHOD *BIO_s_mem(void);
+const BIO_METHOD *BIO_s_mem(void);
 BIO *BIO_new_mem_buf(const void *, int);
 long BIO_set_mem_eof_return(BIO *, int);
 long BIO_get_mem_data(BIO *, char **);

--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -210,7 +210,6 @@ X509_OBJECT *sk_X509_OBJECT_value(Cryptography_STACK_OF_X509_OBJECT *, int);
 X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *);
 Cryptography_STACK_OF_X509_OBJECT *X509_STORE_get0_objects(X509_STORE *);
 X509 *X509_OBJECT_get0_X509(X509_OBJECT *);
-int X509_OBJECT_get_type(const X509_OBJECT *);
 
 /* added in 1.1.0 */
 X509 *X509_STORE_CTX_get0_cert(X509_STORE_CTX *);


### PR DESCRIPTION
constify and remove a func we don't use or need that had a wrong return
type anyway.