### PR TITLE
Add `tbs_precertificate_bytes` property

### DIFF
--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -229,6 +229,12 @@ class Certificate(metaclass=abc.ABCMeta):
         Returns the tbsCertificate payload bytes as defined in RFC 5280.
         """
 
+    @abc.abstractproperty
+    def tbs_precertificate_bytes(self) -> bytes:
+        """
+        Returns the tbsCertificate payload bytes with the SCT list extension stripped.
+        """
+
     @abc.abstractmethod
     def __eq__(self, other: object) -> bool:
         """


### PR DESCRIPTION
- [ ] Unit tests
- [ ] Docs

This is required for verifying embedded SCTs in `sigstore-python`. According to IETF's RFC 6962, this data is part of the digitally signed payload that forms the SCT's signature. This still needs unit tests.

CC: @woodruffw @di 