### PR TITLE
Make verify_interface a no-op

### DIFF
--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -5,7 +5,6 @@
 
 import abc
 import enum
-import inspect
 import sys
 import types
 import typing
@@ -47,37 +46,12 @@ class InterfaceNotImplemented(Exception):
     pass
 
 
-def strip_annotation(signature: inspect.Signature) -> inspect.Signature:
-    return inspect.Signature(
-        [
-            param.replace(annotation=inspect.Parameter.empty)
-            for param in signature.parameters.values()
-        ]
-    )
-
-
 def verify_interface(
     iface: abc.ABCMeta, klass: object, *, check_annotations: bool = False
 ):
-    for method in iface.__abstractmethods__:
-        if not hasattr(klass, method):
-            raise InterfaceNotImplemented(
-                "{} is missing a {!r} method".format(klass, method)
-            )
-        if isinstance(getattr(iface, method), abc.abstractproperty):
-            # Can't properly verify these yet.
-            continue
-        sig = inspect.signature(getattr(iface, method))
-        actual = inspect.signature(getattr(klass, method))
-        if check_annotations:
-            ok = sig == actual
-        else:
-            ok = strip_annotation(sig) == strip_annotation(actual)
-        if not ok:
-            raise InterfaceNotImplemented(
-                "{}.{}'s signature differs from the expected. Expected: "
-                "{!r}. Received: {!r}".format(klass, method, sig, actual)
-            )
+    # Exists exclusively for `aws-encryption-sdk` which relies on it existing,
+    # even though it was never a public API.
+    pass
 
 
 class _DeprecatedValue:

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -4,16 +4,11 @@
 
 import abc
 
-import pytest
-
-from cryptography.utils import (
-    InterfaceNotImplemented,
-    verify_interface,
-)
+from cryptography.utils import verify_interface
 
 
 class TestVerifyInterface:
-    def test_verify_missing_method(self):
+    def test_noop(self):
         class SimpleInterface(metaclass=abc.ABCMeta):
             @abc.abstractmethod
             def method(self):
@@ -22,59 +17,4 @@ class TestVerifyInterface:
         class NonImplementer:
             pass
 
-        with pytest.raises(InterfaceNotImplemented):
-            verify_interface(SimpleInterface, NonImplementer)
-
-    def test_different_arguments(self):
-        class SimpleInterface(metaclass=abc.ABCMeta):
-            @abc.abstractmethod
-            def method(self, a):
-                """Method with one argument"""
-
-        class NonImplementer:
-            def method(self):
-                """Method with no arguments"""
-
-        # Invoke this to ensure the line is covered
-        NonImplementer().method()
-        with pytest.raises(InterfaceNotImplemented):
-            verify_interface(SimpleInterface, NonImplementer)
-
-    def test_handles_abstract_property(self):
-        class SimpleInterface(metaclass=abc.ABCMeta):
-            @abc.abstractproperty
-            def property(self):
-                """An abstract property"""
-
-        class NonImplementer:
-            @property
-            def property(self):
-                """A concrete property"""
-
-        # Invoke this to ensure the line is covered
-        NonImplementer().property
         verify_interface(SimpleInterface, NonImplementer)
-
-    def test_signature_mismatch(self):
-        class SimpleInterface(metaclass=abc.ABCMeta):
-            @abc.abstractmethod
-            def method(self, other: object) -> int:
-                """Method with signature"""
-
-        class ClassWithoutSignature:
-            def method(self, other):
-                """Method without signature"""
-
-        class ClassWithSignature:
-            def method(self, other: object) -> int:
-                """Method with signature"""
-
-        verify_interface(SimpleInterface, ClassWithoutSignature)
-        verify_interface(SimpleInterface, ClassWithSignature)
-        with pytest.raises(InterfaceNotImplemented):
-            verify_interface(
-                SimpleInterface, ClassWithoutSignature, check_annotations=True
-            )
-        verify_interface(
-            SimpleInterface, ClassWithSignature, check_annotations=True
-        )


### PR DESCRIPTION
This should be sufficient to keep aws-encryption-sdk working, but let's us delete the code.