### PR TITLE
don't cache some things, output info about the cache size on hit

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -37,8 +37,13 @@ runs:
           ${{ steps.pip-cache.outputs.dir }}
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
-          ~/.cargo/registry/src/
-          ~/.cargo/git/db/
           src/rust/target/
           ${{ inputs.additional-paths }}
-        key: cargo-pip-${{ runner.os }}-${{ runner.arch }}-${{ inputs.key }}-1-${{ hashFiles('**/Cargo.lock') }}
+        key: cargo-pip-${{ runner.os }}-${{ runner.arch }}-${{ inputs.key }}-2-${{ hashFiles('**/Cargo.lock') }}
+    - name: Size of cache items
+      run: |
+        du -sh ~/.cargo/registry/index/
+        du -sh ~/.cargo/registry/cache/
+        du -sh src/rust/target/
+      shell: bash
+      if: ${{ steps.cache.outputs.cache-hit }}


### PR DESCRIPTION
Apparently registry/src can be restored from registry/cache and this is faster (at least according to https://github.com/Swatinem/rust-cache)