### PR TITLE
Add downstream test for scapy

### DIFF
--- a/.github/downstream.d/scapy.sh
+++ b/.github/downstream.d/scapy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+
+case "${1}" in
+    install)
+        git clone --depth=1 https://github.com/secdev/scapy
+        cd scapy
+        git rev-parse HEAD
+        pip install tox
+        ;;
+    run)
+        cd scapy
+        # this tox case uses sitepackages=true to use local cryptography
+        tox -qe cryptography
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,7 @@ jobs:
           - certbot
           - certbot-josepy
           - mitmproxy
+          - scapy
         PYTHON:
           - 3.9
     name: "Downstream tests for ${{ matrix.DOWNSTREAM }}"


### PR DESCRIPTION
Hi all, @alex,

This PR is a follow-up to https://github.com/pyca/cryptography/pull/7234#issuecomment-1241966358. This runs a subset of our tests (<1min) specifically using the cryptography module.

Thanks for the help :P