### PR TITLE
Replace deprecated `abstractproperty`

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -28,7 +28,8 @@ DSAParametersWithNumbers = DSAParameters
 
 
 class DSAPrivateKey(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         The bit length of the prime modulus.
@@ -78,7 +79,8 @@ DSAPrivateKeyWithSerialization = DSAPrivateKey
 
 
 class DSAPublicKey(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         The bit length of the prime modulus.

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -35,13 +35,15 @@ class EllipticCurveOID:
 
 
 class EllipticCurve(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self) -> str:
         """
         The name of the curve. e.g. secp256r1.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         Bit size of a secret scalar for the curve.
@@ -49,7 +51,8 @@ class EllipticCurve(metaclass=abc.ABCMeta):
 
 
 class EllipticCurveSignatureAlgorithm(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def algorithm(
         self,
     ) -> typing.Union[asym_utils.Prehashed, hashes.HashAlgorithm]:
@@ -74,13 +77,15 @@ class EllipticCurvePrivateKey(metaclass=abc.ABCMeta):
         The EllipticCurvePublicKey for this private key.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def curve(self) -> EllipticCurve:
         """
         The EllipticCurve that this key is on.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         Bit size of a secret scalar for the curve.
@@ -118,13 +123,15 @@ EllipticCurvePrivateKeyWithSerialization = EllipticCurvePrivateKey
 
 
 class EllipticCurvePublicKey(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def curve(self) -> EllipticCurve:
         """
         The EllipticCurve that this key is on.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         Bit size of a secret scalar for the curve.

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -19,7 +19,8 @@ class RSAPrivateKey(metaclass=abc.ABCMeta):
         Decrypts the provided ciphertext.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         The bit length of the public modulus.
@@ -70,7 +71,8 @@ class RSAPublicKey(metaclass=abc.ABCMeta):
         Encrypts the given plaintext.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         The bit length of the public modulus.

--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -60,7 +60,8 @@ class AEADDecryptionContext(AEADCipherContext, metaclass=abc.ABCMeta):
 
 
 class AEADEncryptionContext(AEADCipherContext, metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def tag(self) -> bytes:
         """
         Returns tag bytes. This is only available after encryption is

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -16,7 +16,8 @@ from cryptography.hazmat.primitives.ciphers import algorithms
 
 
 class Mode(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self) -> str:
         """
         A string naming this mode (e.g. "ECB", "CBC").
@@ -31,7 +32,8 @@ class Mode(metaclass=abc.ABCMeta):
 
 
 class ModeWithInitializationVector(Mode, metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def initialization_vector(self) -> bytes:
         """
         The value of the initialization vector for this mode as bytes.
@@ -39,7 +41,8 @@ class ModeWithInitializationVector(Mode, metaclass=abc.ABCMeta):
 
 
 class ModeWithTweak(Mode, metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def tweak(self) -> bytes:
         """
         The value of the tweak for this mode as bytes.
@@ -47,7 +50,8 @@ class ModeWithTweak(Mode, metaclass=abc.ABCMeta):
 
 
 class ModeWithNonce(Mode, metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def nonce(self) -> bytes:
         """
         The value of the nonce for this mode as bytes.
@@ -55,7 +59,8 @@ class ModeWithNonce(Mode, metaclass=abc.ABCMeta):
 
 
 class ModeWithAuthenticationTag(Mode, metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def tag(self) -> typing.Optional[bytes]:
         """
         The value of the tag supplied to the constructor of this mode.

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -153,13 +153,15 @@ class Certificate(metaclass=abc.ABCMeta):
         Returns bytes using digest passed.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def serial_number(self) -> int:
         """
         Returns certificate serial number
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def version(self) -> Version:
         """
         Returns the certificate version
@@ -171,31 +173,36 @@ class Certificate(metaclass=abc.ABCMeta):
         Returns the public key
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def not_valid_before(self) -> datetime.datetime:
         """
         Not before time (represented as UTC datetime)
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def not_valid_after(self) -> datetime.datetime:
         """
         Not after time (represented as UTC datetime)
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def issuer(self) -> Name:
         """
         Returns the issuer name object.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def subject(self) -> Name:
         """
         Returns the subject name object.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_hash_algorithm(
         self,
     ) -> typing.Optional[hashes.HashAlgorithm]:
@@ -204,31 +211,36 @@ class Certificate(metaclass=abc.ABCMeta):
         in the certificate.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_algorithm_oid(self) -> ObjectIdentifier:
         """
         Returns the ObjectIdentifier of the signature algorithm.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def extensions(self) -> Extensions:
         """
         Returns an Extensions object.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature(self) -> bytes:
         """
         Returns the signature bytes.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def tbs_certificate_bytes(self) -> bytes:
         """
         Returns the tbsCertificate payload bytes as defined in RFC 5280.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def tbs_precertificate_bytes(self) -> bytes:
         """
         Returns the tbsCertificate payload bytes with the SCT list extension
@@ -259,19 +271,22 @@ Certificate.register(rust_x509.Certificate)
 
 
 class RevokedCertificate(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def serial_number(self) -> int:
         """
         Returns the serial number of the revoked certificate.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def revocation_date(self) -> datetime.datetime:
         """
         Returns the date of when this certificate was revoked.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def extensions(self) -> Extensions:
         """
         Returns an Extensions object containing a list of Revoked extensions.
@@ -328,7 +343,8 @@ class CertificateRevocationList(metaclass=abc.ABCMeta):
         is not in the CRL.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_hash_algorithm(
         self,
     ) -> typing.Optional[hashes.HashAlgorithm]:
@@ -337,43 +353,50 @@ class CertificateRevocationList(metaclass=abc.ABCMeta):
         in the certificate.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_algorithm_oid(self) -> ObjectIdentifier:
         """
         Returns the ObjectIdentifier of the signature algorithm.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def issuer(self) -> Name:
         """
         Returns the X509Name with the issuer of this CRL.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def next_update(self) -> typing.Optional[datetime.datetime]:
         """
         Returns the date of next update for this CRL.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def last_update(self) -> datetime.datetime:
         """
         Returns the date of last update for this CRL.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def extensions(self) -> Extensions:
         """
         Returns an Extensions object containing a list of CRL extensions.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature(self) -> bytes:
         """
         Returns the signature bytes.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def tbs_certlist_bytes(self) -> bytes:
         """
         Returns the tbsCertList payload bytes as defined in RFC 5280.
@@ -444,13 +467,15 @@ class CertificateSigningRequest(metaclass=abc.ABCMeta):
         Returns the public key
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def subject(self) -> Name:
         """
         Returns the subject name object.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_hash_algorithm(
         self,
     ) -> typing.Optional[hashes.HashAlgorithm]:
@@ -459,19 +484,22 @@ class CertificateSigningRequest(metaclass=abc.ABCMeta):
         in the certificate.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_algorithm_oid(self) -> ObjectIdentifier:
         """
         Returns the ObjectIdentifier of the signature algorithm.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def extensions(self) -> Extensions:
         """
         Returns the extensions in the signing request.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def attributes(self) -> Attributes:
         """
         Returns an Attributes object.
@@ -483,20 +511,23 @@ class CertificateSigningRequest(metaclass=abc.ABCMeta):
         Encodes the request to PEM or DER format.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature(self) -> bytes:
         """
         Returns the signature bytes.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def tbs_certrequest_bytes(self) -> bytes:
         """
         Returns the PKCS#10 CertificationRequestInfo bytes as defined in RFC
         2986.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def is_signature_valid(self) -> bool:
         """
         Verifies signature of signing request.

--- a/src/cryptography/x509/certificate_transparency.py
+++ b/src/cryptography/x509/certificate_transparency.py
@@ -36,49 +36,57 @@ class SignatureAlgorithm(utils.Enum):
 
 
 class SignedCertificateTimestamp(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def version(self) -> Version:
         """
         Returns the SCT version.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def log_id(self) -> bytes:
         """
         Returns an identifier indicating which log this SCT is for.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def timestamp(self) -> datetime.datetime:
         """
         Returns the timestamp for this SCT.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def entry_type(self) -> LogEntryType:
         """
         Returns whether this is an SCT for a certificate or pre-certificate.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_hash_algorithm(self) -> HashAlgorithm:
         """
         Returns the hash algorithm used for the SCT's signature.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_algorithm(self) -> SignatureAlgorithm:
         """
         Returns the signing algorithm used for the SCT's signature.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature(self) -> bytes:
         """
         Returns the signature for this SCT.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def extension_bytes(self) -> bytes:
         """
         Returns the raw bytes of any extensions for this SCT.

--- a/src/cryptography/x509/general_name.py
+++ b/src/cryptography/x509/general_name.py
@@ -24,7 +24,8 @@ class UnsupportedGeneralNameType(Exception):
 
 
 class GeneralName(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def value(self) -> typing.Any:
         """
         Return the value of the object

--- a/src/cryptography/x509/ocsp.py
+++ b/src/cryptography/x509/ocsp.py
@@ -127,25 +127,29 @@ class _SingleResponse:
 
 
 class OCSPRequest(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def issuer_key_hash(self) -> bytes:
         """
         The hash of the issuer public key
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def issuer_name_hash(self) -> bytes:
         """
         The hash of the issuer name
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def hash_algorithm(self) -> hashes.HashAlgorithm:
         """
         The hash algorithm used in the issuer name and key hashes
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def serial_number(self) -> int:
         """
         The serial number of the cert whose status is being checked
@@ -157,7 +161,8 @@ class OCSPRequest(metaclass=abc.ABCMeta):
         Serializes the request to DER
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def extensions(self) -> x509.Extensions:
         """
         The list of request extensions. Not single request extensions.
@@ -165,58 +170,67 @@ class OCSPRequest(metaclass=abc.ABCMeta):
 
 
 class OCSPSingleResponse(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def certificate_status(self) -> OCSPCertStatus:
         """
         The status of the certificate (an element from the OCSPCertStatus enum)
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def revocation_time(self) -> typing.Optional[datetime.datetime]:
         """
         The date of when the certificate was revoked or None if not
         revoked.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def revocation_reason(self) -> typing.Optional[x509.ReasonFlags]:
         """
         The reason the certificate was revoked or None if not specified or
         not revoked.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def this_update(self) -> datetime.datetime:
         """
         The most recent time at which the status being indicated is known by
         the responder to have been correct
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def next_update(self) -> typing.Optional[datetime.datetime]:
         """
         The time when newer information will be available
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def issuer_key_hash(self) -> bytes:
         """
         The hash of the issuer public key
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def issuer_name_hash(self) -> bytes:
         """
         The hash of the issuer name
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def hash_algorithm(self) -> hashes.HashAlgorithm:
         """
         The hash algorithm used in the issuer name and key hashes
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def serial_number(self) -> int:
         """
         The serial number of the cert whose status is being checked
@@ -224,27 +238,31 @@ class OCSPSingleResponse(metaclass=abc.ABCMeta):
 
 
 class OCSPResponse(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def responses(self) -> typing.Iterator[OCSPSingleResponse]:
         """
         An iterator over the individual SINGLERESP structures in the
         response
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def response_status(self) -> OCSPResponseStatus:
         """
         The status of the response. This is a value from the OCSPResponseStatus
         enumeration
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_algorithm_oid(self) -> x509.ObjectIdentifier:
         """
         The ObjectIdentifier of the signature algorithm
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature_hash_algorithm(
         self,
     ) -> typing.Optional[hashes.HashAlgorithm]:
@@ -252,19 +270,22 @@ class OCSPResponse(metaclass=abc.ABCMeta):
         Returns a HashAlgorithm corresponding to the type of the digest signed
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def signature(self) -> bytes:
         """
         The signature bytes
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def tbs_response_bytes(self) -> bytes:
         """
         The tbsResponseData bytes
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def certificates(self) -> typing.List[x509.Certificate]:
         """
         A list of certificates used to help build a chain to verify the OCSP
@@ -272,88 +293,102 @@ class OCSPResponse(metaclass=abc.ABCMeta):
         certificate.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def responder_key_hash(self) -> typing.Optional[bytes]:
         """
         The responder's key hash or None
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def responder_name(self) -> typing.Optional[x509.Name]:
         """
         The responder's Name or None
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def produced_at(self) -> datetime.datetime:
         """
         The time the response was produced
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def certificate_status(self) -> OCSPCertStatus:
         """
         The status of the certificate (an element from the OCSPCertStatus enum)
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def revocation_time(self) -> typing.Optional[datetime.datetime]:
         """
         The date of when the certificate was revoked or None if not
         revoked.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def revocation_reason(self) -> typing.Optional[x509.ReasonFlags]:
         """
         The reason the certificate was revoked or None if not specified or
         not revoked.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def this_update(self) -> datetime.datetime:
         """
         The most recent time at which the status being indicated is known by
         the responder to have been correct
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def next_update(self) -> typing.Optional[datetime.datetime]:
         """
         The time when newer information will be available
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def issuer_key_hash(self) -> bytes:
         """
         The hash of the issuer public key
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def issuer_name_hash(self) -> bytes:
         """
         The hash of the issuer name
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def hash_algorithm(self) -> hashes.HashAlgorithm:
         """
         The hash algorithm used in the issuer name and key hashes
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def serial_number(self) -> int:
         """
         The serial number of the cert whose status is being checked
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def extensions(self) -> x509.Extensions:
         """
         The list of response extensions. Not single response extensions.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def single_extensions(self) -> x509.Extensions:
         """
         The list of single response extensions. Not response extensions.


### PR DESCRIPTION
Deprecated since version 3.3, see
https://docs.python.org/3/library/abc.html#abc.abstractproperty

Two lines instead of one, but it might be better to follow guidelines from the docs.