### PR TITLE
document POLICY_MAPPING and SUBJECT_DIRECTORY_ATTRIBUTES

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -3403,6 +3403,14 @@ instances. The following common OIDs are available as constants.
 
         Corresponds to the dotted string ``"2.5.29.28"``.
 
+    .. attribute:: POLICY_MAPPINGS
+
+        Corresponds to the dotted string ``"2.5.29.33"``.
+
+    .. attribute:: SUBJECT_DIRECTORY_ATTRIBUTES
+
+        Corresponds to the dotted string ``"2.5.29.9"``.
+
 
 .. class:: CRLEntryExtensionOID
 


### PR DESCRIPTION
Found that these two ExtensionOID classes are missing. Not sure if you want them documented, as the implementation of these extensions seems to be missing. Feel free to close if you think it's pointless :-).