### PR TITLE
Increase PR limits for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1024
 
   - package-ecosystem: cargo
     directory: "/src/rust/"
@@ -12,8 +13,10 @@ updates:
     allow:
       # Also update indirect dependencies
       - dependency-type: all
+    open-pull-requests-limit: 1024
 
   - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: daily
+    open-pull-requests-limit: 1024


### PR DESCRIPTION
There's limited value in dragging them out.