### PR TITLE
Don't force an upgrade of cffi

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -234,7 +234,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
 
-      - run: python -m pip install -U pip wheel cffi setuptools-rust
+      - run: python -m pip install -U pip wheel
+      - run: python -m pip install cffi setuptools-rust
       - run: python setup.py sdist
       - run: tar zxvf dist/cryptography*.tar.gz && mkdir wheelhouse
         shell: bash


### PR DESCRIPTION
It breaks on pypy where we always want the cffi that came with pypy, not one from pypi.