### PR TITLE
Revert workaround for yanked OpenSSL

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -2204,11 +2204,8 @@ class Backend:
             res = self._lib.PKCS12_parse(
                 p12, password_buf, evp_pkey_ptr, x509_ptr, sk_x509_ptr
             )
-        # OpenSSL 3.0.6 leaves errors on the stack even in success, so
-        # we consume all errors unconditionally.
-        # https://github.com/openssl/openssl/issues/19389
-        self._consume_errors()
         if res == 0:
+            self._consume_errors()
             raise ValueError("Invalid password or PKCS12 data")
 
         cert = None


### PR DESCRIPTION
Partial revert of 6578d86ec557e0b4af2ba9d0c0a821fe939044ee