### PR TITLE
KBKDF: add CounterLocation.MiddleFixed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,10 @@ Changelog
 * Added :attr:`~cryptography.x509.Certificate.tbs_precertificate_bytes`, allowing
   users to access the to-be-signed pre-certificate data needed for signed
   certificate timestamp verification.
+* :class:`~cryptography.hazmat.primitives.kdf.kbkdf.KBKDFHMAC` and
+  :class:`~cryptography.hazmat.primitives.kdf.kbkdf.KBKDFCMAC` now support
+  :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`
+  counter location.
 
 .. _v37-0-4:
 

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -670,12 +670,19 @@ KBKDF
         may supply your own fixed data. If ``fixed`` is specified, ``label``
         and ``context`` is ignored.
 
+    :param int blocation: An integer that indicates the bytes offset where
+        counter bytes are to be located. Required when ``location`` is
+        :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
+
     :raises TypeError: This exception is raised if ``label`` or ``context``
-        is not ``bytes``. Also raised if ``rlen`` or ``llen`` is not ``int``.
+        is not ``bytes``. Also raised if ``rlen``, ``llen``, or ``blocation``
+        is not ``int``.
 
     :raises ValueError: This exception is raised if ``rlen`` or ``llen``
         is greater than 4 or less than 1. This exception is also raised if
-        you specify a ``label`` or ``context`` and ``fixed``.
+        you specify a ``label`` or ``context`` and ``fixed``. This exception
+        is also raised if you specify ``blocation`` and ``location`` is not
+        :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
 
     .. method:: derive(key_material)
 
@@ -788,20 +795,27 @@ KBKDF
         may supply your own fixed data. If ``fixed`` is specified, ``label``
         and ``context`` is ignored.
 
+    :param int blocation: An integer that indicates the bytes offset where
+        counter bytes are to be located. Required when ``location`` is
+        :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
+
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised
         if ``algorithm`` is not a subclass of
         :class:`~cryptography.hazmat.primitives.ciphers.CipherAlgorithm` and
         :class:`~cryptography.hazmat.primitives.ciphers.BlockCipherAlgorithm`.
 
     :raises TypeError: This exception is raised if ``label`` or ``context``
-        is not ``bytes``, ``rlen`` or ``llen`` is not ``int``, ``mode`` is not
+        is not ``bytes``, ``rlen``, ``llen``, or ``blocation` is not ``int``,
+        ``mode`` is not
         :class:`~cryptography.hazmat.primitives.kdf.kbkdf.Mode` or ``location``
         is not
         :class:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation`.
 
     :raises ValueError: This exception is raised if ``rlen`` or ``llen``
         is greater than 4 or less than 1. This exception is also raised if
-        you specify a ``label`` or ``context`` and ``fixed``.
+        you specify a ``label`` or ``context`` and ``fixed``. This exception
+        is also raised if you specify ``blocation`` and ``location`` is not
+        :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
 
     .. method:: derive(key_material)
 
@@ -860,6 +874,13 @@ KBKDF
 
         The counter iteration variable will be concatenated after
         the fixed input data.
+
+    .. attribute:: MiddleFixed
+
+        .. versionadded:: 38.0
+
+        The counter iteration variable will be concatenated in the middle
+        of the fixed input data.
 
 
 X963KDF

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -670,18 +670,18 @@ KBKDF
         may supply your own fixed data. If ``fixed`` is specified, ``label``
         and ``context`` is ignored.
 
-    :param int blocation: An integer that indicates the bytes offset where
+    :param int break_location: An integer that indicates the bytes offset where
         counter bytes are to be located. Required when ``location`` is
         :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
 
     :raises TypeError: This exception is raised if ``label`` or ``context``
-        is not ``bytes``. Also raised if ``rlen``, ``llen``, or ``blocation``
-        is not ``int``.
+        is not ``bytes``. Also raised if ``rlen``, ``llen``, or
+        ``break_location`` is not ``int``.
 
     :raises ValueError: This exception is raised if ``rlen`` or ``llen``
         is greater than 4 or less than 1. This exception is also raised if
         you specify a ``label`` or ``context`` and ``fixed``. This exception
-        is also raised if you specify ``blocation`` and ``location`` is not
+        is also raised if you specify ``break_location`` and ``location`` is not
         :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
 
     .. method:: derive(key_material)
@@ -795,7 +795,7 @@ KBKDF
         may supply your own fixed data. If ``fixed`` is specified, ``label``
         and ``context`` is ignored.
 
-    :param int blocation: An integer that indicates the bytes offset where
+    :param int break_location: An integer that indicates the bytes offset where
         counter bytes are to be located. Required when ``location`` is
         :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
 
@@ -805,8 +805,8 @@ KBKDF
         :class:`~cryptography.hazmat.primitives.ciphers.BlockCipherAlgorithm`.
 
     :raises TypeError: This exception is raised if ``label`` or ``context``
-        is not ``bytes``, ``rlen``, ``llen``, or ``blocation` is not ``int``,
-        ``mode`` is not
+        is not ``bytes``, ``rlen``, ``llen``, or ``break_location` is not
+        ``int``, ``mode`` is not
         :class:`~cryptography.hazmat.primitives.kdf.kbkdf.Mode` or ``location``
         is not
         :class:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation`.
@@ -814,7 +814,7 @@ KBKDF
     :raises ValueError: This exception is raised if ``rlen`` or ``llen``
         is greater than 4 or less than 1. This exception is also raised if
         you specify a ``label`` or ``context`` and ``fixed``. This exception
-        is also raised if you specify ``blocation`` and ``location`` is not
+        is also raised if you specify ``break_location`` and ``location`` is not
         :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
 
     .. method:: derive(key_material)

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -670,8 +670,9 @@ KBKDF
         may supply your own fixed data. If ``fixed`` is specified, ``label``
         and ``context`` is ignored.
 
-    :param int break_location: An integer that indicates the bytes offset where
-        counter bytes are to be located. Required when ``location`` is
+    :param int break_location: A keyword-only argument. An integer that
+        indicates the bytes offset where counter bytes are to be located.
+        Required when ``location`` is
         :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
 
     :raises TypeError: This exception is raised if ``label`` or ``context``
@@ -795,8 +796,9 @@ KBKDF
         may supply your own fixed data. If ``fixed`` is specified, ``label``
         and ``context`` is ignored.
 
-    :param int break_location: An integer that indicates the bytes offset where
-        counter bytes are to be located. Required when ``location`` is
+    :param int break_location: A keyword-only argument. An integer that
+        indicates the bytes offset where counter bytes are to be located.
+        Required when ``location`` is
         :attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`.
 
     :raises cryptography.exceptions.UnsupportedAlgorithm: This is raised

--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
@@ -185,6 +185,7 @@ class KBKDFHMAC(KeyDerivationFunction):
         context: typing.Optional[bytes],
         fixed: typing.Optional[bytes],
         backend: typing.Any = None,
+        *,
         break_location: typing.Optional[int] = None,
     ):
         if not isinstance(algorithm, hashes.HashAlgorithm):
@@ -242,6 +243,7 @@ class KBKDFCMAC(KeyDerivationFunction):
         context: typing.Optional[bytes],
         fixed: typing.Optional[bytes],
         backend: typing.Any = None,
+        *,
         break_location: typing.Optional[int] = None,
     ):
         if not issubclass(

--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
@@ -40,7 +40,7 @@ class _KBKDFDeriver:
         rlen: int,
         llen: typing.Optional[int],
         location: CounterLocation,
-        blocation: typing.Optional[int],
+        break_location: typing.Optional[int],
         label: typing.Optional[bytes],
         context: typing.Optional[bytes],
         fixed: typing.Optional[bytes],
@@ -53,15 +53,18 @@ class _KBKDFDeriver:
         if not isinstance(location, CounterLocation):
             raise TypeError("location must be of type CounterLocation")
 
-        if blocation is None and location is CounterLocation.MiddleFixed:
-            raise ValueError("Please specify a blocation")
+        if break_location is None and location is CounterLocation.MiddleFixed:
+            raise ValueError("Please specify a break_location")
 
-        if blocation is not None and not isinstance(blocation, int):
-            raise TypeError("blocation must be an integer")
+        if break_location is not None and not isinstance(break_location, int):
+            raise TypeError("break_location must be an integer")
 
-        if blocation is not None and location != CounterLocation.MiddleFixed:
+        if (
+            break_location is not None
+            and location != CounterLocation.MiddleFixed
+        ):
             raise ValueError(
-                "blocation is ignored when location is not"
+                "break_location is ignored when location is not"
                 " CounterLocation.MiddleFixed"
             )
 
@@ -93,7 +96,7 @@ class _KBKDFDeriver:
         self._rlen = rlen
         self._llen = llen
         self._location = location
-        self._blocation = blocation
+        self._break_location = break_location
         self._label = label
         self._context = context
         self._used = False
@@ -142,9 +145,9 @@ class _KBKDFDeriver:
                 h.update(fixed)
                 h.update(counter)
             else:
-                h.update(fixed[: self._blocation])
+                h.update(fixed[: self._break_location])
                 h.update(counter)
-                h.update(fixed[self._blocation :])
+                h.update(fixed[self._break_location :])
 
             output.append(h.finalize())
 
@@ -172,7 +175,7 @@ class KBKDFHMAC(KeyDerivationFunction):
         context: typing.Optional[bytes],
         fixed: typing.Optional[bytes],
         backend: typing.Any = None,
-        blocation: typing.Optional[int] = None,
+        break_location: typing.Optional[int] = None,
     ):
         if not isinstance(algorithm, hashes.HashAlgorithm):
             raise UnsupportedAlgorithm(
@@ -199,7 +202,7 @@ class KBKDFHMAC(KeyDerivationFunction):
             rlen,
             llen,
             location,
-            blocation,
+            break_location,
             label,
             context,
             fixed,
@@ -229,7 +232,7 @@ class KBKDFCMAC(KeyDerivationFunction):
         context: typing.Optional[bytes],
         fixed: typing.Optional[bytes],
         backend: typing.Any = None,
-        blocation: typing.Optional[int] = None,
+        break_location: typing.Optional[int] = None,
     ):
         if not issubclass(
             algorithm, ciphers.BlockCipherAlgorithm
@@ -249,7 +252,7 @@ class KBKDFCMAC(KeyDerivationFunction):
             rlen,
             llen,
             location,
-            blocation,
+            break_location,
             label,
             context,
             fixed,

--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
@@ -132,10 +132,11 @@ class _KBKDFDeriver:
         if rounds > pow(2, len(r_bin) * 8) - 1:
             raise ValueError("There are too many iterations.")
 
+        fixed = self._generate_fixed_input()
+
         for i in range(1, rounds + 1):
             h = self._prf(key_material)
 
-            fixed = self._generate_fixed_input()
             counter = utils.int_to_bytes(i, self._rlen)
 
             if self._location == CounterLocation.BeforeFixed:

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -232,7 +232,7 @@ class TestKBKDFHMAC:
                 backend=backend,
             )
 
-    def test_missing_blocation(self, backend):
+    def test_missing_break_location(self, backend):
         with pytest.raises(ValueError):
             KBKDFHMAC(
                 hashes.SHA256(),
@@ -259,10 +259,10 @@ class TestKBKDFHMAC:
                 b"context",
                 None,
                 backend=backend,
-                blocation=None,
+                break_location=None,
             )
 
-    def test_invalid_blocation(self, backend):
+    def test_invalid_break_location(self, backend):
         with pytest.raises(TypeError):
             KBKDFHMAC(
                 hashes.SHA256(),
@@ -275,10 +275,10 @@ class TestKBKDFHMAC:
                 b"context",
                 None,
                 backend=backend,
-                blocation="10",  # type: ignore[arg-type]
+                break_location="10",  # type: ignore[arg-type]
             )
 
-    def test_ignored_blocation_before(self, backend):
+    def test_ignored_break_location_before(self, backend):
         with pytest.raises(ValueError):
             KBKDFHMAC(
                 hashes.SHA256(),
@@ -291,10 +291,10 @@ class TestKBKDFHMAC:
                 b"context",
                 None,
                 backend=backend,
-                blocation=10,
+                break_location=10,
             )
 
-    def test_ignored_blocation_after(self, backend):
+    def test_ignored_break_location_after(self, backend):
         with pytest.raises(ValueError):
             KBKDFHMAC(
                 hashes.SHA256(),
@@ -307,7 +307,7 @@ class TestKBKDFHMAC:
                 b"context",
                 None,
                 backend=backend,
-                blocation=10,
+                break_location=10,
             )
 
     def test_unsupported_hash(self, backend):
@@ -616,7 +616,7 @@ class TestKBKDFCMAC:
                 backend=backend,
             )
 
-    def test_missing_blocation(self, backend):
+    def test_missing_break_location(self, backend):
         with pytest.raises(ValueError):
             KBKDFCMAC(
                 algorithms.AES,
@@ -643,10 +643,10 @@ class TestKBKDFCMAC:
                 b"context",
                 None,
                 backend=backend,
-                blocation=None,
+                break_location=None,
             )
 
-    def test_invalid_blocation(self, backend):
+    def test_invalid_break_location(self, backend):
         with pytest.raises(TypeError):
             KBKDFCMAC(
                 algorithms.AES,
@@ -659,10 +659,10 @@ class TestKBKDFCMAC:
                 b"context",
                 None,
                 backend=backend,
-                blocation="10",  # type: ignore[arg-type]
+                break_location="10",  # type: ignore[arg-type]
             )
 
-    def test_ignored_blocation_before(self, backend):
+    def test_ignored_break_location_before(self, backend):
         with pytest.raises(ValueError):
             KBKDFCMAC(
                 algorithms.AES,
@@ -675,10 +675,10 @@ class TestKBKDFCMAC:
                 b"context",
                 None,
                 backend=backend,
-                blocation=10,
+                break_location=10,
             )
 
-    def test_ignored_blocation_after(self, backend):
+    def test_ignored_break_location_after(self, backend):
         with pytest.raises(ValueError):
             KBKDFCMAC(
                 algorithms.AES,
@@ -691,7 +691,7 @@ class TestKBKDFCMAC:
                 b"context",
                 None,
                 backend=backend,
-                blocation=10,
+                break_location=10,
             )
 
     def test_unsupported_algorithm(self, backend):

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -232,6 +232,84 @@ class TestKBKDFHMAC:
                 backend=backend,
             )
 
+    def test_missing_blocation(self, backend):
+        with pytest.raises(ValueError):
+            KBKDFHMAC(
+                hashes.SHA256(),
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+            )
+
+        with pytest.raises(ValueError):
+            KBKDFHMAC(
+                hashes.SHA256(),
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                blocation=None,
+            )
+
+    def test_invalid_blocation(self, backend):
+        with pytest.raises(TypeError):
+            KBKDFHMAC(
+                hashes.SHA256(),
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                blocation="10",  # type: ignore[arg-type]
+            )
+
+    def test_ignored_blocation_before(self, backend):
+        with pytest.raises(ValueError):
+            KBKDFHMAC(
+                hashes.SHA256(),
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.BeforeFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                blocation=10,
+            )
+
+    def test_ignored_blocation_after(self, backend):
+        with pytest.raises(ValueError):
+            KBKDFHMAC(
+                hashes.SHA256(),
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.AfterFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                blocation=10,
+            )
+
     def test_unsupported_hash(self, backend):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):
             KBKDFHMAC(
@@ -536,6 +614,84 @@ class TestKBKDFCMAC:
                 b"context",
                 b"fixed",
                 backend=backend,
+            )
+
+    def test_missing_blocation(self, backend):
+        with pytest.raises(ValueError):
+            KBKDFCMAC(
+                algorithms.AES,
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+            )
+
+        with pytest.raises(ValueError):
+            KBKDFCMAC(
+                algorithms.AES,
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                blocation=None,
+            )
+
+    def test_invalid_blocation(self, backend):
+        with pytest.raises(TypeError):
+            KBKDFCMAC(
+                algorithms.AES,
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                blocation="10",  # type: ignore[arg-type]
+            )
+
+    def test_ignored_blocation_before(self, backend):
+        with pytest.raises(ValueError):
+            KBKDFCMAC(
+                algorithms.AES,
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.BeforeFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                blocation=10,
+            )
+
+    def test_ignored_blocation_after(self, backend):
+        with pytest.raises(ValueError):
+            KBKDFCMAC(
+                algorithms.AES,
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.AfterFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                blocation=10,
             )
 
     def test_unsupported_algorithm(self, backend):

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -268,6 +268,24 @@ class TestKBKDFHMAC:
                 break_location=None,
             )
 
+    def test_keyword_only_break_location(self, backend):
+        with pytest.raises(
+            TypeError, match=r"\d+ positional arguments but \d+ were given\Z"
+        ):
+            KBKDFHMAC(
+                hashes.SHA256(),
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend,
+                0,  # break_location
+            )  # type: ignore
+
     def test_invalid_break_location(self, backend):
         with pytest.raises(
             TypeError, match=re.escape("break_location must be an integer")
@@ -705,6 +723,24 @@ class TestKBKDFCMAC:
                 backend=backend,
                 break_location=None,
             )
+
+    def test_keyword_only_break_location(self, backend):
+        with pytest.raises(
+            TypeError, match=r"\d+ positional arguments but \d+ were given\Z"
+        ):
+            KBKDFCMAC(
+                algorithms.AES,
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend,
+                0,  # break_location
+            )  # type: ignore
 
     def test_invalid_break_location(self, backend):
         with pytest.raises(

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import re
+
 import pytest
 
 from cryptography.exceptions import AlreadyFinalized, InvalidKey, _Reasons
@@ -233,7 +235,9 @@ class TestKBKDFHMAC:
             )
 
     def test_missing_break_location(self, backend):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match=re.escape("Please specify a break_location")
+        ):
             KBKDFHMAC(
                 hashes.SHA256(),
                 Mode.CounterMode,
@@ -247,7 +251,9 @@ class TestKBKDFHMAC:
                 backend=backend,
             )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match=re.escape("Please specify a break_location")
+        ):
             KBKDFHMAC(
                 hashes.SHA256(),
                 Mode.CounterMode,
@@ -263,7 +269,9 @@ class TestKBKDFHMAC:
             )
 
     def test_invalid_break_location(self, backend):
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            TypeError, match=re.escape("break_location must be an integer")
+        ):
             KBKDFHMAC(
                 hashes.SHA256(),
                 Mode.CounterMode,
@@ -275,11 +283,53 @@ class TestKBKDFHMAC:
                 b"context",
                 None,
                 backend=backend,
-                break_location="10",  # type: ignore[arg-type]
+                break_location="0",  # type: ignore[arg-type]
             )
 
+        with pytest.raises(
+            ValueError,
+            match=re.escape("break_location must be a positive integer"),
+        ):
+            KBKDFHMAC(
+                hashes.SHA256(),
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                break_location=-1,
+            )
+
+        with pytest.raises(
+            ValueError, match=re.escape("break_location offset > len(fixed)")
+        ):
+            kdf = KBKDFHMAC(
+                hashes.SHA256(),
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                break_location=18,
+            )
+            kdf.derive(b"input key")
+
     def test_ignored_break_location_before(self, backend):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "break_location is ignored when location is not"
+                " CounterLocation.MiddleFixed"
+            ),
+        ):
             KBKDFHMAC(
                 hashes.SHA256(),
                 Mode.CounterMode,
@@ -291,11 +341,17 @@ class TestKBKDFHMAC:
                 b"context",
                 None,
                 backend=backend,
-                break_location=10,
+                break_location=0,
             )
 
     def test_ignored_break_location_after(self, backend):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "break_location is ignored when location is not"
+                " CounterLocation.MiddleFixed"
+            ),
+        ):
             KBKDFHMAC(
                 hashes.SHA256(),
                 Mode.CounterMode,
@@ -307,7 +363,7 @@ class TestKBKDFHMAC:
                 b"context",
                 None,
                 backend=backend,
-                break_location=10,
+                break_location=0,
             )
 
     def test_unsupported_hash(self, backend):
@@ -617,7 +673,9 @@ class TestKBKDFCMAC:
             )
 
     def test_missing_break_location(self, backend):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match=re.escape("Please specify a break_location")
+        ):
             KBKDFCMAC(
                 algorithms.AES,
                 Mode.CounterMode,
@@ -631,7 +689,9 @@ class TestKBKDFCMAC:
                 backend=backend,
             )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match=re.escape("Please specify a break_location")
+        ):
             KBKDFCMAC(
                 algorithms.AES,
                 Mode.CounterMode,
@@ -647,7 +707,9 @@ class TestKBKDFCMAC:
             )
 
     def test_invalid_break_location(self, backend):
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            TypeError, match=re.escape("break_location must be an integer")
+        ):
             KBKDFCMAC(
                 algorithms.AES,
                 Mode.CounterMode,
@@ -659,11 +721,53 @@ class TestKBKDFCMAC:
                 b"context",
                 None,
                 backend=backend,
-                break_location="10",  # type: ignore[arg-type]
+                break_location="0",  # type: ignore[arg-type]
             )
 
+        with pytest.raises(
+            ValueError,
+            match=re.escape("break_location must be a positive integer"),
+        ):
+            KBKDFCMAC(
+                algorithms.AES,
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                break_location=-1,
+            )
+
+        with pytest.raises(
+            ValueError, match=re.escape("break_location offset > len(fixed)")
+        ):
+            kdf = KBKDFCMAC(
+                algorithms.AES,
+                Mode.CounterMode,
+                32,
+                4,
+                4,
+                CounterLocation.MiddleFixed,
+                b"label",
+                b"context",
+                None,
+                backend=backend,
+                break_location=18,
+            )
+            kdf.derive(b"32 bytes long input key material")
+
     def test_ignored_break_location_before(self, backend):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "break_location is ignored when location is not"
+                " CounterLocation.MiddleFixed"
+            ),
+        ):
             KBKDFCMAC(
                 algorithms.AES,
                 Mode.CounterMode,
@@ -675,11 +779,17 @@ class TestKBKDFCMAC:
                 b"context",
                 None,
                 backend=backend,
-                break_location=10,
+                break_location=0,
             )
 
     def test_ignored_break_location_after(self, backend):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "break_location is ignored when location is not"
+                " CounterLocation.MiddleFixed"
+            ),
+        ):
             KBKDFCMAC(
                 algorithms.AES,
                 Mode.CounterMode,
@@ -691,7 +801,7 @@ class TestKBKDFCMAC:
                 b"context",
                 None,
                 backend=backend,
-                break_location=10,
+                break_location=0,
             )
 
     def test_unsupported_algorithm(self, backend):

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -408,19 +408,14 @@ def generate_hkdf_test(param_loader, path, file_names, algorithm):
 
 def generate_kbkdf_counter_mode_test(param_loader, path, file_names):
     def test_kbkdf(self, backend, subtests):
-        all_params = [
-            p
-            for p in _load_all_params(path, file_names, param_loader)
-            if p["ctrlocation"] in ["before_fixed", "after_fixed"]
-        ]
-        for params in all_params:
+        for params in _load_all_params(path, file_names, param_loader):
             with subtests.test():
                 kbkdf_counter_mode_test(backend, params)
 
     return test_kbkdf
 
 
-def _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, params):
+def _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, blocation, params):
     supported_hash_algorithms: typing.Dict[
         str, typing.Type[hashes.HashAlgorithm]
     ] = {
@@ -446,13 +441,14 @@ def _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, params):
         None,
         binascii.unhexlify(params["fixedinputdata"]),
         backend=backend,
+        blocation=blocation,
     )
 
     ko = ctrkdf.derive(binascii.unhexlify(params["ki"]))
     assert binascii.hexlify(ko) == params["ko"]
 
 
-def _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, params):
+def _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, blocation, params):
     supported_cipher_algorithms: typing.Dict[
         str, typing.Type[BlockCipherAlgorithm]
     ] = {
@@ -481,6 +477,7 @@ def _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, params):
         None,
         binascii.unhexlify(params["fixedinputdata"]),
         backend=backend,
+        blocation=blocation,
     )
 
     ko = ctrkdf.derive(binascii.unhexlify(params["ki"]))
@@ -491,19 +488,30 @@ def kbkdf_counter_mode_test(backend, params):
     supported_counter_locations = {
         "before_fixed": CounterLocation.BeforeFixed,
         "after_fixed": CounterLocation.AfterFixed,
+        "middle_fixed": CounterLocation.MiddleFixed,
     }
 
     ctr_loc = supported_counter_locations[params.pop("ctrlocation")]
+    blocation = None
+
+    if ctr_loc == CounterLocation.MiddleFixed:
+        assert "fixedinputdata" not in params
+        params["fixedinputdata"] = params.pop(
+            "databeforectrdata"
+        ) + params.pop("dataafterctrdata")
+
+        blocation = params.pop("databeforectrlen")
+        assert isinstance(blocation, int)
 
     prf = params.get("prf")
     assert prf is not None
     assert isinstance(prf, str)
     del params["prf"]
     if prf.startswith("hmac"):
-        _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, params)
+        _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, blocation, params)
     else:
         assert prf.startswith("cmac")
-        _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, params)
+        _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, blocation, params)
 
 
 def generate_rsa_verification_test(

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -415,7 +415,7 @@ def generate_kbkdf_counter_mode_test(param_loader, path, file_names):
     return test_kbkdf
 
 
-def _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, blocation, params):
+def _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, brk_loc, params):
     supported_hash_algorithms: typing.Dict[
         str, typing.Type[hashes.HashAlgorithm]
     ] = {
@@ -441,14 +441,14 @@ def _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, blocation, params):
         None,
         binascii.unhexlify(params["fixedinputdata"]),
         backend=backend,
-        blocation=blocation,
+        break_location=brk_loc,
     )
 
     ko = ctrkdf.derive(binascii.unhexlify(params["ki"]))
     assert binascii.hexlify(ko) == params["ko"]
 
 
-def _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, blocation, params):
+def _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, brk_loc, params):
     supported_cipher_algorithms: typing.Dict[
         str, typing.Type[BlockCipherAlgorithm]
     ] = {
@@ -477,7 +477,7 @@ def _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, blocation, params):
         None,
         binascii.unhexlify(params["fixedinputdata"]),
         backend=backend,
-        blocation=blocation,
+        break_location=brk_loc,
     )
 
     ko = ctrkdf.derive(binascii.unhexlify(params["ki"]))
@@ -492,7 +492,7 @@ def kbkdf_counter_mode_test(backend, params):
     }
 
     ctr_loc = supported_counter_locations[params.pop("ctrlocation")]
-    blocation = None
+    brk_loc = None
 
     if ctr_loc == CounterLocation.MiddleFixed:
         assert "fixedinputdata" not in params
@@ -500,18 +500,18 @@ def kbkdf_counter_mode_test(backend, params):
             "databeforectrdata"
         ) + params.pop("dataafterctrdata")
 
-        blocation = params.pop("databeforectrlen")
-        assert isinstance(blocation, int)
+        brk_loc = params.pop("databeforectrlen")
+        assert isinstance(brk_loc, int)
 
     prf = params.get("prf")
     assert prf is not None
     assert isinstance(prf, str)
     del params["prf"]
     if prf.startswith("hmac"):
-        _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, blocation, params)
+        _kbkdf_hmac_counter_mode_test(backend, prf, ctr_loc, brk_loc, params)
     else:
         assert prf.startswith("cmac")
-        _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, blocation, params)
+        _kbkdf_cmac_counter_mode_test(backend, prf, ctr_loc, brk_loc, params)
 
 
 def generate_rsa_verification_test(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -784,7 +784,7 @@ def load_nist_kbkdf_vectors(vector_data):
             test_data = {}
             test_data.update(tag)
             vectors.append(test_data)
-        elif line.startswith("L"):
+        elif line.startswith(("L", "DataBeforeCtrLen", "DataAfterCtrLen")):
             name, value = [c.strip() for c in line.split("=")]
             test_data[name.lower()] = int(value)
         else:


### PR DESCRIPTION
Hi,

Would you consider adding support for `CounterLocation.MiddleFixed` in `KBKDFHMAC` and `KBKDFCMAC`?

Currently the counter bytes can only be added at the beginning (`CounterLocation.BeforeFixed`) or end (`CounterLocation.AfterFixed`) of the input. This patch adds support for `CounterLocation.MiddleFixed`, which along with `blocation=`, allows the user to specify a particular byte offset where the counter bytes are to be added to input.

`blocation` is shorthand for "break location".

The MR is based off an internal patch that we make use of. It breaks backward compatibility due to the introduction of the new `blocation=` argument. If it's something worth your while, happy to discuss alternative implementations (to remain backward compatible) and help with adding tests and updating documentation.

Thank you