### PR TITLE
skip memleak tests on pypy

### DIFF
--- a/tests/hazmat/backends/test_openssl_memleak.py
+++ b/tests/hazmat/backends/test_openssl_memleak.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import platform
 import subprocess
 import sys
 import textwrap
@@ -204,8 +205,9 @@ def assert_no_memory_leaks(s, argv=[]):
 
 def skip_if_memtesting_not_supported():
     return pytest.mark.skipif(
-        not Binding().lib.Cryptography_HAS_MEM_FUNCTIONS,
-        reason="Requires OpenSSL memory functions (>=1.1.0)",
+        not Binding().lib.Cryptography_HAS_MEM_FUNCTIONS
+        and platform.python_implementation() != "PyPy",
+        reason="Requires OpenSSL memory functions (>=1.1.0) and not PyPy",
     )
 
 


### PR DESCRIPTION
See: https://github.com/pyca/cryptography/pull/7933#issuecomment-1471865194 + https://foss.heptapod.net/pypy/pypy/-/issues/3905#note_290457 to understand why