### PR TITLE
Remove lazy_static dependency.

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -77,7 +77,7 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "chrono",
- "lazy_static",
+ "once_cell",
  "ouroboros",
  "pem",
  "pyo3",
@@ -114,12 +114,6 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-lazy_static = "1"
+once_cell = "1"
 pyo3 = { version = "0.15.2" }
 asn1 = { version = "0.9.1", default-features = false, features = ["derive"] }
 pem = "1.0"

--- a/src/rust/src/x509/ocsp.rs
+++ b/src/rust/src/x509/ocsp.rs
@@ -5,10 +5,11 @@
 use crate::asn1::PyAsn1Result;
 use crate::x509;
 use crate::x509::oid;
+use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
-lazy_static::lazy_static! {
-    pub(crate) static ref OIDS_TO_HASH: HashMap<&'static asn1::ObjectIdentifier, &'static str> = {
+pub(crate) static OIDS_TO_HASH: Lazy<HashMap<&'static asn1::ObjectIdentifier, &'static str>> =
+    Lazy::new(|| {
         let mut h = HashMap::new();
         h.insert(&oid::SHA1_OID, "SHA1");
         h.insert(&oid::SHA224_OID, "SHA224");
@@ -16,8 +17,9 @@ lazy_static::lazy_static! {
         h.insert(&oid::SHA384_OID, "SHA384");
         h.insert(&oid::SHA512_OID, "SHA512");
         h
-    };
-    pub(crate) static ref HASH_NAME_TO_OIDS: HashMap<&'static str, &'static asn1::ObjectIdentifier> = {
+    });
+pub(crate) static HASH_NAME_TO_OIDS: Lazy<HashMap<&'static str, &'static asn1::ObjectIdentifier>> =
+    Lazy::new(|| {
         let mut h = HashMap::new();
         h.insert("sha1", &oid::SHA1_OID);
         h.insert("sha224", &oid::SHA224_OID);
@@ -25,8 +27,7 @@ lazy_static::lazy_static! {
         h.insert("sha384", &oid::SHA384_OID);
         h.insert("sha512", &oid::SHA512_OID);
         h
-    };
-}
+    });
 
 #[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub(crate) struct CertID<'a> {

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -5,11 +5,14 @@
 use crate::x509;
 use crate::x509::oid;
 
-lazy_static::lazy_static! {
+use once_cell::sync::Lazy;
+
+static NULL_DER: Lazy<Vec<u8>> = Lazy::new(|| {
     // TODO: kind of verbose way to say "\x05\x00".
-    static ref NULL_DER: Vec<u8> = asn1::write_single(&());
-    pub(crate) static ref NULL_TLV: asn1::Tlv<'static> = asn1::parse_single(&NULL_DER).unwrap();
-}
+    asn1::write_single(&())
+});
+pub(crate) static NULL_TLV: Lazy<asn1::Tlv<'static>> =
+    Lazy::new(|| asn1::parse_single(&NULL_DER).unwrap());
 
 enum KeyType {
     Rsa,


### PR DESCRIPTION
We can use once_cell which is already in our dep tree. Eventually once_cell will be in the Rust stdlib and we can drop a dep entirely.