### PR TITLE
raise UnsupportedAlgorithm instead of ValueError in x509 builder sign

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,8 @@ Changelog
   you are using ``cryptography`` to directly invoke OpenSSL's C API. Note that
   these have never been considered a stable, supported, public API by
   ``cryptography``, this note is included as a courtesy.
+* The X.509 builder classes now raise ``UnsupportedAlgorithm`` instead of
+  ``ValueError`` if an unsupported hash algorithm is passed.
 
 
 .. _v39-0-1:

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -36,6 +36,19 @@ from cryptography.x509.oid import ObjectIdentifier
 
 _EARLIEST_UTC_TIME = datetime.datetime(1950, 1, 1)
 
+# This must be kept in sync with sign.rs's list of allowable types in
+# identify_hash_type
+_AllowedHashTypes = typing.Union[
+    hashes.SHA224,
+    hashes.SHA256,
+    hashes.SHA384,
+    hashes.SHA512,
+    hashes.SHA3_224,
+    hashes.SHA3_256,
+    hashes.SHA3_384,
+    hashes.SHA3_512,
+]
+
 
 class AttributeNotFound(Exception):
     def __init__(self, msg: str, oid: ObjectIdentifier) -> None:
@@ -679,7 +692,7 @@ class CertificateSigningRequestBuilder:
     def sign(
         self,
         private_key: CERTIFICATE_PRIVATE_KEY_TYPES,
-        algorithm: typing.Optional[hashes.HashAlgorithm],
+        algorithm: typing.Optional[_AllowedHashTypes],
         backend: typing.Any = None,
     ) -> CertificateSigningRequest:
         """
@@ -900,7 +913,7 @@ class CertificateBuilder:
     def sign(
         self,
         private_key: CERTIFICATE_PRIVATE_KEY_TYPES,
-        algorithm: typing.Optional[hashes.HashAlgorithm],
+        algorithm: typing.Optional[_AllowedHashTypes],
         backend: typing.Any = None,
     ) -> Certificate:
         """
@@ -1047,7 +1060,7 @@ class CertificateRevocationListBuilder:
     def sign(
         self,
         private_key: CERTIFICATE_PRIVATE_KEY_TYPES,
-        algorithm: typing.Optional[hashes.HashAlgorithm],
+        algorithm: typing.Optional[_AllowedHashTypes],
         backend: typing.Any = None,
     ) -> CertificateRevocationList:
         if self._issuer_name is None:

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -106,10 +106,15 @@ fn identify_hash_type(
         "sha3-256" => Ok(HashType::Sha3_256),
         "sha3-384" => Ok(HashType::Sha3_384),
         "sha3-512" => Ok(HashType::Sha3_512),
-        name => Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "Hash algorithm {:?} not supported for signatures",
-            name
-        ))),
+        name => Err(pyo3::PyErr::from_instance(
+            py.import("cryptography.exceptions")?.call_method1(
+                "UnsupportedAlgorithm",
+                (format!(
+                    "Hash algorithm {:?} not supported for signatures",
+                    name
+                ),),
+            )?,
+        )),
     }
 }
 
@@ -221,10 +226,12 @@ pub(crate) fn compute_signature_algorithm<'p>(
         (KeyType::Dsa, HashType::Sha3_224)
         | (KeyType::Dsa, HashType::Sha3_256)
         | (KeyType::Dsa, HashType::Sha3_384)
-        | (KeyType::Dsa, HashType::Sha3_512) => Err(pyo3::exceptions::PyValueError::new_err(
-            "SHA3 hashes are not supported with DSA keys",
+        | (KeyType::Dsa, HashType::Sha3_512) => Err(pyo3::PyErr::from_instance(
+            py.import("cryptography.exceptions")?.call_method1(
+                "UnsupportedAlgorithm",
+                ("SHA3 hashes are not supported with DSA keys",),
+            )?,
         )),
-
         (_, HashType::None) => Err(pyo3::exceptions::PyTypeError::new_err(
             "Algorithm must be a registered hash algorithm, not None.",
         )),

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -10,6 +10,7 @@ import os
 import pytest
 
 from cryptography import x509
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
@@ -917,7 +918,7 @@ class TestOCSPResponseBuilder:
             None,
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedAlgorithm):
             builder.sign(private_key, hashes.BLAKE2b(digest_size=64))
 
     def test_sign_none_hash_not_eddsa(self):

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -14,7 +14,7 @@ import pytest
 import pytz
 
 from cryptography import utils, x509
-from cryptography.exceptions import InvalidSignature
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat.bindings._rust import asn1
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import (
@@ -2853,7 +2853,7 @@ class TestCertificateBuilder:
             .not_valid_before(datetime.datetime(2002, 1, 1, 12, 1))
             .not_valid_after(datetime.datetime(2032, 1, 1, 12, 1))
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedAlgorithm):
             builder.sign(private_key, hash_algorithm, backend)
 
     @pytest.mark.supported(
@@ -2876,8 +2876,10 @@ class TestCertificateBuilder:
             .not_valid_before(datetime.datetime(2002, 1, 1, 12, 1))
             .not_valid_after(datetime.datetime(2032, 1, 1, 12, 1))
         )
-        with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.MD5(), backend)
+        with pytest.raises(UnsupportedAlgorithm):
+            builder.sign(
+                private_key, hashes.MD5(), backend  # type: ignore[arg-type]
+            )
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.dsa_supported(),

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -9,6 +9,7 @@ import pytest
 import pytz
 
 from cryptography import x509
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519
 from cryptography.x509.oid import (
@@ -732,8 +733,10 @@ class TestCertificateRevocationListBuilder:
             .next_update(next_time)
         )
 
-        with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.MD5(), backend)
+        with pytest.raises(UnsupportedAlgorithm):
+            builder.sign(
+                private_key, hashes.MD5(), backend  # type: ignore[arg-type]
+            )
 
     def test_ec_key_sign_md5(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
@@ -755,8 +758,10 @@ class TestCertificateRevocationListBuilder:
             .next_update(next_time)
         )
 
-        with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.MD5(), backend)
+        with pytest.raises(UnsupportedAlgorithm):
+            builder.sign(
+                private_key, hashes.MD5(), backend  # type: ignore[arg-type]
+            )
 
     def test_sign_with_revoked_certificates(self, backend):
         private_key = RSA_KEY_2048.private_key(backend)


### PR DESCRIPTION
Also change the typing to be an explicit union.

fixes #8213 