### PR TITLE
rename unsafe_skip_rsa_key_validation to unsafe_skip_key_validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey`
   and
   :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`.
+* Deprecated and renamed the keyword argument for disabling RSA key validation
+  checks that was added in 39.0.0. The previous name will raise a warning
+  until it is removed in two releases.
 * Added support for parsing SSH certificates in addition to public keys with
   :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_identity`.
   :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_key`

--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -473,11 +473,15 @@ is unavailable.
         A `Chinese remainder theorem`_ coefficient used to speed up RSA
         operations. Calculated as: q\ :sup:`-1` mod p
 
-    .. method:: private_key(*, unsafe_skip_rsa_key_validation=False)
+    .. method:: private_key(*, unsafe_skip_key_validation=False)
 
-        :param unsafe_skip_rsa_key_validation:
+        :param unsafe_skip_key_validation:
 
             .. versionadded:: 39.0.0
+
+            .. versionchanged:: 40.0.0
+                Renamed from ``unsafe_skip_rsa_key_validation``. The old name
+                is deprecated and will be removed in a future release.
 
             A keyword-only argument that defaults to ``False``. If ``True``
             RSA private keys will not be validated. This significantly speeds up
@@ -487,7 +491,7 @@ is unavailable.
             way and attempt to use it OpenSSL may hang, crash, or otherwise
             misbehave.
 
-        :type unsafe_skip_rsa_key_validation: bool
+        :type unsafe_skip_key_validation: bool
 
         :returns: An instance of
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`.

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -125,7 +125,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
     extract the public key with
     :meth:`Certificate.public_key <cryptography.x509.Certificate.public_key>`.
 
-.. function:: load_pem_private_key(data, password, *, unsafe_skip_rsa_key_validation=False)
+.. function:: load_pem_private_key(data, password, *, unsafe_skip_key_validation=False)
 
     .. versionadded:: 0.6
 
@@ -143,9 +143,13 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
         be ``None`` if the private key is not encrypted.
     :type password: :term:`bytes-like`
 
-    :param unsafe_skip_rsa_key_validation:
+    :param unsafe_skip_key_validation:
 
         .. versionadded:: 39.0.0
+
+        .. versionchanged:: 40.0.0
+            Renamed from ``unsafe_skip_rsa_key_validation``. The old name
+            is deprecated and will be removed in a future release.
 
         A keyword-only argument that defaults to ``False``. If ``True``
         RSA private keys will not be validated. This significantly speeds up
@@ -154,7 +158,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
         parameter set to ``True``. If you do load an invalid key this way and
         attempt to use it OpenSSL may hang, crash, or otherwise misbehave.
 
-    :type unsafe_skip_rsa_key_validation: bool
+    :type unsafe_skip_key_validation: bool
 
     :returns: One of
         :class:`~cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey`,
@@ -247,7 +251,7 @@ data is binary. DER keys may be in a variety of formats, but as long as you
 know whether it is a public or private key the loading functions will handle
 the rest.
 
-.. function:: load_der_private_key(data, password, *, unsafe_skip_rsa_key_validation=False)
+.. function:: load_der_private_key(data, password, *, unsafe_skip_key_validation=False)
 
     .. versionadded:: 0.8
 
@@ -261,9 +265,13 @@ the rest.
         be ``None`` if the private key is not encrypted.
     :type password: :term:`bytes-like`
 
-    :param unsafe_skip_rsa_key_validation:
+    :param unsafe_skip_key_validation:
 
         .. versionadded:: 39.0.0
+
+        .. versionchanged:: 40.0.0
+            Renamed from ``unsafe_skip_rsa_key_validation``. The old name
+            is deprecated and will be removed in a future release.
 
         A keyword-only argument that defaults to ``False``. If ``True``
         RSA private keys will not be validated. This significantly speeds up
@@ -272,7 +280,7 @@ the rest.
         parameter set to ``True``. If you do load an invalid key this way and
         attempt to use it OpenSSL may hang, crash, or otherwise misbehave.
 
-    :type unsafe_skip_rsa_key_validation: bool
+    :type unsafe_skip_key_validation: bool
 
     :returns: One of
         :class:`~cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey`,

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -369,7 +369,7 @@ class _RSAPrivateKey(RSAPrivateKey):
         rsa_cdata,
         evp_pkey,
         *,
-        unsafe_skip_rsa_key_validation: bool,
+        unsafe_skip_key_validation: bool,
     ):
         res: int
         # RSA_check_key is slower in OpenSSL 3.0.0 due to improved
@@ -377,7 +377,7 @@ class _RSAPrivateKey(RSAPrivateKey):
         # since users don't load new keys constantly, but for TESTING we've
         # added an init arg that allows skipping the checks. You should not
         # use this in production code unless you understand the consequences.
-        if not unsafe_skip_rsa_key_validation:
+        if not unsafe_skip_key_validation:
             res = backend._lib.RSA_check_key(rsa_cdata)
             if res != 1:
                 errors = backend._consume_errors_with_text()

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -5,11 +5,15 @@
 
 import abc
 import typing
+import warnings
 from math import gcd
 
+from cryptography import utils
 from cryptography.hazmat.primitives import _serialization, hashes
 from cryptography.hazmat.primitives._asymmetric import AsymmetricPadding
 from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
+
+_SENTINEL = object()
 
 
 class RSAPrivateKey(metaclass=abc.ABCMeta):
@@ -358,15 +362,24 @@ class RSAPrivateNumbers:
         self,
         backend: typing.Any = None,
         *,
-        unsafe_skip_rsa_key_validation: bool = False,
+        unsafe_skip_rsa_key_validation=_SENTINEL,
+        unsafe_skip_key_validation: bool = False,
     ) -> RSAPrivateKey:
         from cryptography.hazmat.backends.openssl.backend import (
             backend as ossl,
         )
 
-        return ossl.load_rsa_private_numbers(
-            self, unsafe_skip_rsa_key_validation
-        )
+        if unsafe_skip_rsa_key_validation is not _SENTINEL:
+            warnings.warn(
+                "unsafe_skip_rsa_key_validation is deprecated and will be "
+                "removed in 42.0.0. Please use unsafe_skip_key_validation "
+                "instead.",
+                utils.DeprecatedIn40,
+                stacklevel=2,
+            )
+            unsafe_skip_key_validation = unsafe_skip_rsa_key_validation
+
+        return ossl.load_rsa_private_numbers(self, unsafe_skip_key_validation)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, RSAPrivateNumbers):

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -4,12 +4,16 @@
 
 
 import typing
+import warnings
 
+from cryptography import utils
 from cryptography.hazmat.primitives.asymmetric import dh
 from cryptography.hazmat.primitives.asymmetric.types import (
     PRIVATE_KEY_TYPES,
     PUBLIC_KEY_TYPES,
 )
+
+_SENTINEL = object()
 
 
 def load_pem_private_key(
@@ -17,12 +21,22 @@ def load_pem_private_key(
     password: typing.Optional[bytes],
     backend: typing.Any = None,
     *,
-    unsafe_skip_rsa_key_validation: bool = False,
+    unsafe_skip_rsa_key_validation=_SENTINEL,
+    unsafe_skip_key_validation: bool = False,
 ) -> PRIVATE_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
+    if unsafe_skip_rsa_key_validation is not _SENTINEL:
+        warnings.warn(
+            "unsafe_skip_rsa_key_validation is deprecated and will be removed "
+            "in 42.0.0. Please use unsafe_skip_key_validation instead.",
+            utils.DeprecatedIn40,
+            stacklevel=2,
+        )
+        unsafe_skip_key_validation = unsafe_skip_rsa_key_validation
+
     return ossl.load_pem_private_key(
-        data, password, unsafe_skip_rsa_key_validation
+        data, password, unsafe_skip_key_validation
     )
 
 
@@ -47,12 +61,22 @@ def load_der_private_key(
     password: typing.Optional[bytes],
     backend: typing.Any = None,
     *,
-    unsafe_skip_rsa_key_validation: bool = False,
+    unsafe_skip_rsa_key_validation=_SENTINEL,
+    unsafe_skip_key_validation: bool = False,
 ) -> PRIVATE_KEY_TYPES:
     from cryptography.hazmat.backends.openssl.backend import backend as ossl
 
+    if unsafe_skip_rsa_key_validation is not _SENTINEL:
+        warnings.warn(
+            "unsafe_skip_rsa_key_validation is deprecated and will be removed "
+            "in 42.0.0. Please use unsafe_skip_key_validation instead.",
+            utils.DeprecatedIn40,
+            stacklevel=2,
+        )
+        unsafe_skip_key_validation = unsafe_skip_rsa_key_validation
+
     return ossl.load_der_private_key(
-        data, password, unsafe_skip_rsa_key_validation
+        data, password, unsafe_skip_key_validation
     )
 
 

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -484,7 +484,7 @@ class TestOpenSSLSerializationWithOpenSSL:
         key = backend._create_evp_pkey_gc()
         with raises_unsupported_algorithm(None):
             backend._evp_pkey_to_private_key(
-                key, unsafe_skip_rsa_key_validation=False
+                key, unsafe_skip_key_validation=False
             )
         with raises_unsupported_algorithm(None):
             backend._evp_pkey_to_public_key(key)
@@ -503,7 +503,7 @@ class TestOpenSSLSerializationWithOpenSSL:
                     backend.load_pem_private_key(
                         pemfile.read().encode(),
                         password,
-                        unsafe_skip_rsa_key_validation=False,
+                        unsafe_skip_key_validation=False,
                     )
                 ),
             )

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -10,6 +10,7 @@ import textwrap
 
 import pytest
 
+from cryptography import utils
 from cryptography.hazmat.primitives.asymmetric import (
     dsa,
     ec,
@@ -109,6 +110,34 @@ class TestBufferProtocolSerialization:
         assert key
         assert isinstance(key, rsa.RSAPrivateKey)
         _check_rsa_private_numbers(key.private_numbers())
+
+    def test_deprecated_unsafe_kwargs(self):
+        der = load_vectors_from_file(
+            os.path.join("asymmetric", "DER_Serialization", "testrsa.der"),
+            lambda derfile: derfile.read(),
+            mode="rb",
+        )
+        pem = load_vectors_from_file(
+            os.path.join("asymmetric", "PKCS8", "unenc-rsa-pkcs8.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
+        with pytest.warns(utils.DeprecatedIn40):
+            load_der_private_key(
+                der, None, unsafe_skip_rsa_key_validation=True
+            )
+        with pytest.warns(utils.DeprecatedIn40):
+            load_der_private_key(
+                der, None, unsafe_skip_rsa_key_validation=False
+            )
+        with pytest.warns(utils.DeprecatedIn40):
+            load_pem_private_key(
+                pem, None, unsafe_skip_rsa_key_validation=True
+            )
+        with pytest.warns(utils.DeprecatedIn40):
+            load_pem_private_key(
+                pem, None, unsafe_skip_rsa_key_validation=False
+            )
 
 
 class TestDERSerialization:

--- a/tests/wycheproof/test_rsa.py
+++ b/tests/wycheproof/test_rsa.py
@@ -97,7 +97,7 @@ def test_rsa_pkcs1v15_signature_generation(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode(),
         password=None,
         backend=backend,
-        unsafe_skip_rsa_key_validation=True,
+        unsafe_skip_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
     digest = _DIGESTS[wycheproof.testgroup["sha"]]
@@ -211,7 +211,7 @@ def test_rsa_oaep_encryption(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode("ascii"),
         password=None,
         backend=backend,
-        unsafe_skip_rsa_key_validation=True,
+        unsafe_skip_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
     if backend._fips_enabled and key.key_size < backend._fips_rsa_min_key_size:
@@ -245,7 +245,7 @@ def test_rsa_pkcs1_encryption(backend, wycheproof):
         wycheproof.testgroup["privateKeyPem"].encode("ascii"),
         password=None,
         backend=backend,
-        unsafe_skip_rsa_key_validation=True,
+        unsafe_skip_key_validation=True,
     )
     assert isinstance(key, rsa.RSAPrivateKey)
 

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -1453,7 +1453,7 @@ class TestRSACertificate:
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = RSA_KEY_2048_ALT.private_key(
-            unsafe_skip_rsa_key_validation=True
+            unsafe_skip_key_validation=True
         )
         ca, cert = _generate_ca_and_leaf(
             issuer_private_key, subject_private_key
@@ -1465,7 +1465,7 @@ class TestRSACertificate:
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = RSA_KEY_2048_ALT.private_key(
-            unsafe_skip_rsa_key_validation=True
+            unsafe_skip_key_validation=True
         )
         ca, cert = _generate_ca_and_leaf(
             issuer_private_key, subject_private_key
@@ -1506,7 +1506,7 @@ class TestRSACertificate:
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = RSA_KEY_2048_ALT.private_key(
-            unsafe_skip_rsa_key_validation=True
+            unsafe_skip_key_validation=True
         )
         _, cert = _generate_ca_and_leaf(
             issuer_private_key, subject_private_key


### PR DESCRIPTION
this is in prep for an EC PR that will allow disabling checks for EC keys in a similarly performance sensitive but also footgun-y manner