### PR TITLE
restore some bindings for older pyopenssl temporarily

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -86,6 +86,7 @@ ffi = build_ffi_for_binding(
         "dh",
         "dsa",
         "ec",
+        "ecdh",
         "ecdsa",
         "engine",
         "err",

--- a/src/_cffi_src/openssl/ecdh.py
+++ b/src/_cffi_src/openssl/ecdh.py
@@ -1,0 +1,19 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+
+INCLUDES = """
+#include <openssl/ecdh.h>
+"""
+
+TYPES = """
+"""
+
+FUNCTIONS = """
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+long SSL_CTX_set_ecdh_auto(SSL_CTX *, int);
+"""
+
+CUSTOMIZATIONS = """
+"""

--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -128,6 +128,10 @@ int EVP_PKEY_id(const EVP_PKEY *);
 
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 void EVP_MD_CTX_free(EVP_MD_CTX *);
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+EVP_MD_CTX *Cryptography_EVP_MD_CTX_new(void);
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+void Cryptography_EVP_MD_CTX_free(EVP_MD_CTX *);
 
 /* Added in 1.1.1 */
 int EVP_DigestSign(EVP_MD_CTX *, unsigned char *, size_t *,

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -176,6 +176,8 @@ int X509_REVOKED_get_ext_count(X509_REVOKED *);
 X509_EXTENSION *X509_REVOKED_get_ext(X509_REVOKED *, int);
 
 X509_REVOKED *X509_REVOKED_dup(X509_REVOKED *);
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+X509_REVOKED *Cryptography_X509_REVOKED_dup(X509_REVOKED *);
 
 const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *);
 
@@ -206,10 +208,19 @@ int sk_X509_REVOKED_num(Cryptography_STACK_OF_X509_REVOKED *);
 X509_REVOKED *sk_X509_REVOKED_value(Cryptography_STACK_OF_X509_REVOKED *, int);
 
 long X509_CRL_get_version(X509_CRL *);
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+ASN1_TIME *X509_CRL_get_lastUpdate(X509_CRL *);
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+ASN1_TIME *X509_CRL_get_nextUpdate(X509_CRL *);
 const ASN1_TIME *X509_CRL_get0_lastUpdate(const X509_CRL *);
 const ASN1_TIME *X509_CRL_get0_nextUpdate(const X509_CRL *);
 X509_NAME *X509_CRL_get_issuer(X509_CRL *);
 Cryptography_STACK_OF_X509_REVOKED *X509_CRL_get_REVOKED(X509_CRL *);
+
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+int X509_CRL_set_lastUpdate(X509_CRL *, ASN1_TIME *);
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+int X509_CRL_set_nextUpdate(X509_CRL *, ASN1_TIME *);
 
 int X509_CRL_set1_lastUpdate(X509_CRL *, const ASN1_TIME *);
 int X509_CRL_set1_nextUpdate(X509_CRL *, const ASN1_TIME *);
@@ -225,4 +236,8 @@ const ASN1_TIME *X509_REVOKED_get0_revocationDate(const X509_REVOKED *);
 """
 
 CUSTOMIZATIONS = """
+/* This function is no longer used by pyOpenSSL >= 22.0 */
+X509_REVOKED *Cryptography_X509_REVOKED_dup(X509_REVOKED *rev) {
+    return X509_REVOKED_dup(rev);
+}
 """

--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -94,6 +94,9 @@ static const int X509_V_ERR_EMAIL_MISMATCH;
 static const int X509_V_ERR_IP_ADDRESS_MISMATCH;
 static const int X509_V_ERR_APPLICATION_VERIFICATION;
 
+/* This constant is no longer used by pyOpenSSL >= 22.0 */
+static const long X509_V_FLAG_CB_ISSUER_CHECK;
+
 /* Verification parameters */
 static const long X509_V_FLAG_USE_CHECK_TIME;
 static const long X509_V_FLAG_CRL_CHECK;


### PR DESCRIPTION
These will be removed again in a future release.

All these bindings were relied upon by pyOpenSSL up to the 22.0 release (which was released Jan 29, 2022). We can't remove them quite that fast 😄 