### PR TITLE
Remove trailing white space in docs

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -3159,7 +3159,7 @@ instances. The following common OIDs are available as constants.
         is used to denote that a certificate may be used as a Kerberos
         domain controller certificate authorizing ``PKINIT`` access. For
         more information see :rfc:`4556`.
-        
+
     .. attribute:: IPSEC_IKE
 
         .. versionadded:: 37.0


### PR DESCRIPTION
Apparently none of our linters care