### PR TITLE
Restore the x509 error verification codes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changelog
 * Updated the minimum supported Rust version (MSRV) to 1.56.0, from 1.48.0.
 * Added support for the :class:`~cryptography.x509.OCSPAcceptableResponses`
   OCSP extension.
+* Restored X509 verification error codes to the OpenSSL bindings.
 
 .. _v40-0-1:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,6 @@ Changelog
 * Updated the minimum supported Rust version (MSRV) to 1.56.0, from 1.48.0.
 * Added support for the :class:`~cryptography.x509.OCSPAcceptableResponses`
   OCSP extension.
-* Restored X509 verification error codes to the OpenSSL bindings.
 
 .. _v40-0-1:
 

--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -30,11 +30,68 @@ typedef ... X509_STORE_CTX;
 
 typedef int (*X509_STORE_CTX_get_issuer_fn)(X509 **, X509_STORE_CTX *, X509 *);
 
+static const int X509_V_OK;
+static const int X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT;
+static const int X509_V_ERR_UNABLE_TO_GET_CRL;
+static const int X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE;
+static const int X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE;
+static const int X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY;
+static const int X509_V_ERR_CERT_SIGNATURE_FAILURE;
+static const int X509_V_ERR_CRL_SIGNATURE_FAILURE;
+static const int X509_V_ERR_CERT_NOT_YET_VALID;
+static const int X509_V_ERR_CERT_HAS_EXPIRED;
+static const int X509_V_ERR_CRL_NOT_YET_VALID;
+static const int X509_V_ERR_CRL_HAS_EXPIRED;
+static const int X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD;
+static const int X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD;
+static const int X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD;
+static const int X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD;
+static const int X509_V_ERR_OUT_OF_MEM;
+static const int X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT;
+static const int X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN;
+static const int X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;
+static const int X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE;
+static const int X509_V_ERR_CERT_CHAIN_TOO_LONG;
+static const int X509_V_ERR_CERT_REVOKED;
+static const int X509_V_ERR_INVALID_CA;
+static const int X509_V_ERR_PATH_LENGTH_EXCEEDED;
+static const int X509_V_ERR_INVALID_PURPOSE;
+static const int X509_V_ERR_CERT_UNTRUSTED;
+static const int X509_V_ERR_CERT_REJECTED;
+static const int X509_V_ERR_SUBJECT_ISSUER_MISMATCH;
+static const int X509_V_ERR_AKID_SKID_MISMATCH;
+static const int X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH;
+static const int X509_V_ERR_KEYUSAGE_NO_CERTSIGN;
+static const int X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER;
+static const int X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION;
+static const int X509_V_ERR_KEYUSAGE_NO_CRL_SIGN;
+static const int X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION;
+static const int X509_V_ERR_INVALID_NON_CA;
+static const int X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED;
+static const int X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE;
+static const int X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED;
+static const int X509_V_ERR_INVALID_EXTENSION;
+static const int X509_V_ERR_INVALID_POLICY_EXTENSION;
+static const int X509_V_ERR_NO_EXPLICIT_POLICY;
+static const int X509_V_ERR_DIFFERENT_CRL_SCOPE;
+static const int X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE;
+static const int X509_V_ERR_UNNESTED_RESOURCE;
+static const int X509_V_ERR_PERMITTED_VIOLATION;
+static const int X509_V_ERR_EXCLUDED_VIOLATION;
+static const int X509_V_ERR_SUBTREE_MINMAX;
+static const int X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE;
+static const int X509_V_ERR_UNSUPPORTED_CONSTRAINT_SYNTAX;
+static const int X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
+static const int X509_V_ERR_CRL_PATH_VALIDATION_ERROR;
+static const int X509_V_ERR_HOSTNAME_MISMATCH;
+static const int X509_V_ERR_EMAIL_MISMATCH;
+static const int X509_V_ERR_IP_ADDRESS_MISMATCH;
+static const int X509_V_ERR_APPLICATION_VERIFICATION;
+
+
 /* While these are defined in the source as ints, they're tagged here
    as longs, just in case they ever grow to large, such as what we saw
    with OP_ALL. */
-
-static const int X509_V_OK;
 
 /* Verification parameters */
 static const long X509_V_FLAG_CRL_CHECK;


### PR DESCRIPTION
This is necessary for custom TLS certificate validation logic; see https://github.com/pyca/pyopenssl/issues/1201

The corresponding pyOpenSSL PR is https://github.com/pyca/pyopenssl/pull/1202