### PR TITLE
Disallow wildcards in DNSName for name constraints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,10 @@ Changelog
   :class:`~cryptography.hazmat.primitives.serialization.SSHCertificateBuilder`.
 * Added :meth:`~cryptography.x509.Certificate.verify_directly_issued_by` to
   :class:`~cryptography.x509.Certificate`.
+* Added a check to :class:`~cryptography.x509.NameConstraints` to ensure that
+  :class:`~cryptography.x509.DNSName` constraints do not contain any ``*``
+  wildcards.
+
 
 .. _v39-0-1:
 

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -1276,7 +1276,7 @@ class NameConstraints(ExtensionType):
                     "or None"
                 )
 
-            self._validate_ip_name(permitted_subtrees)
+            self._validate_tree(permitted_subtrees)
 
         if excluded_subtrees is not None:
             excluded_subtrees = list(excluded_subtrees)
@@ -1290,7 +1290,7 @@ class NameConstraints(ExtensionType):
                     "or None"
                 )
 
-            self._validate_ip_name(excluded_subtrees)
+            self._validate_tree(excluded_subtrees)
 
         if permitted_subtrees is None and excluded_subtrees is None:
             raise ValueError(
@@ -1310,6 +1310,10 @@ class NameConstraints(ExtensionType):
             and self.permitted_subtrees == other.permitted_subtrees
         )
 
+    def _validate_tree(self, tree: typing.Iterable[GeneralName]) -> None:
+        self._validate_ip_name(tree)
+        self._validate_dns_name(tree)
+
     def _validate_ip_name(self, tree: typing.Iterable[GeneralName]) -> None:
         if any(
             isinstance(name, IPAddress)
@@ -1321,6 +1325,15 @@ class NameConstraints(ExtensionType):
             raise TypeError(
                 "IPAddress name constraints must be an IPv4Network or"
                 " IPv6Network object"
+            )
+
+    def _validate_dns_name(self, tree: typing.Iterable[GeneralName]) -> None:
+        if any(
+            isinstance(name, DNSName) and "*" in name.value for name in tree
+        ):
+            raise ValueError(
+                "DNSName name constraints must not contain the '*' wildcard"
+                " character"
             )
 
     def __repr__(self) -> str:

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -3652,6 +3652,28 @@ class TestNameConstraints:
         assert nc.permitted_subtrees == permitted
         assert nc.excluded_subtrees == excluded
 
+    def test_dnsname_wrong_value(self):
+        with pytest.raises(ValueError):
+            x509.NameConstraints(
+                permitted_subtrees=[x509.DNSName("*.example.com")],
+                excluded_subtrees=None,
+            )
+
+        with pytest.raises(ValueError):
+            x509.NameConstraints(
+                permitted_subtrees=None,
+                excluded_subtrees=[x509.DNSName("*.example.com")],
+            )
+
+    def test_dnsname_allowed_value(self):
+        permitted = [x509.DNSName("example.com")]
+        excluded = [x509.DNSName("www.example.com")]
+        nc = x509.NameConstraints(
+            permitted_subtrees=permitted, excluded_subtrees=excluded
+        )
+        assert nc.permitted_subtrees == permitted
+        assert nc.excluded_subtrees == excluded
+
     def test_invalid_permitted_subtrees(self):
         with pytest.raises(TypeError):
             x509.NameConstraints("badpermitted", None)  # type:ignore[arg-type]


### PR DESCRIPTION
As discussed in #8253, wildcards are unnecessary according to RFC 5280, and cause issues with at least Firefox.