### PR TITLE
x509: Eq and Hash derives

### DIFF
--- a/src/rust/cryptography-x509/src/certificate.rs
+++ b/src/rust/cryptography-x509/src/certificate.rs
@@ -7,14 +7,14 @@ use crate::extensions;
 use crate::extensions::Extensions;
 use crate::name;
 
-#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Clone)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Eq, Clone)]
 pub struct Certificate<'a> {
     pub tbs_cert: TbsCertificate<'a>,
     pub signature_alg: common::AlgorithmIdentifier<'a>,
     pub signature: asn1::BitString<'a>,
 }
 
-#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Clone)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Eq, Clone)]
 pub struct TbsCertificate<'a> {
     #[explicit(0)]
     #[default(0)]
@@ -41,7 +41,7 @@ impl<'a> TbsCertificate<'a> {
     }
 }
 
-#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Clone)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Eq, Clone)]
 pub struct Validity {
     pub not_before: common::Time,
     pub not_after: common::Time,

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -109,7 +109,7 @@ pub enum AlgorithmParameters<'a> {
     Other(asn1::ObjectIdentifier, Option<asn1::Tlv<'a>>),
 }
 
-#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Clone)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, PartialEq, Eq, Clone)]
 pub struct SubjectPublicKeyInfo<'a> {
     pub algorithm: AlgorithmIdentifier<'a>,
     pub subject_public_key: asn1::BitString<'a>,
@@ -157,7 +157,7 @@ impl<'a> asn1::Asn1Writable for RawTlv<'a> {
     }
 }
 
-#[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Hash, Clone)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Eq, Hash, Clone)]
 pub enum Time {
     UtcTime(asn1::UtcTime),
     GeneralizedTime(asn1::GeneralizedTime),
@@ -172,7 +172,7 @@ impl Time {
     }
 }
 
-#[derive(Hash, PartialEq, Clone)]
+#[derive(Hash, PartialEq, Eq, Clone)]
 pub enum Asn1ReadableOrWritable<'a, T, U> {
     Read(T, PhantomData<&'a ()>),
     Write(U, PhantomData<&'a ()>),


### PR DESCRIPTION
Leaving as a draft until the `rust-asn1` bump is in, since this depends on it.