### PR TITLE
Revert "pin rust nightly until regression is fixed"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
           - {VERSION: "3.10", TOXENV: "py310"}
         RUST:
           - beta
-          - nightly-2022-06-30
+          - nightly
     name: "Rust Coverage"
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Reverts pyca/cryptography#7388

This is not fixed in rust master, opening now, we can merge once rust nightly is out.