### PR TITLE
CT: add `SignedCertificateTimestamp.extensions`

### DIFF
--- a/docs/x509/certificate-transparency.rst
+++ b/docs/x509/certificate-transparency.rst
@@ -76,6 +76,14 @@ issued.
 
         The raw bytes of the signatures embedded in the SCT.
 
+    .. attribute:: extensions
+
+        .. versionadded:: 38.0
+
+        :type: bytes
+
+        Any raw extension bytes.
+
 
 .. class:: Version
 

--- a/src/cryptography/x509/certificate_transparency.py
+++ b/src/cryptography/x509/certificate_transparency.py
@@ -78,5 +78,11 @@ class SignedCertificateTimestamp(metaclass=abc.ABCMeta):
         Returns the signature for this SCT.
         """
 
+    @abc.abstractproperty
+    def extensions(self) -> bytes:
+        """
+        Returns the raw bytes of any extensions for this SCT.
+        """
+
 
 SignedCertificateTimestamp.register(rust_x509.Sct)

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -6060,6 +6060,7 @@ class TestPrecertificateSignedCertificateTimestampsExtension:
             b"\x67\xB2\x07\xE1\x8F\x6D\xAD\xD1\x04\x4A\x5E\xB3\x89\xEF\x7C\x60"
             b"\xC2\x68\x53\xF9\x3D\x1F\x6D"
         )
+        assert sct.extensions == b""
 
     def test_generate(self, backend):
         cert = _load_cert(


### PR DESCRIPTION
Exposes yet another field on the SCT.

`extensions` is currently unspecified for v1 SCTs, but not expressly forbidden. So we need it exposed in order to verify digitally-signed element signatures.

Signed-off-by: William Woodruff <william@trailofbits.com>