### PR TITLE
Switch to an allow-list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,7 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
-exclude = [
-    "_cffi_src",
-    "_cffi_src.*",
-]
+include = ["cryptography*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "cryptography.__version__"}


### PR DESCRIPTION
Right now the rust subdirectory gets processed for packages, which never exist. This can break some development workflows.