### PR TITLE
Fix indentation in docs/x509/reference.rst

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -459,9 +459,8 @@ X.509 Certificate Object
            ...     cert_to_check.signature_hash_algorithm,
            ... )
 
-           An
-           :class:`~cryptography.exceptions.InvalidSignature`
-           exception will be raised if the signature fails to verify.
+       An :class:`~cryptography.exceptions.InvalidSignature` exception will be
+       raised if the signature fails to verify.
 
     .. method:: public_bytes(encoding)
 


### PR DESCRIPTION
This is currently mis-rendered:

<img width="744" alt="image" src="https://user-images.githubusercontent.com/294415/161844129-d34d0fb3-ee29-4697-b628-6223a42f95bc.png">
