### PR TITLE
faster linkcheck and rust jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,7 +528,7 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'linkcheck'))
     runs-on: ubuntu-latest
     name: "linkcheck"
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3.3.0
         with:
@@ -537,11 +537,26 @@ jobs:
       - name: set mtimes for rust dirs
         uses: ./.github/actions/mtime-fix
       - name: Setup python
+        id: setup-python
         uses: actions/setup-python@v4.5.0
         with:
           python-version: 3.11
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
+        with:
+          # This creates the same key as the docs job (as long as they have the same
+          # python version)
+          key: 3.11-${{ steps.setup-python.outputs.python-version }}
       - run: python -m pip install -c ci-constraints-requirements.txt tox
-      - run: tox -r --  --color=yes
+      - name: Build toxenv
+        run: |
+            tox -vvv --notest
+        env:
+          TOXENV: docs-linkcheck
+          CARGO_TARGET_DIR: ${{ format('{0}/src/rust/target/', github.workspace) }}
+      - name: linkcheck
+        run: tox --skip-pkg-install -- --color=yes
         env:
           TOXENV: docs-linkcheck
 

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,9 @@ commands =
 
 [testenv:rust]
 basepython = python3
+skip_install = True
+extras =
+deps =
 changedir = src/rust/
 allowlist_externals =
     cargo


### PR DESCRIPTION
linkcheck now uses caching and separates build from "test"

rust now completely skips all package installation in tox