### PR TITLE
openssl backend.py: do not allow RSA public exponent < F4

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -396,7 +396,7 @@ class Backend:
         self, public_exponent: int, key_size: int
     ) -> bool:
         return (
-            public_exponent >= 3
+            public_exponent >= 65537
             and public_exponent & 1 != 0
             and key_size >= 512
         )

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -140,11 +140,8 @@ def generate_private_key(
 
 
 def _verify_rsa_parameters(public_exponent: int, key_size: int) -> None:
-    if public_exponent not in (3, 65537):
-        raise ValueError(
-            "public_exponent must be either 3 (for legacy compatibility) or "
-            "65537. Almost everyone should choose 65537 here!"
-        )
+    if public_exponent != 65537:
+        raise ValueError("public_exponent must be 65537")
 
     if key_size < 512:
         raise ValueError("key_size must be at least 512-bits.")

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -187,7 +187,7 @@ class TestRSA:
             if key_size < backend._fips_rsa_min_key_size:
                 pytest.skip(f"Key size not FIPS compliant: {key_size}")
             if public_exponent < backend._fips_rsa_min_public_exponent:
-                pytest.skip(f"Exponent not FIPS compliant: {public_exponent}")
+                pytest.skip(f"Exponent too weak: {public_exponent}")
         skey = rsa.generate_private_key(public_exponent, key_size, backend)
         assert skey.key_size == key_size
 


### PR DESCRIPTION
Public Exponents really need to be at least the size of F4 (65537).