### PR TITLE
Revert "don't use flake8 6.0"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ sdist =
     setuptools_rust >= 0.11.4
 pep8test =
     black
-    flake8 != 6.0.0
+    flake8
     flake8-import-order
     pep8-naming
 # This extra is for OpenSSH private keys that use bcrypt KDF


### PR DESCRIPTION
Reverts pyca/cryptography#7838

flake8-import-order released a fix