### PR TITLE
See if we can always enable abi3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,12 +54,6 @@ try:
                 "cryptography.hazmat.bindings._rust",
                 "src/rust/Cargo.toml",
                 py_limited_api=True,
-                # Enable abi3 mode if we're not using PyPy.
-                features=(
-                    []
-                    if platform.python_implementation() == "PyPy"
-                    else ["pyo3/abi3-py37"]
-                ),
                 rust_version=">=1.56.0",
             )
         ],

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 once_cell = "1"
-pyo3 = { version = "0.18" }
+pyo3 = { version = "0.18", features = ["abi3-py37"] }
 asn1 = { version = "0.15.0", default-features = false }
 cryptography-cffi = { path = "cryptography-cffi" }
 cryptography-x509 = { path = "cryptography-x509" }

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.56.0"
 
 [dependencies]
-pyo3 = { version = "0.18" }
+pyo3 = { version = "0.18", features = ["abi3-py37"] }
 openssl-sys = "0.9.87"
 
 [build-dependencies]


### PR DESCRIPTION
Previously it wasn't because pypy doesn't support abi3, but maybe the pyo3 feature works.