### PR TITLE
EC key validation experiment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,19 @@ Changelog
   and
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`.
 * Deprecated and renamed the keyword argument for disabling RSA key validation
-  checks that was added in 39.0.0. The previous name will raise a warning
-  until it is removed in two releases.
+  checks that was added in 39.0.0. The new argument also applies to EC keys
+  (see below). The previous name will raise a warning until it is removed in
+  two releases.
+* Added support for disabling EC key validation checks when loading EC
+  keys via
+  :func:`~cryptography.hazmat.primitives.serialization.load_pem_private_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_der_private_key`,
+  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateNumbers.private_key`,
+  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`,
+  and
+  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers.public_key`.
+  This speeds up key loading but is :term:`unsafe` if you are loading potentially
+  attacker supplied keys.
 * Added support for parsing SSH certificates in addition to public keys with
   :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_identity`.
   :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_key`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey`
   and
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`.
+* Deprecated and renamed the keyword argument for disabling RSA key validation
+  checks that was added in 39.0.0. The previous name will raise a warning
+  until it is removed in two releases.
 * Added support for parsing SSH certificates in addition to public keys with
   :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_identity`.
   :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_key`

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -140,10 +140,24 @@ Elliptic Curve Signature Algorithms
 
         The private value.
 
-    .. method:: private_key()
+    .. method:: private_key(*, unsafe_skip_key_validation=False)
 
         Convert a collection of numbers into a private key suitable for doing
         actual cryptographic operations.
+
+        :param unsafe_skip_key_validation:
+
+            .. versionadded:: 40.0.0
+
+            A keyword-only argument that defaults to ``False``. If ``True``
+            keys will not be validated. This significantly speeds up
+            loading the keys, but is :term:`unsafe` unless you are certain
+            the key is valid. User supplied keys should never be loaded with
+            this parameter set to ``True``. If you do load an invalid key this
+            way and attempt to use it OpenSSL may hang, crash, or otherwise
+            misbehave.
+
+        :type unsafe_skip_key_validation: bool
 
         :returns: A new instance of :class:`EllipticCurvePrivateKey`.
 
@@ -179,10 +193,24 @@ Elliptic Curve Signature Algorithms
 
         The affine y component of the public point used for verifying.
 
-    .. method:: public_key()
+    .. method:: public_key(*, unsafe_skip_key_validation=False)
 
         Convert a collection of numbers into a public key suitable for doing
         actual cryptographic operations.
+
+        :param unsafe_skip_key_validation:
+
+            .. versionadded:: 40.0.0
+
+            A keyword-only argument that defaults to ``False``. If ``True``
+            keys will not be validated. This significantly speeds up
+            loading the keys, but is :term:`unsafe` unless you are certain
+            the key is valid. User supplied keys should never be loaded with
+            this parameter set to ``True``. If you do load an invalid key this
+            way and attempt to use it OpenSSL may hang, crash, or otherwise
+            misbehave.
+
+        :type unsafe_skip_key_validation: bool
 
         :raises ValueError: Raised if the point is invalid for the curve.
         :returns: A new instance of :class:`EllipticCurvePublicKey`.
@@ -712,7 +740,7 @@ Key Interfaces
         Size (in :term:`bits`) of a secret scalar for the curve (as generated
         by :func:`generate_private_key`).
 
-    .. classmethod:: from_encoded_point(curve, data)
+    .. classmethod:: from_encoded_point(curve, data, *, unsafe_skip_key_validation=False)
 
         .. versionadded:: 2.5
 
@@ -725,6 +753,20 @@ Key Interfaces
             instance.
 
         :param bytes data: The serialized point byte string.
+
+        :param unsafe_skip_key_validation:
+
+            .. versionadded:: 40.0.0
+
+            A keyword-only argument that defaults to ``False``. If ``True``
+            keys will not be validated. This significantly speeds up
+            loading the keys, but is :term:`unsafe` unless you are certain
+            the key is valid. User supplied keys should never be loaded with
+            this parameter set to ``True``. If you do load an invalid key this
+            way and attempt to use it OpenSSL may hang, crash, or otherwise
+            misbehave.
+
+        :type unsafe_skip_key_validation: bool
 
         :returns: An :class:`EllipticCurvePublicKey` instance.
 

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -473,11 +473,15 @@ is unavailable.
         A `Chinese remainder theorem`_ coefficient used to speed up RSA
         operations. Calculated as: q\ :sup:`-1` mod p
 
-    .. method:: private_key(*, unsafe_skip_rsa_key_validation=False)
+    .. method:: private_key(*, unsafe_skip_key_validation=False)
 
-        :param unsafe_skip_rsa_key_validation:
+        :param unsafe_skip_key_validation:
 
             .. versionadded:: 39.0.0
+
+            .. versionchanged:: 40.0.0
+                Renamed from ``unsafe_skip_rsa_key_validation``. The old name
+                is deprecated and will be removed in a future release.
 
             A keyword-only argument that defaults to ``False``. If ``True``
             RSA private keys will not be validated. This significantly speeds up
@@ -487,7 +491,7 @@ is unavailable.
             way and attempt to use it OpenSSL may hang, crash, or otherwise
             misbehave.
 
-        :type unsafe_skip_rsa_key_validation: bool
+        :type unsafe_skip_key_validation: bool
 
         :returns: An instance of
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`.

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -125,7 +125,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
     extract the public key with
     :meth:`Certificate.public_key <cryptography.x509.Certificate.public_key>`.
 
-.. function:: load_pem_private_key(data, password, *, unsafe_skip_rsa_key_validation=False)
+.. function:: load_pem_private_key(data, password, *, unsafe_skip_key_validation=False)
 
     .. versionadded:: 0.6
 
@@ -143,9 +143,13 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
         be ``None`` if the private key is not encrypted.
     :type password: :term:`bytes-like`
 
-    :param unsafe_skip_rsa_key_validation:
+    :param unsafe_skip_key_validation:
 
         .. versionadded:: 39.0.0
+
+        .. versionchanged:: 40.0.0
+            Renamed from ``unsafe_skip_rsa_key_validation``. The old name
+            is deprecated and will be removed in a future release.
 
         A keyword-only argument that defaults to ``False``. If ``True``
         RSA private keys will not be validated. This significantly speeds up
@@ -154,7 +158,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
         parameter set to ``True``. If you do load an invalid key this way and
         attempt to use it OpenSSL may hang, crash, or otherwise misbehave.
 
-    :type unsafe_skip_rsa_key_validation: bool
+    :type unsafe_skip_key_validation: bool
 
     :returns: One of
         :class:`~cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey`,
@@ -247,7 +251,7 @@ data is binary. DER keys may be in a variety of formats, but as long as you
 know whether it is a public or private key the loading functions will handle
 the rest.
 
-.. function:: load_der_private_key(data, password, *, unsafe_skip_rsa_key_validation=False)
+.. function:: load_der_private_key(data, password, *, unsafe_skip_key_validation=False)
 
     .. versionadded:: 0.8
 
@@ -261,9 +265,13 @@ the rest.
         be ``None`` if the private key is not encrypted.
     :type password: :term:`bytes-like`
 
-    :param unsafe_skip_rsa_key_validation:
+    :param unsafe_skip_key_validation:
 
         .. versionadded:: 39.0.0
+
+        .. versionchanged:: 40.0.0
+            Renamed from ``unsafe_skip_rsa_key_validation``. The old name
+            is deprecated and will be removed in a future release.
 
         A keyword-only argument that defaults to ``False``. If ``True``
         RSA private keys will not be validated. This significantly speeds up
@@ -272,7 +280,7 @@ the rest.
         parameter set to ``True``. If you do load an invalid key this way and
         attempt to use it OpenSSL may hang, crash, or otherwise misbehave.
 
-    :type unsafe_skip_rsa_key_validation: bool
+    :type unsafe_skip_key_validation: bool
 
     :returns: One of
         :class:`~cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey`,

--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -36,6 +36,7 @@ size_t EC_get_builtin_curves(EC_builtin_curve *, size_t);
 
 EC_KEY *EC_KEY_new(void);
 void EC_KEY_free(EC_KEY *);
+int EC_KEY_check_key(const EC_KEY *);
 
 EC_KEY *EC_KEY_new_by_curve_name(int);
 const EC_GROUP *EC_KEY_get0_group(const EC_KEY *);
@@ -45,11 +46,12 @@ const EC_POINT *EC_KEY_get0_public_key(const EC_KEY *);
 int EC_KEY_set_public_key(EC_KEY *, const EC_POINT *);
 void EC_KEY_set_asn1_flag(EC_KEY *, int);
 int EC_KEY_generate_key(EC_KEY *);
-int EC_KEY_set_public_key_affine_coordinates(EC_KEY *, BIGNUM *, BIGNUM *);
 
 EC_POINT *EC_POINT_new(const EC_GROUP *);
 void EC_POINT_free(EC_POINT *);
 
+int EC_POINT_set_affine_coordinates(const EC_GROUP *, EC_POINT *,
+                                    const BIGNUM *, const BIGNUM *, BN_CTX *);
 int EC_POINT_get_affine_coordinates(const EC_GROUP *, const EC_POINT *,
                                     BIGNUM *, BIGNUM *, BN_CTX *);
 

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -369,7 +369,7 @@ class _RSAPrivateKey(RSAPrivateKey):
         rsa_cdata,
         evp_pkey,
         *,
-        unsafe_skip_rsa_key_validation: bool,
+        unsafe_skip_key_validation: bool,
     ):
         res: int
         # RSA_check_key is slower in OpenSSL 3.0.0 due to improved
@@ -377,7 +377,7 @@ class _RSAPrivateKey(RSAPrivateKey):
         # since users don't load new keys constantly, but for TESTING we've
         # added an init arg that allows skipping the checks. You should not
         # use this in production code unless you understand the consequences.
-        if not unsafe_skip_rsa_key_validation:
+        if not unsafe_skip_key_validation:
             res = backend._lib.RSA_check_key(rsa_cdata)
             if res != 1:
                 errors = backend._consume_errors_with_text()

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -166,7 +166,10 @@ class EllipticCurvePublicKey(metaclass=abc.ABCMeta):
 
     @classmethod
     def from_encoded_point(
-        cls, curve: EllipticCurve, data: bytes
+        cls,
+        curve: EllipticCurve,
+        data: bytes,
+        unsafe_skip_key_validation: bool = False,
     ) -> "EllipticCurvePublicKey":
         utils._check_bytes("data", data)
 
@@ -181,7 +184,9 @@ class EllipticCurvePublicKey(metaclass=abc.ABCMeta):
 
         from cryptography.hazmat.backends.openssl.backend import backend
 
-        return backend.load_elliptic_curve_public_bytes(curve, data)
+        return backend.load_elliptic_curve_public_bytes(
+            curve, data, unsafe_skip_key_validation
+        )
 
 
 EllipticCurvePublicKeyWithSerialization = EllipticCurvePublicKey
@@ -360,12 +365,19 @@ class EllipticCurvePublicNumbers:
         self._x = x
         self._curve = curve
 
-    def public_key(self, backend: typing.Any = None) -> EllipticCurvePublicKey:
+    def public_key(
+        self,
+        backend: typing.Any = None,
+        *,
+        unsafe_skip_key_validation: bool = False,
+    ) -> EllipticCurvePublicKey:
         from cryptography.hazmat.backends.openssl.backend import (
             backend as ossl,
         )
 
-        return ossl.load_elliptic_curve_public_numbers(self)
+        return ossl.load_elliptic_curve_public_numbers(
+            self, unsafe_skip_key_validation
+        )
 
     @property
     def curve(self) -> EllipticCurve:
@@ -417,13 +429,18 @@ class EllipticCurvePrivateNumbers:
         self._public_numbers = public_numbers
 
     def private_key(
-        self, backend: typing.Any = None
+        self,
+        backend: typing.Any = None,
+        *,
+        unsafe_skip_key_validation: bool = False,
     ) -> EllipticCurvePrivateKey:
         from cryptography.hazmat.backends.openssl.backend import (
             backend as ossl,
         )
 
-        return ossl.load_elliptic_curve_private_numbers(self)
+        return ossl.load_elliptic_curve_private_numbers(
+            self, unsafe_skip_key_validation
+        )
 
     @property
     def private_value(self) -> int:

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -5,11 +5,15 @@
 
 import abc
 import typing
+import warnings
 from math import gcd
 
+from cryptography import utils
 from cryptography.hazmat.primitives import _serialization, hashes
 from cryptography.hazmat.primitives._asymmetric import AsymmetricPadding
 from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
+
+_SENTINEL = object()
 
 
 class RSAPrivateKey(metaclass=abc.ABCMeta):
@@ -358,15 +362,24 @@ class RSAPrivateNumbers:
         self,
         backend: typing.Any = None,
         *,
-        unsafe_skip_rsa_key_validation: bool = False,
+        unsafe_skip_rsa_key_validation=_SENTINEL,
+        unsafe_skip_key_validation: bool = False,
     ) -> RSAPrivateKey:
         from cryptography.hazmat.backends.openssl.backend import (
             backend as ossl,
         )
 
-        return ossl.load_rsa_private_numbers(
-            self, unsafe_skip_rsa_key_validation
-        )
+        if unsafe_skip_rsa_key_validation is not _SENTINEL:
+            warnings.warn(
+                "unsafe_skip_rsa_key_validation is deprecated and will be "
+                "removed in 42.0.0. Please use unsafe_skip_key_validation "
+                "instead.",
+                utils.DeprecatedIn40,
+                stacklevel=2,
+            )
+            unsafe_skip_key_validation = unsafe_skip_rsa_key_validation
+
+        return ossl.load_rsa_private_numbers(self, unsafe_skip_key_validation)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, RSAPrivateNumbers):

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -41,16 +41,11 @@ def load_pem_private_key(
 
 
 def load_pem_public_key(
-    data: bytes,
-    backend: typing.Any = None,
-    *,
-    unsafe_skip_key_validation: bool = False,
+    data: bytes, backend: typing.Any = None
 ) -> PUBLIC_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
-    return ossl.load_pem_public_key(
-        data, unsafe_skip_key_validation=unsafe_skip_key_validation
-    )
+    return ossl.load_pem_public_key(data)
 
 
 def load_pem_parameters(
@@ -86,16 +81,11 @@ def load_der_private_key(
 
 
 def load_der_public_key(
-    data: bytes,
-    backend: typing.Any = None,
-    *,
-    unsafe_skip_key_validation: bool = False,
+    data: bytes, backend: typing.Any = None
 ) -> PUBLIC_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
-    return ossl.load_der_public_key(
-        data, unsafe_skip_key_validation=unsafe_skip_key_validation
-    )
+    return ossl.load_der_public_key(data)
 
 
 def load_der_parameters(

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -41,11 +41,16 @@ def load_pem_private_key(
 
 
 def load_pem_public_key(
-    data: bytes, backend: typing.Any = None
+    data: bytes,
+    backend: typing.Any = None,
+    *,
+    unsafe_skip_key_validation: bool = False,
 ) -> PUBLIC_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
-    return ossl.load_pem_public_key(data)
+    return ossl.load_pem_public_key(
+        data, unsafe_skip_key_validation=unsafe_skip_key_validation
+    )
 
 
 def load_pem_parameters(
@@ -81,11 +86,16 @@ def load_der_private_key(
 
 
 def load_der_public_key(
-    data: bytes, backend: typing.Any = None
+    data: bytes,
+    backend: typing.Any = None,
+    *,
+    unsafe_skip_key_validation: bool = False,
 ) -> PUBLIC_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
-    return ossl.load_der_public_key(data)
+    return ossl.load_der_public_key(
+        data, unsafe_skip_key_validation=unsafe_skip_key_validation
+    )
 
 
 def load_der_parameters(

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -4,12 +4,16 @@
 
 
 import typing
+import warnings
 
+from cryptography import utils
 from cryptography.hazmat.primitives.asymmetric import dh
 from cryptography.hazmat.primitives.asymmetric.types import (
     PRIVATE_KEY_TYPES,
     PUBLIC_KEY_TYPES,
 )
+
+_SENTINEL = object()
 
 
 def load_pem_private_key(
@@ -17,12 +21,22 @@ def load_pem_private_key(
     password: typing.Optional[bytes],
     backend: typing.Any = None,
     *,
-    unsafe_skip_rsa_key_validation: bool = False,
+    unsafe_skip_rsa_key_validation=_SENTINEL,
+    unsafe_skip_key_validation: bool = False,
 ) -> PRIVATE_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
+    if unsafe_skip_rsa_key_validation is not _SENTINEL:
+        warnings.warn(
+            "unsafe_skip_rsa_key_validation is deprecated and will be removed "
+            "in 42.0.0. Please use unsafe_skip_key_validation instead.",
+            utils.DeprecatedIn40,
+            stacklevel=2,
+        )
+        unsafe_skip_key_validation = unsafe_skip_rsa_key_validation
+
     return ossl.load_pem_private_key(
-        data, password, unsafe_skip_rsa_key_validation
+        data, password, unsafe_skip_key_validation
     )
 
 
@@ -47,12 +61,22 @@ def load_der_private_key(
     password: typing.Optional[bytes],
     backend: typing.Any = None,
     *,
-    unsafe_skip_rsa_key_validation: bool = False,
+    unsafe_skip_rsa_key_validation=_SENTINEL,
+    unsafe_skip_key_validation: bool = False,
 ) -> PRIVATE_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
+    if unsafe_skip_rsa_key_validation is not _SENTINEL:
+        warnings.warn(
+            "unsafe_skip_rsa_key_validation is deprecated and will be removed "
+            "in 42.0.0. Please use unsafe_skip_key_validation instead.",
+            utils.DeprecatedIn40,
+            stacklevel=2,
+        )
+        unsafe_skip_key_validation = unsafe_skip_rsa_key_validation
+
     return ossl.load_der_private_key(
-        data, password, unsafe_skip_rsa_key_validation
+        data, password, unsafe_skip_key_validation
     )
 
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -487,9 +487,7 @@ class TestOpenSSLSerializationWithOpenSSL:
                 key, unsafe_skip_key_validation=False
             )
         with raises_unsupported_algorithm(None):
-            backend._evp_pkey_to_public_key(
-                key, unsafe_skip_key_validation=False
-            )
+            backend._evp_pkey_to_public_key(key)
 
     def test_very_long_pem_serialization_password(self):
         password = b"x" * 1024

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -484,7 +484,7 @@ class TestOpenSSLSerializationWithOpenSSL:
         key = backend._create_evp_pkey_gc()
         with raises_unsupported_algorithm(None):
             backend._evp_pkey_to_private_key(
-                key, unsafe_skip_rsa_key_validation=False
+                key, unsafe_skip_key_validation=False
             )
         with raises_unsupported_algorithm(None):
             backend._evp_pkey_to_public_key(key)
@@ -503,7 +503,7 @@ class TestOpenSSLSerializationWithOpenSSL:
                     backend.load_pem_private_key(
                         pemfile.read().encode(),
                         password,
-                        unsafe_skip_rsa_key_validation=False,
+                        unsafe_skip_key_validation=False,
                     )
                 ),
             )

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -487,7 +487,9 @@ class TestOpenSSLSerializationWithOpenSSL:
                 key, unsafe_skip_key_validation=False
             )
         with raises_unsupported_algorithm(None):
-            backend._evp_pkey_to_public_key(key)
+            backend._evp_pkey_to_public_key(
+                key, unsafe_skip_key_validation=False
+            )
 
     def test_very_long_pem_serialization_password(self):
         password = b"x" * 1024

--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -292,7 +292,7 @@ class TestOpenSSLMemoryLeaks:
                         '575406618073069185107088229463828921069465902299522926'
                     )
                 )
-            ).private_key(backend)
+            ).private_key(unsafe_skip_key_validation=True)
         """
             )
         )

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -231,7 +231,7 @@ class TestECWithNumbers:
                     ec.EllipticCurvePublicNumbers(
                         vector["x"], vector["y"], curve_type()
                     ),
-                ).private_key(backend)
+                ).private_key(unsafe_skip_key_validation=True)
                 assert key
 
                 priv_num = key.private_numbers()
@@ -263,7 +263,7 @@ class TestECDSAVectors:
                     ec.EllipticCurvePublicNumbers(
                         vector["x"], vector["y"], curve_type()
                     ),
-                ).private_key(backend)
+                ).private_key(unsafe_skip_key_validation=True)
                 assert key
 
                 pkey = key.public_key()
@@ -464,7 +464,7 @@ class TestECDSAVectors:
 
                 key = ec.EllipticCurvePublicNumbers(
                     vector["x"], vector["y"], curve_type()
-                ).public_key(backend)
+                ).public_key(unsafe_skip_key_validation=True)
 
                 signature = encode_dss_signature(vector["r"], vector["s"])
 
@@ -484,7 +484,7 @@ class TestECDSAVectors:
 
                 key = ec.EllipticCurvePublicNumbers(
                     vector["x"], vector["y"], curve_type()
-                ).public_key(backend)
+                ).public_key(unsafe_skip_key_validation=True)
 
                 signature = encode_dss_signature(vector["r"], vector["s"])
 
@@ -625,7 +625,9 @@ class TestECSerialization:
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: pemfile.read().encode(),
         )
-        key = serialization.load_pem_private_key(key_bytes, None, backend)
+        key = serialization.load_pem_private_key(
+            key_bytes, None, unsafe_skip_key_validation=True
+        )
         assert isinstance(key, ec.EllipticCurvePrivateKey)
         serialized = key.private_bytes(
             serialization.Encoding.PEM,
@@ -633,7 +635,7 @@ class TestECSerialization:
             serialization.BestAvailableEncryption(password),
         )
         loaded_key = serialization.load_pem_private_key(
-            serialized, password, backend
+            serialized, password, unsafe_skip_key_validation=True
         )
         assert isinstance(loaded_key, ec.EllipticCurvePrivateKey)
         loaded_priv_num = loaded_key.private_numbers()
@@ -670,7 +672,9 @@ class TestECSerialization:
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: pemfile.read().encode(),
         )
-        key = serialization.load_pem_private_key(key_bytes, None, backend)
+        key = serialization.load_pem_private_key(
+            key_bytes, None, unsafe_skip_key_validation=True
+        )
         assert isinstance(key, ec.EllipticCurvePrivateKey)
         serialized = key.private_bytes(
             serialization.Encoding.DER,
@@ -678,7 +682,7 @@ class TestECSerialization:
             serialization.BestAvailableEncryption(password),
         )
         loaded_key = serialization.load_der_private_key(
-            serialized, password, backend
+            serialized, password, unsafe_skip_key_validation=True
         )
         assert isinstance(loaded_key, ec.EllipticCurvePrivateKey)
         loaded_priv_num = loaded_key.private_numbers()
@@ -718,12 +722,16 @@ class TestECSerialization:
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: pemfile.read().encode(),
         )
-        key = serialization.load_pem_private_key(key_bytes, None, backend)
+        key = serialization.load_pem_private_key(
+            key_bytes, None, unsafe_skip_key_validation=True
+        )
         assert isinstance(key, ec.EllipticCurvePrivateKey)
         serialized = key.private_bytes(
             encoding, fmt, serialization.NoEncryption()
         )
-        loaded_key = loader_func(serialized, None, backend)
+        loaded_key = loader_func(
+            serialized, None, unsafe_skip_key_validation=True
+        )
         assert isinstance(loaded_key, ec.EllipticCurvePrivateKey)
         loaded_priv_num = loaded_key.private_numbers()
         priv_num = key.private_numbers()
@@ -758,7 +766,7 @@ class TestECSerialization:
         key_bytes = load_vectors_from_file(
             key_path, lambda pemfile: pemfile.read(), mode="rb"
         )
-        key = loader_func(key_bytes, None, backend)
+        key = loader_func(key_bytes, None, unsafe_skip_key_validation=True)
         serialized = key.private_bytes(
             encoding,
             serialization.PrivateFormat.TraditionalOpenSSL,
@@ -771,7 +779,7 @@ class TestECSerialization:
         key = load_vectors_from_file(
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
-                pemfile.read().encode(), None, backend
+                pemfile.read().encode(), None, unsafe_skip_key_validation=True
             ),
         )
         with pytest.raises(ValueError):
@@ -786,7 +794,7 @@ class TestECSerialization:
         key = load_vectors_from_file(
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
-                pemfile.read().encode(), None, backend
+                pemfile.read().encode(), None, unsafe_skip_key_validation=True
             ),
         )
         with pytest.raises(TypeError):
@@ -801,7 +809,7 @@ class TestECSerialization:
         key = load_vectors_from_file(
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
-                pemfile.read().encode(), None, backend
+                pemfile.read().encode(), None, unsafe_skip_key_validation=True
             ),
         )
         with pytest.raises(TypeError):
@@ -816,7 +824,7 @@ class TestECSerialization:
         key = load_vectors_from_file(
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
-                pemfile.read().encode(), None, backend
+                pemfile.read().encode(), None, unsafe_skip_key_validation=True
             ),
         )
         with pytest.raises(TypeError):
@@ -831,7 +839,7 @@ class TestECSerialization:
         key = load_vectors_from_file(
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
-                pemfile.read().encode(), None, backend
+                pemfile.read().encode(), None, unsafe_skip_key_validation=True
             ),
         )
         with pytest.raises(ValueError):
@@ -846,7 +854,7 @@ class TestECSerialization:
         key = load_vectors_from_file(
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
-                pemfile.read().encode(), None, backend
+                pemfile.read().encode(), None, unsafe_skip_key_validation=True
             ),
         )
         public = key.public_key()
@@ -854,7 +862,9 @@ class TestECSerialization:
             serialization.Encoding.PEM,
             serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-        parsed_public = serialization.load_pem_public_key(pem, backend)
+        parsed_public = serialization.load_pem_public_key(
+            pem, backend, unsafe_skip_key_validation=True
+        )
         assert parsed_public
 
 
@@ -885,7 +895,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
         key_bytes = load_vectors_from_file(
             key_path, lambda pemfile: pemfile.read(), mode="rb"
         )
-        key = loader_func(key_bytes, backend)
+        key = loader_func(key_bytes, unsafe_skip_key_validation=True)
         serialized = key.public_bytes(
             encoding,
             serialization.PublicFormat.SubjectPublicKeyInfo,
@@ -903,7 +913,9 @@ class TestEllipticCurvePEMPublicKeySerialization:
             lambda pemfile: pemfile.read(),
             mode="rb",
         )
-        key = serialization.load_pem_public_key(key_bytes, backend)
+        key = serialization.load_pem_public_key(
+            key_bytes, unsafe_skip_key_validation=True
+        )
 
         ssh_bytes = key.public_bytes(
             serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH
@@ -928,7 +940,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
                 "asymmetric", "PEM_Serialization", "ec_public_key.pem"
             ),
             lambda pemfile: serialization.load_pem_public_key(
-                pemfile.read().encode(), backend
+                pemfile.read().encode(), unsafe_skip_key_validation=True
             ),
         )
         with pytest.raises(TypeError):
@@ -975,7 +987,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
                 "asymmetric", "PEM_Serialization", "ec_public_key.pem"
             ),
             lambda pemfile: serialization.load_pem_public_key(
-                pemfile.read().encode(), backend
+                pemfile.read().encode(), unsafe_skip_key_validation=True
             ),
         )
         with pytest.raises(TypeError):
@@ -991,7 +1003,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
                 "asymmetric", "PEM_Serialization", "ec_public_key.pem"
             ),
             lambda pemfile: serialization.load_pem_public_key(
-                pemfile.read().encode(), backend
+                pemfile.read().encode(), unsafe_skip_key_validation=True
             ),
         )
         with pytest.raises(ValueError):
@@ -1012,7 +1024,9 @@ class TestEllipticCurvePEMPublicKeySerialization:
         ]
         _skip_curve_unsupported(backend, curve)
         point = binascii.unhexlify(vector["point"])
-        pn = ec.EllipticCurvePublicKey.from_encoded_point(curve, point)
+        pn = ec.EllipticCurvePublicKey.from_encoded_point(
+            curve, point, unsafe_skip_key_validation=True
+        )
         public_num = pn.public_numbers()
         assert public_num.x == int(vector["x"], 16)
         assert public_num.y == int(vector["y"], 16)
@@ -1025,7 +1039,9 @@ class TestEllipticCurvePEMPublicKeySerialization:
         )
         with pytest.raises(ValueError):
             ec.EllipticCurvePublicKey.from_encoded_point(
-                ec.SECP256R1(), uncompressed_point
+                ec.SECP256R1(),
+                uncompressed_point,
+                unsafe_skip_key_validation=True,
             )
 
     def test_from_encoded_point_uncompressed(self):
@@ -1035,7 +1051,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
             "6d"
         )
         pn = ec.EllipticCurvePublicKey.from_encoded_point(
-            ec.SECP256R1(), uncompressed_point
+            ec.SECP256R1(), uncompressed_point, unsafe_skip_key_validation=True
         )
         assert pn.public_numbers().x == int(
             "7399336a9edf2197c2f8eb3d39aed9c34a66e45d918a07dc7684c42c9b37ac68",
@@ -1097,6 +1113,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
                 serialization.Encoding.X962,
                 serialization.PublicFormat.UncompressedPoint,
             ),
+            unsafe_skip_key_validation=True,
         )
         assert (
             key.public_bytes(
@@ -1146,7 +1163,9 @@ class TestECDH:
                         private_numbers.private_key(backend)
                     continue
                 else:
-                    private_key = private_numbers.private_key(backend)
+                    private_key = private_numbers.private_key(
+                        unsafe_skip_key_validation=True
+                    )
 
                 peer_numbers = vector["CAVS"]
                 public_numbers = ec.EllipticCurvePublicNumbers(
@@ -1161,7 +1180,9 @@ class TestECDH:
                         public_numbers.public_key(backend)
                     continue
                 else:
-                    peer_pubkey = public_numbers.public_key(backend)
+                    peer_pubkey = public_numbers.public_key(
+                        unsafe_skip_key_validation=True
+                    )
 
                 z = private_key.exchange(ec.ECDH(), peer_pubkey)
                 zz = int(hexlify(z).decode("ascii"), 16)
@@ -1189,13 +1210,13 @@ class TestECDH:
             ec.EllipticCurvePublicNumbers(
                 int(vector["x_qa"], 16), int(vector["y_qa"], 16), curve
             ),
-        ).private_key(backend)
+        ).private_key(unsafe_skip_key_validation=True)
         peer = ec.EllipticCurvePrivateNumbers(
             int(vector["db"], 16),
             ec.EllipticCurvePublicNumbers(
                 int(vector["x_qb"], 16), int(vector["y_qb"], 16), curve
             ),
-        ).private_key(backend)
+        ).private_key(unsafe_skip_key_validation=True)
         shared_secret = key.exchange(ec.ECDH(), peer.public_key())
         assert shared_secret == binascii.unhexlify(vector["x_z"])
         shared_secret_2 = peer.exchange(ec.ECDH(), key.public_key())
@@ -1207,7 +1228,7 @@ class TestECDH:
         key = load_vectors_from_file(
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
-                pemfile.read().encode(), None, backend
+                pemfile.read().encode(), None, unsafe_skip_key_validation=True
             ),
         )
         assert isinstance(key, ec.EllipticCurvePrivateKey)
@@ -1224,11 +1245,13 @@ class TestECDH:
         key = load_vectors_from_file(
             os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
-                pemfile.read().encode(), None, backend
+                pemfile.read().encode(), None, unsafe_skip_key_validation=True
             ),
         )
         assert isinstance(key, ec.EllipticCurvePrivateKey)
-        public_key = EC_KEY_SECP384R1.public_numbers.public_key(backend)
+        public_key = EC_KEY_SECP384R1.public_numbers.public_key(
+            unsafe_skip_key_validation=True
+        )
 
         with pytest.raises(ValueError):
             key.exchange(ec.ECDH(), public_key)

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -862,9 +862,7 @@ class TestECSerialization:
             serialization.Encoding.PEM,
             serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-        parsed_public = serialization.load_pem_public_key(
-            pem, backend, unsafe_skip_key_validation=True
-        )
+        parsed_public = serialization.load_pem_public_key(pem, backend)
         assert parsed_public
 
 
@@ -895,7 +893,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
         key_bytes = load_vectors_from_file(
             key_path, lambda pemfile: pemfile.read(), mode="rb"
         )
-        key = loader_func(key_bytes, unsafe_skip_key_validation=True)
+        key = loader_func(key_bytes, backend)
         serialized = key.public_bytes(
             encoding,
             serialization.PublicFormat.SubjectPublicKeyInfo,
@@ -913,9 +911,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
             lambda pemfile: pemfile.read(),
             mode="rb",
         )
-        key = serialization.load_pem_public_key(
-            key_bytes, unsafe_skip_key_validation=True
-        )
+        key = serialization.load_pem_public_key(key_bytes, backend)
 
         ssh_bytes = key.public_bytes(
             serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH
@@ -940,7 +936,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
                 "asymmetric", "PEM_Serialization", "ec_public_key.pem"
             ),
             lambda pemfile: serialization.load_pem_public_key(
-                pemfile.read().encode(), unsafe_skip_key_validation=True
+                pemfile.read().encode(), backend
             ),
         )
         with pytest.raises(TypeError):
@@ -987,7 +983,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
                 "asymmetric", "PEM_Serialization", "ec_public_key.pem"
             ),
             lambda pemfile: serialization.load_pem_public_key(
-                pemfile.read().encode(), unsafe_skip_key_validation=True
+                pemfile.read().encode(), backend
             ),
         )
         with pytest.raises(TypeError):
@@ -1003,7 +999,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
                 "asymmetric", "PEM_Serialization", "ec_public_key.pem"
             ),
             lambda pemfile: serialization.load_pem_public_key(
-                pemfile.read().encode(), unsafe_skip_key_validation=True
+                pemfile.read().encode(), backend
             ),
         )
         with pytest.raises(ValueError):
@@ -1249,9 +1245,7 @@ class TestECDH:
             ),
         )
         assert isinstance(key, ec.EllipticCurvePrivateKey)
-        public_key = EC_KEY_SECP384R1.public_numbers.public_key(
-            unsafe_skip_key_validation=True
-        )
+        public_key = EC_KEY_SECP384R1.public_numbers.public_key(backend)
 
         with pytest.raises(ValueError):
             key.exchange(ec.ECDH(), public_key)

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -10,6 +10,7 @@ import textwrap
 
 import pytest
 
+from cryptography import utils
 from cryptography.hazmat.primitives.asymmetric import (
     dsa,
     ec,
@@ -109,6 +110,34 @@ class TestBufferProtocolSerialization:
         assert key
         assert isinstance(key, rsa.RSAPrivateKey)
         _check_rsa_private_numbers(key.private_numbers())
+
+    def test_deprecated_unsafe_kwargs(self):
+        der = load_vectors_from_file(
+            os.path.join("asymmetric", "DER_Serialization", "testrsa.der"),
+            lambda derfile: derfile.read(),
+            mode="rb",
+        )
+        pem = load_vectors_from_file(
+            os.path.join("asymmetric", "PKCS8", "unenc-rsa-pkcs8.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
+        with pytest.warns(utils.DeprecatedIn40):
+            load_der_private_key(
+                der, None, unsafe_skip_rsa_key_validation=True
+            )
+        with pytest.warns(utils.DeprecatedIn40):
+            load_der_private_key(
+                der, None, unsafe_skip_rsa_key_validation=False
+            )
+        with pytest.warns(utils.DeprecatedIn40):
+            load_pem_private_key(
+                pem, None, unsafe_skip_rsa_key_validation=True
+            )
+        with pytest.warns(utils.DeprecatedIn40):
+            load_pem_private_key(
+                pem, None, unsafe_skip_rsa_key_validation=False
+            )
 
 
 class TestDERSerialization:

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -218,7 +218,7 @@ class TestDERSerialization:
         key = load_vectors_from_file(
             os.path.join("asymmetric", *key_path),
             lambda derfile: load_der_private_key(
-                derfile.read(), password, backend
+                derfile.read(), password, unsafe_skip_key_validation=True
             ),
             mode="rb",
         )
@@ -504,7 +504,9 @@ class TestPEMSerialization:
         key = load_vectors_from_file(
             os.path.join("asymmetric", *key_path),
             lambda pemfile: load_pem_private_key(
-                pemfile.read().encode(), password, backend
+                pemfile.read().encode(),
+                password,
+                unsafe_skip_key_validation=True,
             ),
         )
 

--- a/tests/wycheproof/test_ecdh.py
+++ b/tests/wycheproof/test_ecdh.py
@@ -73,8 +73,10 @@ def test_ecdh(backend, wycheproof):
     )
 
     try:
+        # TODO: why is this safe?
         public_key = serialization.load_der_public_key(
-            binascii.unhexlify(wycheproof.testcase["public"]), backend
+            binascii.unhexlify(wycheproof.testcase["public"]),
+            unsafe_skip_key_validation=True,
         )
         assert isinstance(public_key, ec.EllipticCurvePublicKey)
     except ValueError:
@@ -122,7 +124,9 @@ def test_ecdh_ecpoint(backend, wycheproof):
 
     assert wycheproof.valid or wycheproof.acceptable
     public_key = ec.EllipticCurvePublicKey.from_encoded_point(
-        curve, binascii.unhexlify(wycheproof.testcase["public"])
+        curve,
+        binascii.unhexlify(wycheproof.testcase["public"]),
+        unsafe_skip_key_validation=True,
     )
     computed_shared = private_key.exchange(ec.ECDH(), public_key)
     expected_shared = binascii.unhexlify(wycheproof.testcase["shared"])

--- a/tests/wycheproof/test_ecdh.py
+++ b/tests/wycheproof/test_ecdh.py
@@ -76,7 +76,6 @@ def test_ecdh(backend, wycheproof):
         # TODO: why is this safe?
         public_key = serialization.load_der_public_key(
             binascii.unhexlify(wycheproof.testcase["public"]),
-            unsafe_skip_key_validation=True,
         )
         assert isinstance(public_key, ec.EllipticCurvePublicKey)
     except ValueError:

--- a/tests/wycheproof/test_ecdsa.py
+++ b/tests/wycheproof/test_ecdsa.py
@@ -62,7 +62,8 @@ _DIGESTS = {
 def test_ecdsa_signature(backend, wycheproof):
     try:
         key = serialization.load_der_public_key(
-            binascii.unhexlify(wycheproof.testgroup["keyDer"]), backend
+            binascii.unhexlify(wycheproof.testgroup["keyDer"]),
+            unsafe_skip_key_validation=True,
         )
         assert isinstance(key, ec.EllipticCurvePublicKey)
     except (UnsupportedAlgorithm, ValueError):

--- a/tests/wycheproof/test_ecdsa.py
+++ b/tests/wycheproof/test_ecdsa.py
@@ -62,8 +62,7 @@ _DIGESTS = {
 def test_ecdsa_signature(backend, wycheproof):
     try:
         key = serialization.load_der_public_key(
-            binascii.unhexlify(wycheproof.testgroup["keyDer"]),
-            unsafe_skip_key_validation=True,
+            binascii.unhexlify(wycheproof.testgroup["keyDer"])
         )
         assert isinstance(key, ec.EllipticCurvePublicKey)
     except (UnsupportedAlgorithm, ValueError):

--- a/tests/wycheproof/test_rsa.py
+++ b/tests/wycheproof/test_rsa.py
@@ -97,7 +97,7 @@ def test_rsa_pkcs1v15_signature_generation(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode(),
         password=None,
         backend=backend,
-        unsafe_skip_rsa_key_validation=True,
+        unsafe_skip_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
     digest = _DIGESTS[wycheproof.testgroup["sha"]]
@@ -211,7 +211,7 @@ def test_rsa_oaep_encryption(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode("ascii"),
         password=None,
         backend=backend,
-        unsafe_skip_rsa_key_validation=True,
+        unsafe_skip_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
     if backend._fips_enabled and key.key_size < backend._fips_rsa_min_key_size:
@@ -245,7 +245,7 @@ def test_rsa_pkcs1_encryption(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode("ascii"),
         password=None,
         backend=backend,
-        unsafe_skip_rsa_key_validation=True,
+        unsafe_skip_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
 

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -1453,7 +1453,7 @@ class TestRSACertificate:
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = RSA_KEY_2048_ALT.private_key(
-            unsafe_skip_rsa_key_validation=True
+            unsafe_skip_key_validation=True
         )
         ca, cert = _generate_ca_and_leaf(
             issuer_private_key, subject_private_key
@@ -1465,7 +1465,7 @@ class TestRSACertificate:
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = RSA_KEY_2048_ALT.private_key(
-            unsafe_skip_rsa_key_validation=True
+            unsafe_skip_key_validation=True
         )
         ca, cert = _generate_ca_and_leaf(
             issuer_private_key, subject_private_key
@@ -1506,7 +1506,7 @@ class TestRSACertificate:
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = RSA_KEY_2048_ALT.private_key(
-            unsafe_skip_rsa_key_validation=True
+            unsafe_skip_key_validation=True
         )
         _, cert = _generate_ca_and_leaf(
             issuer_private_key, subject_private_key


### PR DESCRIPTION
Previously we loaded EC keys in several different ways. This PR semi-unifies that and then enables using unsafe_skip_key_validation for EC as well.

To make this work we  alter _ec_key_set_public_key_affine_coordinates to implement the equivalent of EC_KEY_set_public_key_affine_coordinates without EC_KEY_check_key (which is now called in the __init__ of 
EllipticCurvePrivateKey and also in the other two load paths). However, we don't implement it on `ECPublicKey.__init__` due to massive performance impact in X.509...something to talk about.

Using this unsafe flag can significantly speed up loading numerous keys. However, don't pass this flag unless you're very sure your keys aren't attacker controlled and are always valid.