### PR TITLE
Pin josepy to 1.13.0 in downstream tests

### DIFF
--- a/.github/downstream.d/certbot-josepy.sh
+++ b/.github/downstream.d/certbot-josepy.sh
@@ -2,7 +2,12 @@
 
 case "${1}" in
     install)
-        git clone --depth=1 https://github.com/certbot/josepy
+        # Josepy is pinned to 1.13.0 because the project is migrating to Poetry, and
+        # this test is not compatible with it yet.
+        #
+        # TODO: Update this test with Poetry once a new release of Josepy includes
+        #       https://github.com/certbot/josepy/pull/129
+        git clone --depth=1 --branch v1.13.0 https://github.com/certbot/josepy
         cd josepy
         git rev-parse HEAD
         pip install -e ".[tests]" -c constraints.txt


### PR DESCRIPTION
Hello dear maintainers of cryptography. We are currently migrating the Josepy project to Poetry, in order to take advantage of the features it provides over pip (venv management, dependency tree resolution, lock mechanism ...) for developers.

The PR for this is https://github.com/certbot/josepy/pull/129

However before merging this PR, we need to do something about the downstream test in cryptography that uses josepy. Indeed once josepy  master branch is updated, the test `.github/downstream.d/certbot-josepy.sh` will crash because of the lack of support (until recently) of editable installs in pip for PEP-518 compliant projects + the removal of `constraints.txt` file.

This PR fixes this by pinning the current git clone of josepy to its latest release at this time, `1.13.0`.

I propose that once josepy has been updated and starts to use poetry, I create a second PR in cryptography to install and use Poetry, so that it re-establishes the current downstream test behavior (testing master branch with upstream dependencies pinning).

Does it sound good to you? Thanks in advance!