### PR TITLE
Use poetry directly to test josepy

### DIFF
--- a/.github/downstream.d/certbot-josepy.sh
+++ b/.github/downstream.d/certbot-josepy.sh
@@ -6,11 +6,12 @@ case "${1}" in
         cd josepy
         git rev-parse HEAD
         curl -sSL https://install.python-poetry.org | python3 -
-        "${HOME}/.local/bin/poetry" install
+        "${HOME}/.local/bin/poetry" export -f requirements.txt --dev --without-hashes > constraints.txt
+        pip install -e . pytest -c constraints.txt
         ;;
     run)
         cd josepy
-        .venv/bin/pytest tests
+        pytest tests
         ;;
     *)
         exit 1

--- a/.github/downstream.d/certbot-josepy.sh
+++ b/.github/downstream.d/certbot-josepy.sh
@@ -2,19 +2,15 @@
 
 case "${1}" in
     install)
-        # Josepy is pinned to 1.13.0 because the project is migrating to Poetry, and
-        # this test is not compatible with it yet.
-        #
-        # TODO: Update this test with Poetry once a new release of Josepy includes
-        #       https://github.com/certbot/josepy/pull/129
-        git clone --depth=1 --branch v1.13.0 https://github.com/certbot/josepy
+        git clone --depth=1 https://github.com/certbot/josepy
         cd josepy
         git rev-parse HEAD
-        pip install -e ".[tests]" -c constraints.txt
+        curl -sSL https://install.python-poetry.org | python3 -
+        "${HOME}/.local/bin/poetry" install
         ;;
     run)
         cd josepy
-        pytest src
+        .venv/bin/pytest tests
         ;;
     *)
         exit 1


### PR DESCRIPTION
Following https://github.com/pyca/cryptography/pull/7063, and since https://github.com/certbot/josepy/pull/129 has been merged on Josepy upstream, this PR adapts the downstream certbot-josepy.sh test to take advantage of Poetry and install the dependencies + dev dependencies before running the tests.

While reviewing the code, I realized that the test was still launching `pytest src`, but the unit tests have been moved out of the src folder, so the actual code is only running the flake8 linting, which is certainly not what we want to do here. I fixed that by running `pytest tests` instead.