### PR TITLE
Replace vendored check job w/ re-actors/alls-green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@198badcb65a1a44528f27d5da555c4be9f12eac6  # v1.2.0
+        uses: re-actors/alls-green@198badcb65a1a44528f27d5da555c4be9f12eac6
         with:
           jobs: ${{ toJSON(needs) }}
       - name: Setup python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@198badcb65a1a44528f27d5da555c4be9f12eac6  # v1.2.0
         with:
           jobs: ${{ toJSON(needs) }}
       - name: Setup python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,12 +523,10 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
-      - run: |
-          echo "# 😢 😢" >> $GITHUB_STEP_SUMMARY
-          echo "At least one CI job failed."
-          exit 1
-        if: ${{ needs.linux.result != 'success' || needs.linux-distros.result != 'success' || needs.linux-rust.result != 'success' || needs.linux-rust-coverage.result != 'success' || needs.macos.result != 'success' || needs.windows.result != 'success' || needs.linux-downstream.result != 'success' }}
-      - run: echo "# 🎉 🎉" >> $GITHUB_STEP_SUMMARY
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
       - name: Setup python
         if: ${{ always() }}
         uses: actions/setup-python@v4.2.0


### PR DESCRIPTION
This makes use of the action that implements "one-check-to-rule-them-all" in a generic way with all the bells and whistles (that I saw in projects implementing this approach, including this one) necessary for corner cases. It should reduce the maintenance burden.

https://github.com/marketplace/actions/alls-green#why

This action has been battle-tested in the projects of aio-libs, cherrypy, setuptools and ansible (off the top of my head but there's more).

Inspired by earlier discoveries @ https://github.com/pyca/cryptography/pull/6512/files#r762373796.