### PR TITLE
Allow Fernet decryption to accept string tokens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Changelog
   Users with the latest ``pip`` will typically get a wheel and not need Rust
   installed, but check :doc:`/installation` for documentation on installing a
   newer ``rustc`` if required.
+* :meth:`~cryptography.fernet.Fernet.decrypt` and related methods now accept
+  both ``str`` and ``bytes`` tokens.
 
 .. _v37-0-1:
 

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -83,8 +83,8 @@ has support for implementing key rotation via :class:`MultiFernet`.
         raised. It is safe to use this data immediately as Fernet verifies
         that the data has not been tampered with prior to returning it.
 
-        :param bytes token: The Fernet token. This is the result of calling
-                            :meth:`encrypt`.
+        :param bytes or str token: The Fernet token. This is the result of
+                                   calling :meth:`encrypt`.
         :param int ttl: Optionally, the number of seconds old a message may be
                         for it to be valid. If the message is older than
                         ``ttl`` seconds (from the time it was originally
@@ -101,7 +101,7 @@ has support for implementing key rotation via :class:`MultiFernet`.
                                                   it does not have a valid
                                                   signature.
         :raises TypeError: This exception is raised if ``token`` is not
-                           ``bytes``.
+                           ``bytes`` or ``str``.
 
     .. method:: decrypt_at_time(token, ttl, current_time)
 
@@ -127,14 +127,14 @@ has support for implementing key rotation via :class:`MultiFernet`.
         Returns the timestamp for the token. The caller can then decide if
         the token is about to expire and, for example, issue a new token.
 
-        :param bytes token: The Fernet token. This is the result of calling
-                            :meth:`encrypt`.
+        :param bytes or str token: The Fernet token. This is the result of
+                                   calling :meth:`encrypt`.
         :returns int: The UNIX timestamp of the token.
         :raises cryptography.fernet.InvalidToken: If the ``token``'s signature
                                                   is invalid this exception
                                                   is raised.
         :raises TypeError: This exception is raised if ``token`` is not
-                           ``bytes``.
+                           ``bytes`` or ``str``.
 
 
 .. class:: MultiFernet(fernets)
@@ -201,14 +201,14 @@ has support for implementing key rotation via :class:`MultiFernet`.
            >>> f2.decrypt(rotated)
            b'Secret message!'
 
-        :param bytes msg: The token to re-encrypt.
+        :param bytes or str msg: The token to re-encrypt.
         :returns bytes: A secure message that cannot be read or altered without
            the key. This is URL-safe base64-encoded. This is referred to as a
            "Fernet token".
         :raises cryptography.fernet.InvalidToken: If a ``token`` is in any
            way invalid this exception is raised.
         :raises TypeError: This exception is raised if the ``msg`` is not
-           ``bytes``.
+           ``bytes`` or ``str``.
 
 
 .. class:: InvalidToken

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -37,7 +37,7 @@ def json_parametrize(keys, filename):
         return pytest.mark.parametrize(
             keys,
             [tuple([entry[k] for k in keys]) for entry in data],
-            ids=_id_gen(),
+            ids=[f"{filename}[{i}] for i in range(len(data))],
         )
 
 

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -5,7 +5,6 @@
 
 import base64
 import calendar
-import itertools
 import json
 import os
 import time

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -5,6 +5,7 @@
 
 import base64
 import calendar
+import itertools
 import json
 import os
 import time
@@ -25,10 +26,18 @@ def json_parametrize(keys, filename):
     vector_file = cryptography_vectors.open_vector_file(
         os.path.join("fernet", filename), "r"
     )
+
+    def _id_gen():
+        # generate readable test identifiers
+        for idx in itertools.count():
+            yield f"{filename}[{idx}]"
+
     with vector_file:
         data = json.load(vector_file)
         return pytest.mark.parametrize(
-            keys, [tuple([entry[k] for k in keys]) for entry in data]
+            keys,
+            [tuple([entry[k] for k in keys]) for entry in data],
+            ids=_id_gen(),
         )
 
 

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -26,12 +26,6 @@ def json_parametrize(keys, filename):
     vector_file = cryptography_vectors.open_vector_file(
         os.path.join("fernet", filename), "r"
     )
-
-    def _id_gen():
-        # generate readable test identifiers
-        for idx in itertools.count():
-            yield f"{filename}[{idx}]"
-
     with vector_file:
         data = json.load(vector_file)
         return pytest.mark.parametrize(

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -68,16 +68,29 @@ class TestFernet:
     def test_verify(
         self, secret, now, src, ttl_sec, token, backend, monkeypatch
     ):
+        # secret & token are both str
         f = Fernet(secret.encode("ascii"), backend=backend)
         current_time = calendar.timegm(iso8601.parse_date(now).utctimetuple())
         payload = f.decrypt_at_time(
-            token.encode("ascii"),
+            token,  # str
             ttl=ttl_sec,
             current_time=current_time,
         )
         assert payload == src.encode("ascii")
+
+        payload = f.decrypt_at_time(
+            token.encode("ascii"),  # bytes
+            ttl=ttl_sec,
+            current_time=current_time,
+        )
+        assert payload == src.encode("ascii")
+
         monkeypatch.setattr(time, "time", lambda: current_time)
-        payload = f.decrypt(token.encode("ascii"), ttl=ttl_sec)
+
+        payload = f.decrypt(token, ttl=ttl_sec)  # str
+        assert payload == src.encode("ascii")
+
+        payload = f.decrypt(token.encode("ascii"), ttl=ttl_sec)  # bytes
         assert payload == src.encode("ascii")
 
     @json_parametrize(("secret", "token", "now", "ttl_sec"), "invalid.json")
@@ -108,13 +121,15 @@ class TestFernet:
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         with pytest.raises(InvalidToken):
             f.decrypt(b"\x00")
+        with pytest.raises(InvalidToken):
+            f.decrypt("nonsensetoken")
 
-    def test_unicode(self, backend):
+    def test_invalid_types(self, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         with pytest.raises(TypeError):
             f.encrypt("")  # type: ignore[arg-type]
         with pytest.raises(TypeError):
-            f.decrypt("")  # type: ignore[arg-type]
+            f.decrypt(12345)  # type: ignore[arg-type]
 
     def test_timestamp_ignored_no_ttl(self, monkeypatch, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
@@ -149,6 +164,7 @@ class TestFernet:
         current_time = 1526138327
         token = f.encrypt_at_time(b"encrypt me", current_time)
         assert f.extract_timestamp(token) == current_time
+        assert f.extract_timestamp(token.decode("ascii")) == current_time
         with pytest.raises(InvalidToken):
             f.extract_timestamp(b"nonsensetoken")
 
@@ -172,8 +188,13 @@ class TestMultiFernet:
         f2 = Fernet(base64.urlsafe_b64encode(b"\x01" * 32), backend=backend)
         f = MultiFernet([f1, f2])
 
+        # token as bytes
         assert f.decrypt(f1.encrypt(b"abc")) == b"abc"
         assert f.decrypt(f2.encrypt(b"abc")) == b"abc"
+
+        # token as str
+        assert f.decrypt(f1.encrypt(b"abc").decode("ascii")) == b"abc"
+        assert f.decrypt(f2.encrypt(b"abc").decode("ascii")) == b"abc"
 
         with pytest.raises(InvalidToken):
             f.decrypt(b"\x00" * 16)
@@ -199,7 +220,7 @@ class TestMultiFernet:
         with pytest.raises(TypeError):
             MultiFernet(None)  # type: ignore[arg-type]
 
-    def test_rotate(self, backend):
+    def test_rotate_bytes(self, backend):
         f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         f2 = Fernet(base64.urlsafe_b64encode(b"\x01" * 32), backend=backend)
 
@@ -212,6 +233,25 @@ class TestMultiFernet:
         assert mf2.decrypt(mf1_ciphertext) == plaintext
 
         rotated = mf2.rotate(mf1_ciphertext)
+
+        assert rotated != mf1_ciphertext
+        assert mf2.decrypt(rotated) == plaintext
+
+        with pytest.raises(InvalidToken):
+            mf1.decrypt(rotated)
+
+    def test_rotate_str(self, backend):
+        f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
+        f2 = Fernet(base64.urlsafe_b64encode(b"\x01" * 32), backend=backend)
+
+        mf1 = MultiFernet([f1])
+        mf2 = MultiFernet([f2, f1])
+
+        plaintext = b"abc"
+        mf1_ciphertext = mf1.encrypt(plaintext).decode("ascii")
+
+        assert mf2.decrypt(mf1_ciphertext) == plaintext
+        rotated = mf2.rotate(mf1_ciphertext).decode("ascii")
 
         assert rotated != mf1_ciphertext
         assert mf2.decrypt(rotated) == plaintext

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -30,7 +30,7 @@ def json_parametrize(keys, filename):
         return pytest.mark.parametrize(
             keys,
             [tuple([entry[k] for k in keys]) for entry in data],
-            ids=[f"{filename}[{i}] for i in range(len(data))],
+            ids=[f"{filename}[{i}]" for i in range(len(data))],
         )
 
 


### PR DESCRIPTION
Fixes https://github.com/pyca/cryptography/issues/7105

Remove some developer friction by allowing string tokens to be passed to Fernet & MultiFernet decryption methods. Because a valid token as generated by `Fernet.encrypt()` is url-safe base64-encoded, a non-ASCII token is definitely invalid.

- when passing a token as part of any JSON payload, stdlib returns strings
- when passing a token as part of a HTTP header, python web frameworks return string values
- it's common to be using strings in test vectors, REPL environments, etc
