### PR TITLE
docs: Fix type returned by get_extension_for_oid() and get_extension_for_class()

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1568,7 +1568,7 @@ X.509 Extensions
 
         :param oid: An :class:`ObjectIdentifier` instance.
 
-        :returns: An instance of the extension class.
+        :returns: An instance of :class:`Extension`.
 
         :raises cryptography.x509.ExtensionNotFound: If the certificate does
             not have the extension requested.
@@ -1585,7 +1585,7 @@ X.509 Extensions
 
         :param extclass: An extension class.
 
-        :returns: An instance of the extension class.
+        :returns: An instance of :class:`Extension`.
 
         :raises cryptography.x509.ExtensionNotFound: If the certificate does
             not have the extension requested.


### PR DESCRIPTION
The previous wording (to me) sounded as if an instance of the specific `ExtensionType` subclass would be returned.

But the methods actually return the parent `Extension` instance, from which the specific `ExtensionType` instance can be accessed through the `value` property:

```
for ext in self:
    if isinstance(ext.value, extclass):
        return ext
```