### PR TITLE
Don't try to compute coverage for anything in ~/.cargo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,13 +336,13 @@ jobs:
             cargo cov -- export \
               ../../.nox/tests/lib/python${{ matrix.PYTHON }}/site-packages/cryptography/hazmat/bindings/_rust.abi3.so \
               -instr-profile=pytest-rust-cov.profdata \
-              --ignore-filename-regex='/.cargo/registry' \
+              --ignore-filename-regex='/.cargo/' \
               --ignore-filename-regex='/rustc/' \
               --ignore-filename-regex='/.rustup/toolchains/' --format=lcov > ../../${COV_UUID}-1.lcov
             cargo cov -- export \
               $(env RUSTFLAGS="-Cinstrument-coverage" cargo test --no-default-features --all --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]") \
               -instr-profile=cargo-test-rust-cov.profdata \
-              --ignore-filename-regex='/.cargo/registry' \
+              --ignore-filename-regex='/.cargo/' \
               --ignore-filename-regex='/rustc/' \
               --ignore-filename-regex='/.rustup/toolchains/' --format=lcov > ../../${COV_UUID}-2.lcov
 


### PR DESCRIPTION
This way it'll exclude ~/.cargo/git as well