### PR TITLE
Remove attrs from ci-constraints-requirements.txt

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -9,9 +9,6 @@ alabaster==0.7.13
     # via sphinx
 argcomplete==3.0.6
     # via nox
-attrs==23.1.0
-    # via
-    #   pytest
 babel==2.12.1
     # via sphinx
 black==23.3.0


### PR DESCRIPTION
It's now unused in pytest: https://github.com/pytest-dev/pytest/commit/310b67b2271cb05f575054c1cdd2ece2412c89a2