### PR TITLE
add support for centos9-fips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
           - {IMAGE: "fedora", TOXENV: "py311", RUNNER: "ubuntu-latest"}
           - {IMAGE: "alpine", TOXENV: "py310", RUNNER: "ubuntu-latest"}
           - {IMAGE: "centos-stream9", TOXENV: "py39", RUNNER: "ubuntu-latest"}
+          - {IMAGE: "centos-stream9-fips", TOXENV: "py39", RUNNER: "ubuntu-latest", FIPS: true}
 
           - {IMAGE: "ubuntu-jammy:aarch64", TOXENV: "py310", RUNNER: [self-hosted, Linux, ARM64]}
           - {IMAGE: "alpine:aarch64", TOXENV: "py310", RUNNER: [self-hosted, Linux, ARM64]}

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -781,6 +781,9 @@ class Backend:
             raise UnsupportedAlgorithm("Unsupported key type.")
 
     def _oaep_hash_supported(self, algorithm: hashes.HashAlgorithm) -> bool:
+        if self._fips_enabled and isinstance(algorithm, hashes.SHA1):
+            return False
+
         return isinstance(
             algorithm,
             (
@@ -810,6 +813,12 @@ class Backend:
             ) and self._oaep_hash_supported(padding._algorithm)
         else:
             return False
+
+    def rsa_encryption_supported(self, padding: AsymmetricPadding) -> bool:
+        if self._fips_enabled and isinstance(padding, PKCS1v15):
+            return False
+        else:
+            return self.rsa_padding_supported(padding)
 
     def generate_dsa_parameters(self, key_size: int) -> dsa.DSAParameters:
         if key_size not in (1024, 2048, 3072, 4096):

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -380,8 +380,8 @@ class TestOpenSSLRSA:
         assert (
             backend.rsa_padding_supported(
                 padding.OAEP(
-                    mgf=padding.MGF1(algorithm=hashes.SHA1()),
-                    algorithm=hashes.SHA1(),
+                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
                     label=None,
                 ),
             )
@@ -397,6 +397,12 @@ class TestOpenSSLRSA:
             hashes.SHA512(),
         ]
         for mgf1alg, oaepalg in itertools.product(hashalgs, hashalgs):
+            if backend._fips_enabled and (
+                isinstance(mgf1alg, hashes.SHA1)
+                or isinstance(oaepalg, hashes.SHA1)
+            ):
+                continue
+
             assert (
                 backend.rsa_padding_supported(
                     padding.OAEP(

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -438,6 +438,12 @@ class TestRSA:
                 ),
             )
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
+            padding.PKCS1v15()
+        ),
+        skip_message="Does not support PKCS1v1.5.",
+    )
     def test_lazy_blinding(self, backend):
         private_key = RSA_KEY_2048.private_key(backend)
         public_key = private_key.public_key()
@@ -1668,7 +1674,7 @@ class TestOAEP:
 
 class TestRSADecryption:
     @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
             padding.PKCS1v15()
         ),
         skip_message="Does not support PKCS1v1.5.",
@@ -1705,7 +1711,7 @@ class TestRSADecryption:
 
     @pytest.mark.supported(
         only_if=lambda backend: (
-            backend.rsa_padding_supported(padding.PKCS1v15())
+            backend.rsa_encryption_supported(padding.PKCS1v15())
             and not backend._lib.Cryptography_HAS_IMPLICIT_RSA_REJECTION
         ),
         skip_message="Does not support PKCS1v1.5.",
@@ -1716,7 +1722,7 @@ class TestRSADecryption:
             private_key.decrypt(b"\x00" * 256, padding.PKCS1v15())
 
     @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
             padding.PKCS1v15()
         ),
         skip_message="Does not support PKCS1v1.5.",
@@ -1727,7 +1733,7 @@ class TestRSADecryption:
             private_key.decrypt(b"\x00" * 257, padding.PKCS1v15())
 
     @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
             padding.PKCS1v15()
         ),
         skip_message="Does not support PKCS1v1.5.",
@@ -1742,7 +1748,7 @@ class TestRSADecryption:
             private_key.decrypt(ct, padding.PKCS1v15())
 
     @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
             padding.OAEP(
                 mgf=padding.MGF1(algorithm=hashes.SHA1()),
                 algorithm=hashes.SHA1(),
@@ -1751,7 +1757,7 @@ class TestRSADecryption:
         ),
         skip_message="Does not support OAEP.",
     )
-    def test_decrypt_oaep_vectors(self, subtests, backend):
+    def test_decrypt_oaep_sha1_vectors(self, subtests, backend):
         for private, public, example in _flatten_pkcs1_examples(
             load_vectors_from_file(
                 os.path.join(
@@ -1782,22 +1788,20 @@ class TestRSADecryption:
                 )
                 assert message == binascii.unhexlify(example["message"])
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
-            padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA224()),
-                algorithm=hashes.SHA224(),
-                label=None,
-            )
-        ),
-        skip_message=(
-            "Does not support OAEP using SHA224 MGF1 and SHA224 hash."
-        ),
-    )
     def test_decrypt_oaep_sha2_vectors(self, backend, subtests):
         vectors = _build_oaep_sha2_vectors()
         for private, public, example, mgf1_alg, hash_alg in vectors:
             with subtests.test():
+                pad = padding.OAEP(
+                    mgf=padding.MGF1(algorithm=mgf1_alg),
+                    algorithm=hash_alg,
+                    label=None,
+                )
+                if not backend.rsa_encryption_supported(pad):
+                    pytest.skip(
+                        f"Does not support OAEP using {mgf1_alg.name} MGF1 "
+                        f"or {hash_alg.name} hash."
+                    )
                 skey = rsa.RSAPrivateNumbers(
                     p=private["p"],
                     q=private["q"],
@@ -1811,16 +1815,12 @@ class TestRSADecryption:
                 ).private_key(backend, unsafe_skip_rsa_key_validation=True)
                 message = skey.decrypt(
                     binascii.unhexlify(example["encryption"]),
-                    padding.OAEP(
-                        mgf=padding.MGF1(algorithm=mgf1_alg),
-                        algorithm=hash_alg,
-                        label=None,
-                    ),
+                    pad,
                 )
                 assert message == binascii.unhexlify(example["message"])
 
     @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
             padding.OAEP(
                 mgf=padding.MGF1(algorithm=hashes.SHA1()),
                 algorithm=hashes.SHA1(),
@@ -1857,7 +1857,7 @@ class TestRSADecryption:
             )
 
     @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
             padding.OAEP(
                 mgf=padding.MGF1(algorithm=hashes.SHA1()),
                 algorithm=hashes.SHA1(),
@@ -1909,7 +1909,7 @@ class TestRSADecryption:
 
 class TestRSAEncryption:
     @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
             padding.OAEP(
                 mgf=padding.MGF1(algorithm=hashes.SHA1()),
                 algorithm=hashes.SHA1(),
@@ -1953,18 +1953,6 @@ class TestRSAEncryption:
         recovered_pt = private_key.decrypt(ct, pad)
         assert recovered_pt == pt
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
-            padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA256()),
-                algorithm=hashes.SHA512(),
-                label=None,
-            )
-        ),
-        skip_message=(
-            "Does not support OAEP using SHA256 MGF1 and SHA512 hash."
-        ),
-    )
     @pytest.mark.parametrize(
         ("mgf1hash", "oaephash"),
         itertools.product(
@@ -1990,6 +1978,11 @@ class TestRSAEncryption:
             algorithm=oaephash,
             label=None,
         )
+        if not backend.rsa_encryption_supported(pad):
+            pytest.skip(
+                f"Does not support OAEP using {mgf1hash.name} MGF1 "
+                f"or {oaephash.name} hash."
+            )
         private_key = RSA_KEY_2048.private_key(backend)
         pt = b"encrypt me using sha2 hashes!"
         public_key = private_key.public_key()
@@ -2000,7 +1993,7 @@ class TestRSAEncryption:
         assert recovered_pt == pt
 
     @pytest.mark.supported(
-        only_if=lambda backend: backend.rsa_padding_supported(
+        only_if=lambda backend: backend.rsa_encryption_supported(
             padding.PKCS1v15()
         ),
         skip_message="Does not support PKCS1v1.5.",
@@ -2051,8 +2044,8 @@ class TestRSAEncryption:
             ),
             (
                 padding.OAEP(
-                    mgf=padding.MGF1(algorithm=hashes.SHA1()),
-                    algorithm=hashes.SHA1(),
+                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
                     label=None,
                 ),
                 padding.PKCS1v15(),
@@ -2061,6 +2054,8 @@ class TestRSAEncryption:
     )
     def test_rsa_encrypt_key_too_small(self, key_data, pad, backend):
         private_key = key_data.private_key(backend)
+        if not backend.rsa_encryption_supported(pad):
+            pytest.skip("PKCS1f15 padding not allowed in FIPS")
         _check_fips_key_length(backend, private_key)
         public_key = private_key.public_key()
         # Slightly smaller than the key size but not enough for padding.

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2055,7 +2055,7 @@ class TestRSAEncryption:
     def test_rsa_encrypt_key_too_small(self, key_data, pad, backend):
         private_key = key_data.private_key(backend)
         if not backend.rsa_encryption_supported(pad):
-            pytest.skip("PKCS1f15 padding not allowed in FIPS")
+            pytest.skip("PKCS1v15 padding not allowed in FIPS")
         _check_fips_key_length(backend, private_key)
         public_key = private_key.public_key()
         # Slightly smaller than the key size but not enough for padding.

--- a/tests/hazmat/primitives/test_ssh.py
+++ b/tests/hazmat/primitives/test_ssh.py
@@ -1129,13 +1129,9 @@ class TestSSHCertificate:
         )
         cert = load_ssh_public_identity(data)
         # we have no public API for getting the hash alg of the sig
-        if (
-            backend._fips_enabled
-            and bytes(cert._inner_sig_type)  # type: ignore[union-attr]
-            == b"ssh-rsa"
-        ):
-            pytest.skip("FIPS does not support RSA SHA1")
         assert isinstance(cert, SSHCertificate)
+        if backend._fips_enabled and bytes(cert._inner_sig_type) == b"ssh-rsa":
+            pytest.skip("FIPS does not support RSA SHA1")
         cert.verify_cert_signature()
 
     @pytest.mark.parametrize(
@@ -1159,14 +1155,10 @@ class TestSSHCertificate:
         # mutate the signature so it's invalid
         data[-10] = 71
         cert = load_ssh_public_identity(data)
-        # we have no public API for getting the hash alg of the sig
-        if (
-            backend._fips_enabled
-            and bytes(cert._inner_sig_type)  # type: ignore[union-attr]
-            == b"ssh-rsa"
-        ):
-            pytest.skip("FIPS does not support RSA SHA1")
         assert isinstance(cert, SSHCertificate)
+        # we have no public API for getting the hash alg of the sig
+        if backend._fips_enabled and bytes(cert._inner_sig_type) == b"ssh-rsa":
+            pytest.skip("FIPS does not support RSA SHA1")
         with pytest.raises(InvalidSignature):
             cert.verify_cert_signature()
 

--- a/tests/hazmat/primitives/test_ssh.py
+++ b/tests/hazmat/primitives/test_ssh.py
@@ -1121,13 +1121,20 @@ class TestSSHCertificate:
             "p256-rsa-sha512.pub",
         ],
     )
-    def test_verify_cert_signature(self, filename):
+    def test_verify_cert_signature(self, filename, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "OpenSSH", "certs", filename),
             lambda f: f.read(),
             mode="rb",
         )
         cert = load_ssh_public_identity(data)
+        # we have no public API for getting the hash alg of the sig
+        if (
+            backend._fips_enabled
+            and bytes(cert._inner_sig_type)  # type: ignore[union-attr]
+            == b"ssh-rsa"
+        ):
+            pytest.skip("FIPS does not support RSA SHA1")
         assert isinstance(cert, SSHCertificate)
         cert.verify_cert_signature()
 
@@ -1142,7 +1149,7 @@ class TestSSHCertificate:
             "p256-rsa-sha512.pub",
         ],
     )
-    def test_invalid_signature(self, filename):
+    def test_invalid_signature(self, filename, backend):
         data = load_vectors_from_file(
             os.path.join("asymmetric", "OpenSSH", "certs", filename),
             lambda f: f.read(),
@@ -1152,6 +1159,13 @@ class TestSSHCertificate:
         # mutate the signature so it's invalid
         data[-10] = 71
         cert = load_ssh_public_identity(data)
+        # we have no public API for getting the hash alg of the sig
+        if (
+            backend._fips_enabled
+            and bytes(cert._inner_sig_type)  # type: ignore[union-attr]
+            == b"ssh-rsa"
+        ):
+            pytest.skip("FIPS does not support RSA SHA1")
         assert isinstance(cert, SSHCertificate)
         with pytest.raises(InvalidSignature):
             cert.verify_cert_signature()

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -4728,7 +4728,7 @@ class TestDSACertificate:
             cert.signature_hash_algorithm,
         )
 
-    def test_verify_directly_issued_by_dsa(self):
+    def test_verify_directly_issued_by_dsa(self, backend):
         issuer_private_key = DSA_KEY_3072.private_key()
         subject_private_key = DSA_KEY_2048.private_key()
         ca, cert = _generate_ca_and_leaf(
@@ -4736,7 +4736,7 @@ class TestDSACertificate:
         )
         cert.verify_directly_issued_by(ca)
 
-    def test_verify_directly_issued_by_dsa_bad_sig(self):
+    def test_verify_directly_issued_by_dsa_bad_sig(self, backend):
         issuer_private_key = DSA_KEY_3072.private_key()
         subject_private_key = DSA_KEY_2048.private_key()
         ca, cert = _generate_ca_and_leaf(


### PR DESCRIPTION
Requires a variety of new FIPS constraints on our tests, including the addition of rsa_encryption_supported