### PR TITLE
Enforce max number of SSH certificate principals

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -1052,6 +1052,9 @@ _SSH_CERT_PRIVATE_KEY_TYPES = typing.Union[
 ]
 
 
+_SSHKEY_CERT_MAX_PRINCIPALS = 256
+
+
 class SSHCertificateBuilder:
     def __init__(
         self,
@@ -1181,6 +1184,12 @@ class SSHCertificateBuilder:
             )
         if self._valid_principals:
             raise ValueError("valid_principals already set")
+
+        if len(valid_principals) >= _SSHKEY_CERT_MAX_PRINCIPALS:
+            raise ValueError(
+                    "Reached or exceeded the maximum number of "
+                    "valid_principals"
+            )
 
         return SSHCertificateBuilder(
             _public_key=self._public_key,


### PR DESCRIPTION
There is an undocumented limit for the maximum number of valid principals accepted by the openssh tooling, as seen at:
* https://github.com/openssh/openssh-portable/blob/27267642699342412964aa785b98afd69d952c88/sshkey.h#L108
* https://github.com/openssh/openssh-portable/blob/25c8a2bbcc10c493d27faea57c42a6bf13fa51f2/sshkey.c#L1801
* https://github.com/openssh/openssh-portable/blob/6180b0fa4f7996687678702806257e661fd5931e/ssh-keygen.c#L1833

This change enforces that same restriction as currently a SSH certificate can be generated that is invalid against the default sshd server. Consideration might be given for any non openssh servers that accept openssh certificates, if they exist and want to allow a greater number of principals.

Of note, the 256 limit is not found in the spec for SSH certificates as defined at https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys. It instead seems to be arbitrarily chosen by the project as some limit was needed.