### PR TITLE
Provide a way to export PKCS12 in a way compatible with major OS (closes #7293)

### DIFF
--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -1002,6 +1002,15 @@ Serialization Encryption Types
 
     :param bytes password: The password to use for encryption.
 
+.. class:: PKCS12CompatibilityEncryption(password)
+
+    Encrypt using 3DES and SHA1 for a given key.
+    This is an option that should be only used to allow exporting PKCS12
+    to devices/software that does not support stronger encryption of PKCS12
+    like macOS 15.x or Android 12.
+
+    :param bytes password: The password to use for encryption.
+
 .. class:: NoEncryption
 
     Do not encrypt.

--- a/src/cryptography/hazmat/primitives/_serialization.py
+++ b/src/cryptography/hazmat/primitives/_serialization.py
@@ -51,5 +51,17 @@ class BestAvailableEncryption(KeySerializationEncryption):
         self.password = password
 
 
+class PKCS12CompatibilityEncryption(KeySerializationEncryption):
+    """
+    Provides the most compatible encryption using 3DES and SHA1 for PKCS12.
+    """
+
+    def __init__(self, password):
+        if not isinstance(password, bytes) or len(password) == 0:
+            raise ValueError("Password must be 1 or more bytes.")
+
+        self.password = password
+
+
 class NoEncryption(KeySerializationEncryption):
     pass

--- a/src/cryptography/hazmat/primitives/serialization/__init__.py
+++ b/src/cryptography/hazmat/primitives/serialization/__init__.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives._serialization import (
     Encoding,
     KeySerializationEncryption,
     NoEncryption,
+    PKCS12CompatibilityEncryption,
     ParameterFormat,
     PrivateFormat,
     PublicFormat,
@@ -41,5 +42,6 @@ __all__ = [
     "ParameterFormat",
     "KeySerializationEncryption",
     "BestAvailableEncryption",
+    "PKCS12CompatibilityEncryption",
     "NoEncryption",
 ]

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -341,6 +341,7 @@ class TestPKCS12Creation:
         ("algorithm", "password"),
         [
             (serialization.BestAvailableEncryption(b"password"), b"password"),
+            (serialization.PKCS12CompatibilityEncryption(b"pass"), b"pass"),
             (serialization.NoEncryption(), None),
         ],
     )


### PR DESCRIPTION
This mainly to get comments if this is a good way for the API to implement this or if another approach should be taken.