### PR TITLE
Added support for handling python buffers in Rust code

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -93,7 +93,10 @@ Glossary
     bytes-like
         A bytes-like object contains binary data and supports the
         `buffer protocol`_. This includes ``bytes``, ``bytearray``, and
-        ``memoryview`` objects.
+        ``memoryview`` objects. It is :term:`unsafe` to pass a mutable object
+        (e.g., a ``bytearray`` or other implementor of the buffer protocol)
+        and to `mutate it concurrently`_ with the operation it has been
+        provided for.
 
     U-label
         The presentational unicode form of an internationalized domain
@@ -108,3 +111,4 @@ Glossary
 .. _`hardware security module`: https://en.wikipedia.org/wiki/Hardware_security_module
 .. _`idna`: https://pypi.org/project/idna/
 .. _`buffer protocol`: https://docs.python.org/3/c-api/buffer.html
+.. _`mutate it concurrently`: https://alexgaynor.net/2022/oct/23/buffers-on-the-edge/

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -61,6 +61,7 @@ hazmat
 Homebrew
 hostname
 hostnames
+implementor
 incrementing
 indistinguishability
 initialisms

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -78,7 +78,7 @@ class PKCS7SignatureBuilder:
         if self._data is not None:
             raise ValueError("data may only be set once")
 
-        return PKCS7SignatureBuilder(bytes(data), self._signers)
+        return PKCS7SignatureBuilder(data, self._signers)
 
     def add_signer(
         self,

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -43,6 +43,13 @@ def int_to_bytes(integer: int, length: typing.Optional[int] = None) -> bytes:
     )
 
 
+def _extract_buffer_length(obj: typing.Any) -> typing.Tuple[int, int]:
+    from cryptography.hazmat.bindings._rust import _openssl
+
+    buf = _openssl.ffi.from_buffer(obj)
+    return int(_openssl.ffi.cast("intptr_t", buf)), len(buf)
+
+
 class InterfaceNotImplemented(Exception):
     pass
 

--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -1,0 +1,45 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use std::{ptr, slice};
+
+pub(crate) struct CffiBuf<'p> {
+    _pyobj: &'p pyo3::PyAny,
+    buf: &'p [u8],
+}
+
+impl CffiBuf<'_> {
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.buf
+    }
+}
+
+impl<'a> pyo3::conversion::FromPyObject<'a> for CffiBuf<'a> {
+    fn extract(pyobj: &'a pyo3::PyAny) -> pyo3::PyResult<Self> {
+        let py = pyobj.py();
+
+        let (ptrval, len): (usize, usize) = py
+            .import("cryptography.utils")?
+            .call_method1("_extract_buffer_length", (pyobj,))?
+            .extract()?;
+        let ptr = if len == 0 {
+            ptr::NonNull::dangling().as_ptr()
+        } else {
+            ptrval as *const u8
+        };
+
+        Ok(CffiBuf {
+            _pyobj: pyobj,
+            // SAFETY: _extract_buffer_length ensures that we have a valid ptr
+            // and length (and we ensure we meet slice's requirements for
+            // 0-length slices above), we're keeping pyobj alive which ensures
+            // the buffer is valid. But! There is no actually guarantee
+            // against concurrent mutation. See
+            // https://alexgaynor.net/2022/oct/23/buffers-on-the-edge/
+            // for details. This is the same as our cffi status quo ante, so
+            // we're doing an unsound thing and living with it.
+            buf: unsafe { slice::from_raw_parts(ptr, len) },
+        })
+    }
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(unknown_lints, clippy::borrow_deref_ref)]
 
 mod asn1;
+mod buf;
 mod error;
 mod intern;
 pub(crate) mod oid;

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -334,6 +334,31 @@ class TestPKCS7Builder:
 
         sig = builder.sign(serialization.Encoding.SMIME, options)
         assert bytes(data) in sig
+        _pkcs7_verify(
+            serialization.Encoding.SMIME,
+            sig,
+            data,
+            [cert],
+            options,
+            backend,
+        )
+
+        data = bytearray(b"")
+        builder = (
+            pkcs7.PKCS7SignatureBuilder()
+            .set_data(data)
+            .add_signer(cert, key, hashes.SHA256())
+        )
+
+        sig = builder.sign(serialization.Encoding.SMIME, options)
+        _pkcs7_verify(
+            serialization.Encoding.SMIME,
+            sig,
+            data,
+            [cert],
+            options,
+            backend,
+        )
 
     def test_sign_pem(self, backend):
         data = b"hello world"


### PR DESCRIPTION
This is extra mega cursed, and strictly speaking unsound. It does, however, match the status quo ante, where someone mutating a buffer while its being used in cffi code will basically always be UB.