### PR TITLE
support equality checks on all public asymmetric key types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changelog
   OCSP extension.
 * Added support for the :class:`~cryptography.x509.MSCertificateTemplate`
   proprietary Microsoft certificate extension.
+* Implemented support for equality checks on all asymmetric public key types.
 
 .. _v40-0-1:
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1049,10 +1049,6 @@ class Backend:
         self.openssl_assert(res == 1)
         return x509.load_der_x509_certificate(self._read_mem_bio(bio))
 
-    def _check_keys_correspond(self, key1, key2) -> None:
-        if self._lib.EVP_PKEY_cmp(key1._evp_pkey, key2._evp_pkey) != 1:
-            raise ValueError("Keys do not correspond")
-
     def _load_key(
         self, openssl_read_func, data, password, unsafe_skip_rsa_key_validation
     ) -> PrivateKeyTypes:

--- a/src/cryptography/hazmat/backends/openssl/dh.py
+++ b/src/cryptography/hazmat/backends/openssl/dh.py
@@ -261,6 +261,20 @@ class _DHPublicKey(dh.DHPublicKey):
     def key_size(self) -> int:
         return self._key_size_bits
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, dh.DHPublicKey):
+            return NotImplemented
+
+        res = self._backend._lib.EVP_PKEY_cmp(
+            self._evp_pkey, other._evp_pkey  # type: ignore[attr-defined]
+        )
+        if res < 0:
+            # DH public keys have two types (DH, DHX) that OpenSSL
+            # considers different types but we do not. Mismatched types
+            # push an error on the stack, so we need to consume it.
+            self._backend._consume_errors()
+        return res == 1
+
     def public_numbers(self) -> dh.DHPublicNumbers:
         p = self._backend._ffi.new("BIGNUM **")
         g = self._backend._ffi.new("BIGNUM **")

--- a/src/cryptography/hazmat/backends/openssl/dh.py
+++ b/src/cryptography/hazmat/backends/openssl/dh.py
@@ -262,12 +262,10 @@ class _DHPublicKey(dh.DHPublicKey):
         return self._key_size_bits
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, dh.DHPublicKey):
+        if not isinstance(other, _DHPublicKey):
             return NotImplemented
 
-        res = self._backend._lib.EVP_PKEY_cmp(
-            self._evp_pkey, other._evp_pkey  # type: ignore[attr-defined]
-        )
+        res = self._backend._lib.EVP_PKEY_cmp(self._evp_pkey, other._evp_pkey)
         if res < 0:
             # DH public keys have two types (DH, DHX) that OpenSSL
             # considers different types but we do not. Mismatched types

--- a/src/cryptography/hazmat/backends/openssl/dsa.py
+++ b/src/cryptography/hazmat/backends/openssl/dsa.py
@@ -190,13 +190,11 @@ class _DSAPublicKey(dsa.DSAPublicKey):
         return self._key_size
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, dsa.DSAPublicKey):
+        if not isinstance(other, _DSAPublicKey):
             return NotImplemented
 
         return (
-            self._backend._lib.EVP_PKEY_cmp(
-                self._evp_pkey, other._evp_pkey  # type: ignore[attr-defined]
-            )
+            self._backend._lib.EVP_PKEY_cmp(self._evp_pkey, other._evp_pkey)
             == 1
         )
 

--- a/src/cryptography/hazmat/backends/openssl/dsa.py
+++ b/src/cryptography/hazmat/backends/openssl/dsa.py
@@ -189,6 +189,17 @@ class _DSAPublicKey(dsa.DSAPublicKey):
     def key_size(self) -> int:
         return self._key_size
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, dsa.DSAPublicKey):
+            return NotImplemented
+
+        return (
+            self._backend._lib.EVP_PKEY_cmp(
+                self._evp_pkey, other._evp_pkey  # type: ignore[attr-defined]
+            )
+            == 1
+        )
+
     def public_numbers(self) -> dsa.DSAPublicNumbers:
         p = self._backend._ffi.new("BIGNUM **")
         q = self._backend._ffi.new("BIGNUM **")

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -236,13 +236,11 @@ class _EllipticCurvePublicKey(ec.EllipticCurvePublicKey):
         return self.curve.key_size
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ec.EllipticCurvePublicKey):
+        if not isinstance(other, _EllipticCurvePublicKey):
             return NotImplemented
 
         return (
-            self._backend._lib.EVP_PKEY_cmp(
-                self._evp_pkey, other._evp_pkey  # type: ignore[attr-defined]
-            )
+            self._backend._lib.EVP_PKEY_cmp(self._evp_pkey, other._evp_pkey)
             == 1
         )
 

--- a/src/cryptography/hazmat/backends/openssl/ec.py
+++ b/src/cryptography/hazmat/backends/openssl/ec.py
@@ -235,6 +235,17 @@ class _EllipticCurvePublicKey(ec.EllipticCurvePublicKey):
     def key_size(self) -> int:
         return self.curve.key_size
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ec.EllipticCurvePublicKey):
+            return NotImplemented
+
+        return (
+            self._backend._lib.EVP_PKEY_cmp(
+                self._evp_pkey, other._evp_pkey  # type: ignore[attr-defined]
+            )
+            == 1
+        )
+
     def public_numbers(self) -> ec.EllipticCurvePublicNumbers:
         group = self._backend._lib.EC_KEY_get0_group(self._ec_key)
         self._backend.openssl_assert(group != self._backend._ffi.NULL)

--- a/src/cryptography/hazmat/backends/openssl/ed25519.py
+++ b/src/cryptography/hazmat/backends/openssl/ed25519.py
@@ -82,10 +82,7 @@ class _Ed25519PublicKey(Ed25519PublicKey):
         if not isinstance(other, Ed25519PublicKey):
             return NotImplemented
 
-        return (
-            self._raw_public_bytes()
-            == other._raw_public_bytes()  # type:ignore[attr-defined]
-        )
+        return self.public_bytes_raw() == other.public_bytes_raw()
 
 
 class _Ed25519PrivateKey(Ed25519PrivateKey):

--- a/src/cryptography/hazmat/backends/openssl/ed25519.py
+++ b/src/cryptography/hazmat/backends/openssl/ed25519.py
@@ -78,6 +78,15 @@ class _Ed25519PublicKey(Ed25519PublicKey):
             self._backend._consume_errors()
             raise exceptions.InvalidSignature
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Ed25519PublicKey):
+            return NotImplemented
+
+        return (
+            self._raw_public_bytes()
+            == other._raw_public_bytes()  # type:ignore[attr-defined]
+        )
+
 
 class _Ed25519PrivateKey(Ed25519PrivateKey):
     def __init__(self, backend: Backend, evp_pkey):

--- a/src/cryptography/hazmat/backends/openssl/ed448.py
+++ b/src/cryptography/hazmat/backends/openssl/ed448.py
@@ -79,6 +79,15 @@ class _Ed448PublicKey(Ed448PublicKey):
             self._backend._consume_errors()
             raise exceptions.InvalidSignature
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Ed448PublicKey):
+            return NotImplemented
+
+        return (
+            self._raw_public_bytes()
+            == other._raw_public_bytes()  # type: ignore[attr-defined]
+        )
+
 
 class _Ed448PrivateKey(Ed448PrivateKey):
     def __init__(self, backend: Backend, evp_pkey):

--- a/src/cryptography/hazmat/backends/openssl/ed448.py
+++ b/src/cryptography/hazmat/backends/openssl/ed448.py
@@ -83,10 +83,7 @@ class _Ed448PublicKey(Ed448PublicKey):
         if not isinstance(other, Ed448PublicKey):
             return NotImplemented
 
-        return (
-            self._raw_public_bytes()
-            == other._raw_public_bytes()  # type: ignore[attr-defined]
-        )
+        return self.public_bytes_raw() == other.public_bytes_raw()
 
 
 class _Ed448PrivateKey(Ed448PrivateKey):

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -538,13 +538,11 @@ class _RSAPublicKey(RSAPublicKey):
         return self._key_size
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, RSAPublicKey):
+        if not isinstance(other, _RSAPublicKey):
             return NotImplemented
 
         return (
-            self._backend._lib.EVP_PKEY_cmp(
-                self._evp_pkey, other._evp_pkey  # type: ignore[attr-defined]
-            )
+            self._backend._lib.EVP_PKEY_cmp(self._evp_pkey, other._evp_pkey)
             == 1
         )
 

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -537,6 +537,17 @@ class _RSAPublicKey(RSAPublicKey):
     def key_size(self) -> int:
         return self._key_size
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, RSAPublicKey):
+            return NotImplemented
+
+        return (
+            self._backend._lib.EVP_PKEY_cmp(
+                self._evp_pkey, other._evp_pkey  # type: ignore[attr-defined]
+            )
+            == 1
+        )
+
     def encrypt(self, plaintext: bytes, padding: AsymmetricPadding) -> bytes:
         return _enc_dec_rsa(self._backend, self, plaintext, padding)
 

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -200,6 +200,12 @@ class DHPublicKey(metaclass=abc.ABCMeta):
         Returns the key serialized as bytes.
         """
 
+    @abc.abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality.
+        """
+
 
 DHPublicKeyWithSerialization = DHPublicKey
 

--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -120,6 +120,12 @@ class DSAPublicKey(metaclass=abc.ABCMeta):
         Verifies the signature of the data.
         """
 
+    @abc.abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality.
+        """
+
 
 DSAPublicKeyWithSerialization = DSAPublicKey
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -184,6 +184,12 @@ class EllipticCurvePublicKey(metaclass=abc.ABCMeta):
 
         return backend.load_elliptic_curve_public_bytes(curve, data)
 
+    @abc.abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality.
+        """
+
 
 EllipticCurvePublicKeyWithSerialization = EllipticCurvePublicKey
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ed25519.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ed25519.py
@@ -51,6 +51,12 @@ class Ed25519PublicKey(metaclass=abc.ABCMeta):
         Verify the signature.
         """
 
+    @abc.abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality.
+        """
+
 
 class Ed25519PrivateKey(metaclass=abc.ABCMeta):
     @classmethod

--- a/src/cryptography/hazmat/primitives/asymmetric/ed448.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ed448.py
@@ -48,6 +48,12 @@ class Ed448PublicKey(metaclass=abc.ABCMeta):
         Verify the signature.
         """
 
+    @abc.abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality.
+        """
+
 
 class Ed448PrivateKey(metaclass=abc.ABCMeta):
     @classmethod

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -118,6 +118,12 @@ class RSAPublicKey(metaclass=abc.ABCMeta):
         Recovers the original data from the signature.
         """
 
+    @abc.abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality.
+        """
+
 
 RSAPublicKeyWithSerialization = RSAPublicKey
 

--- a/src/cryptography/hazmat/primitives/asymmetric/x25519.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x25519.py
@@ -41,6 +41,12 @@ class X25519PublicKey(metaclass=abc.ABCMeta):
         Equivalent to public_bytes(Raw, Raw).
         """
 
+    @abc.abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality.
+        """
+
 
 # For LibreSSL
 if hasattr(rust_openssl, "x25519"):

--- a/src/cryptography/hazmat/primitives/asymmetric/x448.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/x448.py
@@ -41,6 +41,12 @@ class X448PublicKey(metaclass=abc.ABCMeta):
         Equivalent to public_bytes(Raw, Raw).
         """
 
+    @abc.abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """
+        Checks equality.
+        """
+
 
 if hasattr(rust_openssl, "x448"):
     X448PublicKey.register(rust_openssl.x448.X448PublicKey)

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -127,6 +127,18 @@ impl X25519PublicKey {
     ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
         utils::pkey_public_bytes(py, &self.pkey, encoding, format)
     }
+
+    fn __richcmp__(
+        &self,
+        other: pyo3::PyRef<'_, X25519PublicKey>,
+        op: pyo3::basic::CompareOp,
+    ) -> pyo3::PyResult<bool> {
+        match op {
+            pyo3::basic::CompareOp::Eq => Ok(self.pkey.public_eq(&other.pkey)),
+            pyo3::basic::CompareOp::Ne => Ok(!self.pkey.public_eq(&other.pkey)),
+            _ => Err(pyo3::exceptions::PyTypeError::new_err("Cannot be ordered")),
+        }
+    }
 }
 
 pub(crate) fn create_module(py: pyo3::Python<'_>) -> pyo3::PyResult<&pyo3::prelude::PyModule> {

--- a/src/rust/src/backend/x448.rs
+++ b/src/rust/src/backend/x448.rs
@@ -127,6 +127,18 @@ impl X448PublicKey {
     ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
         utils::pkey_public_bytes(py, &self.pkey, encoding, format)
     }
+
+    fn __richcmp__(
+        &self,
+        other: pyo3::PyRef<'_, X448PublicKey>,
+        op: pyo3::basic::CompareOp,
+    ) -> pyo3::PyResult<bool> {
+        match op {
+            pyo3::basic::CompareOp::Eq => Ok(self.pkey.public_eq(&other.pkey)),
+            pyo3::basic::CompareOp::Ne => Ok(!self.pkey.public_eq(&other.pkey)),
+            _ => Err(pyo3::exceptions::PyTypeError::new_err("Cannot be ordered")),
+        }
+    }
 }
 
 pub(crate) fn create_module(py: pyo3::Python<'_>) -> pyo3::PyResult<&pyo3::prelude::PyModule> {

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -738,15 +738,17 @@ fn create_ocsp_response(
         let tbs_bytes = asn1::write_single(&tbs_response_data)?;
         let signature = x509::sign::sign_data(py, private_key, hash_algorithm, &tbs_bytes)?;
 
-        py.import("cryptography.hazmat.backends.openssl.backend")?
-            .getattr(pyo3::intern!(py, "backend"))?
-            .call_method1(
-                "_check_keys_correspond",
-                (
-                    responder_cert.call_method0("public_key")?,
-                    private_key.call_method0("public_key")?,
+        if !responder_cert
+            .call_method0("public_key")?
+            .eq(private_key.call_method0("public_key")?)
+            .unwrap()
+        {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err(
+                    "Certificate public key and provided private key do not match",
                 ),
-            )?;
+            ));
+        }
 
         py_certs = builder.getattr(pyo3::intern!(py, "_certs"))?.extract()?;
         let certs = py_certs.as_ref().map(|py_certs| {

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -740,8 +740,7 @@ fn create_ocsp_response(
 
         if !responder_cert
             .call_method0("public_key")?
-            .eq(private_key.call_method0("public_key")?)
-            .unwrap()
+            .eq(private_key.call_method0("public_key")?)?
         {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err(

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -464,6 +464,28 @@ class TestDH:
         assert int.from_bytes(symkey1, "big") == int(vector["z"], 16)
         assert int.from_bytes(symkey2, "big") == int(vector["z"], 16)
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.dh_x942_serialization_supported(),
+        skip_message="DH X9.42 not supported",
+    )
+    def test_public_key_equality(self, backend):
+        key_bytes = load_vectors_from_file(
+            os.path.join("asymmetric", "DH", "dhpub.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
+        key_bytes_2 = load_vectors_from_file(
+            os.path.join("asymmetric", "DH", "dhpub_rfc5114_2.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
+        key1 = serialization.load_pem_public_key(key_bytes)
+        key2 = serialization.load_pem_public_key(key_bytes)
+        key3 = serialization.load_pem_public_key(key_bytes_2)
+        assert key1 == key2
+        assert key1 != key3
+        assert key1 != object()
+
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.dh_supported(),

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -384,6 +384,18 @@ class TestDSA:
             x=pn.x,
         ).private_key(backend)
 
+    def test_public_key_equality(self, backend):
+        key_bytes = load_vectors_from_file(
+            os.path.join("asymmetric", "PKCS8", "unenc-dsa-pkcs8.pem"),
+            lambda pemfile: pemfile.read().encode(),
+        )
+        key1 = serialization.load_pem_private_key(key_bytes, None).public_key()
+        key2 = serialization.load_pem_private_key(key_bytes, None).public_key()
+        key3 = DSA_KEY_2048.private_key().public_key()
+        assert key1 == key2
+        assert key1 != key3
+        assert key1 != object()
+
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.dsa_supported(),

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -565,7 +565,7 @@ class TestECDSAVectors:
             )
 
 
-class TestECNumbersEquality:
+class TestECEquality:
     def test_public_numbers_eq(self):
         pub = ec.EllipticCurvePublicNumbers(1, 2, ec.SECP192R1())
         assert pub == ec.EllipticCurvePublicNumbers(1, 2, ec.SECP192R1())
@@ -600,6 +600,19 @@ class TestECNumbersEquality:
             1, ec.EllipticCurvePublicNumbers(1, 2, ec.SECP521R1())
         )
         assert priv != object()
+
+    def test_public_key_equality(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+        key_bytes = load_vectors_from_file(
+            os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
+            lambda pemfile: pemfile.read().encode(),
+        )
+        key1 = serialization.load_pem_private_key(key_bytes, None).public_key()
+        key2 = serialization.load_pem_private_key(key_bytes, None).public_key()
+        key3 = ec.generate_private_key(ec.SECP256R1()).public_key()
+        assert key1 == key2
+        assert key1 != key3
+        assert key1 != object()
 
 
 class TestECSerialization:

--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -247,3 +247,21 @@ class TestEd25519Signing:
             )
             == private_bytes
         )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.ed25519_supported(),
+    skip_message="Requires OpenSSL with Ed25519 support",
+)
+def test_public_key_equality(backend):
+    key_bytes = load_vectors_from_file(
+        os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8.der"),
+        lambda derfile: derfile.read(),
+        mode="rb",
+    )
+    key1 = serialization.load_der_private_key(key_bytes, None).public_key()
+    key2 = serialization.load_der_private_key(key_bytes, None).public_key()
+    key3 = Ed25519PrivateKey.generate().public_key()
+    assert key1 == key2
+    assert key1 != key3
+    assert key1 != object()

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -260,3 +260,21 @@ class TestEd448Signing:
         key = Ed448PublicKey.from_public_bytes(public_bytes)
         with pytest.raises(InvalidSignature):
             key.verify(signature, b"8")
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.ed448_supported(),
+    skip_message="Requires OpenSSL with Ed448 support",
+)
+def test_public_key_equality(backend):
+    key_bytes = load_vectors_from_file(
+        os.path.join("asymmetric", "Ed448", "ed448-pkcs8.der"),
+        lambda derfile: derfile.read(),
+        mode="rb",
+    )
+    key1 = serialization.load_der_private_key(key_bytes, None).public_key()
+    key2 = serialization.load_der_private_key(key_bytes, None).public_key()
+    key3 = Ed448PrivateKey.generate().public_key()
+    assert key1 == key2
+    assert key1 != key3
+    assert key1 != object()

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2763,3 +2763,15 @@ class TestRSAPEMPublicKeySerialization:
         key = rsa_key_2048.public_key()
         with pytest.raises(ValueError):
             key.public_bytes(encoding, fmt)
+
+    def test_public_key_equality(self, rsa_key_2048: rsa.RSAPrivateKey):
+        key1 = rsa_key_2048.public_key()
+        key2 = RSA_KEY_2048.private_key(
+            unsafe_skip_rsa_key_validation=True
+        ).public_key()
+        key3 = RSA_KEY_2048_ALT.private_key(
+            unsafe_skip_rsa_key_validation=True
+        ).public_key()
+        assert key1 == key2
+        assert key1 != key3
+        assert key1 != object()

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -336,4 +336,4 @@ def test_public_key_equality(backend):
     assert key1 != key3
     assert key1 != object()
     with pytest.raises(TypeError):
-        key1 < key2
+        key1 < key2  # type: ignore[operator]

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -317,3 +317,23 @@ class TestX25519Exchange:
             )
             == private_bytes
         )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.x25519_supported(),
+    skip_message="Requires OpenSSL with X25519 support",
+)
+def test_public_key_equality(backend):
+    key_bytes = load_vectors_from_file(
+        os.path.join("asymmetric", "X25519", "x25519-pkcs8.der"),
+        lambda derfile: derfile.read(),
+        mode="rb",
+    )
+    key1 = serialization.load_der_private_key(key_bytes, None).public_key()
+    key2 = serialization.load_der_private_key(key_bytes, None).public_key()
+    key3 = X25519PrivateKey.generate().public_key()
+    assert key1 == key2
+    assert key1 != key3
+    assert key1 != object()
+    with pytest.raises(TypeError):
+        key1 < key2

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -272,4 +272,4 @@ def test_public_key_equality(backend):
     assert key1 != key3
     assert key1 != object()
     with pytest.raises(TypeError):
-        key1 < key2
+        key1 < key2  # type: ignore[operator]

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -253,3 +253,23 @@ class TestX448Exchange:
             )
             == private_bytes
         )
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.x448_supported(),
+    skip_message="Requires OpenSSL with X448 support",
+)
+def test_public_key_equality(backend):
+    key_bytes = load_vectors_from_file(
+        os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
+        lambda derfile: derfile.read(),
+        mode="rb",
+    )
+    key1 = serialization.load_der_private_key(key_bytes, None).public_key()
+    key2 = serialization.load_der_private_key(key_bytes, None).public_key()
+    key3 = X448PrivateKey.generate().public_key()
+    assert key1 == key2
+    assert key1 != key3
+    assert key1 != object()
+    with pytest.raises(TypeError):
+        key1 < key2


### PR DESCRIPTION
I don't think the `__richcmp__` implementation for X25519/X448 is actually equivalent to the Python `__eq__` method in the other objects since it can't return `NotImplementedError`. It is consistent with how we implemented `ObjectIdentifier` though.