### PR TITLE
Handle error generating DH params with very very large key size

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1709,7 +1709,9 @@ class Backend:
         res = self._lib.DH_generate_parameters_ex(
             dh_param_cdata, key_size, generator, self._ffi.NULL
         )
-        self.openssl_assert(res == 1)
+        if res != 1:
+            errors = self._consume_errors_with_text()
+            raise ValueError("Unable to generate DH parameters", errors)
 
         return _DHParameters(self, dh_param_cdata)
 

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -148,6 +148,10 @@ class TestDH:
         with pytest.raises(ValueError):
             dh.generate_parameters(7, 512, backend)
 
+    def test_large_key_generate_dh(self):
+        with pytest.raises(ValueError):
+            dh.generate_parameters(2, 1 << 30)
+
     @pytest.mark.skip_fips(reason="non-FIPS parameters")
     def test_dh_parameters_supported(self, backend):
         valid_p = int(


### PR DESCRIPTION
Detected by OSS-Fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52024