### PR TITLE
sphinx-rtd-theme constraint for docs dep

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,8 +66,8 @@ test =
     pytz
     hypothesis>=1.11.4,!=3.79.2
 docs =
-    sphinx >= 1.6.5,!=1.8.0,!=3.1.0,!=3.1.1,!=5.2.0,!=5.2.0.post0
-    sphinx_rtd_theme
+    sphinx >= 5.3.0
+    sphinx-rtd-theme>=1.1.1
 docstest =
     pyenchant >= 1.6.11
     twine >= 1.12.0


### PR DESCRIPTION
This fixes an issue where we install a newer sphinx than sphinx_rtd_theme supports, causing the pip resolver to go find an old version that declares no constraints.