### PR TITLE
Remove invalid OPENSSL_NO_PSK defined guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - {VERSION: "3.10", TOXENV: "py310", OPENSSL: {TYPE: "openssl", VERSION: "1.1.0l"}}
           - {VERSION: "3.10", TOXENV: "py310", OPENSSL: {TYPE: "openssl", VERSION: "1.1.1n"}}
           - {VERSION: "3.10", TOXENV: "py310-ssh", OPENSSL: {TYPE: "openssl", VERSION: "1.1.1n"}}
-          - {VERSION: "3.10", TOXENV: "py310", OPENSSL: {TYPE: "openssl", VERSION: "1.1.1n", CONFIG_FLAGS: "no-engine no-rc2 no-srtp no-ct"}}
+          - {VERSION: "3.10", TOXENV: "py310", OPENSSL: {TYPE: "openssl", VERSION: "1.1.1n", CONFIG_FLAGS: "no-engine no-rc2 no-srtp no-ct no-psk"}}
           - {VERSION: "3.10", TOXENV: "py310", OPENSSL: {TYPE: "openssl", VERSION: "3.0.2"}}
           - {VERSION: "3.10", TOXENV: "py310", TOXARGS: "--enable-fips=1", OPENSSL: {TYPE: "openssl", CONFIG_FLAGS: "enable-fips", VERSION: "3.0.2"}}
           - {VERSION: "3.10", TOXENV: "py310", OPENSSL: {TYPE: "libressl", VERSION: "3.1.5"}}

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -785,8 +785,7 @@ void (*SSL_CTX_set_cookie_verify_cb)(SSL_CTX *,
 static const long Cryptography_HAS_SSL_COOKIE = 1;
 #endif
 #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_111 || \
-    CRYPTOGRAPHY_IS_LIBRESSL || CRYPTOGRAPHY_IS_BORINGSSL || \
-    defined(OPENSSL_NO_PSK)
+    CRYPTOGRAPHY_IS_LIBRESSL || CRYPTOGRAPHY_IS_BORINGSSL
 static const long Cryptography_HAS_PSK_TLSv1_3 = 0;
 void (*SSL_CTX_set_psk_find_session_callback)(SSL_CTX *,
                                            int (*)(


### PR DESCRIPTION
These symbols are not conditional on `OPENSSL_NO_PSK` in `ssl.h`

`SSL_CTX_set_psk_find_session_callback`:
https://github.com/openssl/openssl/blob/openssl-3.0.2/include/openssl/ssl.h.in#L847

`SSL_CTX_set_psk_use_session_callback`:
https://github.com/openssl/openssl/blob/openssl-3.0.2/include/openssl/ssl.h.in#L850-L851

As such we can not guard the fallback with `defined(OPENSSL_NO_PSK)`
as this will result in redeclaration errors.

Fixes:
```c
build/temp.linux-sparc64-3.10/_openssl.c:2286:8: error: 'SSL_CTX_set_psk_find_session_callback' redeclared as different kind of symbol
 2286 | void (*SSL_CTX_set_psk_find_session_callback)(SSL_CTX *,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from build/temp.linux-sparc64-3.10/_openssl.c:832:
/home/giuliobenetti/autobuild/run/instance-0/output-1/host/sparc64-buildroot-linux-gnu/sysroot/usr/include/openssl/ssl.h:855:6: note: previous declaration of 'SSL_CTX_set_psk_find_session_callback' was here
  855 | void SSL_CTX_set_psk_find_session_callback(SSL_CTX *ctx,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
build/temp.linux-sparc64-3.10/_openssl.c:2293:8: error: 'SSL_CTX_set_psk_use_session_callback' redeclared as different kind of symbol
 2293 | void (*SSL_CTX_set_psk_use_session_callback)(SSL_CTX *,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from build/temp.linux-sparc64-3.10/_openssl.c:832:
/home/giuliobenetti/autobuild/run/instance-0/output-1/host/sparc64-buildroot-linux-gnu/sysroot/usr/include/openssl/ssl.h:858:6: note: previous declaration of 'SSL_CTX_set_psk_use_session_callback' was here
  858 | void SSL_CTX_set_psk_use_session_callback(SSL_CTX *ctx,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```