### PR TITLE
remove proto_version getters and most SSL_SESSION_* bindings

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -313,6 +313,8 @@ Cryptography_STACK_OF_X509_NAME *SSL_load_client_CA_file(const char *);
 const char *SSL_get_servername(const SSL *, const int);
 const char *SSL_CIPHER_get_version(const SSL_CIPHER *);
 
+SSL_SESSION *SSL_get_session(const SSL *);
+
 uint64_t SSL_set_options(SSL *, uint64_t);
 uint64_t SSL_get_options(SSL *);
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -313,13 +313,6 @@ Cryptography_STACK_OF_X509_NAME *SSL_load_client_CA_file(const char *);
 const char *SSL_get_servername(const SSL *, const int);
 const char *SSL_CIPHER_get_version(const SSL_CIPHER *);
 
-SSL_SESSION *SSL_get_session(const SSL *);
-const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *, unsigned int *);
-long SSL_SESSION_get_time(const SSL_SESSION *);
-long SSL_SESSION_get_timeout(const SSL_SESSION *);
-int SSL_SESSION_has_ticket(const SSL_SESSION *);
-unsigned long SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *);
-
 uint64_t SSL_set_options(SSL *, uint64_t);
 uint64_t SSL_get_options(SSL *);
 
@@ -330,13 +323,6 @@ long SSL_total_renegotiations(SSL *);
 
 long SSL_CTX_set_min_proto_version(SSL_CTX *, int);
 long SSL_CTX_set_max_proto_version(SSL_CTX *, int);
-long SSL_set_min_proto_version(SSL *, int);
-long SSL_set_max_proto_version(SSL *, int);
-
-long SSL_CTX_get_min_proto_version(SSL_CTX *);
-long SSL_CTX_get_max_proto_version(SSL_CTX *);
-long SSL_get_min_proto_version(SSL *);
-long SSL_get_max_proto_version(SSL *);
 
 long SSL_CTX_set_tmp_ecdh(SSL_CTX *, EC_KEY *);
 long SSL_CTX_set_tmp_dh(SSL_CTX *, DH *);


### PR DESCRIPTION
These were added in https://github.com/pyca/cryptography/pull/4205 and https://github.com/pyca/cryptography/pull/5595