### PR TITLE
Upload wheels before sdist at release

### DIFF
--- a/release.py
+++ b/release.py
@@ -130,9 +130,9 @@ def release(version):
         github_token, version
     )
 
-    # Upload sdist and wheels
-    run("twine", "upload", "-s", *sdist)
+    # Upload wheels and sdist
     run("twine", "upload", *github_actions_wheel_paths)
+    run("twine", "upload", "-s", *sdist)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```
$ curl -s https://pypi.org/pypi/cryptography/json | jq '.info.requires_dist'
null
```
pypi populates this information according to the first artifact that is uploaded for a release, and doesn't do it for source distributions.  So uploading the sdist first results in the above.  

The desired output is something like

```
$ curl -s https://pypi.org/pypi/cryptography/json | jq '.info.requires_dist'
[
  "cffi >=1.12"
]
```
This is helpful for package managers that use this API to determine dependency trees.

pypi is not very helpful here, but releasing wheels first works around its oddities.