### PR TITLE
fix pypi-publish.yml to trigger on workflow runs

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,7 +12,7 @@ on:
         type: choice
         options: ["testpypi", "pypi"]
   workflow_run:
-    workflows: ["wheel-builder.yml"]
+    workflows: ["Wheel Builder"]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
looks like it really wants name, and not filename