### PR TITLE
Update invalid EC key test for compatibility with upcoming OpenSSL changes

### DIFF
--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -479,8 +479,9 @@ class TestECDSAVectors:
         # BoringSSL rejects infinity points before it ever gets to us, so it
         # uses a more generic error message.
         match = (
-            r'infinity|invalid form' \
-                if not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL else None
+            r"infinity|invalid form"
+            if not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL
+            else None
         )
         with pytest.raises(ValueError, match=match):
             serialization.load_pem_public_key(

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -479,7 +479,7 @@ class TestECDSAVectors:
         # BoringSSL rejects infinity points before it ever gets to us, so it
         # uses a more generic error message.
         match = (
-            "infinity" if not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL else None
+            r'infinity|invalid form' if not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL else None
         )
         with pytest.raises(ValueError, match=match):
             serialization.load_pem_public_key(

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -479,7 +479,8 @@ class TestECDSAVectors:
         # BoringSSL rejects infinity points before it ever gets to us, so it
         # uses a more generic error message.
         match = (
-            r'infinity|invalid form' if not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL else None
+            r'infinity|invalid form' \
+                if not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL else None
         )
         with pytest.raises(ValueError, match=match):
             serialization.load_pem_public_key(


### PR DESCRIPTION
One of the tests checking behavior with invalid EC keys hardcoded the error reason.

This commit replaces the string matching with a regex to match both the current string and a new reason, introduced by upcoming OpenSSL changes [0], which would otherwise trigger a false positive failure.

[0]: https://github.com/openssl/openssl/pull/19681