### PR TITLE
no more types-requests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,7 +83,6 @@ pep8test =
     black
     ruff
     mypy
-    types-requests
     check-manifest
 # This extra is for OpenSSH private keys that use bcrypt KDF
 # Versions: v3.1.3 - ignore_few_rounds, v3.1.5 - abi3


### PR DESCRIPTION
I don't think we need this for mypy any more as of the OIDC PR, but let's see what CI has to say.