### PR TITLE
Refs #7079 -- added basic scaffolding for benchmarks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ line-length = 79
 target-version = ["py36"]
 
 [tool.pytest.ini_options]
-addopts = "-r s --capture=no --strict-markers"
+addopts = "-r s --capture=no --strict-markers --benchmark-disable"
 markers = [
     "skip_fips: this test is not executed in FIPS mode",
     "supported: parametrized test requiring only_if and skip_message",

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ exclude =
 [options.extras_require]
 test =
     pytest>=6.2.0
+    pytest-benchmark
     pytest-cov
     pytest-subtests
     pytest-xdist

--- a/tests/bench/test_x509.py
+++ b/tests/bench/test_x509.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from cryptography import x509
+
+
+def test_aki_public_bytes(benchmark):
+    aki = x509.AuthorityKeyIdentifier(
+        key_identifier=b"\x00" * 16,
+        authority_cert_issuer=None,
+        authority_cert_serial_number=None,
+    )
+    benchmark(aki.public_bytes)


### PR DESCRIPTION
As it turns out, pytest-benchmark does basically what we want so there's not much to this.