### PR TITLE
remove cffi helper funcs and args that are no longer needed

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -8,73 +8,12 @@ import os
 import pathlib
 import platform
 import sys
-from distutils import dist
-from distutils.ccompiler import get_default_compiler
-from distutils.command.config import config
 
 # Add the src directory to the path so we can import _cffi_src.utils
 src_dir = str(pathlib.Path(__file__).parent.parent)
 sys.path.insert(0, src_dir)
 
-from _cffi_src.utils import build_ffi_for_binding, compiler_type  # noqa: E402
-
-
-def _get_openssl_libraries(platform):
-    if os.environ.get("CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS", None):
-        return []
-    # OpenSSL goes by a different library name on different operating systems.
-    if platform == "win32" and compiler_type() == "msvc":
-        return [
-            "libssl",
-            "libcrypto",
-            "advapi32",
-            "crypt32",
-            "gdi32",
-            "user32",
-            "ws2_32",
-        ]
-    else:
-        # darwin, linux, mingw all use this path
-        # In some circumstances, the order in which these libs are
-        # specified on the linker command-line is significant;
-        # libssl must come before libcrypto
-        # (https://marc.info/?l=openssl-users&m=135361825921871)
-        # -lpthread required due to usage of pthread an potential
-        # existence of a static part containing e.g. pthread_atfork
-        # (https://github.com/pyca/cryptography/issues/5084)
-        if sys.platform == "zos":
-            return ["ssl", "crypto"]
-        else:
-            return ["ssl", "crypto", "pthread"]
-
-
-def _extra_compile_args(platform):
-    """
-    We set -Wconversion args here so that we only do Wconversion checks on the
-    code we're compiling and not on cffi itself (as passing -Wconversion in
-    CFLAGS would do). We set no error on sign conversion because some
-    function signatures in LibreSSL differ from OpenSSL have changed on long
-    vs. unsigned long in the past. Since that isn't a precision issue we don't
-    care.
-    """
-    # make sure the compiler used supports the flags to be added
-    is_gcc = False
-    if get_default_compiler() == "unix":
-        d = dist.Distribution()
-        cmd = config(d)
-        cmd._check_compiler()
-        is_gcc = (
-            "gcc" in cmd.compiler.compiler[0]
-            or "clang" in cmd.compiler.compiler[0]
-        )
-    if is_gcc or not (
-        platform in ["win32", "hp-ux11", "sunos5"]
-        or platform.startswith("aix")
-    ):
-        return ["-Wconversion", "-Wno-error=sign-conversion"]
-    else:
-        return []
-
+from _cffi_src.utils import build_ffi_for_binding  # noqa: E402
 
 ffi = build_ffi_for_binding(
     module_name="_openssl",
@@ -113,8 +52,6 @@ ffi = build_ffi_for_binding(
         "pkcs7",
         "callbacks",
     ],
-    libraries=_get_openssl_libraries(sys.platform),
-    extra_compile_args=_extra_compile_args(sys.platform),
 )
 
 if __name__ == "__main__":

--- a/src/_cffi_src/utils.py
+++ b/src/_cffi_src/utils.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 import os
 import platform
 import sys
-from distutils.ccompiler import new_compiler
-from distutils.dist import Distribution
 
 from cffi import FFI
 
@@ -23,8 +21,6 @@ def build_ffi_for_binding(
     module_name,
     module_prefix,
     modules,
-    libraries,
-    extra_compile_args,
 ):
     """
     Modules listed in ``modules`` should have the following attributes:
@@ -54,8 +50,6 @@ def build_ffi_for_binding(
         module_name,
         cdef_source="\n".join(types + functions),
         verify_source=verify_source,
-        libraries=libraries,
-        extra_compile_args=extra_compile_args,
     )
 
 
@@ -63,8 +57,6 @@ def build_ffi(
     module_name,
     cdef_source,
     verify_source,
-    libraries,
-    extra_compile_args,
 ):
     ffi = FFI()
     # Always add the CRYPTOGRAPHY_PACKAGE_VERSION to the shared object
@@ -88,20 +80,5 @@ int Cryptography_make_openssl_module(void) {
     ffi.set_source(
         module_name,
         verify_source,
-        libraries=libraries,
-        extra_compile_args=extra_compile_args,
     )
     return ffi
-
-
-def compiler_type():
-    """
-    Gets the compiler type from distutils. On Windows with MSVC it will be
-    "msvc". On macOS and linux it is "unix".
-    """
-    dist = Distribution()
-    dist.parse_config_files()
-    cmd = dist.get_command_obj("build")
-    cmd.ensure_finalized()
-    compiler = new_compiler(compiler=cmd.compiler)
-    return compiler.compiler_type


### PR DESCRIPTION
as a bonus we no longer import anything from `distutils`.