### PR TITLE
Add constants for allowed PKCS12 and OpenSSH key types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,12 @@ Changelog
   :class:`~cryptography.hazmat.primitives.serialization.SSHCertificateBuilder`.
 * Added :meth:`~cryptography.x509.Certificate.verify_directly_issued_by` to
   :class:`~cryptography.x509.Certificate`.
+* Added constants
+  :const:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12_KEY_TYPES_TUPLE`,
+  :const:`~cryptography.hazmat.primitives.serialization.ssh.SSH_PRIVATE_KEY_TYPES_TUPLE`,
+  :const:`~cryptography.hazmat.primitives.serialization.ssh.SSH_PUBLIC_KEY_TYPES_TUPLE`
+  to check whether a key type is supported by the serialization format.
+
 
 .. _v39-0-0:
 

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -388,6 +388,20 @@ DSA keys look almost identical but begin with ``ssh-dss`` rather than
 ``ssh-rsa``. ECDSA keys have a slightly different format, they begin with
 ``ecdsa-sha2-{curve}``.
 
+.. currentmodule:: cryptography.hazmat.primitives.serialization.ssh
+
+.. data:: SSH_PUBLIC_KEY_TYPES_TUPLE
+
+    .. versionadded::  40.0
+
+    Tuple of public key types that can be serialized in OpenSSH format.
+    To check whether a public key is allowed, use::
+
+        if isinstance(public_key, SSH_PUBLIC_KEY_TYPES_TUPLE):
+
+
+.. currentmodule:: cryptography.hazmat.primitives.serialization
+
 .. function:: load_ssh_public_key(data)
 
     .. versionadded:: 0.7
@@ -435,6 +449,21 @@ An example ECDSA key in OpenSSH format::
     MAAAAga/VGV2asRlL3kXXao0aochQ59nXHA2xEGeAoQd952r0AAAAJbWFya29AdmZmAQID
     BAUGBw==
     -----END OPENSSH PRIVATE KEY-----
+
+
+.. currentmodule:: cryptography.hazmat.primitives.serialization.ssh
+
+.. data:: SSH_PRIVATE_KEY_TYPES_TUPLE
+
+    .. versionadded::  40.0
+
+    Tuple of private key types that can be serialized in OpenSSH format.
+    To check whether a private key is allowed, use::
+
+        if isinstance(private_key, SSH_PRIVATE_KEY_TYPES_TUPLE):
+
+
+.. currentmodule:: cryptography.hazmat.primitives.serialization
 
 .. function:: load_ssh_private_key(data, password)
 
@@ -778,6 +807,15 @@ file suffix.
     ``cryptography`` only supports a single private key and associated
     certificates when parsing PKCS12 files at this time.
 
+.. data:: PKCS12_KEY_TYPES_TUPLE
+
+    .. versionadded::  40.0
+
+    Tuple of private key types that can be serialized with PKCS12.
+    To check whether a private key is allowed, use::
+
+        if isinstance(private_key, PKCS12_KEY_TYPES_TUPLE):
+
 .. function:: load_key_and_certificates(data, password)
 
     .. versionadded:: 2.5
@@ -848,6 +886,8 @@ file suffix.
     :type name: bytes
 
     :param key: The private key to include in the structure.
+        To check whether a private key type is supported, see
+        :const:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12_KEY_TYPES_TUPLE`.
     :type key: An
         :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`
         ,
@@ -1230,6 +1270,9 @@ Serialization Formats
             ...
             -----END OPENSSH PRIVATE KEY-----
 
+        To check whether a private key can be serialized for OpenSSH, see
+        :const:`~cryptography.hazmat.primitives.serialization.ssh.SSH_PRIVATE_KEY_TYPES_TUPLE`.
+
     .. attribute:: PKCS12
 
         .. versionadded:: 38.0.0
@@ -1321,6 +1364,9 @@ Serialization Formats
 
         The public key format used by OpenSSH (e.g. as found in
         ``~/.ssh/id_rsa.pub`` or ``~/.ssh/authorized_keys``).
+
+        To check whether a public key can be serialized for OpenSSH, see
+        :const:`~cryptography.hazmat.primitives.serialization.ssh.SSH_PUBLIC_KEY_TYPES_TUPLE`.
 
     .. attribute:: Raw
 

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -20,6 +20,7 @@ __all__ = [
     "PBES",
     "PKCS12Certificate",
     "PKCS12KeyAndCertificates",
+    "PKCS12_KEY_TYPES_TUPLE",
     "load_key_and_certificates",
     "load_pkcs12",
     "serialize_key_and_certificates",
@@ -32,6 +33,16 @@ _ALLOWED_PKCS12_TYPES = typing.Union[
     ed25519.Ed25519PrivateKey,
     ed448.Ed448PrivateKey,
 ]
+
+PKCS12_KEY_TYPES_TUPLE: typing.Tuple[
+    typing.Type[_ALLOWED_PKCS12_TYPES], ...
+] = (
+    rsa.RSAPrivateKey,
+    dsa.DSAPrivateKey,
+    ec.EllipticCurvePrivateKey,
+    ed25519.Ed25519PrivateKey,
+    ed448.Ed448PrivateKey,
+)
 
 
 class PKCS12Certificate:
@@ -80,16 +91,7 @@ class PKCS12KeyAndCertificates:
         cert: typing.Optional[PKCS12Certificate],
         additional_certs: typing.List[PKCS12Certificate],
     ):
-        if key is not None and not isinstance(
-            key,
-            (
-                rsa.RSAPrivateKey,
-                dsa.DSAPrivateKey,
-                ec.EllipticCurvePrivateKey,
-                ed25519.Ed25519PrivateKey,
-                ed448.Ed448PrivateKey,
-            ),
-        ):
+        if key is not None and not isinstance(key, PKCS12_KEY_TYPES_TUPLE):
             raise TypeError(
                 "Key must be RSA, DSA, EllipticCurve, ED25519, or ED448"
                 " private key, or None."
@@ -177,16 +179,7 @@ def serialize_key_and_certificates(
     cas: typing.Optional[typing.Iterable[_PKCS12_CAS_TYPES]],
     encryption_algorithm: serialization.KeySerializationEncryption,
 ) -> bytes:
-    if key is not None and not isinstance(
-        key,
-        (
-            rsa.RSAPrivateKey,
-            dsa.DSAPrivateKey,
-            ec.EllipticCurvePrivateKey,
-            ed25519.Ed25519PrivateKey,
-            ed448.Ed448PrivateKey,
-        ),
-    ):
+    if key is not None and not isinstance(key, PKCS12_KEY_TYPES_TUPLE):
         raise TypeError(
             "Key must be RSA, DSA, EllipticCurve, ED25519, or ED448"
             " private key, or None."

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -567,6 +567,15 @@ _SSH_PRIVATE_KEY_TYPES = typing.Union[
     ed25519.Ed25519PrivateKey,
 ]
 
+SSH_PRIVATE_KEY_TYPES_TUPLE: typing.Tuple[
+    typing.Type[_SSH_PRIVATE_KEY_TYPES], ...
+] = (
+    ec.EllipticCurvePrivateKey,
+    rsa.RSAPrivateKey,
+    dsa.DSAPrivateKey,
+    ed25519.Ed25519PrivateKey,
+)
+
 
 def load_ssh_private_key(
     data: bytes,
@@ -736,6 +745,15 @@ _SSH_PUBLIC_KEY_TYPES = typing.Union[
     dsa.DSAPublicKey,
     ed25519.Ed25519PublicKey,
 ]
+
+SSH_PUBLIC_KEY_TYPES_TUPLE: typing.Tuple[
+    typing.Type[_SSH_PUBLIC_KEY_TYPES], ...
+] = (
+    ec.EllipticCurvePublicKey,
+    rsa.RSAPublicKey,
+    dsa.DSAPublicKey,
+    ed25519.Ed25519PublicKey,
+)
 
 _SSH_CERT_PUBLIC_KEY_TYPES = typing.Union[
     ec.EllipticCurvePublicKey,


### PR DESCRIPTION
Added constants that can be used to check whether a key type is valid for PKCS12 or OpenSSH serialization, as discussed in #8039.

Closes #8039.

PS: I think it was a mistake to use UPPER_SNAKE_CASE for the type aliases in cryptography.hazmat.primitives.asymmetric.types. In other projects, type aliases such as Unions still typically use CamelCase like class names. But I guess it's too late to change that.

That's why I appended the `_TUPLE` to these constant names, so a constant `CERTIFICATE_PRIVATE_KEY_TYPES_TUPLE` could be created that doesn't conflict with the already existing `CERTIFICATE_PRIVATE_KEY_TYPES` type alias.
