### PR TITLE
Error in doc of Random number generation

### DIFF
--- a/docs/random-numbers.rst
+++ b/docs/random-numbers.rst
@@ -18,7 +18,7 @@ you can obtain them with:
     >>> import os
     >>> iv = os.urandom(16)
 
-This will use ``/dev/urandom`` on UNIX platforms, and ``CryptGenRandom`` on
+This will use ``/dev/urandom`` on UNIX platforms, and ``BCryptGenRandom()`` on
 Windows.
 
 If you need your random number as an integer (for example, for


### PR DESCRIPTION
Under Windows, `os.urandom` doesn't use `CryptGenRandom` anymore as it is deprecated. 
It uses now `BCryptGenRandom()`
See: [https://docs.python.org/3/library/os.html#os.urandom](https://docs.python.org/3/library/os.html#os.urandom)