### PR TITLE
Add SSL_CTX_set_msg_callback functions

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -296,7 +296,16 @@ void SSL_CTX_set_client_CA_list(SSL_CTX *, Cryptography_STACK_OF_X509_NAME *);
 void SSL_CTX_set_info_callback(SSL_CTX *, void (*)(const SSL *, int, int));
 void (*SSL_CTX_get_info_callback(SSL_CTX *))(const SSL *, int, int);
 
-void SSL_CTX_set_msg_callback(SSL_CTX *, void (*)(int, int, int, const void *, size_t, SSL *, void *));
+void SSL_CTX_set_msg_callback(SSL_CTX *,
+                              void (*)(
+                                int,
+                                int,
+                                int,
+                                const void *,
+                                size_t,
+                                SSL *,
+                                void *
+                              ));
 void SSL_CTX_set_msg_callback_arg(SSL_CTX *, void *);
 
 void SSL_CTX_set_keylog_callback(SSL_CTX *,

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -296,6 +296,9 @@ void SSL_CTX_set_client_CA_list(SSL_CTX *, Cryptography_STACK_OF_X509_NAME *);
 void SSL_CTX_set_info_callback(SSL_CTX *, void (*)(const SSL *, int, int));
 void (*SSL_CTX_get_info_callback(SSL_CTX *))(const SSL *, int, int);
 
+void SSL_CTX_set_msg_callback(SSL_CTX *, void (*)(int, int, int, const void *, size_t, SSL *, void *));
+void SSL_CTX_set_msg_callback_arg(SSL_CTX *, void *);
+
 void SSL_CTX_set_keylog_callback(SSL_CTX *,
                                  void (*)(const SSL *, const char *));
 void (*SSL_CTX_get_keylog_callback(SSL_CTX *))(const SSL *, const char *);


### PR DESCRIPTION
This PR adds the following function definitions to openssl/ssl.py file:

- SSL_CTX_set_msg_callback
- SSL_CTX_set_msg_callback_arg

Please let me know if anything is missing.
Thank you!