### PR TITLE
docs: fix linting tox env name

### DIFF
--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -22,7 +22,7 @@ When in doubt, refer to :pep:`8` for Python code. You can check if your code
 meets our automated requirements by formatting it with ``black`` and running
 ``flake8`` against it. If you've installed the development requirements this
 will automatically use our configuration. You can also run the ``tox`` job with
-``tox -e pep8``.
+``tox -e flake``.
 
 `Write comments as complete sentences.`_
 


### PR DESCRIPTION
The command for linting is `tox -e flake` not `tox -e pep8` as of 488379122