### PR TITLE
support PSS signatures in verify_directly_issued_by

### DIFF
--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -335,7 +335,7 @@ impl Certificate {
                 ),
             ));
         };
-        sign::verify_signature_with_oid(
+        sign::verify_signature_with_signature_algorithm(
             py,
             issuer.public_key(py)?,
             &self.raw.borrow_value().signature_alg,

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -393,7 +393,7 @@ impl CertificateRevocationList {
         // being an invalid signature.
         sign::identify_public_key_type(py, public_key)?;
 
-        Ok(sign::verify_signature_with_oid(
+        Ok(sign::verify_signature_with_signature_algorithm(
             py,
             public_key,
             &slf.owned.borrow_value().signature_algorithm,

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -235,9 +235,10 @@ impl CertificateSigningRequest {
         slf: pyo3::PyRef<'_, Self>,
         py: pyo3::Python<'_>,
     ) -> CryptographyResult<bool> {
-        Ok(sign::verify_signature_with_oid(
+        let public_key = slf.public_key(py)?;
+        Ok(sign::verify_signature_with_signature_algorithm(
             py,
-            slf.public_key(py)?,
+            public_key,
             &slf.raw.borrow_value().signature_alg,
             slf.raw.borrow_value().signature.as_bytes(),
             &asn1::write_single(&slf.raw.borrow_value().csr_info)?,


### PR DESCRIPTION
This performs a significant refactoring in moving the impl of `signature_algorithm_parameters` into a standalone func `identify_signature_algorithm_parameters` and then using that in `verify_signature_with_signature_parameters` (which is a refactored `verify_signature_with_oid`).

Outstanding question: this refactor likely means CSR and CRL could verify a PSS signature, but we don't permit creating them and I don't have any test vectors so we should decide one of the following:
* Don't care, they're unsupported for now.
* Do care, we need test vectors (either implementing support so we can create them or digging them up somewhere)

This work triggered filing #8907 as well.