### PR TITLE
Fix: _key_identifier_from_public_key digest inconsistency with openssl and gnutls

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -53,7 +53,7 @@ def _key_identifier_from_public_key(
     if isinstance(public_key, RSAPublicKey):
         data = public_key.public_bytes(
             serialization.Encoding.DER,
-            serialization.PublicFormat.PKCS1,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
         )
     elif isinstance(public_key, EllipticCurvePublicKey):
         data = public_key.public_bytes(


### PR DESCRIPTION
A snippet code of proof on cryptography==40.0.1:
```
import hashlib
import base64

from cryptography.hazmat.primitives import serialization
from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
from cryptography import x509

def main():

    # Generate a new RSA key
    # `$ openssl genrsa -out example.key 2048`

    # OpenSSL

    # `$ openssl rsa -in example.key -pubout -outform DER | openssl dgst -sha1 -c`
    # > writing RSA key
    # > (stdin)= e9:12:c5:57:c4:34:97:cb:bd:38:99:a5:69:73:6b:7a:b6:b0:24:4c

    # GnuTLS

    # `$ certtool --load-privkey example.key --pubkey-info`
    # > ...
    # > Public Key ID:
    # >         sha1:e912c557c43497cbbd3899a569736b7ab6b0244c
    # >         sha256:5c421b5f2ea93a1a761ea478d906c5d8c32cb53a0809033776864df5a99a4db0
    # > ...

    file_content = base64.b64decode(
'''
LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVB
eHBkOXpzandkTG4zREVmQXc2cUhBTTVaWk1sb0lJZkw2NVhWcEZtSEZvYzZNQ0FY
Ci8wQjhkL0Q1TmhCa0phQ3M0SW9kTHNScGFsZyt2cGYyTEh6dk9aeU1zdzM3cTZh
TkhYajVlaG5hcjQxSVpJV1QKbUp0aThSOVdLWUpGSGRLZUJEQ1QyeVYzSDgyc21J
SVM2T0NQV255ODlIUllwcTFkc2M3aVZuS0k1TmhIMmNQMgpQL1Qwb0M2WjVMZDFl
VC9sb0Vha0xUS2dVK1plblRjOERtdFhEZWEyeU9jOW9PUEVNRzMxREJpZ0hHVjdO
RGRiCkdPUlNYOW14cUp5amJ1MHBXK1JvNEhCSUpVRTdsbUM1Z1lHNDRSZVREVC82
UW5LNS9RR1hvLzhXNTFNTkJuVi8KcXJxUm9Sblk4aDZxUFNWWXJIeVVsU2tMK2pk
SWFUalR4MU1nQXdJREFRQUJBb0lCQUVZS1kvcXNiL0liTElDTwpSZlE4am9UQVFs
TURuYy9yVlFadnYvdkkvNVg0ZDVORm5uRU9BMWdpQ3lNQVFQSHNhMHgrS2JDMjRS
NzZwSlovCjdmamV6MWlZV0I5R2pUNks3VFk1MW5Nejd5Yi9RMHNBdVgrWFBod2dt
empra3cvam1vdUx2bm9LQ3F1UzFJNnQKUVpJVXNUcU94KzNIb3dTV0hIZDdxZVFu
WFJTb2V3S2htQ1NyVWxERVlRbkN0NGRNcDV3SjFsMURSZG1PVS9iMAp3dUtscFc5
QUh1UVZMOWJwSVZzaHZha2krck9EV2dUdDRRZ2pFeVgvemFVM3VJWHU0b29HTEZS
djhkRUx5YXJPCkpLdmNQTi8yZ0xTNko0dVdNYWhvV0RNQjVLS2xLbCtuWURFT1BX
NGxDTkJaUXB4ZGEvZVpDTngzSUUzMm1UQ1gKeHBRVmY1RUNnWUVBL1JqTXdINkti
bXRuRG4ybGlkeWs5MkVEVXpKUmtMOWFtM3czbEVSUzNuS2tHL3gzOEFtMQpISmts
cmhaSUg1ODNSTUJwQWFXMW9nRlEzZ01OMEZSUGgweVk4WW5RbFBjWFhlUDlKdXd1
SStucmNKU21HajRjCjhXcnU2MGlLUFlieENkd0VUZzdSVWp2bmZUakMrc1lBNXlo
eWlSakNRYnZKMy9vaG14cEFZNDhDZ1lFQXlONmsKTTRtWjhGUzhYRU41MXNSejlQ
T0RMR1Y1WWFtNGJKSUhEajZtRDFXcW1qaHJvSHFURUFJYTFpZyswT29DRjhyTApZ
YkNnMTJNNFQ3OTFwRWZKMGJnQysrSTNoVVcyNm9tekZCOXRxdS9wNnV5NnlkNWtw
N3hzLzZjSTd0dHBncUxiCnNxZ0xqZVQ3SzFwWjhtNm9lM2p6M2RhT2VlbDN6bUhW
YTNLbzhrMENnWUVBMlJta3lKbkM5T1I4Q2hvTkhTeCsKOVJQcVhqc1RiQzQzOHBl
aXRUUEdRYm5rdTN6ZEJMSFBBVEQ4K1U5em5teGNaRVVIemJudkM0QkZkYXI0OW5M
YgpwUnMzTmprWkNpN0poR2hFaGxhaFhYMFIwQWd5VXVCa3cxRU9rQlF4UUlXM3pO
VkZmQStKemhoRWdVMW5NdVVWCmNUTm95K0RKQU1tc2FNdU9lQlVVbGxFQ2dZQkdV
M1RIdW5oVDVVYmhRcHFJcjlVdFFJaC9aYk9lbHM1RDdNaGQKbTErR1pPYkxBYy9r
cXFXTWFFQS9GRzRSdEt3dzZrWlVtSU5uaFl4MGwwSzMxbzU1UjJSOERaS0VyWWpD
Q3AzUgpBTVBqb2dXU3cza09MamV0WmxIL0c5c0x6WFBlVWVoN1gweFVUSVFIaEtX
VE5GejJoYjFUd01lM05SOUYrWWpBCkNxL056UUtCZ0FOYzNQVlk4eEVzdnVta3VD
bnl4S083RlNJSGNXVEhocnpZME1GdytYN0pKcFNWa0lvNXVBd3cKemFIaTlGclRH
ditSV09qOHBtQUxoSXlBNndCdWZiaVVNZUtQK0pDaWRubnhvZ2c2MFFQOXE5QmJj
T0lTakQ5TQpMU2xDUEkycGludVBjQWJqdWQ0SlhuODBIQlM5c0traVpnakpzdGhY
QTduWVYzOUdxRVY1Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
'''
    )

    example_public_key = serialization.load_pem_private_key(
        data=file_content, password=None
    ).public_key()

    assert isinstance(example_public_key, RSAPublicKey)

    assert (
        x509.extensions._key_identifier_from_public_key(
            example_public_key
        ).hex() == "f7d49899bcc50f3501589b18a86892312aeb2b3e"
    )

    assert (
        hashlib.sha1(
            example_public_key.public_bytes(
                serialization.Encoding.DER,
                serialization.PublicFormat.SubjectPublicKeyInfo
            )
        ).digest().hex() == "e912c557c43497cbbd3899a569736b7ab6b0244c"
    )

if __name__ == "__main__":
    main()
```