### PR TITLE
src/_cffi_src/openssl/evp.py: export EVP_PKEY_set_alias_type in FUNCTIONS  to support to use SM2 algorithms

### DIFF
--- a/src/_cffi_src/openssl/evp.py
+++ b/src/_cffi_src/openssl/evp.py
@@ -31,6 +31,7 @@ static const int EVP_CTRL_AEAD_SET_IVLEN;
 static const int EVP_CTRL_AEAD_GET_TAG;
 static const int EVP_CTRL_AEAD_SET_TAG;
 
+static const int Cryptography_HAS_EVP_PKEY_set_alias_type;
 static const int Cryptography_HAS_SCRYPT;
 static const int Cryptography_HAS_EVP_PKEY_DHX;
 static const int Cryptography_HAS_EVP_PKEY_get_set_tls_encodedpoint;
@@ -121,6 +122,7 @@ int EVP_PKEY_keygen(EVP_PKEY_CTX *, EVP_PKEY **);
 int EVP_PKEY_derive_init(EVP_PKEY_CTX *);
 int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *, EVP_PKEY *);
 int EVP_PKEY_derive(EVP_PKEY_CTX *, unsigned char *, size_t *);
+int EVP_PKEY_set_alias_type(EVP_PKEY *, int);
 int EVP_PKEY_set_type(EVP_PKEY *, int);
 
 int EVP_PKEY_id(const EVP_PKEY *);
@@ -179,6 +181,14 @@ EVP_MD_CTX *Cryptography_EVP_MD_CTX_new(void) {
 void Cryptography_EVP_MD_CTX_free(EVP_MD_CTX *md) {
     EVP_MD_CTX_free(md);
 }
+
+#if CRYPTOGRAPHY_IS_LIBRESSL || CRYPTOGRAPHY_OPENSSL_300_OR_GREATER || \
+        CRYPTOGRAPHY_IS_BORINGSSL
+static const int Cryptography_HAS_EVP_PKEY_set_alias_type = 0;
+int (*EVP_PKEY_set_alias_type)(EVP_PKEY *, int) = NULL;
+#else
+static const int Cryptography_HAS_EVP_PKEY_set_alias_type = 1;
+#endif
 
 #if CRYPTOGRAPHY_IS_LIBRESSL || defined(OPENSSL_NO_SCRYPT)
 static const long Cryptography_HAS_SCRYPT = 0;

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -42,6 +42,12 @@ def cryptography_has_tls_st() -> typing.List[str]:
     ]
 
 
+def cryptography_has_evp_pkey_set_alias_type() -> typing.List[str]:
+    return [
+        "EVP_PKEY_set_alias_type",
+    ]
+
+
 def cryptography_has_scrypt() -> typing.List[str]:
     return [
         "EVP_PBE_scrypt",
@@ -303,6 +309,9 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_SET_CERT_CB": cryptography_has_set_cert_cb,
     "Cryptography_HAS_SSL_ST": cryptography_has_ssl_st,
     "Cryptography_HAS_TLS_ST": cryptography_has_tls_st,
+    "Cryptography_HAS_EVP_PKEY_set_alias_type": (
+        cryptography_has_evp_pkey_set_alias_type
+    ),
     "Cryptography_HAS_SCRYPT": cryptography_has_scrypt,
     "Cryptography_HAS_EVP_PKEY_DHX": cryptography_has_evp_pkey_dhx,
     "Cryptography_HAS_MEM_FUNCTIONS": cryptography_has_mem_functions,


### PR DESCRIPTION
In openssl 1.1.1 docs/man3/EVP_PKEY_set1_RSA.pod
(https://github.com/openssl/openssl/blob/OpenSSL_1_1_1/doc/man3/EVP_PKEY_set1_RSA.pod) The EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2) API is possible to convert it to using SM2 algorithms After loading an ECC key.

So the EVP_PKEY_set_alias_type API is important for people who want to use cryptography with using SM2 algorithms. Therefore, we need to export EVP_PKEY_set_alias_type in FUNCTIONS.

Fixes: #7934 
Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>