### PR TITLE
Fix the boringbot committer/author information

### DIFF
--- a/.github/workflows/boring-open-version-bump.yml
+++ b/.github/workflows/boring-open-version-bump.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           commit-message: "Bump BoringSSL and/or OpenSSL in CI"
           title: "Bump BoringSSL and/or OpenSSSL in CI"
-          author: "BoringSSL Bot <pyca-boringbot@users.noreply.github.com>"
+          author: "pyca-boringbot[bot] <pyca-boringbot[bot]+106132319@users.noreply.github.com>"
           body: |
             ${{ steps.check-sha-boring.outputs.COMMIT_MSG }}
             ${{ steps.check-sha-openssl.outputs.COMMIT_MSG }}


### PR DESCRIPTION
This patch makes the commit author field use the correct "user noreply" email. It helps GitHub to correctly assign the commit authorship in the UI.

Refs:
* https://github.com/sanitizers/patchback-github-app/commit/cee09976
* https://api.github.com/users/pyca-boringbot[bot]