### PR TITLE
support X.509 certificate PSS signing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ Changelog
 * Added support for obtaining X.509 certificate signature algorithm parameters
   (including PSS) via
   :meth:`~cryptography.x509.Certificate.signature_algorithm_parameters`.
+* Support signing :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+  X.509 certificates via a new keyword-only argument on
+  :meth:`~cryptography.x509.CertificateBuilder.sign`.
 
 .. _v40-0-2:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Changelog
   (including PSS) via
   :meth:`~cryptography.x509.Certificate.signature_algorithm_parameters`.
 * Support signing :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
-  X.509 certificates via a new keyword-only argument on
+  X.509 certificates via the new keyword-only argument ``rsa_padding`` on
   :meth:`~cryptography.x509.CertificateBuilder.sign`.
 
 .. _v40-0-2:

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -872,7 +872,7 @@ X.509 Certificate Builder
         :param critical: Set to ``True`` if the extension must be understood and
              handled by whoever reads the certificate.
 
-    .. method:: sign(private_key, algorithm)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None)
 
         Sign the certificate using the CA's private key.
 
@@ -890,6 +890,22 @@ X.509 Certificate Builder
             and an instance of a
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
             otherwise.
+
+        :param rsa_padding:
+
+            .. versionadded:: 41.0.0
+
+            This is a keyword-only argument. If ``private_key`` is an
+            ``RSAPrivateKey`` then this can be set to either
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15` or
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` to sign
+            with those respective paddings. If this is ``None`` then RSA
+            keys will default to ``PKCS1v15`` padding. All other key types **must**
+            not pass a value other than ``None``.
+
+        :type rsa_padding: ``None``,
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
+            or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
 
         :returns: :class:`~cryptography.x509.Certificate`
 

--- a/src/cryptography/hazmat/bindings/_rust/x509.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/x509.pyi
@@ -6,6 +6,7 @@ import typing
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.padding import PSS, PKCS1v15
 from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
 
 def load_pem_x509_certificate(data: bytes) -> x509.Certificate: ...
@@ -23,6 +24,7 @@ def create_x509_certificate(
     builder: x509.CertificateBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: typing.Optional[hashes.HashAlgorithm],
+    padding: typing.Optional[typing.Union[PKCS1v15, PSS]],
 ) -> x509.Certificate: ...
 def create_x509_csr(
     builder: x509.CertificateSigningRequestBuilder,

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -6,7 +6,7 @@ use crate::oid;
 use asn1::Asn1DefinedByWritable;
 use std::marker::PhantomData;
 
-#[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Hash, Clone, Eq)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Hash, Clone, Eq, Debug)]
 pub struct AlgorithmIdentifier<'a> {
     pub oid: asn1::DefinedByMarker<asn1::ObjectIdentifier>,
     #[defined_by(oid)]
@@ -19,7 +19,7 @@ impl AlgorithmIdentifier<'_> {
     }
 }
 
-#[derive(asn1::Asn1DefinedByRead, asn1::Asn1DefinedByWrite, PartialEq, Eq, Hash, Clone)]
+#[derive(asn1::Asn1DefinedByRead, asn1::Asn1DefinedByWrite, PartialEq, Eq, Hash, Clone, Debug)]
 pub enum AlgorithmParameters<'a> {
     #[defined_by(oid::SHA1_OID)]
     Sha1(asn1::Null),
@@ -31,6 +31,14 @@ pub enum AlgorithmParameters<'a> {
     Sha384(asn1::Null),
     #[defined_by(oid::SHA512_OID)]
     Sha512(asn1::Null),
+    #[defined_by(oid::SHA3_224_OID)]
+    Sha3_224(asn1::Null),
+    #[defined_by(oid::SHA3_256_OID)]
+    Sha3_256(asn1::Null),
+    #[defined_by(oid::SHA3_384_OID)]
+    Sha3_384(asn1::Null),
+    #[defined_by(oid::SHA3_512_OID)]
+    Sha3_512(asn1::Null),
 
     #[defined_by(oid::ED25519_OID)]
     Ed25519,
@@ -225,7 +233,7 @@ pub const PSS_SHA1_HASH_ALG: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
 // This is defined as an AlgorithmIdentifier in RFC 4055,
 // but the mask generation algorithm **must** contain an AlgorithmIdentifier
 // in its params, so we define it this way.
-#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, Clone, PartialEq, Eq)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, Clone, PartialEq, Eq, Debug)]
 pub struct MaskGenAlgorithm<'a> {
     pub oid: asn1::ObjectIdentifier,
     pub params: AlgorithmIdentifier<'a>,
@@ -245,7 +253,7 @@ pub const PSS_SHA1_MASK_GEN_ALG: MaskGenAlgorithm<'_> = MaskGenAlgorithm {
 //                               mgf1SHA1Identifier,
 //     saltLength         [2] INTEGER DEFAULT 20,
 //     trailerField       [3] INTEGER DEFAULT 1  }
-#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, Clone, PartialEq, Eq)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, Clone, PartialEq, Eq, Debug)]
 pub struct RsaPssParameters<'a> {
     #[explicit(0)]
     #[default(PSS_SHA1_HASH_ALG)]
@@ -258,7 +266,7 @@ pub struct RsaPssParameters<'a> {
     pub salt_length: u16,
     #[explicit(3)]
     #[default(1u8)]
-    _trailer_field: u8,
+    pub _trailer_field: u8,
 }
 
 /// A VisibleString ASN.1 element whose contents is not validated as meeting the

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -130,7 +130,13 @@ fn sign_and_serialize<'p>(
         {
             (
                 None,
-                x509::sign::sign_data(py, py_private_key, py_hash_alg, &data_with_header)?,
+                x509::sign::sign_data(
+                    py,
+                    py_private_key,
+                    py_hash_alg,
+                    py.None().into_ref(py),
+                    &data_with_header,
+                )?,
             )
         } else {
             let mut authenticated_attrs = vec![];
@@ -175,7 +181,13 @@ fn sign_and_serialize<'p>(
                 Some(common::Asn1ReadableOrWritable::new_write(
                     asn1::SetOfWriter::new(authenticated_attrs),
                 )),
-                x509::sign::sign_data(py, py_private_key, py_hash_alg, &signed_data)?,
+                x509::sign::sign_data(
+                    py,
+                    py_private_key,
+                    py_hash_alg,
+                    py.None().into_ref(py),
+                    &signed_data,
+                )?,
             )
         };
 
@@ -201,6 +213,7 @@ fn sign_and_serialize<'p>(
                 py,
                 py_private_key,
                 py_hash_alg,
+                py.None().into_ref(py),
             )?,
             encrypted_digest: signature,
             unauthenticated_attributes: None,

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1002,8 +1002,10 @@ fn create_x509_certificate(
     builder: &pyo3::PyAny,
     private_key: &pyo3::PyAny,
     hash_algorithm: &pyo3::PyAny,
+    rsa_padding: &pyo3::PyAny,
 ) -> CryptographyResult<Certificate> {
-    let sigalg = x509::sign::compute_signature_algorithm(py, private_key, hash_algorithm)?;
+    let sigalg =
+        x509::sign::compute_signature_algorithm(py, private_key, hash_algorithm, rsa_padding)?;
     let serialization_mod = py.import(pyo3::intern!(
         py,
         "cryptography.hazmat.primitives.serialization"
@@ -1056,7 +1058,8 @@ fn create_x509_certificate(
     };
 
     let tbs_bytes = asn1::write_single(&tbs_cert)?;
-    let signature = x509::sign::sign_data(py, private_key, hash_algorithm, &tbs_bytes)?;
+    let signature =
+        x509::sign::sign_data(py, private_key, hash_algorithm, rsa_padding, &tbs_bytes)?;
     let data = asn1::write_single(&cryptography_x509::certificate::Certificate {
         tbs_cert,
         signature_alg: sigalg,

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -580,8 +580,12 @@ fn create_x509_crl(
     private_key: &pyo3::PyAny,
     hash_algorithm: &pyo3::PyAny,
 ) -> CryptographyResult<CertificateRevocationList> {
-    let sigalg = x509::sign::compute_signature_algorithm(py, private_key, hash_algorithm)?;
-
+    let sigalg = x509::sign::compute_signature_algorithm(
+        py,
+        private_key,
+        hash_algorithm,
+        py.None().into_ref(py),
+    )?;
     let mut revoked_certs = vec![];
     for py_revoked_cert in builder
         .getattr(pyo3::intern!(py, "_revoked_certificates"))?
@@ -628,7 +632,13 @@ fn create_x509_crl(
     };
 
     let tbs_bytes = asn1::write_single(&tbs_cert_list)?;
-    let signature = x509::sign::sign_data(py, private_key, hash_algorithm, &tbs_bytes)?;
+    let signature = x509::sign::sign_data(
+        py,
+        private_key,
+        hash_algorithm,
+        py.None().into_ref(py),
+        &tbs_bytes,
+    )?;
     let data = asn1::write_single(&crl::CertificateRevocationList {
         tbs_cert_list,
         signature_algorithm: sigalg,

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -294,7 +294,12 @@ fn create_x509_csr(
     private_key: &pyo3::PyAny,
     hash_algorithm: &pyo3::PyAny,
 ) -> CryptographyResult<CertificateSigningRequest> {
-    let sigalg = x509::sign::compute_signature_algorithm(py, private_key, hash_algorithm)?;
+    let sigalg = x509::sign::compute_signature_algorithm(
+        py,
+        private_key,
+        hash_algorithm,
+        py.None().into_ref(py),
+    )?;
     let serialization_mod = py.import(pyo3::intern!(
         py,
         "cryptography.hazmat.primitives.serialization"
@@ -364,7 +369,13 @@ fn create_x509_csr(
     };
 
     let tbs_bytes = asn1::write_single(&csr_info)?;
-    let signature = x509::sign::sign_data(py, private_key, hash_algorithm, &tbs_bytes)?;
+    let signature = x509::sign::sign_data(
+        py,
+        private_key,
+        hash_algorithm,
+        py.None().into_ref(py),
+        &tbs_bytes,
+    )?;
     let data = asn1::write_single(&Csr {
         csr_info,
         signature_alg: sigalg,

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -679,9 +679,20 @@ fn create_ocsp_response(
             )?,
         };
 
-        let sigalg = x509::sign::compute_signature_algorithm(py, private_key, hash_algorithm)?;
+        let sigalg = x509::sign::compute_signature_algorithm(
+            py,
+            private_key,
+            hash_algorithm,
+            py.None().into_ref(py),
+        )?;
         let tbs_bytes = asn1::write_single(&tbs_response_data)?;
-        let signature = x509::sign::sign_data(py, private_key, hash_algorithm, &tbs_bytes)?;
+        let signature = x509::sign::sign_data(
+            py,
+            private_key,
+            hash_algorithm,
+            py.None().into_ref(py),
+            &tbs_bytes,
+        )?;
 
         if !responder_cert
             .call_method0(pyo3::intern!(py, "public_key"))?

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -2429,6 +2429,8 @@ class TestCertificateBuilder:
     def test_sign_pss(
         self, rsa_key_2048: rsa.RSAPrivateKey, alg, mgf_alg, backend
     ):
+        if not backend.signature_hash_supported(alg):
+            pytest.skip(f"{alg} signature not supported")
         builder = (
             x509.CertificateBuilder()
             .subject_name(


### PR DESCRIPTION
This enables X.509 certificate signing using PSS with SHA2/SHA3 (for both hash algorithm and MGF1 hash). No support for CSR or others at this time -- I'd like to hear use cases there.