### PR TITLE
Update invalid EC key test for compatibility with upcoming OpenSSL changes

### DIFF
--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -411,7 +411,9 @@ class TestECDSAVectors:
         # BoringSSL rejects infinity points before it ever gets to us, so it
         # uses a more generic error message.
         match = (
-            "infinity" if not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL else None
+            r"infinity|invalid form"
+            if not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL
+            else None
         )
         with pytest.raises(ValueError, match=match):
             serialization.load_pem_public_key(


### PR DESCRIPTION
This is a rebase of #7829 to target `main` rather than `38.0.x`, [as requested](https://github.com/pyca/cryptography/pull/7829#issuecomment-1323559962).

## The original description:

> One of the tests checking behavior with invalid EC keys hardcoded the error reason.
>
> This commit replaces the string matching with a regex to match both the current string and a new reason, introduced by upcoming OpenSSL changes [0], which would otherwise trigger a false positive failure.
>
> [0]: https://github.com/openssl/openssl/pull/19681

---

## Asking for help

Ping @alex, who has been helping me since #7829 (thanks!)

Ping @levitte and @mspncp who also might lend me a hand (or four) in figuring out how to root cause the remaining errors. This PR is rebased on latest `main@pyca` and includes formatting amendments to my original patch to appease `flake`, but it does still trigger the same errors that i mentioned in <https://github.com/openssl/openssl/pull/19681#issuecomment-1323430908>. I also include again a discussion of the same [`log.txt`][log.txt] below.

[log.txt]: https://github.com/openssl/openssl/files/10066335/log.txt

---

## Surprising errors specific to `main@pyca/cryptography`

- :paperclip: [`log.txt`][log.txt]

The log above is obtained running `test_external_pyca` from the tip of openssl/openssl#19681, after ensuring the submodule `pyca-cryptography` points to an older (but equivalent) version of this PR.

These errors are not triggered when checking out `openssl-3.1` and the same commit under `pyca-cryptography/`, so it seems they are an indirect consequence of the openssl/openssl#19681 changes.

The errors are due to a `param of incompatible type` left on the error stack during teardown, but are surprising and hard to debug because they happen during the teardown of seemingly unrelated tests, e.g. :

~~~bash
$ cat log.txt |grep "ERROR at" |cut -c -110
_ ERROR at teardown of TestDSASerialization.test_private_bytes_encrypted_pem[PrivateFormat.PKCS8-s] _
_ ERROR at teardown of TestDSASerialization.test_private_bytes_encrypted_pem[PrivateFormat.PKCS8-longerpasswor
_ ERROR at teardown of TestDSASerialization.test_private_bytes_encrypted_pem[PrivateFormat.PKCS8-!*$&(@#$*&($T
_ ERROR at teardown of TestDSASerialization.test_private_bytes_encrypted_pem[PrivateFormat.PKCS8-\x01\x01\x01\
_ ERROR at teardown of TestEd25519Signing.test_round_trip_private_serialization[Encoding.PEM-PrivateFormat.PKC
_ ERROR at teardown of TestEd448Signing.test_round_trip_private_serialization[Encoding.PEM-PrivateFormat.PKCS8
_ ERROR at teardown of TestECSerialization.test_private_bytes_encrypted_pem[PrivateFormat.PKCS8-s] _
_ ERROR at teardown of TestECSerialization.test_private_bytes_encrypted_pem[PrivateFormat.PKCS8-longerpassword
_ ERROR at teardown of TestECSerialization.test_private_bytes_encrypted_pem[PrivateFormat.PKCS8-!*$&(@#$*&($T@
_ ERROR at teardown of TestECSerialization.test_private_bytes_encrypted_pem[PrivateFormat.PKCS8-\x01\x01\x01\x
_ ERROR at teardown of TestX448Exchange.test_round_trip_private_serialization[Encoding.PEM-PrivateFormat.PKCS8
_ ERROR at teardown of TestX25519Exchange.test_round_trip_private_serialization[Encoding.PEM-PrivateFormat.PKC
~~~

Notice that these errors are specific to `main@pyca/cryptography`, and they are not triggered when running against the `38.0.x` branch (as exemplified by the original #7829.