### PR TITLE
handle timezones for our mtime fixer

### DIFF
--- a/.github/actions/mtime-fix/action.yml
+++ b/.github/actions/mtime-fix/action.yml
@@ -6,7 +6,7 @@ runs:
 
   steps:
     - run: |
-        GIT_WORKS=$(git rev-parse --is-inside-work-tree 2>/dev/null)
+        GIT_WORKS=$(git rev-parse --is-inside-work-tree 2>/dev/null || true)
         if [ "$GIT_WORKS" != "true" ]; then
           echo "The git available is probably too old so checkout didn't create a real git clone, skipping mtime fix"
           exit 0

--- a/.github/actions/mtime-fix/action.yml
+++ b/.github/actions/mtime-fix/action.yml
@@ -8,7 +8,7 @@ runs:
     - run: |
         ls -Rla src/rust/src
         echo "Setting mtimes for rust dirs"
-        for f in $(git ls-files src/rust); do touch -t $(git log --pretty=format:%cd --date=format:%Y%m%d%H%M.%S -1 HEAD -- "$f") "$f"; done
+        for f in $(git ls-files src/rust); do touch -t $(git log --pretty=format:%cd --date=format-local:%Y%m%d%H%M.%S -1 HEAD -- "$f") "$f"; done
         echo "Done"
         ls -Rla src/rust/src
       shell: bash

--- a/.github/actions/mtime-fix/action.yml
+++ b/.github/actions/mtime-fix/action.yml
@@ -6,6 +6,11 @@ runs:
 
   steps:
     - run: |
+        GIT_WORKS=$(git rev-parse --is-inside-work-tree 2>/dev/null)
+        if [ "$GIT_WORKS" != "true" ]; then
+          echo "The git available is probably too old so checkout didn't create a real git clone, skipping mtime fix"
+          exit 0
+        fi
         ls -Rla src/rust/src
         echo "Verifying commits are monotonic because if they're not caching gets wrecked"
         COMMIT_ORDER=$(git log --pretty=format:%cd --date=format-local:%Y%m%d%H%M.%S -5)

--- a/.github/actions/mtime-fix/action.yml
+++ b/.github/actions/mtime-fix/action.yml
@@ -7,6 +7,13 @@ runs:
   steps:
     - run: |
         ls -Rla src/rust/src
+        echo "Verifying commits are monotonic because if they're not caching gets wrecked"
+        COMMIT_ORDER=$(git log --pretty=format:%cd --date=format-local:%Y%m%d%H%M.%S -5)
+        SORTED_COMMIT_ORDER=$(git log --pretty=format:%cd --date=format-local:%Y%m%d%H%M.%S -5 | sort -rn)
+        if [ "$COMMIT_ORDER" != "$SORTED_COMMIT_ORDER" ]; then
+          echo "Commits are not monotonic, git may have changed how date formatting works"
+          exit 1
+        fi
         echo "Setting mtimes for rust dirs"
         for f in $(git ls-files src/rust); do touch -t $(git log --pretty=format:%cd --date=format-local:%Y%m%d%H%M.%S -1 HEAD -- "$f") "$f"; done
         echo "Done"


### PR DESCRIPTION
avoids setting mtime into the future, which messes up the cache