### PR TITLE
automate boringssl update PRs

### DIFF
--- a/.github/workflows/boringssl-version-bump.yml
+++ b/.github/workflows/boringssl-version-bump.yml
@@ -30,14 +30,14 @@ jobs:
           sed -E -i "s/TYPE: \"boringssl\", VERSION: \"[0-9a-f]{40}\"/TYPE: \"boringssl\", VERSION: \"${{ steps.check-sha.outputs.BORING_SHA }}\"/" .github/workflows/ci.yml
           git status
         if: steps.check-sha.outputs.BORING_SHA
-      - uses: tibdex/github-app-token@v1.5.2
+      - uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe
         id: generate-token
         with:
           app_id: ${{ secrets.BORINGBOT_APP_ID }}
           private_key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
         if: steps.check-sha.outputs.BORING_SHA
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4.0.3
+        uses: peter-evans/create-pull-request@f094b77505fb89581e68a1163fbd2fffece39da1
         with:
           commit-message: "Bump BoringSSL version to ${{ steps.check-sha.outputs.BORING_SHA }}"
           title: "Bump BoringSSL version to ${{ steps.check-sha.outputs.BORING_SHA }}"

--- a/.github/workflows/boringssl-version-bump.yml
+++ b/.github/workflows/boringssl-version-bump.yml
@@ -1,8 +1,6 @@
 name: Bump BoringSSL version
 permissions:
-  contents: write
-  pull-requests: write
-  actions: write
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/boringssl-version-bump.yml
+++ b/.github/workflows/boringssl-version-bump.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
       - id: check-sha
         run: |
-          SHA=$(git ls-remote https://boringssl.googlesource.com/boringssl HEAD | cut -f1)
+          SHA=$(git ls-remote https://boringssl.googlesource.com/boringssl refs/heads/master | cut -f1)
           if ! grep -q "$SHA" .github/workflows/ci.yml; then
             echo "::set-output name=BORING_SHA::$SHA"
           fi

--- a/.github/workflows/boringssl-version-bump.yml
+++ b/.github/workflows/boringssl-version-bump.yml
@@ -1,7 +1,8 @@
 name: Bump BoringSSL version
 permissions:
-  issues: write
-  contents: read
+  contents: write
+  pull-requests: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -11,25 +12,35 @@ on:
 
 jobs:
   bump:
+    if: github.repository_owner == 'pyca'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
-      - run: git clone https://boringssl.googlesource.com/boringssl
       - id: check-sha
         run: |
-          SHA=$(git -C boringssl/ rev-parse HEAD)
+          SHA=$(git ls-remote https://boringssl.googlesource.com/boringssl HEAD | cut -f1)
           if ! grep -q "$SHA" .github/workflows/ci.yml; then
             echo "::set-output name=BORING_SHA::$SHA"
           fi
-      - uses: actions/github-script@v6
+      - name: Update boring
+        run: |
+          set -xe
+          CURRENT_DATE=$(date "+%b %d, %Y")
+          sed -E -i "s/Latest commit on the master branch.*/Latest commit on the master branch, as of ${CURRENT_DATE}./" .github/workflows/ci.yml
+          sed -E -i "s/TYPE: \"boringssl\", VERSION: \"[0-9a-f]{40}\"/TYPE: \"boringssl\", VERSION: \"${{ steps.check-sha.outputs.BORING_SHA }}\"/" .github/workflows/ci.yml
+          git status
+        if: steps.check-sha.outputs.BORING_SHA
+      - uses: tibdex/github-app-token@v1.5.2
+        id: generate-token
         with:
-          script: |
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: "BoringSSL in ci.yml needs to be updated",
-              body: `The latest version of BoringSSL is \`${process.env.BORING_SHA}\``,
-            })
-        env:
-          BORING_SHA: ${{ steps.check-sha.outputs.BORING_SHA }}
+          app_id: ${{ secrets.BORINGBOT_APP_ID }}
+          private_key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
+        if: steps.check-sha.outputs.BORING_SHA
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4.0.3
+        with:
+          commit-message: "Bump BoringSSL version to ${{ steps.check-sha.outputs.BORING_SHA }}"
+          title: "Bump BoringSSL version to ${{ steps.check-sha.outputs.BORING_SHA }}"
+          author: "BoringSSL Bot <pyca-boringbot@users.noreply.github.com>"
+          token: ${{ steps.generate-token.outputs.token }}
         if: steps.check-sha.outputs.BORING_SHA


### PR DESCRIPTION
This switches to a GH app + dynamically created token from that app to auto-submit PRs.

This also uses ls-remote to avoid cloning the entire boring repo, which is much faster.

This adds the following:
* New GH app named pyca-boringbot (org level, limited so only pyca can install it). The app has repository write, pull request write, and workflows write permissions. The last bit is why we can't use the default GITHUB_TOKEN, which cannot be granted the permission to modify a workflow.
* That app installed only for pyca/cryptography
* Two secrets under the pyca/cryptography secrets (private key and app ID for the GH app)

You can see a run here: https://github.com/pyca/cryptography/runs/6566527847?check_suite_focus=true

and here's a PR it created: https://github.com/pyca/cryptography/pull/7256

We can avoid the app if we want to just use a PAT, but that doesn't really seem appropriate. Ideally we wouldn't need to pull in two third party actions for this, both of which significantly increase our risk surface for tokens that have write access to the repository. However, in researching it looks like Dependabot may properly support updating hash pins now and we significantly lower our risk by directly pinning to hash here so I've updated the PR to do that for these two actions.

If we want to remove them then the PR creator can probably be replaced with a series of octokit commands, although that'll be ugly and painful to figure out. Similarly, we could make direct calls to octokit to create our token for the app. That seems relatively simple (https://github.com/tibdex/github-app-token/blob/c95b1c441a4dacd6d24f231b9697a5f9a04c607e/src/fetch-installation-token.ts)