### PR TITLE
Use defined_by for RSA signature AlgorithmIdentifiers

### DIFF
--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -26,6 +26,24 @@ pub enum AlgorithmParameters<'a> {
     #[defined_by(oid::ED448_OID)]
     Ed448,
 
+    #[defined_by(oid::RSA_WITH_SHA224_OID)]
+    RsaWithSha224(Option<asn1::Null>),
+    #[defined_by(oid::RSA_WITH_SHA256_OID)]
+    RsaWithSha256(Option<asn1::Null>),
+    #[defined_by(oid::RSA_WITH_SHA384_OID)]
+    RsaWithSha384(Option<asn1::Null>),
+    #[defined_by(oid::RSA_WITH_SHA512_OID)]
+    RsaWithSha512(Option<asn1::Null>),
+
+    #[defined_by(oid::RSA_WITH_SHA3_224_OID)]
+    RsaWithSha3_224(Option<asn1::Null>),
+    #[defined_by(oid::RSA_WITH_SHA3_256_OID)]
+    RsaWithSha3_256(Option<asn1::Null>),
+    #[defined_by(oid::RSA_WITH_SHA3_384_OID)]
+    RsaWithSha3_384(Option<asn1::Null>),
+    #[defined_by(oid::RSA_WITH_SHA3_512_OID)]
+    RsaWithSha3_512(Option<asn1::Null>),
+
     #[default]
     Other(asn1::ObjectIdentifier, Option<asn1::Tlv<'a>>),
 }

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -196,59 +196,35 @@ pub(crate) fn compute_signature_algorithm<'p>(
 
         (KeyType::Rsa, HashType::Sha224) => Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Other(
-                (oid::RSA_WITH_SHA224_OID).clone(),
-                Some(*NULL_TLV),
-            ),
+            params: common::AlgorithmParameters::RsaWithSha224(Some(())),
         }),
         (KeyType::Rsa, HashType::Sha256) => Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Other(
-                (oid::RSA_WITH_SHA256_OID).clone(),
-                Some(*NULL_TLV),
-            ),
+            params: common::AlgorithmParameters::RsaWithSha256(Some(())),
         }),
         (KeyType::Rsa, HashType::Sha384) => Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Other(
-                (oid::RSA_WITH_SHA384_OID).clone(),
-                Some(*NULL_TLV),
-            ),
+            params: common::AlgorithmParameters::RsaWithSha384(Some(())),
         }),
         (KeyType::Rsa, HashType::Sha512) => Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Other(
-                (oid::RSA_WITH_SHA512_OID).clone(),
-                Some(*NULL_TLV),
-            ),
+            params: common::AlgorithmParameters::RsaWithSha512(Some(())),
         }),
         (KeyType::Rsa, HashType::Sha3_224) => Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Other(
-                (oid::RSA_WITH_SHA3_224_OID).clone(),
-                Some(*NULL_TLV),
-            ),
+            params: common::AlgorithmParameters::RsaWithSha3_224(Some(())),
         }),
         (KeyType::Rsa, HashType::Sha3_256) => Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Other(
-                (oid::RSA_WITH_SHA3_256_OID).clone(),
-                Some(*NULL_TLV),
-            ),
+            params: common::AlgorithmParameters::RsaWithSha3_256(Some(())),
         }),
         (KeyType::Rsa, HashType::Sha3_384) => Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Other(
-                (oid::RSA_WITH_SHA3_384_OID).clone(),
-                Some(*NULL_TLV),
-            ),
+            params: common::AlgorithmParameters::RsaWithSha3_384(Some(())),
         }),
         (KeyType::Rsa, HashType::Sha3_512) => Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Other(
-                (oid::RSA_WITH_SHA3_512_OID).clone(),
-                Some(*NULL_TLV),
-            ),
+            params: common::AlgorithmParameters::RsaWithSha3_512(Some(())),
         }),
 
         (KeyType::Dsa, HashType::Sha224) => Ok(common::AlgorithmIdentifier {


### PR DESCRIPTION
I had hoped the parameters would just be Null (no Option<>), but a review of the RFC (3447, 4055) indicates that both should be allowed, though the WebPKI enforces greater constraints.