### PR TITLE
Set mtimes to improve cargo caching

### DIFF
--- a/.github/actions/mtime-fix/action.yml
+++ b/.github/actions/mtime-fix/action.yml
@@ -1,0 +1,14 @@
+name: Fix mtime
+description: Fixes mtime so cargo will reuse caches more effectively
+
+runs:
+  using: "composite"
+
+  steps:
+    - run: |
+        ls -Rla src/rust/src
+        echo "Setting mtimes for rust dirs"
+        for f in $(git ls-files src/rust); do touch -t $(git log --pretty=format:%cd --date=format:%Y%m%d%H%M.%S -1 HEAD -- "$f") "$f"; done
+        echo "Done"
+        ls -Rla src/rust/src
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - '*.*.x'
+      - ridiculous
     tags:
       - '*.*'
       - '*.*.*'
@@ -51,6 +52,9 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: set mtimes for rust dirs
+        uses: ./.github/actions/mtime-fix
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@v4.5.0
@@ -166,6 +170,12 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: git config shenanigans
+        run: |
+          git config --global --add safe.directory $(pwd) # needed for the mtime fix since git doesn't think it owns the files due to being in containers
+      - name: set mtimes for rust dirs
+        uses: ./.github/actions/mtime-fix
       - uses: actions/cache@v3.2.5
         timeout-minutes: 5
         with:
@@ -233,6 +243,9 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: set mtimes for rust dirs
+        uses: ./.github/actions/mtime-fix
       - uses: actions/cache@v3.2.5
         timeout-minutes: 5
         with:
@@ -289,6 +302,9 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: set mtimes for rust dirs
+        uses: ./.github/actions/mtime-fix
       - uses: dtolnay/rust-toolchain@c758e63728211bd4acda6501cfa2a16c5c751fc4
         id: rust-toolchain
         with:
@@ -388,6 +404,9 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: set mtimes for rust dirs
+        uses: ./.github/actions/mtime-fix
       - uses: actions/cache@v3.2.5
         timeout-minutes: 5
         with:
@@ -457,6 +476,9 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: set mtimes for rust dirs
+        uses: ./.github/actions/mtime-fix
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@v4.5.0
@@ -531,6 +553,9 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: set mtimes for rust dirs
+        uses: ./.github/actions/mtime-fix
       - uses: actions/cache@v3.2.5
         timeout-minutes: 5
         with:
@@ -580,6 +605,9 @@ jobs:
       - uses: actions/checkout@v3.3.0
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: set mtimes for rust dirs
+        uses: ./.github/actions/mtime-fix
       - name: Setup python
         uses: actions/setup-python@v4.5.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - '*.*.x'
-      - ridiculous
     tags:
       - '*.*'
       - '*.*.*'
@@ -71,7 +70,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-cargo-5-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-cargo-1-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/checkout@v3.3.0
         timeout-minutes: 3
@@ -187,7 +186,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-${{ matrix.IMAGE.IMAGE }}-${{ runner.arch }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.IMAGE.IMAGE }}-${{ runner.arch }}-cargo-1-${{ hashFiles('**/Cargo.lock') }}
 
       - uses: actions/checkout@v3.3.0
         timeout-minutes: 3
@@ -257,7 +256,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.RUST }}
+          key: ${{ runner.os }}-cargo-1-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.RUST }}
 
       - name: Setup python
         uses: actions/setup-python@v4.5.0
@@ -321,7 +320,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}-rust-${{ steps.rust-toolchain.outputs.cachekey }}-coverage
+          key: ${{ runner.os }}-cargo-1-${{ hashFiles('**/Cargo.lock') }}-rust-${{ steps.rust-toolchain.outputs.cachekey }}-coverage
 
       - name: Setup python
         uses: actions/setup-python@v4.5.0
@@ -418,7 +417,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.PYTHON.VERSION }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.PYTHON.VERSION }}-cargo-1-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup python
         uses: actions/setup-python@v4.5.0
@@ -496,7 +495,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ steps.setup-python.outputs.python-version }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ steps.setup-python.outputs.python-version }}-cargo-1-${{ hashFiles('**/Cargo.lock') }}
 
       - run: python -m pip install -c ci-constraints-requirements.txt "tox>3" requests coverage[toml]
       - name: Download OpenSSL
@@ -567,7 +566,7 @@ jobs:
             ~/.cargo/registry/src/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-1-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup python
         uses: actions/setup-python@v4.5.0


### PR DESCRIPTION
This also resets the cache keys so the first builds aren't going to be fast.