### PR TITLE
replace use of EC_KEY_set_public_key_affine_coordinates

### DIFF
--- a/src/_cffi_src/openssl/ec.py
+++ b/src/_cffi_src/openssl/ec.py
@@ -45,11 +45,14 @@ const EC_POINT *EC_KEY_get0_public_key(const EC_KEY *);
 int EC_KEY_set_public_key(EC_KEY *, const EC_POINT *);
 void EC_KEY_set_asn1_flag(EC_KEY *, int);
 int EC_KEY_generate_key(EC_KEY *);
-int EC_KEY_set_public_key_affine_coordinates(EC_KEY *, BIGNUM *, BIGNUM *);
 
 EC_POINT *EC_POINT_new(const EC_GROUP *);
 void EC_POINT_free(EC_POINT *);
+int EC_POINT_cmp(const EC_GROUP *, const EC_POINT *, const EC_POINT *,
+                 BN_CTX *);
 
+int EC_POINT_set_affine_coordinates(const EC_GROUP *, EC_POINT *,
+                                    const BIGNUM *, const BIGNUM *, BN_CTX *);
 int EC_POINT_get_affine_coordinates(const EC_GROUP *, const EC_POINT *,
                                     BIGNUM *, BIGNUM *, BN_CTX *);
 


### PR DESCRIPTION
EC_KEY_set_public_key_affine_coordinates calls EC_KEY_check_key, which checks the point isn't at infinity (which we do in our EC object constructor), that it is on the curve (which has already been done by EC_POINT_set_affine_coordinates), and that the private scalar matches the public point.

We don't want to do expensive checks twice, so instead we swap to calling EC_POINT_set_affine_coordinates directly and implement a "private scalar matches public point" check of our own.

Also we no longer call deprecated functions.