### PR TITLE
x509/common: make SPKI algorithm public

### DIFF
--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -111,7 +111,7 @@ pub enum AlgorithmParameters<'a> {
 
 #[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Clone)]
 pub struct SubjectPublicKeyInfo<'a> {
-    _algorithm: AlgorithmIdentifier<'a>,
+    pub algorithm: AlgorithmIdentifier<'a>,
     pub subject_public_key: asn1::BitString<'a>,
 }
 


### PR DESCRIPTION
No functional changes; this will be needed for path validation.