### PR TITLE
Pin python dev dependencies in CI with a pip constraints file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
   - package-ecosystem: cargo
     directory: "/src/rust/"
     schedule:
@@ -11,3 +12,8 @@ updates:
     allow:
       # Also update indirect dependencies
       - dependency-type: all
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,11 +35,13 @@ jobs:
       - name: Create virtualenv (main)
         run: |
           python -m venv .venv-main
+          # TODO: add -c ./cryptography-main/ci-constraints-requirements.txt
+          # after https://github.com/pyca/cryptography/pull/7962 is merged
           .venv-main/bin/pip install -v "./cryptography-main[test]" ./cryptography-main/vectors/
       - name: Create virtualenv (PR)
         run: |
           python -m venv .venv-pr
-          .venv-pr/bin/pip install -v "./cryptography-pr[test]" ./cryptography-main/vectors/
+          .venv-pr/bin/pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt "./cryptography-pr[test]" ./cryptography-pr/vectors/
 
       - name: Run benchmarks (main)
         run: .venv-main/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-main.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           repository: "google/wycheproof"
           path: "wycheproof"
           ref: "master"
-      - run: python -m pip install tox requests coverage[toml]
+      - run: python -m pip install -c ci-constraints-requirements.txt tox requests coverage[toml]
       - name: Compute config hash and set config vars
         run: |
           DEFAULT_CONFIG_FLAGS="shared no-ssl2 no-ssl3"
@@ -175,6 +175,7 @@ jobs:
           echo "OPENSSL_FORCE_FIPS_MODE=1" >> $GITHUB_ENV
           echo "CFLAGS=-DUSE_OSRANDOM_RNG_FOR_TESTING" >> $GITHUB_ENV
         if: matrix.IMAGE.FIPS
+      - run: /venv/bin/python -m pip install -c ci-constraints-requirements.txt tox
       - run: '/venv/bin/tox -vvv -- --wycheproof-root="wycheproof"'
         env:
           TOXENV: ${{ matrix.IMAGE.TOXENV }}
@@ -234,7 +235,7 @@ jobs:
           repository: "google/wycheproof"
           path: "wycheproof"
           ref: "master"
-      - run: python -m pip install tox coverage[toml]
+      - run: python -m pip install -c ci-constraints-requirements.txt tox coverage[toml]
       - name: Tests
         run: |
             tox -vvv -r --  --color=yes --wycheproof-root=wycheproof
@@ -290,7 +291,7 @@ jobs:
           repository: "google/wycheproof"
           path: "wycheproof"
           ref: "master"
-      - run: python -m pip install tox coverage[toml]
+      - run: python -m pip install -c ci-constraints-requirements.txt tox coverage[toml]
       - name: Tests
         run: |
             tox -vvv -r --  --color=yes --wycheproof-root=wycheproof
@@ -363,7 +364,7 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
 
-      - run: python -m pip install tox requests coverage[toml]
+      - run: python -m pip install -c ci-constraints-requirements.txt tox requests coverage[toml]
 
       - uses: actions/checkout@v3.2.0
         timeout-minutes: 3
@@ -428,7 +429,7 @@ jobs:
             src/rust/target/
           key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ steps.setup-python.outputs.python-version }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
 
-      - run: python -m pip install tox requests coverage[toml]
+      - run: python -m pip install -c ci-constraints-requirements.txt "tox>3" requests coverage[toml]
       - name: Download OpenSSL
         run: |
             python .github/workflows/download_openssl.py windows openssl-${{ matrix.WINDOWS.WINDOWS }}
@@ -530,7 +531,7 @@ jobs:
         uses: actions/setup-python@v4.4.0
         with:
           python-version: 3.11
-      - run: python -m pip install -U tox
+      - run: python -m pip install -c ci-constraints-requirements.txt tox
       - run: tox -r --  --color=yes
         env:
           TOXENV: docs-linkcheck
@@ -554,7 +555,7 @@ jobs:
         uses: actions/setup-python@v4.4.0
         with:
           python-version: '3.10'
-      - run: pip install coverage[toml]
+      - run: pip install -c ci-constraints-requirements.txt coverage[toml]
         if: ${{ always() }}
       - name: Download coverage data
         if: ${{ always() }}

--- a/.github/workflows/macarm64.yml
+++ b/.github/workflows/macarm64.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup venv and install deps
         run: |
           $BIN_PATH -m venv venv
-          venv/bin/python -m pip install tox requests
+          venv/bin/python -m pip install -c ci-constraints-requirements.txt tox requests
         env:
           BIN_PATH: ${{ matrix.PYTHON.BIN_PATH }}
       - name: Download OpenSSL

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
         if: contains(matrix.PYTHON.VERSION, 'pypy')
-      - run: ${{ matrix.PYTHON.BIN_PATH }} -m pip install -U requests
+      - run: ${{ matrix.PYTHON.BIN_PATH }} -m pip install -c ci-constraints-requirements.txt -U requests
       - name: Download OpenSSL
         run: |
             ${{ matrix.PYTHON.BIN_PATH }} .github/workflows/download_openssl.py macos openssl-macos-universal2
@@ -255,7 +255,7 @@ jobs:
           toolchain: stable
           target: ${{ matrix.WINDOWS.RUST_TRIPLE }}
 
-      - run: pip install requests
+      - run: pip install -c ci-constraints-requirements.txt requests
       - name: Download OpenSSL
         run: |
             python .github/workflows/download_openssl.py windows openssl-${{ matrix.WINDOWS.WINDOWS }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,6 @@ recursive-exclude vectors *
 
 recursive-exclude .github *
 
-exclude release.py .readthedocs.yml dev-requirements.txt tox.ini mypy.ini
+exclude release.py .readthedocs.yml ci-constraints-requirements.txt tox.ini mypy.ini
 
 recursive-exclude .circleci *

--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -1,0 +1,223 @@
+# This is named ambigiously, but it's a pip constraints file, named like a
+# requirements file so dependabot will update the pins.
+# It was originally generated with;
+#    pip-compile --extra=docs --extra=docstest --extra=pep8test --extra=test --extra=test-randomorder --extra=tox --resolver=backtracking --strip-extras setup.cfg
+# and then manually massaged to remove non-dev dependencies and add version
+# specifiers to packages whose versions vary by Python version
+
+alabaster==0.7.12
+    # via sphinx
+attrs==22.2.0
+    # via
+    #   hypothesis
+    #   pytest
+babel==2.11.0
+    # via sphinx
+black==22.12.0
+    # via cryptography (setup.cfg)
+bleach==5.0.1
+    # via readme-renderer
+build==0.9.0
+    # via check-manifest
+cachetools==5.2.0
+    # via tox
+certifi==2022.12.7
+    # via requests
+chardet==5.1.0
+    # via tox
+charset-normalizer==2.1.1; python_version >= "3.7"
+    # via requests
+check-manifest==0.49
+    # via cryptography (setup.cfg)
+click==8.1.3
+    # via black
+colorama==0.4.6; python_version >= "3.7"
+    # via tox
+commonmark==0.9.1
+    # via rich
+coverage==7.0.1; python_version >= "3.7"
+    # via pytest-cov
+distlib==0.3.6
+    # via virtualenv
+docutils==0.17.1
+    # via
+    #   readme-renderer
+    #   sphinx
+    #   sphinx-rtd-theme
+exceptiongroup==1.1.0
+    # via
+    #   hypothesis
+    #   pytest
+execnet==1.9.0
+    # via pytest-xdist
+filelock==3.9.0; python_version >= "3.7"
+    # via
+    #   tox
+    #   virtualenv
+hypothesis==6.61.0; python_version >= "3.7"
+    # via cryptography (setup.cfg)
+idna==3.4
+    # via requests
+imagesize==1.4.1
+    # via sphinx
+importlib-metadata==6.0.0; python_version >= "3.7"
+    # via
+    #   keyring
+    #   twine
+iniconfig==1.1.1
+    # via pytest
+iso8601==1.1.0
+    # via cryptography (setup.cfg)
+jaraco-classes==3.2.3
+    # via keyring
+jinja2==3.1.2
+    # via sphinx
+keyring==23.13.1
+    # via twine
+markupsafe==2.1.1
+    # via jinja2
+more-itertools==9.0.0
+    # via jaraco-classes
+mypy==0.991
+    # via cryptography (setup.cfg)
+mypy-extensions==0.4.3
+    # via
+    #   black
+    #   mypy
+packaging==22.0; python_version >= "3.7"
+    # via
+    #   build
+    #   pyproject-api
+    #   pytest
+    #   sphinx
+    #   tox
+pathspec==0.10.3
+    # via black
+pep517==0.13.0
+    # via build
+pkginfo==1.9.2
+    # via twine
+platformdirs==2.6.2; python_version >= "3.7"
+    # via
+    #   black
+    #   tox
+    #   virtualenv
+pluggy==1.0.0; python_version >= "3.7"
+    # via
+    #   pytest
+    #   tox
+pretend==1.0.9
+    # via cryptography (setup.cfg)
+py-cpuinfo==9.0.0
+    # via pytest-benchmark
+pyenchant==3.2.2
+    # via
+    #   cryptography (setup.cfg)
+    #   sphinxcontrib-spelling
+pygments==2.14.0
+    # via
+    #   readme-renderer
+    #   rich
+    #   sphinx
+pyproject-api==1.2.1
+    # via tox
+pytest==7.2.0; python_version >= "3.7"
+    # via
+    #   cryptography (setup.cfg)
+    #   pytest-benchmark
+    #   pytest-cov
+    #   pytest-randomly
+    #   pytest-shard
+    #   pytest-subtests
+    #   pytest-xdist
+pytest-benchmark==4.0.0; python_version >= "3.7"
+    # via cryptography (setup.cfg)
+pytest-cov==4.0.0
+    # via cryptography (setup.cfg)
+pytest-randomly==3.12.0
+    # via cryptography (setup.cfg)
+pytest-shard==0.1.2
+    # via cryptography (setup.cfg)
+pytest-subtests==0.9.0; python_version >= "3.7"
+    # via cryptography (setup.cfg)
+pytest-xdist==3.1.0; python_version >= "3.7"
+    # via cryptography (setup.cfg)
+pytz==2022.7
+    # via
+    #   babel
+    #   cryptography (setup.cfg)
+readme-renderer==37.3
+    # via twine
+requests==2.28.1; python_version >= "3.7"
+    # via
+    #   requests-toolbelt
+    #   sphinx
+    #   twine
+requests-toolbelt==0.10.1
+    # via twine
+rfc3986==2.0.0
+    # via twine
+rich==13.0.0
+    # via twine
+ruff==0.0.206
+    # via cryptography (setup.cfg)
+six==1.16.0
+    # via bleach
+snowballstemmer==2.2.0
+    # via sphinx
+sortedcontainers==2.4.0
+    # via hypothesis
+sphinx==5.3.0
+    # via
+    #   cryptography (setup.cfg)
+    #   sphinx-rtd-theme
+    #   sphinxcontrib-spelling
+sphinx-rtd-theme==1.1.1
+    # via cryptography (setup.cfg)
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==2.0.0
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.5
+    # via sphinx
+sphinxcontrib-spelling==7.7.0
+    # via cryptography (setup.cfg)
+tomli==2.0.1
+    # via
+    #   black
+    #   build
+    #   check-manifest
+    #   coverage
+    #   mypy
+    #   pep517
+    #   pyproject-api
+    #   pytest
+    #   tox
+tox==4.1.2; python_version >= "3.7"
+    # via cryptography (setup.cfg)
+twine==4.0.2
+    # via cryptography (setup.cfg)
+types-pytz==2022.7.0.0
+    # via cryptography (setup.cfg)
+types-requests==2.28.11.7
+    # via cryptography (setup.cfg)
+types-urllib3==1.26.25.4
+    # via types-requests
+typing-extensions==4.4.0; python_version >= "3.7"
+    # via mypy
+urllib3==1.26.13
+    # via
+    #   requests
+    #   twine
+virtualenv==20.17.1
+    # via tox
+webencodings==0.5.1
+    # via bleach
+zipp==3.11.0; python_version >= "3.7"
+    # via importlib-metadata

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,0 @@
-click
-tox >= 2.4.1
-twine >= 1.8.0
--e .[test,docs,docstest,pep8test]
--e vectors

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -3,37 +3,26 @@ Getting started
 
 Development dependencies
 ------------------------
+
 Working on ``cryptography`` requires the installation of a small number of
 development dependencies in addition to the dependencies for
-:doc:`/installation`. These are listed in ``dev-requirements.txt`` and they can
-be installed in a `virtualenv`_ using `pip`_. Before you install them, follow
-the **build** instructions in :doc:`/installation` (be sure to stop before
-actually installing ``cryptography``). Once you've done that, install the
-development dependencies, and then install ``cryptography`` in ``editable``
-mode. For example:
+:doc:`/installation`. These are handled by the use of ``tox``, which can be
+installed with ``pip``.
 
 .. code-block:: console
 
     $ # Create a virtualenv and activate it
     $ # Set up your cryptography build environment
-    $ pip install --requirement dev-requirements.txt
-    $ pip install --editable .
-
-Make sure that ``pip install --requirement ...`` has installed the Python
-package ``vectors/`` and packages on ``tests/`` . If it didn't, you may
-install them manually by using ``pip`` on each directory.
-
-You will also need to install ``enchant`` using your system's package manager
-to check spelling in the documentation.
-
-You are now ready to run the tests and build the documentation.
+    $ pip install tox
+    $ # Specify your Python version here.
+    $ tox -e py310
 
 OpenSSL on macOS
 ~~~~~~~~~~~~~~~~
 
 You must have installed `OpenSSL`_ via `Homebrew`_ or `MacPorts`_ and must set
-``CFLAGS`` and ``LDFLAGS`` environment variables before installing the
-``dev-requirements.txt`` otherwise pip will fail with include errors.
+``CFLAGS`` and ``LDFLAGS`` environment variables before running ``tox``
+otherwise pip will fail with include errors.
 
 For example, with `Homebrew`_:
 
@@ -41,7 +30,7 @@ For example, with `Homebrew`_:
 
     $ env LDFLAGS="-L$(brew --prefix openssl@1.1)/lib" \
         CFLAGS="-I$(brew --prefix openssl@1.1)/include" \
-        pip install --requirement ./dev-requirements.txt
+        tox -e py310
 
 Alternatively for a static build you can specify
 ``CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS=1`` and ensure ``LDFLAGS`` points to the
@@ -54,20 +43,16 @@ Running tests
 -------------
 
 ``cryptography`` unit tests are found in the ``tests/`` directory and are
-designed to be run using `pytest`_. `pytest`_ will discover the tests
-automatically, so all you have to do is:
+designed to be run using `pytest`_. ``tox`` automatically invokes ``pytest``:
 
 .. code-block:: console
 
-    $ pytest
+    $ tox -e py310
     ...
     62746 passed in 220.43 seconds
 
-This runs the tests with the default Python interpreter.
-
-You can also verify that the tests pass on other supported Python interpreters.
-For this we use `tox`_, which will automatically create a `virtualenv`_ for
-each supported Python version and run the tests. For example:
+You can also verify that the tests pass on other supported Python interpreters
+with ``tox``. For example:
 
 .. code-block:: console
 
@@ -75,6 +60,9 @@ each supported Python version and run the tests. For example:
     ...
     ERROR:   pypy: InterpreterNotFound: pypy
      py38: commands succeeded
+     py39: commands succeeded
+     py310: commands succeeded
+     py311: commands succeeded
      docs: commands succeeded
      pep8: commands succeeded
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,11 @@ exclude =
     _cffi_src.*
 
 [options.extras_require]
+tox =
+    tox
 test =
     pytest>=6.2.0
+    pytest-shard>=0.1.2
     pytest-benchmark
     pytest-cov
     pytest-subtests
@@ -65,6 +68,8 @@ test =
     iso8601
     pytz
     hypothesis>=1.11.4,!=3.79.2
+test-randomorder:
+    pytest-randomly
 docs =
     sphinx >= 5.3.0
     sphinx-rtd-theme>=1.1.1
@@ -77,6 +82,10 @@ sdist =
 pep8test =
     black
     ruff
+    mypy
+    types-pytz
+    types-requests
+    check-manifest
 # This extra is for OpenSSH private keys that use bcrypt KDF
 # Versions: v3.1.3 - ignore_few_rounds, v3.1.5 - abi3
 ssh =

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,9 @@ isolated_build = True
 extras =
     test
     ssh: ssh
+    randomorder: test-randomorder
 deps =
     -e ./vectors
-    pytest-shard>=0.1.2
-    randomorder: pytest-randomly
 passenv =
     ARCHFLAGS
     LDFLAGS
@@ -26,6 +25,8 @@ passenv =
     CRYPTOGRAPHY_OPENSSL_NO_LEGACY
     OPENSSL_ENABLE_SHA1_SIGNATURES
     CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS
+setenv =
+    PIP_CONSTRAINT=ci-constraints-requirements.txt
 commands =
     pip list
     !nocoverage: pytest -n auto --cov=cryptography --cov=tests --durations=10 {posargs} tests/
@@ -59,11 +60,6 @@ extras =
     pep8test
     test
     ssh
-deps =
-    mypy
-    types-pytz
-    types-requests
-    check-manifest
 commands =
     ruff .
     black --check .


### PR DESCRIPTION
follow ups:
- [ ] fix TODO in benchmark.yml
- [ ] Don't pre-install tox in the docker contains
- [ ] add a TODO item on the drop py36 issue to remove the version branches