### PR TITLE
Remove usage of actions-rs actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
           - {VERSION: "3.10", TOXENV: "py310-randomorder"}
           # Latest commit on the master branch, as of Jul 15, 2022.
           - {VERSION: "3.10", TOXENV: "py310", OPENSSL: {TYPE: "boringssl", VERSION: "b6f47e88b09703e925c894ca77a5d90ee413e6b5"}}
-        RUST:
-          - stable
     name: "${{ matrix.PYTHON.TOXENV }} ${{ matrix.PYTHON.OPENSSL.TYPE }} ${{ matrix.PYTHON.OPENSSL.VERSION }} ${{ matrix.PYTHON.TOXARGS }} ${{ matrix.PYTHON.OPENSSL.CONFIG_FLAGS }}"
     timeout-minutes: 15
     steps:
@@ -74,12 +72,6 @@ jobs:
             src/rust/target/
           key: ${{ runner.os }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.RUST }}
-          override: true
-          default: true
       - uses: actions/checkout@v3.0.2
         timeout-minutes: 3
         with:
@@ -225,12 +217,9 @@ jobs:
         uses: actions/setup-python@v4.1.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+      - uses: dtolnay/rust-toolchain@3d5c338b548e8aff8b55d96390e28fa86945e1b2
         with:
-          profile: minimal
           toolchain: ${{ matrix.RUST }}
-          override: true
-          default: true
       - uses: actions/checkout@v3.0.2
         timeout-minutes: 3
         with:
@@ -280,17 +269,11 @@ jobs:
         uses: actions/setup-python@v4.1.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+      - uses: dtolnay/rust-toolchain@3d5c338b548e8aff8b55d96390e28fa86945e1b2
         with:
-          profile: minimal
           toolchain: ${{ matrix.RUST }}
-          override: true
-          default: true
           components: llvm-tools-preview
-      - uses: actions-rs/install@9da1d2adcfe5e7c16992e8242ca33a56b6d9b101
-        with:
-          crate: cargo-binutils
-          version: latest
+      - run: cargo install cargo-binutils
         if: steps.cargo-cache.outputs.cache-hit != 'true'
 
       - uses: actions/checkout@v3.0.2
@@ -347,8 +330,6 @@ jobs:
         PYTHON:
           - {VERSION: "3.6", TOXENV: "py36", EXTRA_CFLAGS: ""}
           - {VERSION: "3.10.3", TOXENV: "py310", EXTRA_CFLAGS: "-DUSE_OSRANDOM_RNG_FOR_TESTING"}
-        RUST:
-          - stable
     name: "${{ matrix.PYTHON.TOXENV }} on macOS"
     timeout-minutes: 15
     steps:
@@ -373,12 +354,6 @@ jobs:
         uses: actions/setup-python@v4.1.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.RUST }}
-          override: true
-          default: true
 
       - run: python -m pip install tox requests coverage[toml]
 
@@ -413,13 +388,11 @@ jobs:
       fail-fast: false
       matrix:
         WINDOWS:
-          - {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc'}
-          - {ARCH: 'x64', WINDOWS: 'win64', RUST_TRIPLE: 'x86_64-pc-windows-msvc'}
+          - {ARCH: 'x86', WINDOWS: 'win32'}
+          - {ARCH: 'x64', WINDOWS: 'win64'}
         PYTHON:
           - {VERSION: "3.6", TOXENV: "py36-nocoverage", CL_FLAGS: ""}
           - {VERSION: "3.10", TOXENV: "py310", CL_FLAGS: "/D USE_OSRANDOM_RNG_FOR_TESTING"}
-        RUST:
-          - stable
         JOB_NUMBER: [0, 1, 2]
     name: "${{ matrix.PYTHON.TOXENV }} on ${{ matrix.WINDOWS.WINDOWS }} (part ${{ matrix.JOB_NUMBER }})"
     timeout-minutes: 15
@@ -446,14 +419,6 @@ jobs:
             ~/.cargo/git/db/
             src/rust/target/
           key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ steps.setup-python.outputs.python-version }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.RUST }}
-          override: true
-          default: true
-          target: ${{ matrix.WINDOWS.RUST_TRIPLE }}
 
       - run: python -m pip install tox requests coverage[toml]
       - name: Download OpenSSL
@@ -494,8 +459,6 @@ jobs:
           - certbot
           - certbot-josepy
           - mitmproxy
-        RUST:
-          - stable
         PYTHON:
           - 3.9
     name: "Downstream tests for ${{ matrix.DOWNSTREAM }}"
@@ -522,12 +485,6 @@ jobs:
         uses: actions/setup-python@v4.1.0
         with:
           python-version: ${{ matrix.PYTHON }}
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.RUST }}
-          override: true
-          default: true
       - run: ./.github/downstream.d/${{ matrix.DOWNSTREAM }}.sh install
       - run: pip install .
         env:
@@ -547,12 +504,6 @@ jobs:
         uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.9
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          default: true
       - run: python -m pip install -U tox
       - run: tox -r --  --color=yes
         env:

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -146,12 +146,9 @@ jobs:
             ${{ matrix.PYTHON.BIN_PATH }} .github/workflows/download_openssl.py macos openssl-macos-universal2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+      - uses: dtolnay/rust-toolchain@3d5c338b548e8aff8b55d96390e28fa86945e1b2
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-          default: true
           # Add the arm64 target in addition to the native arch (x86_64)
           target: aarch64-apple-darwin
 
@@ -216,12 +213,9 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           architecture: ${{ matrix.WINDOWS.ARCH }}
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+      - uses: dtolnay/rust-toolchain@3d5c338b548e8aff8b55d96390e28fa86945e1b2
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-          default: true
           target: ${{ matrix.WINDOWS.RUST_TRIPLE }}
 
       - run: pip install requests


### PR DESCRIPTION
They appear to be unmaintained at this point: https://github.com/actions-rs/toolchain/issues/216

Also for most of these we can simply use the Rust that comes with the GHA image