### PR TITLE
Python 3.6 compatibility fix.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ exclude_lines = [
 [tool.ruff]
 # UP006: Minimum Python 3.9
 # UP007, UP038: Minimum Python 3.10
-ignore = ['N818', 'UP006', 'UP007', 'UP038']
+# UP022: Minimum Python 3.7
+ignore = ['N818', 'UP006', 'UP007', 'UP038', 'UP022']
 select = ['E', 'F', 'I', 'N', 'W', 'UP']
 line-length = 79
 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ except:  # noqa: E722
             # If for any reason `rustc --version` fails, silently ignore it
             rustc_output = subprocess.run(
                 ["rustc", "--version"],
-                capture_output=True,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 timeout=0.5,
                 encoding="utf8",
                 check=True,

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ except:  # noqa: E722
             # If for any reason `rustc --version` fails, silently ignore it
             rustc_output = subprocess.run(
                 ["rustc", "--version"],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 timeout=0.5,
                 encoding="utf8",
                 check=True,


### PR DESCRIPTION
The capture_output argument to subprocess.run() was not introduced until Python 3.7.  Use stdout=subprocess.PIPE and stderr=subprocess.PIPE instead, which is equivalent.