### PR TITLE
More fixes for PyPI OIDC publishing (still doesn't work)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -66,4 +66,4 @@ jobs:
               f.write("TWINE_PASSWORD={pypi_token}\n")
         shell: python
 
-      - run: find dist/ -type f -name 'cryptography*' -exec twine upload --repository $TWINE_REPO {} \;
+      - run: find dist/ -type f -name 'cryptography*' | xargs twine upload --repository $TWINE_REPO

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,7 +10,7 @@ on:
         description: Which PyPI environment to upload to
         required: true
         type: choice
-        options: ["pypi", "testpypi"]
+        options: ["testpypi", "pypi"]
   # Disabled until this has been validated with `workflow_dispatch` + Test PyPI.
   # workflow_run:
   #   workflows: ["wheel-builder.yml"]
@@ -36,11 +36,13 @@ jobs:
           echo "OIDC_AUDIENCE=pypi" >> $GITHUB_ENV
           echo "PYPI_DOMAIN=pypi.org" >> $GITHUB_ENV
           echo "TWINE_REPO=pypi" >> $GITHUB_ENV
+          echo "TWINE_USERNAME=__token__" >> $GITHUB_ENV
         if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'pypi')
       - run: |
           echo "OIDC_AUDIENCE=testpypi" >> $GITHUB_ENV
           echo "PYPI_DOMAIN=test.pypi.org" >> $GITHUB_ENV
           echo "TWINE_REPO=testpypi" >> $GITHUB_ENV
+          echo "TWINE_USERNAME=__token__" >> $GITHUB_ENV
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testpypi'
 
       - run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -64,4 +64,4 @@ jobs:
               f.write("TWINE_PASSWORD={pypi_token}\n")
         shell: python
 
-      - run: "twine upload --repository $TWINE_REPO dist/**"
+      - run: find dist/ -type f -name 'cryptography*' -exec twine upload --repository $TWINE_REPO {} \;


### PR DESCRIPTION
At least a few issues still remain:

1) It's failing with a 403 ~~but not failing the build~~ (see: https://github.com/pyca/cryptography/actions/runs/4391875928/jobs/7691301517) so we need to both get uploading actually working ~~and have failed builds actually fail~~ (failing builds are fixed with xargs now) 😄 
2) We need to upload to both cryptography and cryptography_vectors so we may need @di to allowlist on one more package.
3) @alex if you want to add me as an owner on the cryptography package I can add you on cryptography_vectors (but you have to verify your email before it will let me)