### PR TITLE
x509: fix SignedCertificateTimestamp interface

### DIFF
--- a/src/cryptography/x509/certificate_transparency.py
+++ b/src/cryptography/x509/certificate_transparency.py
@@ -61,7 +61,7 @@ class SignedCertificateTimestamp(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractproperty
-    def hash_algorithm(self) -> HashAlgorithm:
+    def signature_hash_algorithm(self) -> HashAlgorithm:
         """
         Returns the hash algorithm used for the SCT's signature.
         """


### PR DESCRIPTION
This didn't get renamed correctly in the last PR.

Signed-off-by: William Woodruff <william@yossarian.net>