### PR TITLE
Add support for PSS.AUTO and PSS.DIGEST_LENGTH

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,13 @@ Changelog
   :class:`~cryptography.hazmat.primitives.serialization.pkcs7.serialize_certificates`.
 * Added support for parsing :rfc:`4514` strings with
   :meth:`~cryptography.x509.Name.from_rfc4514_string`.
+* Added :attr:`~cryptography.hazmat.primitives.asymmetric.padding.PSS.AUTO` to
+  :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`. This can
+  be used to verify a signature where the salt length is not already known.
+* Added :attr:`~cryptography.hazmat.primitives.asymmetric.padding.PSS.DIGEST_LENGTH`
+  to :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`. This
+  constant will set the salt length to the same length as the ``PSS`` hash
+  algorithm.
 
 .. _v36-0-2:
 

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -295,12 +295,20 @@ Padding
         supported MGF is :class:`MGF1`.
 
     :param int salt_length: The length of the salt. It is recommended that this
-        be set to ``PSS.MAX_LENGTH``.
+        be set to ``PSS.DIGEST_LENGTH`` or ``PSS.MAX_LENGTH``.
 
     .. attribute:: MAX_LENGTH
 
         Pass this attribute to ``salt_length`` to get the maximum salt length
         available.
+
+    .. attribute:: DIGEST_LENGTH
+
+        .. versionadded:: 37.0
+
+        Pass this attribute to ``salt_length`` to set the salt length to the
+        byte length of the digest passed when calling ``sign``. Note that this
+        is **not** the length of the digest passed to ``MGF1``.
 
     .. attribute:: AUTO
 

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -302,6 +302,13 @@ Padding
         Pass this attribute to ``salt_length`` to get the maximum salt length
         available.
 
+    .. attribute:: AUTO
+
+        .. versionadded:: 37.0
+
+        Pass this attribute to ``salt_length`` to automatically determine the
+        salt length when verifying. Raises ``ValueError`` if used when signing.
+
 .. class:: OAEP(mgf, algorithm, label)
 
     .. versionadded:: 0.4

--- a/src/_cffi_src/openssl/rsa.py
+++ b/src/_cffi_src/openssl/rsa.py
@@ -45,7 +45,8 @@ int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *, EVP_MD *);
 """
 
 CUSTOMIZATIONS = """
-// BoringSSL doesn't define this constant
+// BoringSSL doesn't define this constant, but the value is used for
+// automatic salt length computation as in OpenSSL and LibreSSL
 #if !defined(RSA_PSS_SALTLEN_AUTO)
 #define RSA_PSS_SALTLEN_AUTO -2
 #endif

--- a/src/_cffi_src/openssl/rsa.py
+++ b/src/_cffi_src/openssl/rsa.py
@@ -15,6 +15,7 @@ static const int RSA_NO_PADDING;
 static const int RSA_PKCS1_OAEP_PADDING;
 static const int RSA_PKCS1_PSS_PADDING;
 static const int RSA_F4;
+static const int RSA_PSS_SALTLEN_AUTO;
 """
 
 FUNCTIONS = """
@@ -44,4 +45,8 @@ int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *, EVP_MD *);
 """
 
 CUSTOMIZATIONS = """
+// BoringSSL doesn't define this constant
+#if !defined(RSA_PSS_SALTLEN_AUTO)
+#define RSA_PSS_SALTLEN_AUTO -2
+#endif
 """

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -45,7 +45,7 @@ def _get_rsa_pss_salt_length(
     pss: PSS,
     key: typing.Union[RSAPrivateKey, RSAPublicKey],
     hash_algorithm: hashes.HashAlgorithm,
-) -> typing.Union[int, _MaxLength, _Auto, _DigestLength]:
+) -> int:
     salt = pss._salt_length
 
     if isinstance(salt, _MaxLength):
@@ -57,7 +57,7 @@ def _get_rsa_pss_salt_length(
             raise ValueError(
                 "PSS salt length can only be set to AUTO when verifying"
             )
-        return backend._lib.RSA_PSS_SALTLEN_AUTO  # this is really just -2
+        return backend._lib.RSA_PSS_SALTLEN_AUTO
     else:
         return salt
 

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -23,6 +23,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import (
     OAEP,
     PKCS1v15,
     PSS,
+    _Auto,
     _MaxLength,
     calculate_max_pss_salt_length,
 )
@@ -42,11 +43,18 @@ def _get_rsa_pss_salt_length(
     pss: PSS,
     key: typing.Union[RSAPrivateKey, RSAPublicKey],
     hash_algorithm: hashes.HashAlgorithm,
-) -> typing.Union[int, _MaxLength]:
+) -> typing.Union[int, _MaxLength, _Auto]:
     salt = pss._salt_length
 
     if isinstance(salt, _MaxLength):
         return calculate_max_pss_salt_length(key, hash_algorithm)
+    elif isinstance(salt, _Auto):
+        if isinstance(key, RSAPrivateKey):
+            raise ValueError(
+                "PSS salt length can only be set to AUTO when verifying"
+            )
+        # TODO: use a constant. BoringSSL doesn't declare it though
+        return -2
     else:
         return salt
 

--- a/src/cryptography/hazmat/primitives/asymmetric/padding.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/padding.py
@@ -25,20 +25,30 @@ class _Auto:
     "Sentinel value for `AUTO`."
 
 
+class _DigestLength:
+    "Sentinel value for `DIGEST_LENGTH`."
+
+
 class PSS(AsymmetricPadding):
     MAX_LENGTH = _MaxLength()
     AUTO = _Auto()
+    DIGEST_LENGTH = _DigestLength()
     name = "EMSA-PSS"
-    _salt_length: typing.Union[int, _MaxLength]
+    _salt_length: typing.Union[int, _MaxLength, _Auto, _DigestLength]
 
     def __init__(
-        self, mgf: "MGF", salt_length: typing.Union[int, _MaxLength, _Auto]
+        self,
+        mgf: "MGF",
+        salt_length: typing.Union[int, _MaxLength, _Auto, _DigestLength],
     ) -> None:
         self._mgf = mgf
 
-        if not isinstance(salt_length, (int, _MaxLength, _Auto)):
+        if not isinstance(
+            salt_length, (int, _MaxLength, _Auto, _DigestLength)
+        ):
             raise TypeError(
-                "salt_length must be an integer, MAX_LENGTH, or AUTO"
+                "salt_length must be an integer, MAX_LENGTH, "
+                "DIGEST_LENGTH, or AUTO"
             )
 
         if isinstance(salt_length, int) and salt_length < 0:

--- a/src/cryptography/hazmat/primitives/asymmetric/padding.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/padding.py
@@ -21,20 +21,27 @@ class _MaxLength:
     "Sentinel value for `MAX_LENGTH`."
 
 
+class _Auto:
+    "Sentinel value for `AUTO`."
+
+
 class PSS(AsymmetricPadding):
     MAX_LENGTH = _MaxLength()
+    AUTO = _Auto()
     name = "EMSA-PSS"
     _salt_length: typing.Union[int, _MaxLength]
 
     def __init__(
-        self, mgf: "MGF", salt_length: typing.Union[int, _MaxLength]
+        self, mgf: "MGF", salt_length: typing.Union[int, _MaxLength, _Auto]
     ) -> None:
         self._mgf = mgf
 
-        if not isinstance(salt_length, (int, _MaxLength)):
-            raise TypeError("salt_length must be an integer.")
+        if not isinstance(salt_length, (int, _MaxLength, _Auto)):
+            raise TypeError(
+                "salt_length must be an integer, MAX_LENGTH, or AUTO"
+            )
 
-        if not isinstance(salt_length, _MaxLength) and salt_length < 0:
+        if isinstance(salt_length, int) and salt_length < 0:
             raise ValueError("salt_length must be zero or greater.")
 
         self._salt_length = salt_length

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -582,6 +582,27 @@ class TestRSASignature:
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.AUTO,
+            )
+        ),
+        skip_message="Does not support PSS.",
+    )
+    def test_pss_sign_unsupported_auto(self, backend):
+        private_key = RSA_KEY_2048.private_key()
+        with pytest.raises(ValueError):
+            private_key.sign(
+                b"some data",
+                padding.PSS(
+                    mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.AUTO,
+                ),
+                hashes.SHA256(),
+            )
+
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.rsa_padding_supported(
             padding.PKCS1v15()
         ),
         skip_message="Does not support PKCS1v1.5.",
@@ -855,6 +876,35 @@ class TestRSAVerification:
                     ),
                     hashes.SHA1(),
                 )
+
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.rsa_padding_supported(
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.AUTO,
+            )
+        ),
+        skip_message="Does not support PSS.",
+    )
+    def test_pss_verify_auto_salt_length(self, backend):
+        private_key = RSA_KEY_2048.private_key()
+        signature = private_key.sign(
+            b"some data",
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+        private_key.public_key().verify(
+            signature,
+            b"some data",
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.AUTO,
+            ),
+            hashes.SHA256(),
+        )
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.rsa_padding_supported(


### PR DESCRIPTION
PSS.AUTO allows for verification of signatures where the salt length is not known a priori.

PSS.DIGEST_LENGTH is a convenience constant to make it easier to match the more common PSS conventions in use today (salt length equal to PSS digest length).