### PR TITLE
Remove binding for X509_STORE_get_get_issuer

### DIFF
--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -211,7 +211,6 @@ Cryptography_STACK_OF_X509_OBJECT *X509_STORE_get0_objects(X509_STORE *);
 X509 *X509_OBJECT_get0_X509(X509_OBJECT *);
 
 X509 *X509_STORE_CTX_get0_cert(X509_STORE_CTX *);
-X509_STORE_CTX_get_issuer_fn X509_STORE_get_get_issuer(X509_STORE *);
 void X509_STORE_set_get_issuer(X509_STORE *, X509_STORE_CTX_get_issuer_fn);
 """
 
@@ -219,7 +218,6 @@ CUSTOMIZATIONS = """
 #if CRYPTOGRAPHY_IS_LIBRESSL
 static const long Cryptography_HAS_X509_STORE_CTX_GET_ISSUER = 0;
 typedef void *X509_STORE_CTX_get_issuer_fn;
-X509_STORE_CTX_get_issuer_fn (*X509_STORE_get_get_issuer)(X509_STORE *) = NULL;
 void (*X509_STORE_set_get_issuer)(X509_STORE *,
                                   X509_STORE_CTX_get_issuer_fn) = NULL;
 #else

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -64,7 +64,6 @@ def cryptography_has_mem_functions() -> typing.List[str]:
 
 def cryptography_has_x509_store_ctx_get_issuer() -> typing.List[str]:
     return [
-        "X509_STORE_get_get_issuer",
         "X509_STORE_set_get_issuer",
     ]
 


### PR DESCRIPTION
This was added alongside X509_STORE_set_get_issuer in 21ef4080ec7666299f1268f3bbfb136582744359. It makes sense to want to override issuer lookup, but I've never seen a valid use case for querying the callbacks. If you're trying to get at the function that was already configured, you presumably already know it. (And if you don't, it's not safe to call because an arbitrary callback may have been written to only be usable in particular contexts.)

(I got some mysterious "bad magic number" error in a few tests when I tried to test this locally, so relying on CI to fully test.)