### PR TITLE
Expose SSL_OP_IGNORE_UNEXPECTED_EOF

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -95,6 +95,7 @@ static const long SSL_OP_ALL;
 static const long SSL_OP_SINGLE_ECDH_USE;
 static const long SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION;
 static const long SSL_OP_LEGACY_SERVER_CONNECT;
+static const long SSL_OP_IGNORE_UNEXPECTED_EOF;
 static const long SSL_VERIFY_PEER;
 static const long SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 static const long SSL_VERIFY_CLIENT_ONCE;

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -41,6 +41,7 @@ static const long Cryptography_HAS_OP_NO_RENEGOTIATION;
 static const long Cryptography_HAS_SSL_OP_MSIE_SSLV2_RSA_PADDING;
 static const long Cryptography_HAS_SSL_SET_SSL_CTX;
 static const long Cryptography_HAS_SSL_OP_NO_TICKET;
+static const long Cryptography_HAS_SSL_OP_IGNORE_UNEXPECTED_EOF;
 static const long Cryptography_HAS_ALPN;
 static const long Cryptography_HAS_NEXTPROTONEG;
 static const long Cryptography_HAS_SET_CERT_CB;
@@ -602,6 +603,13 @@ static const long Cryptography_HAS_OP_NO_RENEGOTIATION = 1;
 #else
 static const long Cryptography_HAS_OP_NO_RENEGOTIATION = 0;
 static const long SSL_OP_NO_RENEGOTIATION = 0;
+#endif
+
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+static const long Cryptography_HAS_SSL_OP_IGNORE_UNEXPECTED_EOF = 1;
+#else
+static const long Cryptography_HAS_SSL_OP_IGNORE_UNEXPECTED_EOF = 0;
+static const long SSL_OP_IGNORE_UNEXPECTED_EOF = 1;
 #endif
 
 #if CRYPTOGRAPHY_IS_LIBRESSL

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -309,6 +309,12 @@ def cryptography_has_pkcs12_set_mac() -> typing.List[str]:
     return ["PKCS12_set_mac"]
 
 
+def cryptography_has_ssl_op_ignore_unexpected_eof() -> typing.List[str]:
+    return [
+        "SSL_OP_IGNORE_UNEXPECTED_EOF",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -369,4 +375,7 @@ CONDITIONAL_NAMES = {
         cryptography_has_unexpected_eof_while_reading
     ),
     "Cryptography_HAS_PKCS12_SET_MAC": cryptography_has_pkcs12_set_mac,
+    "Cryptography_HAS_SSL_OP_IGNORE_UNEXPECTED_EOF": (
+        cryptography_has_ssl_op_ignore_unexpected_eof
+    ),
 }


### PR DESCRIPTION
Expose SSL_OP_IGNORE_UNEXPECTED_EOF.

https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_options.html#:~:text=this%20by%20default.-,SSL_OP_IGNORE_UNEXPECTED_EOF,-Some%20TLS%20implementations