### PR TITLE
fix some binding declarations

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -372,18 +372,13 @@ long SSL_CTX_add_extra_chain_cert(SSL_CTX *, X509 *);
 uint64_t SSL_CTX_set_options(SSL_CTX *, uint64_t);
 uint64_t SSL_CTX_clear_options(SSL_CTX *, uint64_t);
 uint64_t SSL_CTX_get_options(SSL_CTX *);
-/* Defined as unsigned long rather than long because SSL_OP_ALL is greater
-    than signed 32-bit. OpenSSL treats this as a bitfield, but
-    cffi is smart and refuses to allow integer overflow, so when
-    sizeof(long) is 32-bit (all Windows and most 32-bit OSes) then
-    cffi errors. Calling this unsigned long makes the compiler mad
-    but c'est la vie. */
-unsigned long SSL_CTX_set_mode(SSL_CTX *, unsigned long);
-unsigned long SSL_CTX_clear_mode(SSL_CTX *, unsigned long);
-unsigned long SSL_CTX_get_mode(SSL_CTX *);
-unsigned long SSL_set_mode(SSL *, unsigned long);
-unsigned long SSL_clear_mode(SSL *, unsigned long);
-unsigned long SSL_get_mode(SSL *);
+
+long SSL_CTX_set_mode(SSL_CTX *, long);
+long SSL_CTX_clear_mode(SSL_CTX *, long);
+long SSL_CTX_get_mode(SSL_CTX *);
+long SSL_set_mode(SSL *, long);
+long SSL_clear_mode(SSL *, long);
+long SSL_get_mode(SSL *);
 
 const SSL_METHOD *DTLS_method(void);
 const SSL_METHOD *DTLS_server_method(void);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -342,14 +342,10 @@ const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *, unsigned int *);
 long SSL_SESSION_get_time(const SSL_SESSION *);
 long SSL_SESSION_get_timeout(const SSL_SESSION *);
 int SSL_SESSION_has_ticket(const SSL_SESSION *);
-long SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *);
+unsigned long SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *);
 
-unsigned long SSL_set_mode(SSL *, unsigned long);
-unsigned long SSL_clear_mode(SSL *, unsigned long);
-unsigned long SSL_get_mode(SSL *);
-
-unsigned long SSL_set_options(SSL *, unsigned long);
-unsigned long SSL_get_options(SSL *);
+uint64_t SSL_set_options(SSL *, uint64_t);
+uint64_t SSL_get_options(SSL *);
 
 int SSL_want_read(const SSL *);
 int SSL_want_write(const SSL *);
@@ -367,19 +363,27 @@ long SSL_CTX_get_max_proto_version(SSL_CTX *);
 long SSL_get_min_proto_version(SSL *);
 long SSL_get_max_proto_version(SSL *);
 
-/* Defined as unsigned long because SSL_OP_ALL is greater than signed 32-bit
-   and Windows defines long as 32-bit. */
-unsigned long SSL_CTX_set_options(SSL_CTX *, unsigned long);
-unsigned long SSL_CTX_clear_options(SSL_CTX *, unsigned long);
-unsigned long SSL_CTX_get_options(SSL_CTX *);
+long SSL_CTX_set_tmp_ecdh(SSL_CTX *, EC_KEY *);
+long SSL_CTX_set_tmp_dh(SSL_CTX *, DH *);
+long SSL_CTX_set_session_cache_mode(SSL_CTX *, long);
+long SSL_CTX_get_session_cache_mode(SSL_CTX *);
+long SSL_CTX_add_extra_chain_cert(SSL_CTX *, X509 *);
+
+uint64_t SSL_CTX_set_options(SSL_CTX *, uint64_t);
+uint64_t SSL_CTX_clear_options(SSL_CTX *, uint64_t);
+uint64_t SSL_CTX_get_options(SSL_CTX *);
+/* Defined as unsigned long rather than long because SSL_OP_ALL is greater
+    than signed 32-bit. OpenSSL treats this as a bitfield, but
+    cffi is smart and refuses to allow integer overflow, so when
+    sizeof(long) is 32-bit (all Windows and most 32-bit OSes) then
+    cffi errors. Calling this unsigned long makes the compiler mad
+    but c'est la vie. */
 unsigned long SSL_CTX_set_mode(SSL_CTX *, unsigned long);
 unsigned long SSL_CTX_clear_mode(SSL_CTX *, unsigned long);
 unsigned long SSL_CTX_get_mode(SSL_CTX *);
-unsigned long SSL_CTX_set_session_cache_mode(SSL_CTX *, unsigned long);
-unsigned long SSL_CTX_get_session_cache_mode(SSL_CTX *);
-unsigned long SSL_CTX_set_tmp_dh(SSL_CTX *, DH *);
-unsigned long SSL_CTX_set_tmp_ecdh(SSL_CTX *, EC_KEY *);
-unsigned long SSL_CTX_add_extra_chain_cert(SSL_CTX *, X509 *);
+unsigned long SSL_set_mode(SSL *, unsigned long);
+unsigned long SSL_clear_mode(SSL *, unsigned long);
+unsigned long SSL_get_mode(SSL *);
 
 const SSL_METHOD *DTLS_method(void);
 const SSL_METHOD *DTLS_server_method(void);

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -58,23 +58,6 @@ class TestOpenSSL:
         assert resp == expected_options
         assert b.lib.SSL_get_options(ssl) == expected_options
 
-    def test_ssl_mode(self):
-        # Test that we're properly handling 32-bit unsigned on all platforms.
-        b = Binding()
-        # SSL_OP_ALL is 0 on BoringSSL
-        if not b.lib.CRYPTOGRAPHY_IS_BORINGSSL:
-            assert b.lib.SSL_OP_ALL > 0
-        ctx = b.lib.SSL_CTX_new(b.lib.TLS_method())
-        assert ctx != b.ffi.NULL
-        ctx = b.ffi.gc(ctx, b.lib.SSL_CTX_free)
-        ssl = b.lib.SSL_new(ctx)
-        ssl = b.ffi.gc(ssl, b.lib.SSL_free)
-        current_options = b.lib.SSL_get_mode(ssl)
-        resp = b.lib.SSL_set_mode(ssl, b.lib.SSL_OP_ALL)
-        expected_options = current_options | b.lib.SSL_OP_ALL
-        assert resp == expected_options
-        assert b.lib.SSL_get_mode(ssl) == expected_options
-
     def test_conditional_removal(self):
         b = Binding()
 


### PR DESCRIPTION
These align more closely with OpenSSL 3.

also adds a comment about why we deliberately incorrectly declare some of them, sigh