### PR TITLE
switch to AES-256-CBC by default for encrypted serialization of PKCS12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ Changelog
 
 * Final deprecation of OpenSSL 1.1.0. The next release of ``cryptography``
   will drop support.
+* :class:`~cryptography.hazmat.primitives.serialization.BestAvailableEncryption`
+  has been updated to use AES 256 CBC by default on PKCS12 files. Users needing
+  compatibility with older Windows (2016 or earlier) and Java (8) versions may
+  use
+  :class:`~cryptography.hazmat.primitives.serialization.LegacyPKCS12TripleDESEncryption`
+  .
 * We no longer ship ``manylinux2010`` wheels. Users should upgrade to the
   latest ``pip`` to ensure this doesn't cause issues downloading wheels on
   their platform.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,8 @@ Changelog
 * Final deprecation of OpenSSL 1.1.0. The next release of ``cryptography``
   will drop support.
 * :class:`~cryptography.hazmat.primitives.serialization.BestAvailableEncryption`
-  has been updated to use AES 256 CBC by default on PKCS12 files. Users needing
-  compatibility with older Windows (2016 or earlier) and Java (8) versions may
+  has been updated to use AES-256-CBC by default on PKCS12 files. Users needing
+  compatibility with older Windows (2016 or earlier) or Java 8 may
   use
   :class:`~cryptography.hazmat.primitives.serialization.LegacyPKCS12TripleDESEncryption`
   .

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -998,6 +998,18 @@ Serialization Encryption Types
 
     :param bytes password: The password to use for encryption.
 
+.. class:: LegacyPKCS12TripleDESEncryption(password)
+
+    .. versionadded:: 38.0
+
+    Encrypt a PKCS12 payload using
+    :class:`~cryptography.hazmat.primitives.ciphers.algorithms.TripleDES`
+    encryption. This is included for compatibility with older Windows and
+    Java versions. Users should strongly prefer
+    :class:`BestAvailableEncryption` where possible.
+
+    :param bytes password: The password to use for encryption.
+
 .. class:: NoEncryption
 
     Do not encrypt.

--- a/src/cryptography/hazmat/primitives/_serialization.py
+++ b/src/cryptography/hazmat/primitives/_serialization.py
@@ -53,3 +53,11 @@ class BestAvailableEncryption(KeySerializationEncryption):
 
 class NoEncryption(KeySerializationEncryption):
     pass
+
+
+class LegacyPKCS12TripleDESEncryption(KeySerializationEncryption):
+    def __init__(self, password: bytes):
+        if not isinstance(password, bytes) or len(password) == 0:
+            raise ValueError("Password must be 1 or more bytes.")
+
+        self.password = password

--- a/src/cryptography/hazmat/primitives/serialization/__init__.py
+++ b/src/cryptography/hazmat/primitives/serialization/__init__.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives._serialization import (
     BestAvailableEncryption,
     Encoding,
     KeySerializationEncryption,
+    LegacyPKCS12TripleDESEncryption,
     NoEncryption,
     ParameterFormat,
     PrivateFormat,
@@ -41,5 +42,6 @@ __all__ = [
     "ParameterFormat",
     "KeySerializationEncryption",
     "BestAvailableEncryption",
+    "LegacyPKCS12TripleDESEncryption",
     "NoEncryption",
 ]

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -469,6 +469,10 @@ class TestPKCS12Creation:
     @pytest.mark.parametrize(
         ("encryption_algorithm", "password"),
         [
+            (
+                serialization.LegacyPKCS12TripleDESEncryption(b"password"),
+                b"password",
+            ),
             (serialization.BestAvailableEncryption(b"password"), b"password"),
             (serialization.NoEncryption(), None),
         ],
@@ -488,6 +492,10 @@ class TestPKCS12Creation:
     @pytest.mark.parametrize(
         ("encryption_algorithm", "password"),
         [
+            (
+                serialization.LegacyPKCS12TripleDESEncryption(b"password"),
+                b"password",
+            ),
             (serialization.BestAvailableEncryption(b"password"), b"password"),
             (serialization.NoEncryption(), None),
         ],

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives.serialization import (
     BestAvailableEncryption,
     Encoding,
     KeySerializationEncryption,
+    LegacyPKCS12TripleDESEncryption,
     NoEncryption,
     PrivateFormat,
     PublicFormat,
@@ -66,6 +67,20 @@ def _skip_fips_format(key_path, password, backend):
                 "The encrypted PKCS8 DER vectors currently have encryption "
                 "that is not FIPS approved in the 3.0 provider"
             )
+
+
+def test_pkcs12_key_serialization_unsupported():
+    key = load_vectors_from_file(
+        os.path.join("asymmetric", "DER_Serialization", "testrsa.der"),
+        lambda derfile: load_der_private_key(derfile.read(), None),
+        mode="rb",
+    )
+    with pytest.raises(ValueError):
+        key.private_bytes(
+            Encoding.PEM,
+            PrivateFormat.PKCS8,
+            LegacyPKCS12TripleDESEncryption(b"password"),
+        )
 
 
 class TestBufferProtocolSerialization:


### PR DESCRIPTION
Add fallback LegacyPKCS12TripleDESEncryption for compatibility with The Past(tm)

fixes #7043