### PR TITLE
refactor PBKDF2HMAC test vectors and skip one test

### DIFF
--- a/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
@@ -2,23 +2,36 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+import binascii
+import os
 
 import pytest
 
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
-from ...utils import load_nist_vectors
-from .utils import generate_pbkdf2_test
+from ...utils import load_nist_vectors, load_vectors_from_file
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.pbkdf2_hmac_supported(hashes.SHA1()),
     skip_message="Does not support SHA1 for PBKDF2HMAC",
 )
-class TestPBKDF2HMACSHA1:
-    test_pbkdf2_sha1 = generate_pbkdf2_test(
+def test_pbkdf2_hmacsha1_vectors(subtests, backend):
+    params = load_vectors_from_file(
+        os.path.join("KDF", "rfc-6070-PBKDF2-SHA1.txt"),
         load_nist_vectors,
-        "KDF",
-        ["rfc-6070-PBKDF2-SHA1.txt"],
-        hashes.SHA1(),
     )
+    for param in params:
+        with subtests.test():
+            iterations = int(param["iterations"])
+            if iterations > 1_000_000:
+                pytest.skip("Skipping test due to iteration count")
+            kdf = PBKDF2HMAC(
+                hashes.SHA1(),
+                int(param["length"]),
+                param["salt"],
+                iterations,
+            )
+            derived_key = kdf.derive(param["password"])
+            assert binascii.hexlify(derived_key) == param["derived_key"]

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -31,7 +31,6 @@ from cryptography.hazmat.primitives.kdf.kbkdf import (
     CounterLocation,
     Mode,
 )
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from ...utils import load_vectors_from_file
 
@@ -248,30 +247,6 @@ def hmac_test(backend, algorithm, params):
     h = hmac.HMAC(binascii.unhexlify(key), algorithm, backend=backend)
     h.update(binascii.unhexlify(msg))
     assert h.finalize() == binascii.unhexlify(md.encode("ascii"))
-
-
-def generate_pbkdf2_test(param_loader, path, file_names, algorithm):
-    def test_pbkdf2(self, backend, subtests):
-        for params in _load_all_params(path, file_names, param_loader):
-            with subtests.test():
-                pbkdf2_test(backend, algorithm, params)
-
-    return test_pbkdf2
-
-
-def pbkdf2_test(backend, algorithm, params):
-    # Password and salt can contain \0, which should be loaded as a null char.
-    # The NIST loader loads them as literal strings so we replace with the
-    # proper value.
-    kdf = PBKDF2HMAC(
-        algorithm,
-        int(params["length"]),
-        params["salt"],
-        int(params["iterations"]),
-        backend,
-    )
-    derived_key = kdf.derive(params["password"])
-    assert binascii.hexlify(derived_key) == params["derived_key"]
 
 
 def generate_aead_exception_test(cipher_factory, mode_factory):


### PR DESCRIPTION
The test in question has 2**24 iterations and doesn't represent an interesting edge case in the algorithm, just a high iteration count.