### PR TITLE
Add SSL_use_* OpenSSL bindings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Changelog
   that the ``Extension`` ``critical`` field must be correctly encoded DER. See
   `the issue <https://github.com/pyca/cryptography/issues/6368>`_ for complete
   details.
+* Added two new OpenSSL functions to the bindings to support an upcoming
+  ``pyOpenSSL`` release.
 
 .. _v37-0-2:
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -200,6 +200,8 @@ int SSL_shutdown(SSL *);
 int SSL_renegotiate(SSL *);
 int SSL_renegotiate_pending(SSL *);
 const char *SSL_get_cipher_list(const SSL *, int);
+int SSL_use_certificate(SSL *, X509 *);
+int SSL_use_PrivateKey(SSL *, EVP_PKEY *);
 
 /*  context */
 void SSL_CTX_free(SSL_CTX *);


### PR DESCRIPTION
On our quest to use two shared `SSL.Context` instances in mitmproxy, we need two more bindings exposed. :)
A corresponding PR for pyOpenSSL will follow.