### PR TITLE
Add typings to default_backend()

### DIFF
--- a/src/cryptography/hazmat/backends/__init__.py
+++ b/src/cryptography/hazmat/backends/__init__.py
@@ -1,9 +1,10 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+from typing import Any
 
 
-def default_backend():
+def default_backend() -> Any:
     from cryptography.hazmat.backends.openssl.backend import backend
 
     return backend


### PR DESCRIPTION
This commit adds back a return type for default_backend, so mypy would consider this function typed.