### PR TITLE
add support for bytes-like objects in data and associated_data in aead algorithms

### DIFF
--- a/docs/hazmat/primitives/aead.rst
+++ b/docs/hazmat/primitives/aead.rst
@@ -56,10 +56,12 @@ also support providing integrity for associated data which is not encrypted.
 
         :param nonce: A 12 byte value. **NEVER REUSE A NONCE** with a key.
         :type nonce: :term:`bytes-like`
-        :param bytes data: The data to encrypt.
-        :param bytes associated_data: Additional data that should be
+        :param data: The data to encrypt.
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data that should be
             authenticated with the key, but does not need to be encrypted. Can
             be ``None``.
+        :type associated_data: :term:`bytes-like`
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
         :raises OverflowError: If ``data`` or ``associated_data`` is larger
             than 2\ :sup:`31` - 1 bytes.
@@ -73,9 +75,11 @@ also support providing integrity for associated data which is not encrypted.
         :param nonce: A 12 byte value. **NEVER REUSE A NONCE** with a
             key.
         :type nonce: :term:`bytes-like`
-        :param bytes data: The data to decrypt (with tag appended).
-        :param bytes associated_data: Additional data to authenticate. Can be
+        :param data: The data to decrypt (with tag appended).
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data to authenticate. Can be
             ``None`` if none was passed during encryption.
+        :type associated_data: :term:`bytes-like`
         :returns bytes: The original plaintext.
         :raises cryptography.exceptions.InvalidTag: If the authentication tag
             doesn't validate this exception will be raised. This will occur
@@ -130,9 +134,11 @@ also support providing integrity for associated data which is not encrypted.
             performance but it can be up to 2\ :sup:`64` - 1 :term:`bits`.
             **NEVER REUSE A NONCE** with a key.
         :type nonce: :term:`bytes-like`
-        :param bytes data: The data to encrypt.
-        :param bytes associated_data: Additional data that should be
+        :param data: The data to encrypt.
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
+        :type associated_data: :term:`bytes-like`
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
         :raises OverflowError: If ``data`` or ``associated_data`` is larger
             than 2\ :sup:`31` - 1 bytes.
@@ -147,9 +153,11 @@ also support providing integrity for associated data which is not encrypted.
             performance but it can be up to 2\ :sup:`64` - 1 :term:`bits`.
             **NEVER REUSE A NONCE** with a key.
         :type nonce: :term:`bytes-like`
-        :param bytes data: The data to decrypt (with tag appended).
-        :param bytes associated_data: Additional data to authenticate. Can be
+        :param data: The data to decrypt (with tag appended).
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data to authenticate. Can be
             ``None`` if none was passed during encryption.
+        :type associated_data: :term:`bytes-like`
         :returns bytes: The original plaintext.
         :raises cryptography.exceptions.InvalidTag: If the authentication tag
             doesn't validate this exception will be raised. This will occur
@@ -204,9 +212,11 @@ also support providing integrity for associated data which is not encrypted.
 
         :param nonce: A 12-15 byte value. **NEVER REUSE A NONCE** with a key.
         :type nonce: :term:`bytes-like`
-        :param bytes data: The data to encrypt.
-        :param bytes associated_data: Additional data that should be
+        :param data: The data to encrypt.
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
+        :type associated_data: :term:`bytes-like`
         :returns bytes: The ciphertext bytes with the 16 byte tag appended.
         :raises OverflowError: If ``data`` or ``associated_data`` is larger
             than 2\ :sup:`31` - 1 bytes.
@@ -219,9 +229,11 @@ also support providing integrity for associated data which is not encrypted.
 
         :param nonce: A 12 byte value. **NEVER REUSE A NONCE** with a key.
         :type nonce: :term:`bytes-like`
-        :param bytes data: The data to decrypt (with tag appended).
-        :param bytes associated_data: Additional data to authenticate. Can be
+        :param data: The data to decrypt (with tag appended).
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data to authenticate. Can be
             ``None`` if none was passed during encryption.
+        :type associated_data: :term:`bytes-like`
         :returns bytes: The original plaintext.
         :raises cryptography.exceptions.InvalidTag: If the authentication tag
             doesn't validate this exception will be raised. This will occur
@@ -288,8 +300,9 @@ also support providing integrity for associated data which is not encrypted.
         authenticating the ``associated_data``.  The output of this can be
         passed directly to the ``decrypt`` method.
 
-        :param bytes data: The data to encrypt.
-        :param list associated_data: An optional ``list`` of ``bytes``. This
+        :param data: The data to encrypt.
+        :type data: :term:`bytes-like`
+        :param list associated_data: An optional ``list`` of ``bytes-like objects``. This
             is additional data that should be authenticated with the key, but
             is not encrypted. Can be ``None``.  In SIV mode the final element
             of this list is treated as a ``nonce``.
@@ -304,7 +317,7 @@ also support providing integrity for associated data which is not encrypted.
         ``associated_data`` in decrypt or the integrity check will fail.
 
         :param bytes data: The data to decrypt (with tag **prepended**).
-        :param list associated_data: An optional ``list`` of ``bytes``. This
+        :param list associated_data: An optional ``list`` of ``bytes-like objects``. This
             is additional data that should be authenticated with the key, but
             is not encrypted. Can be ``None`` if none was used during
             encryption.
@@ -377,9 +390,11 @@ also support providing integrity for associated data which is not encrypted.
             ``len(data) < 2 ** (8 * (15 - len(nonce)))``
             **NEVER REUSE A NONCE** with a key.
         :type nonce: :term:`bytes-like`
-        :param bytes data: The data to encrypt.
-        :param bytes associated_data: Additional data that should be
+        :param data: The data to encrypt.
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data that should be
             authenticated with the key, but is not encrypted. Can be ``None``.
+        :type associated_data: :term:`bytes-like`
         :returns bytes: The ciphertext bytes with the tag appended.
         :raises OverflowError: If ``data`` or ``associated_data`` is larger
             than 2\ :sup:`31` - 1 bytes.
@@ -394,9 +409,11 @@ also support providing integrity for associated data which is not encrypted.
             is the same value used when you originally called encrypt.
             **NEVER REUSE A NONCE** with a key.
         :type nonce: :term:`bytes-like`
-        :param bytes data: The data to decrypt (with tag appended).
-        :param bytes associated_data: Additional data to authenticate. Can be
+        :param data: The data to decrypt (with tag appended).
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data to authenticate. Can be
             ``None`` if none was passed during encryption.
+        :type associated_data: :term:`bytes-like`
         :returns bytes: The original plaintext.
         :raises cryptography.exceptions.InvalidTag: If the authentication tag
             doesn't validate this exception will be raised. This will occur

--- a/src/cryptography/hazmat/backends/openssl/aead.py
+++ b/src/cryptography/hazmat/backends/openssl/aead.py
@@ -168,9 +168,9 @@ def _set_length(backend: "Backend", ctx, data_len: int) -> None:
 
 def _process_aad(backend: "Backend", ctx, associated_data: bytes) -> None:
     outlen = backend._ffi.new("int *")
-    associated_data_ptr = backend._ffi.from_buffer(associated_data)
+    a_data_ptr = backend._ffi.from_buffer(associated_data)
     res = backend._lib.EVP_CipherUpdate(
-        ctx, backend._ffi.NULL, outlen, associated_data_ptr, len(associated_data)
+        ctx, backend._ffi.NULL, outlen, a_data_ptr, len(associated_data)
     )
     backend.openssl_assert(res != 0)
 
@@ -289,8 +289,8 @@ def _decrypt(
     if isinstance(cipher, AESCCM):
         outlen = backend._ffi.new("int *")
         buf = backend._ffi.new("unsigned char[]", len(data))
-        data_ptr = backend._ffi.from_buffer(data)
-        res = backend._lib.EVP_CipherUpdate(ctx, buf, outlen, data_ptr, len(data))
+        d_ptr = backend._ffi.from_buffer(data)
+        res = backend._lib.EVP_CipherUpdate(ctx, buf, outlen, d_ptr, len(data))
         if res != 1:
             backend._consume_errors()
             raise InvalidTag

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -79,8 +79,8 @@ class ChaCha20Poly1305:
         associated_data: bytes,
     ) -> None:
         utils._check_byteslike("nonce", nonce)
-        utils._check_bytes("data", data)
-        utils._check_bytes("associated_data", associated_data)
+        utils._check_byteslike("data", data)
+        utils._check_byteslike("associated_data", associated_data)
         if len(nonce) != 12:
             raise ValueError("Nonce must be 12 bytes")
 
@@ -164,8 +164,8 @@ class AESCCM:
         self, nonce: bytes, data: bytes, associated_data: bytes
     ) -> None:
         utils._check_byteslike("nonce", nonce)
-        utils._check_bytes("data", data)
-        utils._check_bytes("associated_data", associated_data)
+        utils._check_byteslike("data", data)
+        utils._check_byteslike("associated_data", associated_data)
         if not 7 <= len(nonce) <= 13:
             raise ValueError("Nonce must be between 7 and 13 bytes")
 
@@ -227,8 +227,8 @@ class AESGCM:
         associated_data: bytes,
     ) -> None:
         utils._check_byteslike("nonce", nonce)
-        utils._check_bytes("data", data)
-        utils._check_bytes("associated_data", associated_data)
+        utils._check_byteslike("data", data)
+        utils._check_byteslike("associated_data", associated_data)
         if len(nonce) < 8 or len(nonce) > 128:
             raise ValueError("Nonce must be between 8 and 128 bytes")
 
@@ -296,8 +296,8 @@ class AESOCB3:
         associated_data: bytes,
     ) -> None:
         utils._check_byteslike("nonce", nonce)
-        utils._check_bytes("data", data)
-        utils._check_bytes("associated_data", associated_data)
+        utils._check_byteslike("data", data)
+        utils._check_byteslike("associated_data", associated_data)
         if len(nonce) < 12 or len(nonce) > 15:
             raise ValueError("Nonce must be between 12 and 15 bytes")
 
@@ -365,10 +365,10 @@ class AESSIV:
         data: bytes,
         associated_data: typing.List[bytes],
     ) -> None:
-        utils._check_bytes("data", data)
+        utils._check_byteslike("data", data)
         if len(data) == 0:
             raise ValueError("data must not be zero length")
         if not isinstance(associated_data, list) or not all(
-            isinstance(x, bytes) for x in associated_data
+            isinstance(x, (bytes, bytearray, memoryview)) for x in associated_data
         ):
             raise TypeError("associated_data must be a list of bytes or None")

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -370,17 +370,16 @@ class AESSIV:
             raise ValueError("data must not be zero length")
 
         msg = "associated_data must be a list of bytes-like objects or None"
-        if associated_data is not None:
-            raise_except = False
+        raise_except = False
 
-            if not isinstance(associated_data, list):
-                raise_except = True
-            else:
-                for x in associated_data:
-                    try:
-                        utils._check_byteslike("associated_data", x)
-                    except TypeError:
-                        raise_except = True
-                        break
-            if raise_except:
-                raise TypeError(msg)
+        if not isinstance(associated_data, list):
+            raise_except = True
+        else:
+            for x in associated_data:
+                try:
+                    utils._check_byteslike("associated_data", x)
+                except TypeError:
+                    raise_except = True
+                    break
+        if raise_except:
+            raise TypeError(msg)

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -369,17 +369,7 @@ class AESSIV:
         if len(data) == 0:
             raise ValueError("data must not be zero length")
 
-        msg = "associated_data must be a list of bytes-like objects or None"
-        raise_except = False
-
         if not isinstance(associated_data, list):
-            raise_except = True
-        else:
-            for x in associated_data:
-                try:
-                    utils._check_byteslike("associated_data", x)
-                except TypeError:
-                    raise_except = True
-                    break
-        if raise_except:
-            raise TypeError(msg)
+            raise TypeError("associated_data must be a list of bytes-like objects or None")
+        for x in associated_data:
+            utils._check_byteslike("associated_data elements", x)

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -369,6 +369,7 @@ class AESSIV:
         if len(data) == 0:
             raise ValueError("data must not be zero length")
         if not isinstance(associated_data, list) or not all(
-            isinstance(x, (bytes, bytearray, memoryview)) for x in associated_data
+            isinstance(x, (bytes, bytearray, memoryview))
+            for x in associated_data
         ):
             raise TypeError("associated_data must be a list of bytes or None")

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -368,8 +368,17 @@ class AESSIV:
         utils._check_byteslike("data", data)
         if len(data) == 0:
             raise ValueError("data must not be zero length")
-        if not isinstance(associated_data, list) or not all(
-            isinstance(x, (bytes, bytearray, memoryview))
-            for x in associated_data
-        ):
-            raise TypeError("associated_data must be a list of bytes or None")
+
+        if associated_data is not None:
+            raise_except = False
+            if not isinstance(associated_data, list):
+                raise_except = True
+            else:
+                for x in associated_data:
+                    try:
+                        utils._check_byteslike("associated_data", x)
+                    except TypeError:
+                        raise_except = True
+                        break
+            if raise_except:
+                raise TypeError("associated_data must be a list of bytes-like objects or None")

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -370,6 +370,8 @@ class AESSIV:
             raise ValueError("data must not be zero length")
 
         if not isinstance(associated_data, list):
-            raise TypeError("associated_data must be a list of bytes-like objects or None")
+            raise TypeError(
+                "associated_data must be a list of bytes-like objects or None"
+            )
         for x in associated_data:
             utils._check_byteslike("associated_data elements", x)

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -369,8 +369,10 @@ class AESSIV:
         if len(data) == 0:
             raise ValueError("data must not be zero length")
 
+        msg = "associated_data must be a list of bytes-like objects or None"
         if associated_data is not None:
             raise_except = False
+
             if not isinstance(associated_data, list):
                 raise_except = True
             else:
@@ -381,4 +383,4 @@ class AESSIV:
                         raise_except = True
                         break
             if raise_except:
-                raise TypeError("associated_data must be a list of bytes-like objects or None")
+                raise TypeError(msg)

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -466,12 +466,24 @@ class TestAESGCM:
         aesgcm2 = AESGCM(bytearray(key))
         ct2 = aesgcm2.encrypt(bytearray(nonce), bytearray(pt), bytearray(ad))
         assert ct2 == ct
-        computed_pt2 = aesgcm2.decrypt(bytearray(nonce), bytearray(ct2), bytearray(ad))
+        computed_pt2 = aesgcm2.decrypt(
+            bytearray(nonce),
+            bytearray(ct2),
+            bytearray(ad)
+        )
         assert computed_pt2 == pt
         aesgcm3 = AESGCM(memoryview(key))
-        ct3 = aesgcm3.encrypt(memoryview(nonce), memoryview(pt), memoryview(ad))
+        ct3 = aesgcm3.encrypt(
+            memoryview(nonce),
+            memoryview(pt),
+            memoryview(ad)
+        )
         assert ct3 == ct
-        computed_pt3 = aesgcm3.decrypt(memoryview(nonce), memoryview(ct2), memoryview(ad))
+        computed_pt3 = aesgcm3.decrypt(
+            memoryview(nonce),
+            memoryview(ct2),
+            memoryview(ad)
+        )
         assert computed_pt3 == pt
 
 

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -464,10 +464,15 @@ class TestAESGCM:
         computed_pt = aesgcm.decrypt(nonce, ct, ad)
         assert computed_pt == pt
         aesgcm2 = AESGCM(bytearray(key))
-        ct2 = aesgcm2.encrypt(bytearray(nonce), pt, ad)
+        ct2 = aesgcm2.encrypt(bytearray(nonce), bytearray(pt), bytearray(ad))
         assert ct2 == ct
-        computed_pt2 = aesgcm2.decrypt(bytearray(nonce), ct2, ad)
+        computed_pt2 = aesgcm2.decrypt(bytearray(nonce), bytearray(ct2), bytearray(ad))
         assert computed_pt2 == pt
+        aesgcm3 = AESGCM(memoryview(key))
+        ct3 = aesgcm3.encrypt(memoryview(nonce), memoryview(pt), memoryview(ad))
+        assert ct3 == ct
+        computed_pt3 = aesgcm3.decrypt(memoryview(nonce), memoryview(ct2), memoryview(ad))
+        assert computed_pt3 == pt
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -466,24 +466,19 @@ class TestAESGCM:
         aesgcm2 = AESGCM(bytearray(key))
         ct2 = aesgcm2.encrypt(bytearray(nonce), bytearray(pt), bytearray(ad))
         assert ct2 == ct
-        computed_pt2 = aesgcm2.decrypt(
-            bytearray(nonce),
-            bytearray(ct2),
-            bytearray(ad)
-        )
+        b_nonce = bytearray(nonce)
+        b_ct2 = bytearray(ct2)
+        b_ad = bytearray(ad)
+        computed_pt2 = aesgcm2.decrypt(b_nonce, b_ct2, b_ad)
         assert computed_pt2 == pt
         aesgcm3 = AESGCM(memoryview(key))
-        ct3 = aesgcm3.encrypt(
-            memoryview(nonce),
-            memoryview(pt),
-            memoryview(ad)
-        )
+        m_nonce = memoryview(nonce)
+        m_pt = memoryview(pt)
+        m_ad = memoryview(ad)
+        ct3 = aesgcm3.encrypt(m_nonce, m_pt, m_ad)
         assert ct3 == ct
-        computed_pt3 = aesgcm3.decrypt(
-            memoryview(nonce),
-            memoryview(ct2),
-            memoryview(ad)
-        )
+        m_ct3 = memoryview(ct3)
+        computed_pt3 = aesgcm3.decrypt(m_nonce, m_ct3, m_ad)
         assert computed_pt3 == pt
 
 


### PR DESCRIPTION
fixes https://github.com/pyca/cryptography/issues/8175

small test file :

```python
from cryptography.hazmat.primitives.ciphers.aead import *
import os


data = b'1' * 4 * 1024 * 1024

for alg in [ChaCha20Poly1305, AESGCM, AESOCB3, AESSIV, AESCCM]:
    print(f"Checking algorithm {alg}")
    keymaterial = os.urandom(32 + 12 + 32)
    memview_keymaterial = memoryview(keymaterial)

    key = memview_keymaterial[0:32]
    nonce = memview_keymaterial[32:32+12]
    associated_data = memview_keymaterial[32+12:32+12+32]

    enc = alg(key)
    if alg == AESSIV:
        encrypted = enc.encrypt(data, [associated_data])
    else:
        encrypted = enc.encrypt(nonce, data, associated_data)

    on_the_wire = nonce.tobytes() + associated_data.tobytes() + encrypted

    # send on_the_wire over the network


    memview = memoryview(on_the_wire)


    server_nonce = memview[:12]
    server_associated_data = memview[12:12+32]
    server_encrypted = memview[32+12:]

    dec = alg(key)
    if alg == AESSIV:
        decrypted_data = dec.decrypt(server_encrypted, [server_associated_data])
    else:
        decrypted_data = dec.decrypt(server_nonce, server_encrypted, server_associated_data)

    assert(data == decrypted_data)
```

everything seems fine:
```

Checking algorithm <class 'cryptography.hazmat.primitives.ciphers.aead.ChaCha20Poly1305'>
Checking algorithm <class 'cryptography.hazmat.primitives.ciphers.aead.AESGCM'>
Checking algorithm <class 'cryptography.hazmat.primitives.ciphers.aead.AESOCB3'>
Checking algorithm <class 'cryptography.hazmat.primitives.ciphers.aead.AESSIV'>
Checking algorithm <class 'cryptography.hazmat.primitives.ciphers.aead.AESCCM'>
```
