### PR TITLE
make our rust/pip cache a composite action

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,0 +1,38 @@
+name: Cache rust and pip
+description: Caches rust and pip data to speed builds
+inputs:
+  additional-paths:
+    description: 'Additional paths to add to the cache'
+    required: false
+    default: ''
+  key:
+    description: 'cache key'
+    required: true
+
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        # Determine the path to our Python. It's in venv for our containers
+        # but just standard $PATH for setup-python pythons.
+        if [[ -f "/venv/bin/python" ]]; then
+          echo "dir=$(venv/bin/python -m pip cache dir)" >> $GITHUB_OUTPUT
+        elif which python >/dev/null; then
+          echo "dir=$(python -m pip cache dir)" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+    - uses: actions/cache@v3.2.5
+      with:
+        path: |
+          ${{ steps.pip-cache.outputs.dir }}
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/registry/src/
+          ~/.cargo/git/db/
+          src/rust/target/
+          ${{ inputs.additional-paths }}
+        key: ${{ inputs.key }}

--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -8,6 +8,10 @@ inputs:
   key:
     description: 'cache key'
     required: true
+outputs:
+  cache-hit:
+    description: 'Was the cache hit?'
+    value: ${{ steps.cache.outputs.cache-hit }}
 
 
 runs:
@@ -20,12 +24,13 @@ runs:
         # Determine the path to our Python. It's in venv for our containers
         # but just standard $PATH for setup-python pythons.
         if [[ -f "/venv/bin/python" ]]; then
-          echo "dir=$(venv/bin/python -m pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(/venv/bin/python -m pip cache dir)" >> $GITHUB_OUTPUT
         elif which python >/dev/null; then
           echo "dir=$(python -m pip cache dir)" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - uses: actions/cache@v3.2.5
+      id: cache
       with:
         path: |
           ${{ steps.pip-cache.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,18 +59,11 @@ jobs:
         uses: actions/setup-python@v4.5.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
-      - uses: actions/cache@v3.2.5
-        timeout-minutes: 5
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
         with:
-          path: |
-            ~/.cache/pip/wheels
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/src/
-            ~/.cargo/git/db/
-            src/rust/target/
           key: ${{ runner.os }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Clone wycheproof
         timeout-minutes: 2
         uses: ./.github/actions/wycheproof
@@ -171,18 +164,11 @@ jobs:
           git config --global --add safe.directory $(pwd) # needed for the mtime fix since git doesn't think it owns the files due to being in containers
       - name: set mtimes for rust dirs
         uses: ./.github/actions/mtime-fix
-      - uses: actions/cache@v3.2.5
-        timeout-minutes: 5
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
         with:
-          path: |
-            ~/.cache/pip/wheels
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/src/
-            ~/.cargo/git/db/
-            src/rust/target/
           key: ${{ runner.os }}-${{ matrix.IMAGE.IMAGE }}-${{ runner.arch }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Clone wycheproof
         timeout-minutes: 2
         uses: ./.github/actions/wycheproof
@@ -237,18 +223,11 @@ jobs:
           fetch-depth: 0
       - name: set mtimes for rust dirs
         uses: ./.github/actions/mtime-fix
-      - uses: actions/cache@v3.2.5
-        timeout-minutes: 5
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
         with:
-          path: |
-            ~/.cache/pip/wheels
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/src/
-            ~/.cargo/git/db/
-            src/rust/target/
           key: ${{ runner.os }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.RUST }}
-
       - name: Setup python
         uses: actions/setup-python@v4.5.0
         with:
@@ -297,19 +276,11 @@ jobs:
         with:
           toolchain: ${{ matrix.RUST }}
           components: llvm-tools-preview
-      - uses: actions/cache@v3.2.5
-        id: cargo-cache
-        timeout-minutes: 5
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
         with:
-          path: |
-            ~/.cache/pip/wheels
-            ~/.cargo/bin/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/src/
-            ~/.cargo/git/db/
-            src/rust/target/
           key: ${{ runner.os }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}-rust-${{ steps.rust-toolchain.outputs.cachekey }}-coverage
-
       - name: Setup python
         uses: actions/setup-python@v4.5.0
         with:
@@ -391,16 +362,10 @@ jobs:
           fetch-depth: 0
       - name: set mtimes for rust dirs
         uses: ./.github/actions/mtime-fix
-      - uses: actions/cache@v3.2.5
-        timeout-minutes: 5
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
         with:
-          path: |
-            ~/Library/Caches/pip/wheels
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/src/
-            ~/.cargo/git/db/
-            src/rust/target/
           key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.PYTHON.VERSION }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup python
@@ -465,18 +430,11 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           architecture: ${{ matrix.WINDOWS.ARCH }}
-      - uses: actions/cache@v3.2.5
-        timeout-minutes: 5
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
         with:
-          path: |
-            ~/AppData/Local/pip/Cache/wheels
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/src/
-            ~/.cargo/git/db/
-            src/rust/target/
           key: ${{ runner.os }}-${{ matrix.WINDOWS.ARCH }}-${{ steps.setup-python.outputs.python-version }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
-
       - run: python -m pip install -c ci-constraints-requirements.txt "tox>3" requests coverage[toml]
       - name: Download OpenSSL
         run: |
@@ -532,18 +490,11 @@ jobs:
           fetch-depth: 0
       - name: set mtimes for rust dirs
         uses: ./.github/actions/mtime-fix
-      - uses: actions/cache@v3.2.5
-        timeout-minutes: 5
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
         with:
-          path: |
-            ~/.cache/pip/wheels
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/registry/src/
-            ~/.cargo/git/db/
-            src/rust/target/
           key: ${{ runner.os }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Setup python
         uses: actions/setup-python@v4.5.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,10 +277,13 @@ jobs:
           toolchain: ${{ matrix.RUST }}
           components: llvm-tools-preview
       - name: Cache rust and pip
+        id: cargo-cache
         uses: ./.github/actions/cache
         timeout-minutes: 2
         with:
           key: ${{ runner.os }}-cargo-3-${{ hashFiles('**/Cargo.lock') }}-rust-${{ steps.rust-toolchain.outputs.cachekey }}-coverage
+          additional-paths: |
+            ~/.cargo/bin/
       - name: Setup python
         uses: actions/setup-python@v4.5.0
         with:


### PR DESCRIPTION
This re-caches `index` on nightly, which is not required, but as soon as 1.68 is released we can remove that cache line and enable sparse registry everywhere.