### PR TITLE
remove the last vestiges of sha1 out of pkcs7

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -88,7 +88,6 @@ class PKCS7SignatureBuilder:
         if not isinstance(
             hash_algorithm,
             (
-                hashes.SHA1,
                 hashes.SHA224,
                 hashes.SHA256,
                 hashes.SHA384,
@@ -96,7 +95,7 @@ class PKCS7SignatureBuilder:
             ),
         ):
             raise TypeError(
-                "hash_algorithm must be one of hashes.SHA1, SHA224, "
+                "hash_algorithm must be one of hashes.SHA224, "
                 "SHA256, SHA384, or SHA512"
             )
         if not isinstance(certificate, x509.Certificate):

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -32,7 +32,6 @@ static EMPTY_STRING_TLV: Lazy<asn1::Tlv<'static>> =
 
 static OIDS_TO_MIC_NAME: Lazy<HashMap<&asn1::ObjectIdentifier, &str>> = Lazy::new(|| {
     let mut h = HashMap::new();
-    h.insert(&x509::oid::SHA1_OID, "sha1");
     h.insert(&x509::oid::SHA224_OID, "sha-224");
     h.insert(&x509::oid::SHA256_OID, "sha-256");
     h.insert(&x509::oid::SHA384_OID, "sha-384");


### PR DESCRIPTION
we already didn't support signing (released in 39.0)