### PR TITLE
add binding for PKCS12_set_mac

### DIFF
--- a/src/_cffi_src/openssl/pkcs12.py
+++ b/src/_cffi_src/openssl/pkcs12.py
@@ -8,6 +8,8 @@ INCLUDES = """
 """
 
 TYPES = """
+static const long Cryptography_HAS_PKCS12_SET_MAC;
+
 typedef ... PKCS12;
 """
 
@@ -20,7 +22,16 @@ int PKCS12_parse(PKCS12 *, const char *, EVP_PKEY **, X509 **,
                  Cryptography_STACK_OF_X509 **);
 PKCS12 *PKCS12_create(char *, char *, EVP_PKEY *, X509 *,
                       Cryptography_STACK_OF_X509 *, int, int, int, int, int);
+int PKCS12_set_mac(PKCS12 *, const char *, int, unsigned char *, int, int,
+                   const EVP_MD *);
 """
 
 CUSTOMIZATIONS = """
+#if CRYPTOGRAPHY_IS_BORINGSSL
+static const long Cryptography_HAS_PKCS12_SET_MAC = 0;
+int (*PKCS12_set_mac)(PKCS12 *, const char *, int, unsigned char *, int, int,
+                      const EVP_MD *) = NULL;
+#else
+static const long Cryptography_HAS_PKCS12_SET_MAC = 1;
+#endif
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -305,6 +305,10 @@ def cryptography_has_unexpected_eof_while_reading() -> typing.List[str]:
     return ["SSL_R_UNEXPECTED_EOF_WHILE_READING"]
 
 
+def cryptography_has_pkcs12_set_mac() -> typing.List[str]:
+    return ["PKCS12_set_mac"]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -364,4 +368,5 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_UNEXPECTED_EOF_WHILE_READING": (
         cryptography_has_unexpected_eof_while_reading
     ),
+    "Cryptography_HAS_PKCS12_SET_MAC": cryptography_has_pkcs12_set_mac,
 }


### PR DESCRIPTION
OpenSSL 3 changed the default MAC to sha256, which is fine and good except Windows Server 2016 can't handle that so we need to build some APIs allowing worse things and name them scary legacy names. This binding is part of that.

refs #7043 