### PR TITLE
feat: drop max password length of 72 characters from `serialize_ssh_private_key`

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -53,7 +53,6 @@ _BCRYPT = b"bcrypt"
 _NONE = b"none"
 _DEFAULT_CIPHER = b"aes256-ctr"
 _DEFAULT_ROUNDS = 16
-_MAX_PASSWORD = 72
 
 # re is only way to work on bytes-like data
 _PEM_RC = re.compile(_SK_START + b"(.*?)" + _SK_END, re.DOTALL)
@@ -609,11 +608,6 @@ def serialize_ssh_private_key(
     """Serialize private key with OpenSSH custom encoding."""
     if password is not None:
         utils._check_bytes("password", password)
-    if password and len(password) > _MAX_PASSWORD:
-        raise ValueError(
-            "Passwords longer than 72 bytes are not supported by "
-            "OpenSSH private key format"
-        )
 
     if isinstance(private_key, ec.EllipticCurvePrivateKey):
         key_type = _ecdsa_key_type(private_key.public_key())


### PR DESCRIPTION
### Summary

_OpenSSH_ encoded private keys using password encryption are currently limited to passwords `<= 72` characters in length when using `cryptography`. This requirement is unnecessary as `bcrypt_pbkdf2`, the key derivation function used by _OpenSSH_, pre-hashes the supplied password avoiding the 72 character input limit that `bcrypt` implementations may impose. Therefore this PR removes the character limit.

Closes #7436.