### PR TITLE
support setting more PKCS12 serialization encryption options

### DIFF
--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -570,7 +570,7 @@ file suffix.
         ...     PrivateFormat.PKCS12.encryption_builder().
         ...     kdf_rounds(50000).
         ...     key_cert_algorithm(pkcs12.PBES.PBESv1SHA1And3KeyTripleDESCBC).
-        ...     mac_algorithm(hashes.SHA1()).build(b"my password")
+        ...     hmac_hash(hashes.SHA1()).build(b"my password")
         ... )
         >>> cert = x509.load_pem_x509_certificate(ca_cert)
         >>> key = load_pem_private_key(ca_key, None)
@@ -631,8 +631,8 @@ file suffix.
 
     .. attribute:: PBESv2SHA256AndAES256CBC
 
-        PBESv2 using SHA256 as the KDF PRF and AES256 as the cipher. This is
-        only supported on OpenSSL 3.0.0 or newer.
+        PBESv2 using SHA256 as the KDF PRF and AES256-CBC as the cipher. This
+        is only supported on OpenSSL 3.0.0 or newer.
 
 
 PKCS7
@@ -914,7 +914,7 @@ Serialization Formats
             ...     PrivateFormat.PKCS12.encryption_builder().
             ...     kdf_rounds(50000).
             ...     key_cert_algorithm(pkcs12.PBES.PBESv2SHA256AndAES256CBC).
-            ...     mac_algorithm(hashes.SHA256()).build(b"my password")
+            ...     hmac_hash(hashes.SHA256()).build(b"my password")
             ... )
             >>> p12 = pkcs12.serialize_key_and_certificates(
             ...     b"friendlyname", key, None, None, encryption
@@ -1135,9 +1135,9 @@ Serialization Encryption Types
         :param algorithm: A value from the :class:`~cryptography.hazmat.primitives.serialization.pkcs12.PBES`
             enumeration.
 
-    .. method:: mac_algorithm(algorithm)
+    .. method:: hmac_hash(algorithm)
 
-        Set the MAC algorithm to use for a PKCS12 structure.
+        Set the hash algorithm to use within the MAC for a PKCS12 structure.
 
         :param algorithm: An instance of a
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -559,7 +559,7 @@ file suffix.
         ... )
 
     This example uses an ``encryption_builder()`` to create a PKCS12 with more
-    compatible, but substantially worse, encryption.
+    compatible, but substantially less secure, encryption.
 
     .. doctest::
 

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -627,7 +627,7 @@ file suffix.
 
     .. attribute:: PBESv1SHA1And3KeyTripleDESCBC
 
-        PBESv1 using SHA1 as the KDF PRF and 3-key triple DES as the cipher.
+        PBESv1 using SHA1 as the KDF PRF and 3-key triple DES-CBC as the cipher.
 
     .. attribute:: PBESv2SHA256AndAES256CBC
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2317,14 +2317,14 @@ class Backend:
                 assert keycertalg is None
                 # We use OpenSSL's defaults
 
-            if encryption_algorithm._mac_algorithm is not None:
+            if encryption_algorithm._hmac_hash is not None:
                 if not self._lib.Cryptography_HAS_PKCS12_SET_MAC:
                     raise UnsupportedAlgorithm(
                         "Setting MAC algorithm is not supported by this "
                         "version of OpenSSL."
                     )
                 mac_alg = self._evp_md_non_null_from_algorithm(
-                    encryption_algorithm._mac_algorithm
+                    encryption_algorithm._hmac_hash
                 )
                 self.openssl_assert(mac_alg != self._ffi.NULL)
             else:

--- a/src/cryptography/hazmat/primitives/_serialization.py
+++ b/src/cryptography/hazmat/primitives/_serialization.py
@@ -77,43 +77,46 @@ class KeySerializationEncryptionBuilder(object):
         format: PrivateFormat,
         *,
         _kdf_rounds: typing.Optional[int] = None,
-        _mac_algorithm: typing.Optional[HashAlgorithm] = None,
+        _hmac_hash: typing.Optional[HashAlgorithm] = None,
         _key_cert_algorithm: typing.Optional[PBES] = None,
     ) -> None:
         self._format = format
 
         self._kdf_rounds = _kdf_rounds
-        self._mac_algorithm = _mac_algorithm
+        self._hmac_hash = _hmac_hash
         self._key_cert_algorithm = _key_cert_algorithm
 
     def kdf_rounds(self, rounds: int) -> "KeySerializationEncryptionBuilder":
         if self._kdf_rounds is not None:
             raise ValueError("kdf_rounds already set")
 
-        if not isinstance(rounds, int) or rounds < 1:
+        if not isinstance(rounds, int):
+            raise TypeError("kdf_rounds must be an integer")
+
+        if rounds < 1:
             raise ValueError("kdf_rounds must be a positive integer")
 
         return KeySerializationEncryptionBuilder(
             self._format,
             _kdf_rounds=rounds,
-            _mac_algorithm=self._mac_algorithm,
+            _hmac_hash=self._hmac_hash,
             _key_cert_algorithm=self._key_cert_algorithm,
         )
 
-    def mac_algorithm(
+    def hmac_hash(
         self, algorithm: HashAlgorithm
     ) -> "KeySerializationEncryptionBuilder":
         if self._format is not PrivateFormat.PKCS12:
             raise TypeError(
-                "mac_algorithm only supported with PrivateFormat.PKCS12"
+                "hmac_hash only supported with PrivateFormat.PKCS12"
             )
 
-        if self._mac_algorithm is not None:
-            raise ValueError("mac_algorithm already set")
+        if self._hmac_hash is not None:
+            raise ValueError("hmac_hash already set")
         return KeySerializationEncryptionBuilder(
             self._format,
             _kdf_rounds=self._kdf_rounds,
-            _mac_algorithm=algorithm,
+            _hmac_hash=algorithm,
             _key_cert_algorithm=self._key_cert_algorithm,
         )
 
@@ -130,7 +133,7 @@ class KeySerializationEncryptionBuilder(object):
         return KeySerializationEncryptionBuilder(
             self._format,
             _kdf_rounds=self._kdf_rounds,
-            _mac_algorithm=self._mac_algorithm,
+            _hmac_hash=self._hmac_hash,
             _key_cert_algorithm=algorithm,
         )
 
@@ -142,7 +145,7 @@ class KeySerializationEncryptionBuilder(object):
             self._format,
             password,
             kdf_rounds=self._kdf_rounds,
-            mac_algorithm=self._mac_algorithm,
+            hmac_hash=self._hmac_hash,
             key_cert_algorithm=self._key_cert_algorithm,
         )
 
@@ -154,12 +157,12 @@ class _KeySerializationEncryption(KeySerializationEncryption):
         password: bytes,
         *,
         kdf_rounds: typing.Optional[int],
-        mac_algorithm: typing.Optional[HashAlgorithm],
+        hmac_hash: typing.Optional[HashAlgorithm],
         key_cert_algorithm: typing.Optional[PBES],
     ):
         self._format = format
         self.password = password
 
         self._kdf_rounds = kdf_rounds
-        self._mac_algorithm = mac_algorithm
+        self._hmac_hash = hmac_hash
         self._key_cert_algorithm = key_cert_algorithm

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -6,6 +6,7 @@ import typing
 
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives._serialization import PBES as PBES
 from cryptography.hazmat.primitives.asymmetric import (
     dsa,
     ec,
@@ -17,6 +18,14 @@ from cryptography.hazmat.primitives.asymmetric.types import (
     PRIVATE_KEY_TYPES,
 )
 
+__all__ = [
+    "PBES",
+    "PKCS12Certificate",
+    "PKCS12KeyAndCertificates",
+    "load_key_and_certificates",
+    "load_pkcs12",
+    "serialize_key_and_certificates",
+]
 
 _ALLOWED_PKCS12_TYPES = typing.Union[
     rsa.RSAPrivateKey,

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -537,18 +537,18 @@ class TestPKCS12Creation:
         [
             (
                 PBES.PBESv2SHA256AndAES256CBC,
-                (
+                [
                     b"\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x05\x0d",  # PBESv2
                     b"\x06\x09\x60\x86\x48\x01\x65\x03\x04\x01\x2a",  # AES
-                ),
+                ],
             ),
             (
                 PBES.PBESv1SHA1And3KeyTripleDESCBC,
-                (b"\x06\x0a\x2a\x86\x48\x86\xf7\x0d\x01\x0c\x01\x03",),
+                [b"\x06\x0a\x2a\x86\x48\x86\xf7\x0d\x01\x0c\x01\x03"],
             ),
             (
                 None,
-                set(),
+                [],
             ),
         ],
     )
@@ -665,7 +665,7 @@ class TestPKCS12Creation:
         skip_message="Requires OpenSSL without PKCS12_set_mac (boring only)",
     )
     @pytest.mark.parametrize(
-        ("algorithm"),
+        "algorithm",
         [
             serialization.PrivateFormat.PKCS12.encryption_builder()
             .key_cert_algorithm(PBES.PBESv1SHA1And3KeyTripleDESCBC)

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -593,7 +593,7 @@ class TestPKCS12Creation:
         if enc_alg is not None:
             builder = builder.key_cert_algorithm(enc_alg)
         if mac_alg is not None:
-            builder = builder.mac_algorithm(mac_alg)
+            builder = builder.hmac_hash(mac_alg)
         if iters is not None:
             builder = builder.kdf_rounds(iters)
 
@@ -669,7 +669,7 @@ class TestPKCS12Creation:
         [
             serialization.PrivateFormat.PKCS12.encryption_builder()
             .key_cert_algorithm(PBES.PBESv1SHA1And3KeyTripleDESCBC)
-            .mac_algorithm(hashes.SHA256())
+            .hmac_hash(hashes.SHA256())
             .build(b"password"),
         ],
     )

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import pytest
 
 from cryptography import x509
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends.openssl.backend import _RC2
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import (
@@ -24,6 +25,7 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
 )
 from cryptography.hazmat.primitives.serialization.pkcs12 import (
+    PBES,
     PKCS12Certificate,
     PKCS12KeyAndCertificates,
     load_key_and_certificates,
@@ -529,6 +531,156 @@ class TestPKCS12Creation:
                 DummyKeySerializationEncryption(),
             )
         assert str(exc.value) == "Unsupported key encryption type"
+
+    @pytest.mark.parametrize(
+        ("enc_alg", "enc_alg_der"),
+        [
+            (
+                PBES.PBESv2SHA256AndAES256CBC,
+                (
+                    b"\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x05\x0d",  # PBESv2
+                    b"\x06\x09\x60\x86\x48\x01\x65\x03\x04\x01\x2a",  # AES
+                ),
+            ),
+            (
+                PBES.PBESv1SHA1And3KeyTripleDESCBC,
+                (b"\x06\x0a\x2a\x86\x48\x86\xf7\x0d\x01\x0c\x01\x03",),
+            ),
+            (
+                None,
+                set(),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("mac_alg", "mac_alg_der"),
+        [
+            (hashes.SHA1(), b"\x06\x05\x2b\x0e\x03\x02\x1a"),
+            (hashes.SHA256(), b"\x06\t`\x86H\x01e\x03\x04\x02\x01"),
+            (None, None),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("iters", "iter_der"),
+        [
+            (420, b"\x02\x02\x01\xa4"),
+            (22222, b"\x02\x02\x56\xce"),
+            (None, None),
+        ],
+    )
+    def test_key_serialization_encryption(
+        self,
+        backend,
+        enc_alg,
+        enc_alg_der,
+        mac_alg,
+        mac_alg_der,
+        iters,
+        iter_der,
+    ):
+        if (
+            enc_alg is PBES.PBESv2SHA256AndAES256CBC
+        ) and not backend._lib.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER:
+            pytest.skip("PBESv2 is not supported on OpenSSL < 3.0")
+
+        if (
+            mac_alg is not None
+            and not backend._lib.Cryptography_HAS_PKCS12_SET_MAC
+        ):
+            pytest.skip("PKCS12_set_mac is not supported (boring)")
+
+        builder = serialization.PrivateFormat.PKCS12.encryption_builder()
+        if enc_alg is not None:
+            builder = builder.key_cert_algorithm(enc_alg)
+        if mac_alg is not None:
+            builder = builder.mac_algorithm(mac_alg)
+        if iters is not None:
+            builder = builder.kdf_rounds(iters)
+
+        encryption = builder.build(b"password")
+        key = ec.generate_private_key(ec.SECP256R1())
+        cacert, cakey = _load_ca(backend)
+        now = datetime.utcnow()
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(cacert.subject)
+            .issuer_name(cacert.subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now)
+            .sign(cakey, hashes.SHA256())
+        )
+        assert isinstance(cert, x509.Certificate)
+        p12 = serialize_key_and_certificates(
+            b"name", key, cert, [cacert], encryption
+        )
+        # We want to know if we've serialized something that has the parameters
+        # we expect, so we match on specific byte strings of OIDs & DER values.
+        for der in enc_alg_der:
+            assert der in p12
+        if mac_alg_der is not None:
+            assert mac_alg_der in p12
+        if iter_der is not None:
+            assert iter_der in p12
+        parsed_key, parsed_cert, parsed_more_certs = load_key_and_certificates(
+            p12, b"password", backend
+        )
+        assert parsed_cert == cert
+        assert isinstance(parsed_key, ec.EllipticCurvePrivateKey)
+        assert parsed_key.public_key().public_bytes(
+            Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+        ) == key.public_key().public_bytes(
+            Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+        )
+        assert parsed_more_certs == [cacert]
+
+    @pytest.mark.supported(
+        only_if=lambda backend: (
+            not backend._lib.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER
+        ),
+        skip_message="Requires OpenSSL < 3.0.0 (or Libre/Boring)",
+    )
+    @pytest.mark.parametrize(
+        ("algorithm"),
+        [
+            serialization.PrivateFormat.PKCS12.encryption_builder()
+            .key_cert_algorithm(PBES.PBESv2SHA256AndAES256CBC)
+            .build(b"password"),
+        ],
+    )
+    def test_key_serialization_encryption_unsupported(
+        self, algorithm, backend
+    ):
+        cacert, cakey = _load_ca(backend)
+        with pytest.raises(UnsupportedAlgorithm):
+            serialize_key_and_certificates(
+                b"name", cakey, cacert, [], algorithm
+            )
+
+    @pytest.mark.supported(
+        only_if=lambda backend: (
+            not backend._lib.Cryptography_HAS_PKCS12_SET_MAC
+        ),
+        skip_message="Requires OpenSSL without PKCS12_set_mac (boring only)",
+    )
+    @pytest.mark.parametrize(
+        ("algorithm"),
+        [
+            serialization.PrivateFormat.PKCS12.encryption_builder()
+            .key_cert_algorithm(PBES.PBESv1SHA1And3KeyTripleDESCBC)
+            .mac_algorithm(hashes.SHA256())
+            .build(b"password"),
+        ],
+    )
+    def test_key_serialization_encryption_set_mac_unsupported(
+        self, algorithm, backend
+    ):
+        cacert, cakey = _load_ca(backend)
+        with pytest.raises(UnsupportedAlgorithm):
+            serialize_key_and_certificates(
+                b"name", cakey, cacert, [], algorithm
+            )
 
 
 @pytest.mark.skip_fips(

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -2453,7 +2453,7 @@ class TestEncryptionBuilder:
             b.kdf_rounds(0)
         with pytest.raises(ValueError):
             b.kdf_rounds(-1)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             b.kdf_rounds("string")  # type: ignore[arg-type]
 
     def test_invalid_password(self):
@@ -2468,12 +2468,12 @@ class TestEncryptionBuilder:
         with pytest.raises(TypeError):
             b.key_cert_algorithm(PBES.PBESv1SHA1And3KeyTripleDESCBC)
         with pytest.raises(TypeError):
-            b.mac_algorithm(SHA1())
+            b.hmac_hash(SHA1())
 
-    def test_duplicate_mac_algorithm(self):
-        b = PrivateFormat.PKCS12.encryption_builder().mac_algorithm(SHA1())
+    def test_duplicate_hmac_hash(self):
+        b = PrivateFormat.PKCS12.encryption_builder().hmac_hash(SHA1())
         with pytest.raises(ValueError):
-            b.mac_algorithm(SHA1())
+            b.hmac_hash(SHA1())
 
     def test_duplicate_key_cert_algorithm(self):
         b = PrivateFormat.PKCS12.encryption_builder().key_cert_algorithm(


### PR DESCRIPTION
This is limited support, but makes it possible to set different PBES choices as well as set KDF rounds and MAC algorithm.