### PR TITLE
Add Certificate.verify_signed_by

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Changelog
   continues to support only public keys.
 * Added support for generating SSH certificates with
   :class:`~cryptography.hazmat.primitives.serialization.SSHCertificateBuilder`.
-* Added :meth:`~cryptography.x509.Certificate.verify_signed_by` to
+* Added :meth:`~cryptography.x509.Certificate.verify_issued_by` to
   :class:`~cryptography.x509.Certificate`.
 
 .. _v39-0-0:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Changelog
   continues to support only public keys.
 * Added support for generating SSH certificates with
   :class:`~cryptography.hazmat.primitives.serialization.SSHCertificateBuilder`.
+* Added :meth:`~cryptography.x509.Certificate.verify_signed_by` to
+  :class:`~cryptography.x509.Certificate`.
 
 .. _v39-0-0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Changelog
   continues to support only public keys.
 * Added support for generating SSH certificates with
   :class:`~cryptography.hazmat.primitives.serialization.SSHCertificateBuilder`.
-* Added :meth:`~cryptography.x509.Certificate.verify_issued_by` to
+* Added :meth:`~cryptography.x509.Certificate.verify_directly_issued_by` to
   :class:`~cryptography.x509.Certificate`.
 
 .. _v39-0-0:

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -486,7 +486,7 @@ X.509 Certificate Object
        An :class:`~cryptography.exceptions.InvalidSignature` exception will be
        raised if the signature fails to verify.
 
-    .. method:: verify_issued_by(issuer)
+    .. method:: verify_directly_issued_by(issuer)
 
         .. versionadded:: 40.0
 
@@ -494,12 +494,13 @@ X.509 Certificate Object
         :type issuer: :class:`~cryptography.x509.Certificate`
 
         .. warning::
-            This method verifies that certificate issuer name matches the
+            This method verifies that the certificate issuer name matches the
             issuer subject name and that the certificate is signed by the
             issuer's private key. **No other validation is performed.**
             Callers are responsible for performing any additional
             validations required for their use case (e.g. checking the validity
-            period, whether the signer is allowed to issue certificates, etc).
+            period, whether the signer is allowed to issue certificates,
+            that the issuing certificate has a strong public key, etc).
 
         Validates that the certificate is signed by the provided issuer and
         that the issuer's subject name matches the issuer name of the

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -508,9 +508,10 @@ X.509 Certificate Object
 
         :return: None
         :raise ValueError: If the issuer name on the certificate does
-            not match the subject name of the issuer.
-        :raise cryptography.exceptions.UnsupportedAlgorithm: If the
-            signature algorithm is unsupported.
+            not match the subject name of the issuer or the signature
+            algorithm is unsupported.
+        :raise TypeError: If the issuer does not have a supported public
+            key type.
         :raise cryptography.exceptions.InvalidSignature: If the
             signature fails to verify.
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -486,6 +486,26 @@ X.509 Certificate Object
        An :class:`~cryptography.exceptions.InvalidSignature` exception will be
        raised if the signature fails to verify.
 
+    .. method:: verify_signed_by(issuer)
+
+        .. versionadded:: 40.0
+
+        :param issuer: The issuer certificate to check against.
+        :type issuer: :class:`~cryptography.x509.Certificate`
+
+        .. warning::
+            This method **only** verifies that the certificate is signed by the
+            issuer certificate's private key. **No other validation is
+            performed**. Callers are responsible for performing any additional
+            validations required for their use case (e.g. checking the validity
+            period, whether the signer is allowed to issue certificates, etc).
+
+        Validates that the certificate is signed by the provided issuer.
+
+        :return: None
+        :raise cryptography.exceptions.InvalidSignature: If the
+            signature fails to verify.
+
 
     .. attribute:: tbs_precertificate_bytes
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -486,7 +486,7 @@ X.509 Certificate Object
        An :class:`~cryptography.exceptions.InvalidSignature` exception will be
        raised if the signature fails to verify.
 
-    .. method:: verify_signed_by(issuer)
+    .. method:: verify_issued_by(issuer)
 
         .. versionadded:: 40.0
 
@@ -494,15 +494,20 @@ X.509 Certificate Object
         :type issuer: :class:`~cryptography.x509.Certificate`
 
         .. warning::
-            This method **only** verifies that the certificate is signed by the
-            issuer certificate's private key. **No other validation is
-            performed**. Callers are responsible for performing any additional
+            This method verifies that certificate issuer name matches the
+            issuer subject name and that the certificate is signed by the
+            issuer's private key. **No other validation is performed.**
+            Callers are responsible for performing any additional
             validations required for their use case (e.g. checking the validity
             period, whether the signer is allowed to issue certificates, etc).
 
-        Validates that the certificate is signed by the provided issuer.
+        Validates that the certificate is signed by the provided issuer and
+        that the issuer's subject name matches the issuer name of the
+        certificate.
 
         :return: None
+        :raise ValueError: If the issuer name on the certificate does
+            not match the subject name of the issuer.
         :raise cryptography.exceptions.InvalidSignature: If the
             signature fails to verify.
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -508,6 +508,8 @@ X.509 Certificate Object
         :return: None
         :raise ValueError: If the issuer name on the certificate does
             not match the subject name of the issuer.
+        :raise cryptography.exceptions.UnsupportedAlgorithm: If the
+            signature algorithm is unsupported.
         :raise cryptography.exceptions.InvalidSignature: If the
             signature fails to verify.
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -266,9 +266,10 @@ class Certificate(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def verify_signed_by(self, issuer: "Certificate") -> None:
+    def verify_issued_by(self, issuer: "Certificate") -> None:
         """
-        This method **only** verifies that the certificate is signed by the
+        This method verifies that certificate issuer name matches the
+        issuer subject name and that the certificate is signed by the
         issuer's private key. No other validation is performed.
         """
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -265,6 +265,13 @@ class Certificate(metaclass=abc.ABCMeta):
         Serializes the certificate to PEM or DER format.
         """
 
+    @abc.abstractmethod
+    def verify_signed_by(self, issuer: "Certificate") -> None:
+        """
+        This method **only** verifies that the certificate is signed by the
+        issuer's private key. No other validation is performed.
+        """
+
 
 # Runtime isinstance checks need this since the rust class is not a subclass.
 Certificate.register(rust_x509.Certificate)

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -266,7 +266,7 @@ class Certificate(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def verify_issued_by(self, issuer: "Certificate") -> None:
+    def verify_directly_issued_by(self, issuer: "Certificate") -> None:
         """
         This method verifies that certificate issuer name matches the
         issuer subject name and that the certificate is signed by the

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -339,7 +339,7 @@ impl Certificate {
             public_key,
             signature_oid,
             signature_hash,
-            &self.raw.borrow_value().signature.as_bytes(),
+            self.raw.borrow_value().signature.as_bytes(),
             &tbs_bytes,
         )
     }

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -7,7 +7,7 @@ use crate::asn1::{
     PyAsn1Error, PyAsn1Result,
 };
 use crate::x509;
-use crate::x509::{crl, extensions, oid, sct, Asn1ReadableOrWritable};
+use crate::x509::{crl, extensions, oid, sct, sign, Asn1ReadableOrWritable};
 use chrono::Datelike;
 use pyo3::ToPyObject;
 use std::collections::hash_map::DefaultHasher;
@@ -318,6 +318,98 @@ impl Certificate {
                 _ => parse_cert_ext(py, oid.clone(), ext_data),
             },
         )
+    }
+
+    fn verify_signed_by<'p>(
+        &self,
+        py: pyo3::Python<'p>,
+        issuer: pyo3::PyRef<'_, Certificate>,
+    ) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let public_key = issuer.public_key(py)?;
+        let key_type = identify_public_key_type(py, public_key)?;
+        let hash_alg = self.signature_hash_algorithm(py)?;
+        match key_type {
+            sign::KeyType::Ed25519 | sign::KeyType::Ed448 => public_key.call_method1(
+                "verify",
+                (self.signature(py), self.tbs_certificate_bytes(py)?),
+            ),
+            sign::KeyType::Ec => {
+                let ec_mod = py.import("cryptography.hazmat.primitives.asymmetric.ec")?;
+                let ecdsa = ec_mod
+                    .getattr(crate::intern!(py, "ECDSA"))?
+                    .call1((hash_alg,))?;
+                public_key.call_method1(
+                    "verify",
+                    (self.signature(py), self.tbs_certificate_bytes(py)?, ecdsa),
+                )
+            }
+            sign::KeyType::Rsa => {
+                let padding_mod = py.import("cryptography.hazmat.primitives.asymmetric.padding")?;
+                let pkcs1v15 = padding_mod
+                    .getattr(crate::intern!(py, "PKCS1v15"))?
+                    .call0()?;
+                public_key.call_method1(
+                    "verify",
+                    (
+                        self.signature(py),
+                        self.tbs_certificate_bytes(py)?,
+                        pkcs1v15,
+                        hash_alg,
+                    ),
+                )
+            }
+            sign::KeyType::Dsa => public_key.call_method1(
+                "verify",
+                (
+                    self.signature(py),
+                    self.tbs_certificate_bytes(py)?,
+                    hash_alg,
+                ),
+            ),
+        }?;
+        Ok(py.None().into_ref(py))
+    }
+}
+
+fn identify_public_key_type(
+    py: pyo3::Python<'_>,
+    public_key: &pyo3::PyAny,
+) -> pyo3::PyResult<sign::KeyType> {
+    let rsa_key_type: &pyo3::types::PyType = py
+        .import("cryptography.hazmat.primitives.asymmetric.rsa")?
+        .getattr(crate::intern!(py, "RSAPublicKey"))?
+        .extract()?;
+    let dsa_key_type: &pyo3::types::PyType = py
+        .import("cryptography.hazmat.primitives.asymmetric.dsa")?
+        .getattr(crate::intern!(py, "DSAPublicKey"))?
+        .extract()?;
+    let ec_key_type: &pyo3::types::PyType = py
+        .import("cryptography.hazmat.primitives.asymmetric.ec")?
+        .getattr(crate::intern!(py, "EllipticCurvePublicKey"))?
+        .extract()?;
+    let ed25519_key_type: &pyo3::types::PyType = py
+        .import("cryptography.hazmat.primitives.asymmetric.ed25519")?
+        .getattr(crate::intern!(py, "Ed25519PublicKey"))?
+        .extract()?;
+    let ed448_key_type: &pyo3::types::PyType = py
+        .import("cryptography.hazmat.primitives.asymmetric.ed448")?
+        .getattr(crate::intern!(py, "Ed448PublicKey"))?
+        .extract()?;
+
+    if rsa_key_type.is_instance(public_key)? {
+        Ok(sign::KeyType::Rsa)
+    } else if dsa_key_type.is_instance(public_key)? {
+        Ok(sign::KeyType::Dsa)
+    } else if ec_key_type.is_instance(public_key)? {
+        Ok(sign::KeyType::Ec)
+    } else if ed25519_key_type.is_instance(public_key)? {
+        Ok(sign::KeyType::Ed25519)
+    } else if ed448_key_type.is_instance(public_key)? {
+        Ok(sign::KeyType::Ed448)
+    } else {
+        Err(pyo3::exceptions::PyTypeError::new_err(
+            "Key must be an rsa, dsa, ec, ed25519, or ed448 public key.",
+        ))
     }
 }
 

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -505,14 +505,14 @@ mod tests {
     #[test]
     fn test_py_hash_from_hash_type() {
         for item in [
-            (HashType::Sha224, "sha224"),
-            (HashType::Sha256, "sha256"),
-            (HashType::Sha384, "sha384"),
-            (HashType::Sha512, "sha512"),
-            (HashType::Sha3_224, "sha3-224"),
-            (HashType::Sha3_256, "sha3-256"),
-            (HashType::Sha3_384, "sha3-384"),
-            (HashType::Sha3_512, "sha3-512"),
+            (HashType::Sha224, "SHA224"),
+            (HashType::Sha256, "SHA256"),
+            (HashType::Sha384, "SHA384"),
+            (HashType::Sha512, "SHA512"),
+            (HashType::Sha3_224, "SHA3_224"),
+            (HashType::Sha3_256, "SHA3_256"),
+            (HashType::Sha3_384, "SHA3_384"),
+            (HashType::Sha3_512, "SHA3_512"),
         ] {
             let hash = item.0;
             let name = item.1;

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -14,7 +14,7 @@ static NULL_DER: Lazy<Vec<u8>> = Lazy::new(|| {
 pub(crate) static NULL_TLV: Lazy<asn1::Tlv<'static>> =
     Lazy::new(|| asn1::parse_single(&NULL_DER).unwrap());
 
-enum KeyType {
+pub(crate) enum KeyType {
     Rsa,
     Dsa,
     Ec,

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -288,9 +288,9 @@ pub(crate) fn verify_signature_with_oid<'p>(
             "Signature algorithm does not match issuer key type",
         )));
     }
-    let sig_hash_str = py_hash_name_from_hash_type(sig_hash_type);
+    let sig_hash_name = py_hash_name_from_hash_type(sig_hash_type);
     let hashes = py.import("cryptography.hazmat.primitives.hashes")?;
-    let signature_hash = match sig_hash_str {
+    let signature_hash = match sig_hash_name {
         Some(data) => hashes.getattr(data)?.call0()?,
         None => py.None().into_ref(py),
     };

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -15,7 +15,7 @@ static NULL_DER: Lazy<Vec<u8>> = Lazy::new(|| {
 pub(crate) static NULL_TLV: Lazy<asn1::Tlv<'static>> =
     Lazy::new(|| asn1::parse_single(&NULL_DER).unwrap());
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 enum KeyType {
     Rsa,
     Dsa,
@@ -370,4 +370,30 @@ fn identify_key_type_for_oid(oid: &asn1::ObjectIdentifier) -> pyo3::PyResult<Key
             "Unsupported signature algorithm",
         )),
     }
+}
+
+#[test]
+fn test_identify_unknown_key_type_for_oid() {
+    // The non-error cases are tested through the Python path but more is more
+    assert_eq!(
+        identify_key_type_for_oid(&oid::RSA_WITH_SHA256_OID).unwrap(),
+        KeyType::Rsa
+    );
+    assert_eq!(
+        identify_key_type_for_oid(&oid::ECDSA_WITH_SHA256_OID).unwrap(),
+        KeyType::Ec
+    );
+    assert_eq!(
+        identify_key_type_for_oid(&oid::ED25519_OID).unwrap(),
+        KeyType::Ed25519
+    );
+    assert_eq!(
+        identify_key_type_for_oid(&oid::ED448_OID).unwrap(),
+        KeyType::Ed448
+    );
+    assert_eq!(
+        identify_key_type_for_oid(&oid::DSA_WITH_SHA256_OID).unwrap(),
+        KeyType::Dsa
+    );
+    assert!(identify_key_type_for_oid(&oid::TLS_FEATURE_OID).is_err());
 }

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -15,7 +15,6 @@ import pytest
 import pytz
 
 from cryptography import utils, x509
-from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.bindings._rust import asn1
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import (
@@ -1604,7 +1603,7 @@ class TestRSACertificate:
         )
         leaf = builder.sign(private_key, None)
 
-        with pytest.raises(UnsupportedAlgorithm):
+        with pytest.raises(TypeError):
             cert.verify_directly_issued_by(leaf)
 
 

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -83,8 +83,8 @@ def _load_cert(filename, loader: typing.Callable[..., T], backend=None) -> T:
 
 
 def _generate_ca_and_leaf(
-    issuer_private_key: types.PRIVATE_KEY_TYPES,
-    subject_private_key: types.PRIVATE_KEY_TYPES,
+    issuer_private_key: types.CERTIFICATE_PRIVATE_KEY_TYPES,
+    subject_private_key: types.CERTIFICATE_PRIVATE_KEY_TYPES,
 ):
     if isinstance(
         issuer_private_key,

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -1545,7 +1545,15 @@ class TestRSACertificate:
         with pytest.raises(ValueError):
             cert.verify_issued_by(ca2)
 
-    def test_verify_issued_by_unsupported_algorithm(self):
+    @pytest.mark.supported(
+        only_if=lambda backend: (
+            not backend._lib.CRYPTOGRAPHY_IS_LIBRESSL
+            and not backend._lib.CRYPTOGRAPHY_IS_BORINGSSL
+            and not backend._lib.CRYPTOGRAPHY_OPENSSL_LESS_THAN_111E
+        ),
+        skip_message="Does not support RSA PSS loading",
+    )
+    def test_verify_issued_by_unsupported_algorithm(self, backend):
         cert = _load_cert(
             os.path.join("x509", "custom", "rsa_pss_cert.pem"),
             x509.load_pem_x509_certificate,


### PR DESCRIPTION
Verify that the signature on a certificate was created by the private key belonging to another certificate's public key.

This code does not validate anything else! It is not a path builder, general x509 validator, etc.