### PR TITLE
Allow loading of RSA-PSS public keys

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -706,6 +706,19 @@ class Backend:
             self.openssl_assert(rsa_cdata != self._ffi.NULL)
             rsa_cdata = self._ffi.gc(rsa_cdata, self._lib.RSA_free)
             return _RSAPublicKey(self, rsa_cdata, evp_pkey)
+        elif (
+            key_type == self._lib.EVP_PKEY_RSA_PSS
+            and not self._lib.CRYPTOGRAPHY_IS_LIBRESSL
+            and not self._lib.CRYPTOGRAPHY_IS_BORINGSSL
+            and not self._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111E
+        ):
+            rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
+            self.openssl_assert(rsa_cdata != self._ffi.NULL)
+            rsa_cdata = self._ffi.gc(rsa_cdata, self._lib.RSA_free)
+            bio = self._create_mem_bio_gc()
+            res = self._lib.i2d_RSAPublicKey_bio(bio, rsa_cdata)
+            self.openssl_assert(res == 1)
+            return self.load_der_public_key(self._read_mem_bio(bio))
         elif key_type == self._lib.EVP_PKEY_DSA:
             dsa_cdata = self._lib.EVP_PKEY_get1_DSA(evp_pkey)
             self.openssl_assert(dsa_cdata != self._ffi.NULL)

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -688,6 +688,33 @@ class TestRevokedCertificate:
         assert crl[2].serial_number == 3
 
 
+class TestRSAPSSCertificate:
+    @pytest.mark.supported(
+        only_if=lambda backend: (
+            not backend._lib.CRYPTOGRAPHY_IS_LIBRESSL
+            and not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL
+            and not backend._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111E
+        ),
+        skip_message="Does not support RSA PSS loading",
+    )
+    def test_load_cert_pub_key(self, backend):
+        cert = _load_cert(
+            os.path.join("x509", "custom", "rsa_pss_cert.pem"),
+            x509.load_pem_x509_certificate,
+            backend,
+        )
+        assert isinstance(cert, x509.Certificate)
+        expected_pub_key = _load_cert(
+            os.path.join("asymmetric", "PKCS8", "rsa_pss_2048_pub.der"),
+            serialization.load_der_public_key,
+            backend,
+        )
+        assert (
+            cert.public_key().public_numbers()
+            == expected_pub_key.public_numbers()
+        )
+
+
 class TestRSACertificate:
     def test_load_pem_cert(self, backend):
         cert = _load_cert(

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -709,10 +709,10 @@ class TestRSAPSSCertificate:
             serialization.load_der_public_key,
             backend,
         )
-        assert (
-            cert.public_key().public_numbers()
-            == expected_pub_key.public_numbers()
-        )
+        assert isinstance(expected_pub_key, rsa.RSAPublicKey)
+        pub_key = cert.public_key()
+        assert isinstance(pub_key, rsa.RSAPublicKey)
+        assert pub_key.public_numbers() == expected_pub_key.public_numbers()
 
 
 class TestRSACertificate:


### PR DESCRIPTION
This does not enforce PSS constraints and instead loads them as normal
RSA public keys, similar to the support we added for private keys.

fixes #4858