### PR TITLE
update cache key to reflect all rust files, not just cargo.lock

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -43,7 +43,7 @@ runs:
           ~/.cargo/registry/cache/
           src/rust/target/
           ${{ inputs.additional-paths }}
-        key: cargo-pip-${{ runner.os }}-${{ runner.arch }}-${{ inputs.key }}-3-${{ hashFiles('**/Cargo.lock') }}-${{ steps.rust-version.version }}
+        key: cargo-pip-${{ runner.os }}-${{ runner.arch }}-${{ inputs.key }}-3-${{ hashFiles('**/Cargo.lock', '**/*.rs') }}-${{ steps.rust-version.version }}
     - name: Size of cache items
       run: |
         du -sh ~/.cargo/registry/index/


### PR DESCRIPTION
rust uses mtime to determine if files are fresh or not. However, if the mtime of a file in main is newer than the mtime of a commit in a PR then it will load the cache and there will be weird errors since it thinks the cache is new enough but in reality the code has changed. This change ties our cache keys to all our rust files, not just our cargo.lock, and should resolve this issue.