### PR TITLE
Stop using Certbot's pip_install_editable

### DIFF
--- a/.github/downstream.d/certbot.sh
+++ b/.github/downstream.d/certbot.sh
@@ -5,8 +5,8 @@ case "${1}" in
         git clone --depth=1 https://github.com/certbot/certbot
         cd certbot
         git rev-parse HEAD
-        tools/pip_install_editable.py ./acme[test]
-        tools/pip_install_editable.py ./certbot[test]
+        tools/pip_install.py -e ./acme[test]
+        tools/pip_install.py -e ./certbot[test]
         pip install -U pyopenssl
         ;;
     run)


### PR DESCRIPTION
I'm planning on removing this weirdly specific script from the Certbot repo soon. `tools/pip_install.py` already exists and will do the same thing as `pip_install_editable.py` after we add `-e` to the command line.