### PR TITLE
Replace more deprecated `abstractproperty`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ tests =[
 [tool.coverage.report]
 exclude_lines = [
     "@abc.abstractmethod",
-    "@abc.abstractproperty",
     "@typing.overload",
     "if typing.TYPE_CHECKING",
 ]

--- a/src/cryptography/hazmat/primitives/_asymmetric.py
+++ b/src/cryptography/hazmat/primitives/_asymmetric.py
@@ -9,7 +9,8 @@ import abc
 
 
 class AsymmetricPadding(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self) -> str:
         """
         A string naming this padding (e.g. "PSS", "PKCS1").

--- a/src/cryptography/hazmat/primitives/_cipheralgorithm.py
+++ b/src/cryptography/hazmat/primitives/_cipheralgorithm.py
@@ -10,19 +10,22 @@ import typing
 
 
 class CipherAlgorithm(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self) -> str:
         """
         A string naming this mode (e.g. "AES", "Camellia").
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_sizes(self) -> typing.FrozenSet[int]:
         """
         Valid key sizes for this algorithm in bits
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         The size of the key being used as an integer in bits (e.g. 128, 256).
@@ -32,7 +35,8 @@ class CipherAlgorithm(metaclass=abc.ABCMeta):
 class BlockCipherAlgorithm(metaclass=abc.ABCMeta):
     key: bytes
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def block_size(self) -> int:
         """
         The size of a block as an integer in bits (e.g. 64, 128).

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -170,7 +170,8 @@ DHParametersWithSerialization = DHParameters
 
 
 class DHPublicKey(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         The bit length of the prime modulus.
@@ -203,7 +204,8 @@ DHPublicKeyWithSerialization = DHPublicKey
 
 
 class DHPrivateKey(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def key_size(self) -> int:
         """
         The bit length of the prime modulus.

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -10,19 +10,22 @@ from cryptography.exceptions import AlreadyFinalized
 
 
 class HashAlgorithm(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self) -> str:
         """
         A string naming this algorithm (e.g. "sha256", "md5").
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def digest_size(self) -> int:
         """
         The size of the resulting digest in bytes.
         """
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def block_size(self) -> typing.Optional[int]:
         """
         The internal block size of the hash function, or None if the hash
@@ -31,7 +34,8 @@ class HashAlgorithm(metaclass=abc.ABCMeta):
 
 
 class HashContext(metaclass=abc.ABCMeta):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def algorithm(self) -> HashAlgorithm:
         """
         A HashAlgorithm that will be used by this context.


### PR DESCRIPTION
Follow up on https://github.com/pyca/cryptography/pull/7943 (for some reason, forgot to replace some of them).

As a side note (stated @https://github.com/jpadilla/pyjwt/pull/843#issuecomment-1366190629), I think `HashAlgorithm` implementations should use the `property` decorator, e.g.:

```python
class SHA256(HashAlgorithm):
    @property
    def name() -> str:
        return "sha256"
    ...
```

But imo another pattern should be used, as these classes are only storing data (perhaps dataclasses).