### PR TITLE
Add the rustc version to debug assistance output when setup.py fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ except:  # noqa: E722
             # If for any reason `rustc --version` fails, silently ignore it
             rustc_output = subprocess.run(["rustc", "--version"], capture_output=True, timeout=0.5, encoding="utf8").stdout
             version = rustc_output.rpartition(" ")[-1]
-        except Exception:
+        except subprocess.SubprocessError:
             pass
     print(f"    rustc: {version}")
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@
 
 import os
 import platform
+import re
+import shutil
+import subprocess
 import sys
 
 from setuptools import setup
@@ -99,7 +102,7 @@ except:  # noqa: E722
                 timeout=0.5,
                 encoding="utf8",
             ).stdout
-            version = rustc_output.strip().removeprefix("rustc ")
+            version = re.sub("^rustc ", "", rustc_output.strip())
         except subprocess.SubprocessError:
             pass
     print(f"    rustc: {version}")

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ except:  # noqa: E722
                 capture_output=True,
                 timeout=0.5,
                 encoding="utf8",
+                check=True
             ).stdout
             version = re.sub("^rustc ", "", rustc_output.strip())
         except subprocess.SubprocessError:

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ except:  # noqa: E722
                 capture_output=True,
                 timeout=0.5,
                 encoding="utf8",
-                check=True
+                check=True,
             ).stdout
             version = re.sub("^rustc ", "", rustc_output.strip())
         except subprocess.SubprocessError:

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,16 @@ except:  # noqa: E722
         except pkg_resources.DistributionNotFound:
             version = "n/a"
         print(f"    {dist}: {version}")
+    version = "n/a"
+    if shutil.which("rustc") is not None:
+        try:
+            # If for any reason `rustc --version` fails, silently ignore it
+            rustc_output = subprocess.run(["rustc", "--version"], capture_output=True, timeout=0.5, encoding="utf8").stdout
+            version = rustc_output.rpartition(" ")[-1]
+        except Exception:
+            pass
+    print(f"    rustc: {version}")
+
     print(
         """\
     =============================DEBUG ASSISTANCE=============================

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,13 @@ except:  # noqa: E722
     if shutil.which("rustc") is not None:
         try:
             # If for any reason `rustc --version` fails, silently ignore it
-            rustc_output = subprocess.run(["rustc", "--version"], capture_output=True, timeout=0.5, encoding="utf8").stdout
-            version = rustc_output.rpartition(" ")[-1]
+            rustc_output = subprocess.run(
+                ["rustc", "--version"],
+                capture_output=True,
+                timeout=0.5,
+                encoding="utf8",
+            ).stdout
+            version = rustc_output.strip().removeprefix("rustc ")
         except subprocess.SubprocessError:
             pass
     print(f"    rustc: {version}")


### PR DESCRIPTION
Resolves #7381.

Example output:

rustc on path:
```
    Python: 3.10.5
    platform: Linux-5.17.5-76051705-generic-x86_64-with-glibc2.31
    pip: 22.0.4
    setuptools: 62.0.0
    setuptools_rust: n/a
    rustc: 1.63.0-dev
```

rustc not on path:
```
    Python: 3.10.5
    platform: Linux-5.17.5-76051705-generic-x86_64-with-glibc2.31
    pip: 22.0.3
    setuptools: 45.2.0
    setuptools_rust: n/a
    rustc: n/a
```