### PR TITLE
cache ECDH values in wycheproof too

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -913,11 +913,11 @@ class WycheproofTest:
     def has_flag(self, flag: str) -> bool:
         return flag in self.testcase["flags"]
 
-    def cache_group_value(self, cache_key: str, func):
+    def cache_value_to_group(self, cache_key: str, func):
         cache_val = self.testgroup.get(cache_key)
         if cache_val is not None:
             return cache_val
-        self.testgroup[cache_key] = cache_val = func(self.testgroup)
+        self.testgroup[cache_key] = cache_val = func()
         return cache_val
 
 

--- a/tests/wycheproof/test_ecdh.py
+++ b/tests/wycheproof/test_ecdh.py
@@ -67,12 +67,15 @@ def test_ecdh(backend, wycheproof):
             "Unsupported curve ({})".format(wycheproof.testgroup["curve"])
         )
     _skip_exchange_algorithm_unsupported(backend, ec.ECDH(), curve)
-
-    private_key = ec.derive_private_key(
-        int(wycheproof.testcase["private"], 16), curve, backend
+    private_key = wycheproof.cache_value_to_group(
+        f"private_key_{wycheproof.testcase['private']}",
+        lambda: ec.derive_private_key(
+            int(wycheproof.testcase["private"], 16), curve
+        ),
     )
 
     try:
+        # caching these values shows no performance improvement
         public_key = serialization.load_der_public_key(
             binascii.unhexlify(wycheproof.testcase["public"]), backend
         )
@@ -109,8 +112,11 @@ def test_ecdh_ecpoint(backend, wycheproof):
     assert isinstance(curve, ec.EllipticCurve)
     _skip_exchange_algorithm_unsupported(backend, ec.ECDH(), curve)
 
-    private_key = ec.derive_private_key(
-        int(wycheproof.testcase["private"], 16), curve, backend
+    private_key = wycheproof.cache_value_to_group(
+        f"private_key_{wycheproof.testcase['private']}",
+        lambda: ec.derive_private_key(
+            int(wycheproof.testcase["private"], 16), curve
+        ),
     )
 
     if wycheproof.invalid:
@@ -121,6 +127,7 @@ def test_ecdh_ecpoint(backend, wycheproof):
         return
 
     assert wycheproof.valid or wycheproof.acceptable
+    # caching these values shows no performance improvement
     public_key = ec.EllipticCurvePublicKey.from_encoded_point(
         curve, binascii.unhexlify(wycheproof.testcase["public"])
     )

--- a/tests/wycheproof/test_ecdsa.py
+++ b/tests/wycheproof/test_ecdsa.py
@@ -61,10 +61,10 @@ _DIGESTS = {
 )
 def test_ecdsa_signature(backend, wycheproof):
     try:
-        key = wycheproof.cache_group_value(
+        key = wycheproof.cache_value_to_group(
             "cache_key",
-            lambda group: serialization.load_der_public_key(
-                binascii.unhexlify(group["keyDer"]), backend
+            lambda: serialization.load_der_public_key(
+                binascii.unhexlify(wycheproof.testgroup["keyDer"])
             ),
         )
         assert isinstance(key, ec.EllipticCurvePublicKey)

--- a/tests/wycheproof/test_rsa.py
+++ b/tests/wycheproof/test_rsa.py
@@ -63,10 +63,10 @@ def should_verify(backend, wycheproof):
     "rsa_signature_4096_sha512_256_test.json",
 )
 def test_rsa_pkcs1v15_signature(backend, wycheproof):
-    key = wycheproof.cache_group_value(
+    key = wycheproof.cache_value_to_group(
         "cached_key",
-        lambda group: serialization.load_der_public_key(
-            binascii.unhexlify(group["keyDer"]), backend
+        lambda: serialization.load_der_public_key(
+            binascii.unhexlify(wycheproof.testgroup["keyDer"]),
         ),
     )
     assert isinstance(key, rsa.RSAPublicKey)
@@ -96,10 +96,10 @@ def test_rsa_pkcs1v15_signature(backend, wycheproof):
 
 @wycheproof_tests("rsa_sig_gen_misc_test.json")
 def test_rsa_pkcs1v15_signature_generation(backend, wycheproof):
-    key = wycheproof.cache_group_value(
+    key = wycheproof.cache_value_to_group(
         "cached_key",
-        lambda group: serialization.load_pem_private_key(
-            group["privateKeyPem"].encode("ascii"),
+        lambda: serialization.load_pem_private_key(
+            wycheproof.testgroup["privateKeyPem"].encode("ascii"),
             password=None,
             unsafe_skip_rsa_key_validation=True,
         ),
@@ -142,10 +142,10 @@ def test_rsa_pss_signature(backend, wycheproof):
     if backend._fips_enabled and isinstance(digest, hashes.SHA1):
         pytest.skip("Invalid params for FIPS. SHA1 is disallowed")
 
-    key = wycheproof.cache_group_value(
+    key = wycheproof.cache_value_to_group(
         "cached_key",
-        lambda group: serialization.load_der_public_key(
-            binascii.unhexlify(group["keyDer"]), backend
+        lambda: serialization.load_der_public_key(
+            binascii.unhexlify(wycheproof.testgroup["keyDer"]),
         ),
     )
     assert isinstance(key, rsa.RSAPublicKey)
@@ -218,10 +218,10 @@ def test_rsa_oaep_encryption(backend, wycheproof):
             f"or {digest.name} hash."
         )
 
-    key = wycheproof.cache_group_value(
+    key = wycheproof.cache_value_to_group(
         "cached_key",
-        lambda group: serialization.load_pem_private_key(
-            group["privateKeyPem"].encode("ascii"),
+        lambda: serialization.load_pem_private_key(
+            wycheproof.testgroup["privateKeyPem"].encode("ascii"),
             password=None,
             unsafe_skip_rsa_key_validation=True,
         ),
@@ -254,10 +254,10 @@ def test_rsa_oaep_encryption(backend, wycheproof):
     "rsa_pkcs1_4096_test.json",
 )
 def test_rsa_pkcs1_encryption(backend, wycheproof):
-    key = wycheproof.cache_group_value(
+    key = wycheproof.cache_value_to_group(
         "cached_key",
-        lambda group: serialization.load_pem_private_key(
-            group["privateKeyPem"].encode("ascii"),
+        lambda: serialization.load_pem_private_key(
+            wycheproof.testgroup["privateKeyPem"].encode("ascii"),
             password=None,
             unsafe_skip_rsa_key_validation=True,
         ),


### PR DESCRIPTION
this alters and renames the caching function a bit since it caches **to the group** object but the actual values (in ECDH) come from the testcase itself