### PR TITLE
add unsafe_skip_rsa_key_validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,14 @@ Changelog
   other X.509 builders has been removed.
 * Added support for
   :ref:`disabling the legacy provider in OpenSSL 3.0.x<legacy-provider>`.
+* Added support for disabling RSA key validation checks when loading RSA
+  keys via
+  :func:`~cryptography.hazmat.primitives.serialization.load_pem_private_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_der_private_key`,
+  and
+  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers.private_key`.
+  This speeds up key loading but is :term:`unsafe` if you are loading potentially
+  attacker supplied keys.
 
 .. _v38-0-1:
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -100,6 +100,11 @@ Glossary
         name. U-labels use unicode characters outside the ASCII range and
         are encoded as A-labels when stored in certificates.
 
+    unsafe
+        This is a term used to describe an operation where the user must
+        ensure that the input is correct. Failure to do so can result in
+        crashes, hangs, and other security issues.
+
 .. _`hardware security module`: https://en.wikipedia.org/wiki/Hardware_security_module
 .. _`idna`: https://pypi.org/project/idna/
 .. _`buffer protocol`: https://docs.python.org/3/c-api/buffer.html

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -479,7 +479,7 @@ is unavailable.
 
             .. versionadded:: 39.0.0
 
-            A ``kwarg`` only argument that defaults to ``False``. If ``True``
+            A keyword-only argument that defaults to ``False``. If ``True``
             RSA private keys will not be validated. This significantly speeds up
             loading the keys, but is is :term:`unsafe` unless you are certain
             the key is valid. User supplied keys should never be loaded with

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -473,7 +473,21 @@ is unavailable.
         A `Chinese remainder theorem`_ coefficient used to speed up RSA
         operations. Calculated as: q\ :sup:`-1` mod p
 
-    .. method:: private_key()
+    .. method:: private_key(*, unsafe_skip_rsa_key_validation=False)
+
+        :param unsafe_skip_rsa_key_validation:
+
+            .. versionadded:: 39.0.0
+
+            A ``kwarg`` only argument that defaults to ``False``. If ``True``
+            RSA private keys will not be validated. This significantly speeds up
+            loading the keys, but is is :term:`unsafe` unless you are certain
+            the key is valid. User supplied keys should never be loaded with
+            this parameter set to ``True``. If you do load an invalid key this
+            way and attempt to use it OpenSSL may hang, crash, or otherwise
+            misbehave.
+
+        :type unsafe_skip_rsa_key_validation: bool
 
         :returns: An instance of
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`.

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -147,7 +147,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
 
         .. versionadded:: 39.0.0
 
-        A ``kwarg`` only argument that defaults to ``False``. If ``True``
+        A keyword-only argument that defaults to ``False``. If ``True``
         RSA private keys will not be validated. This significantly speeds up
         loading the keys, but is is :term:`unsafe` unless you are certain the
         key is valid. User supplied keys should never be loaded with this
@@ -265,7 +265,7 @@ the rest.
 
         .. versionadded:: 39.0.0
 
-        A ``kwarg`` only argument that defaults to ``False``. If ``True``
+        A keyword-only argument that defaults to ``False``. If ``True``
         RSA private keys will not be validated. This significantly speeds up
         loading the keys, but is is :term:`unsafe` unless you are certain the
         key is valid. User supplied keys should never be loaded with this

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -125,7 +125,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
     extract the public key with
     :meth:`Certificate.public_key <cryptography.x509.Certificate.public_key>`.
 
-.. function:: load_pem_private_key(data, password)
+.. function:: load_pem_private_key(data, password, *, unsafe_skip_rsa_key_validation=False)
 
     .. versionadded:: 0.6
 
@@ -141,7 +141,20 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
 
     :param password: The password to use to decrypt the data. Should
         be ``None`` if the private key is not encrypted.
-    :type data: :term:`bytes-like`
+    :type password: :term:`bytes-like`
+
+    :param unsafe_skip_rsa_key_validation:
+
+        .. versionadded:: 39.0.0
+
+        A ``kwarg`` only argument that defaults to ``False``. If ``True``
+        RSA private keys will not be validated. This significantly speeds up
+        loading the keys, but is is :term:`unsafe` unless you are certain the
+        key is valid. User supplied keys should never be loaded with this
+        parameter set to ``True``. If you do load an invalid key this way and
+        attempt to use it OpenSSL may hang, crash, or otherwise misbehave.
+
+    :type unsafe_skip_rsa_key_validation: bool
 
     :returns: One of
         :class:`~cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey`,
@@ -234,7 +247,7 @@ data is binary. DER keys may be in a variety of formats, but as long as you
 know whether it is a public or private key the loading functions will handle
 the rest.
 
-.. function:: load_der_private_key(data, password)
+.. function:: load_der_private_key(data, password, *, unsafe_skip_rsa_key_validation=False)
 
     .. versionadded:: 0.8
 
@@ -247,6 +260,19 @@ the rest.
     :param password: The password to use to decrypt the data. Should
         be ``None`` if the private key is not encrypted.
     :type password: :term:`bytes-like`
+
+    :param unsafe_skip_rsa_key_validation:
+
+        .. versionadded:: 39.0.0
+
+        A ``kwarg`` only argument that defaults to ``False``. If ``True``
+        RSA private keys will not be validated. This significantly speeds up
+        loading the keys, but is is :term:`unsafe` unless you are certain the
+        key is valid. User supplied keys should never be loaded with this
+        parameter set to ``True``. If you do load an invalid key this way and
+        attempt to use it OpenSSL may hang, crash, or otherwise misbehave.
+
+    :type unsafe_skip_rsa_key_validation: bool
 
     :returns: One of
         :class:`~cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey`,

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -186,7 +186,6 @@ class Backend:
         self._binding = binding.Binding()
         self._ffi = self._binding.ffi
         self._lib = self._binding.lib
-        self._rsa_skip_check_key = False
         self._fips_enabled = self._is_fips_enabled()
 
         self._cipher_registry = {}

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -367,7 +367,12 @@ class _RSAPrivateKey(RSAPrivateKey):
     _key_size: int
 
     def __init__(
-        self, backend: "Backend", rsa_cdata, evp_pkey, _skip_check_key: bool
+        self,
+        backend: "Backend",
+        rsa_cdata,
+        evp_pkey,
+        *,
+        unsafe_skip_rsa_key_validation: bool,
     ):
         res: int
         # RSA_check_key is slower in OpenSSL 3.0.0 due to improved
@@ -375,7 +380,7 @@ class _RSAPrivateKey(RSAPrivateKey):
         # since users don't load new keys constantly, but for TESTING we've
         # added an init arg that allows skipping the checks. You should not
         # use this in production code unless you understand the consequences.
-        if not _skip_check_key:
+        if not unsafe_skip_rsa_key_validation:
             res = backend._lib.RSA_check_key(rsa_cdata)
             if res != 1:
                 errors = backend._consume_errors_with_text()

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -354,12 +354,19 @@ class RSAPrivateNumbers:
     def public_numbers(self) -> "RSAPublicNumbers":
         return self._public_numbers
 
-    def private_key(self, backend: typing.Any = None) -> RSAPrivateKey:
+    def private_key(
+        self,
+        backend: typing.Any = None,
+        *,
+        unsafe_skip_rsa_key_validation: bool = False,
+    ) -> RSAPrivateKey:
         from cryptography.hazmat.backends.openssl.backend import (
             backend as ossl,
         )
 
-        return ossl.load_rsa_private_numbers(self)
+        return ossl.load_rsa_private_numbers(
+            self, unsafe_skip_rsa_key_validation
+        )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, RSAPrivateNumbers):

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -16,10 +16,14 @@ def load_pem_private_key(
     data: bytes,
     password: typing.Optional[bytes],
     backend: typing.Any = None,
+    *,
+    unsafe_skip_rsa_key_validation: bool = False,
 ) -> PRIVATE_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
-    return ossl.load_pem_private_key(data, password)
+    return ossl.load_pem_private_key(
+        data, password, unsafe_skip_rsa_key_validation
+    )
 
 
 def load_pem_public_key(
@@ -42,10 +46,14 @@ def load_der_private_key(
     data: bytes,
     password: typing.Optional[bytes],
     backend: typing.Any = None,
+    *,
+    unsafe_skip_rsa_key_validation: bool = False,
 ) -> PRIVATE_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
-    return ossl.load_der_private_key(data, password)
+    return ossl.load_der_private_key(
+        data, password, unsafe_skip_rsa_key_validation
+    )
 
 
 def load_der_public_key(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,12 +46,3 @@ def backend(request):
     # Ensure the error stack is clear after the test
     errors = openssl_backend._consume_errors_with_text()
     assert not errors
-
-
-@pytest.fixture
-def disable_rsa_checks(backend):
-    # Use this fixture to skip RSA key checks in tests that need the
-    # performance.
-    backend._rsa_skip_check_key = True
-    yield
-    backend._rsa_skip_check_key = False

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -477,7 +477,9 @@ class TestOpenSSLSerializationWithOpenSSL:
     def test_unsupported_evp_pkey_type(self):
         key = backend._create_evp_pkey_gc()
         with raises_unsupported_algorithm(None):
-            backend._evp_pkey_to_private_key(key)
+            backend._evp_pkey_to_private_key(
+                key, unsafe_skip_rsa_key_validation=False
+            )
         with raises_unsupported_algorithm(None):
             backend._evp_pkey_to_public_key(key)
 
@@ -493,7 +495,9 @@ class TestOpenSSLSerializationWithOpenSSL:
                 ),
                 lambda pemfile: (
                     backend.load_pem_private_key(
-                        pemfile.read().encode(), password
+                        pemfile.read().encode(),
+                        password,
+                        unsafe_skip_rsa_key_validation=False,
                     )
                 ),
             )

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -487,7 +487,7 @@ class TestRSASignature:
         ),
         skip_message="Does not support SHA1 signature.",
     )
-    def test_pkcs1v15_signing(self, backend, disable_rsa_checks, subtests):
+    def test_pkcs1v15_signing(self, backend, subtests):
         vectors = _flatten_pkcs1_examples(
             load_vectors_from_file(
                 os.path.join("asymmetric", "RSA", "pkcs1v15sign-vectors.txt"),
@@ -506,7 +506,7 @@ class TestRSASignature:
                     public_numbers=rsa.RSAPublicNumbers(
                         e=private["public_exponent"], n=private["modulus"]
                     ),
-                ).private_key(backend)
+                ).private_key(backend, unsafe_skip_rsa_key_validation=True)
                 signature = private_key.sign(
                     binascii.unhexlify(example["message"]),
                     padding.PKCS1v15(),
@@ -1682,9 +1682,7 @@ class TestRSADecryption:
         ),
         skip_message="Does not support PKCS1v1.5.",
     )
-    def test_decrypt_pkcs1v15_vectors(
-        self, backend, disable_rsa_checks, subtests
-    ):
+    def test_decrypt_pkcs1v15_vectors(self, backend, subtests):
         vectors = _flatten_pkcs1_examples(
             load_vectors_from_file(
                 os.path.join("asymmetric", "RSA", "pkcs1v15crypt-vectors.txt"),
@@ -1703,7 +1701,7 @@ class TestRSADecryption:
                     public_numbers=rsa.RSAPublicNumbers(
                         e=private["public_exponent"], n=private["modulus"]
                     ),
-                ).private_key(backend)
+                ).private_key(backend, unsafe_skip_rsa_key_validation=True)
                 ciphertext = binascii.unhexlify(example["encryption"])
                 assert len(ciphertext) == (skey.key_size + 7) // 8
                 message = skey.decrypt(ciphertext, padding.PKCS1v15())
@@ -1804,9 +1802,7 @@ class TestRSADecryption:
             "Does not support OAEP using SHA224 MGF1 and SHA224 hash."
         ),
     )
-    def test_decrypt_oaep_sha2_vectors(
-        self, backend, disable_rsa_checks, subtests
-    ):
+    def test_decrypt_oaep_sha2_vectors(self, backend, subtests):
         vectors = _build_oaep_sha2_vectors()
         for private, public, example, mgf1_alg, hash_alg in vectors:
             with subtests.test():
@@ -1820,7 +1816,7 @@ class TestRSADecryption:
                     public_numbers=rsa.RSAPublicNumbers(
                         e=private["public_exponent"], n=private["modulus"]
                     ),
-                ).private_key(backend)
+                ).private_key(backend, unsafe_skip_rsa_key_validation=True)
                 message = skey.decrypt(
                     binascii.unhexlify(example["encryption"]),
                     padding.OAEP(

--- a/tests/wycheproof/test_rsa.py
+++ b/tests/wycheproof/test_rsa.py
@@ -98,6 +98,7 @@ def test_rsa_pkcs1v15_signature_generation(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode(),
         password=None,
         backend=backend,
+        unsafe_skip_rsa_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
     digest = _DIGESTS[wycheproof.testgroup["sha"]]
@@ -193,6 +194,7 @@ def test_rsa_oaep_encryption(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode("ascii"),
         password=None,
         backend=backend,
+        unsafe_skip_rsa_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
     digest = _DIGESTS[wycheproof.testgroup["sha"]]
@@ -228,6 +230,7 @@ def test_rsa_pkcs1_encryption(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode("ascii"),
         password=None,
         backend=backend,
+        unsafe_skip_rsa_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
 

--- a/tests/wycheproof/utils.py
+++ b/tests/wycheproof/utils.py
@@ -3,9 +3,7 @@ from ..utils import load_wycheproof_tests
 
 def wycheproof_tests(*paths):
     def wrapper(func):
-        def run_wycheproof(
-            backend, disable_rsa_checks, subtests, pytestconfig
-        ):
+        def run_wycheproof(backend, subtests, pytestconfig):
             wycheproof_root = pytestconfig.getoption(
                 "--wycheproof-root", skip=True
             )


### PR DESCRIPTION
This allows users to skip RSA key validation when calling load_pem_private_key, load_der_private_key, and
RSAPrivateNumbers.private_key. This is a significant performance improvement but is **only safe if you know the key is valid**. If you use this when the key is invalid OpenSSL makes no guarantees about what might happen. Infinite loops, crashes, and all manner of terrible things become possible if that occurs. Beware, beware, beware.