### PR TITLE
Try building this in release mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Rust Tests
         run: |
             cd src/rust
-            cargo test --no-default-features
+            cargo test --no-default-features --release
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "rust-cov/cov-%m-%p.profraw"
@@ -343,7 +343,7 @@ jobs:
               --ignore-filename-regex='/rustc/' \
               --ignore-filename-regex='/.rustup/toolchains/' --format=lcov > ../../${COV_UUID}-1.lcov
             cargo cov -- export \
-              $(env RUSTFLAGS="-Cinstrument-coverage" cargo test --no-default-features --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]") \
+              $(env RUSTFLAGS="-Cinstrument-coverage" cargo test --no-default-features --release --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]") \
               -instr-profile=cargo-test-rust-cov.profdata \
               --ignore-filename-regex='/.cargo/registry' \
               --ignore-filename-regex='/rustc/' \


### PR DESCRIPTION
Our Python tests already use release mode, so this avoids a 2x compilation