### PR TITLE
yank 38.0.2 release due to openssl withdrawal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,8 +41,12 @@ Changelog
 
 .. _v38-0-2:
 
-38.0.2 - 2022-10-11
-~~~~~~~~~~~~~~~~~~~
+38.0.2 - 2022-10-11 (YANKED)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attention::
+
+    This release was subsequently yanked from PyPI due to a regression in OpenSSL.
 
 * Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.6.
 


### PR DESCRIPTION
Multiple regressions have forced them to withdraw the release. We are unaffected by the 3.0.5 security issue as we don't bind against the affected function(s) so we've made the decision to yank 38.0.2.