### PR TITLE
implement __deepcopy__() for ObjectIdentifier (fixes #7587)

### DIFF
--- a/src/rust/src/oid.rs
+++ b/src/rust/src/oid.rs
@@ -35,6 +35,10 @@ impl ObjectIdentifier {
             .getattr(crate::intern!(py, "_OID_NAMES"))?;
         oid_names.call_method1("get", (slf, "Unknown OID"))
     }
+
+    fn __deepcopy__(slf: pyo3::PyRef<'_, Self>, _memo: pyo3::PyObject) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::prelude::pyproto]

--- a/tests/hazmat/test_oid.py
+++ b/tests/hazmat/test_oid.py
@@ -2,6 +2,7 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+import copy
 
 import pytest
 
@@ -10,6 +11,15 @@ from cryptography.hazmat._oid import ObjectIdentifier
 
 def test_basic_oid():
     assert ObjectIdentifier("1.2.3.4").dotted_string == "1.2.3.4"
+
+
+def test_oid_equal():
+    assert ObjectIdentifier("1.2.3.4") == ObjectIdentifier("1.2.3.4")
+
+
+def test_oid_deepcopy():
+    oid = ObjectIdentifier("1.2.3.4")
+    assert oid == copy.deepcopy(oid)
 
 
 def test_oid_constraint():


### PR DESCRIPTION
implement `__deepcopy__()` for Object Identifiers.