### PR TITLE
Remove vestiges of doc8

### DIFF
--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -95,7 +95,7 @@ Documentation
 -------------
 
 All features should be documented with prose in the ``docs`` section. To ensure
-it builds and passes `doc8`_ style checks you can run ``tox -e docs``.
+it builds you can run ``tox -e docs``.
 
 Because of the inherent challenges in implementing correct cryptographic
 systems, we want to make our documentation point people in the right directions
@@ -148,4 +148,3 @@ So, specifically:
 .. _`syntax`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists
 .. _`Studies have shown`: https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/
 .. _`our mailing list`: https://mail.python.org/mailman/listinfo/cryptography-dev
-.. _`doc8`: https://github.com/openstack/doc8

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,3 @@ ignore = E203,E211,W503,W504,N818
 exclude = .tox,*.egg,.git,_build,.hypothesis
 select = E,W,F,N,I
 application-import-names = cryptography,cryptography_vectors,tests
-
-[doc8]
-extensions = rst


### PR DESCRIPTION
We don't use it since 1eccc52b637a4745a38e61ca2f9f21d383862175