### PR TITLE
update MSRV 1.48.0 -> 1.56.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,16 +204,8 @@ jobs:
         PYTHON:
           - {VERSION: "3.11", TOXENV: "py311"}
         RUST:
-          # Cover MSRV (and likely next MSRV). In-dev versions are below in
-          # the linux-rust-coverage section. Once our MSRV is 1.60 we can
-          # remove this section entirely.
-          - 1.48.0
-          # 1.49.0 is the MSRV for parking_lot 0.12
-          # 1.51 - const generics (for rust-asn1)
-          # 1.56 - new versions of once_cell and bumpalo
+          # Cover MSRV. 1.60+ and beta/nightly are in the linux-rust-coverage section.
           - 1.56.0
-          # Potential future MSRVs
-          # 1.60 - new version of cxx
     name: "${{ matrix.PYTHON.TOXENV }} with Rust ${{ matrix.RUST }}"
     timeout-minutes: 15
     steps:
@@ -260,6 +252,8 @@ jobs:
         PYTHON:
           - {VERSION: "3.11", TOXENV: "py311"}
         RUST:
+          # 1.60 - new version of cxx
+          - 1.60.0
           - beta
           - nightly
     name: "Rust Coverage"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changelog
 * **BACKWARDS INCOMPATIBLE:** Support for OpenSSL less than 1.1.1d has been
   removed.  Users on older version of OpenSSL will need to upgrade.
 * **BACKWARDS INCOMPATIBLE:** Support for Python 3.6 has been removed.
+* Updated the minimum supported Rust version (MSRV) to 1.56.0, from 1.48.0.
 
 .. _v40-0-0:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -137,7 +137,7 @@ Fedora/RHEL/CentOS
 .. warning::
 
     For RHEL and CentOS you must be on version 8.3 or newer for the command
-    below to install a sufficiently new Rust. If your Rust is less than 1.48.0
+    below to install a sufficiently new Rust. If your Rust is less than 1.56.0
     please see the :ref:`Rust installation instructions <installation:Rust>`
     for information about installing a newer Rust.
 
@@ -315,7 +315,7 @@ Rust
     a Rust toolchain.
 
 Building ``cryptography`` requires having a working Rust toolchain. The current
-minimum supported Rust version is 1.48.0. **This is newer than the Rust some
+minimum supported Rust version is 1.56.0. **This is newer than the Rust some
 package managers ship**, so users may need to install with the
 instructions below.
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ try:
                     if platform.python_implementation() == "PyPy"
                     else ["pyo3/abi3-py36"]
                 ),
-                rust_version=">=1.48.0",
+                rust_version=">=1.56.0",
             )
         ],
     )

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -64,9 +64,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "cc"
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The cryptography developers <cryptography-dev@python.org>"]
 edition = "2018"
 publish = false
 # This specifies the MSRV
-rust-version = "1.48.0"
+rust-version = "1.56.0"
 
 [dependencies]
 once_cell = "1"


### PR DESCRIPTION
Doesn't bump parking_lot because `cargo update -p parking_lot` decided it didn't want to do anything 😄 

This should merge after the 1.1.1d drop.