### PR TITLE
Make sure that one of full_name, relative_name or crl_issuer is set i…

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -589,6 +589,11 @@ class DistributionPoint:
                 "You cannot provide both full_name and relative_name, at "
                 "least one must be None."
             )
+        if not full_name and not relative_name and not crl_issuer:
+            raise ValueError(
+                "Either full_name, relative_name or crl_issuer must be "
+                "provided."
+            )
 
         if full_name is not None:
             full_name = list(full_name)
@@ -623,12 +628,6 @@ class DistributionPoint:
             raise ValueError(
                 "unspecified and remove_from_crl are not valid reasons in a "
                 "DistributionPoint"
-            )
-
-        if reasons and not crl_issuer and not (full_name or relative_name):
-            raise ValueError(
-                "You must supply crl_issuer, full_name, or relative_name when "
-                "reasons is not None"
             )
 
         self._full_name = full_name

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -3968,6 +3968,10 @@ class TestDistributionPoint:
                 "data", "notname", None, None  # type:ignore[arg-type]
             )
 
+    def test_no_full_name_relative_name_or_crl_issuer(self):
+        with pytest.raises(ValueError):
+            x509.DistributionPoint(None, None, None, None)
+
     def test_crl_issuer_not_general_names(self):
         with pytest.raises(TypeError):
             x509.DistributionPoint(


### PR DESCRIPTION
Noticed that it's possible to create Distribution Points with no full name, relative name or issuer:

```python
>>> x509.DistributionPoint(None, None, None, None)
<DistributionPoint(full_name=None, relative_name=None, reasons=None, crl_issuer=None)>
```

RFC 5280, section 4.2.1.13 says:

```quote
... either distributionPoint or cRLIssuer MUST be present.
```
