### PR TITLE
extensions: add `Extensions::iter`

### DIFF
--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -56,6 +56,15 @@ impl<'a> Extensions<'a> {
     pub fn as_raw(&self) -> &Option<RawExtensions<'_>> {
         &self.0
     }
+
+    /// Returns an iterator over the underlying extensions.
+    pub fn iter(&self) -> impl Iterator<Item = Extension> {
+        self.as_raw()
+            .clone()
+            .map(|raw| raw.unwrap_read().clone())
+            .into_iter()
+            .flatten()
+    }
 }
 
 #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Eq, Hash, Clone)]

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -261,4 +261,26 @@ mod tests {
             .get_extension(&AUTHORITY_KEY_IDENTIFIER_OID)
             .is_none());
     }
+
+    #[test]
+    fn test_extensions_iter() {
+        let extension_value = BasicConstraints {
+            ca: true,
+            path_length: Some(3),
+        };
+        let extension = Extension {
+            extn_id: BASIC_CONSTRAINTS_OID,
+            critical: true,
+            extn_value: &asn1::write_single(&extension_value).unwrap(),
+        };
+        let extensions = SequenceOfWriter::new(vec![extension]);
+
+        let der = asn1::write_single(&extensions).unwrap();
+
+        let extensions: Extensions =
+            Extensions::from_raw_extensions(Some(&asn1::parse_single(&der).unwrap())).unwrap();
+
+        let extension_list: Vec<_> = extensions.iter().collect();
+        assert_eq!(extension_list.len(), 1);
+    }
 }


### PR DESCRIPTION
This will make it easier to do criticality checks across the whole extensions sequence.

~~Probably needs a unit test.~~