### PR TITLE
remove more BN bindings

### DIFF
--- a/src/_cffi_src/openssl/bignum.py
+++ b/src/_cffi_src/openssl/bignum.py
@@ -9,28 +9,19 @@ INCLUDES = """
 """
 
 TYPES = """
-static const long Cryptography_HAS_BN_FLAGS;
+static const long Cryptography_HAS_PRIME_CHECKS;
 
 typedef ... BN_CTX;
-typedef ... BN_MONT_CTX;
 typedef ... BIGNUM;
 typedef int... BN_ULONG;
 """
 
 FUNCTIONS = """
-#define BN_FLG_CONSTTIME ...
-
-void BN_set_flags(BIGNUM *, int);
-
 BIGNUM *BN_new(void);
 void BN_free(BIGNUM *);
 void BN_clear_free(BIGNUM *);
 
 int BN_rand_range(BIGNUM *, const BIGNUM *);
-
-BN_MONT_CTX *BN_MONT_CTX_new(void);
-int BN_MONT_CTX_set(BN_MONT_CTX *, const BIGNUM *, BN_CTX *);
-void BN_MONT_CTX_free(BN_MONT_CTX *);
 
 int BN_set_word(BIGNUM *, BN_ULONG);
 
@@ -44,11 +35,6 @@ int BN_num_bits(const BIGNUM *);
 
 int BN_is_negative(const BIGNUM *);
 int BN_is_odd(const BIGNUM *);
-int BN_mod_exp_mont(BIGNUM *, const BIGNUM *, const BIGNUM *, const BIGNUM *,
-                    BN_CTX *, BN_MONT_CTX *);
-int BN_mod_exp_mont_consttime(BIGNUM *, const BIGNUM *, const BIGNUM *,
-                              const BIGNUM *, BN_CTX *, BN_MONT_CTX *);
-BIGNUM *BN_mod_inverse(BIGNUM *, const BIGNUM *, const BIGNUM *, BN_CTX *);
 
 int BN_num_bytes(const BIGNUM *);
 
@@ -61,12 +47,9 @@ const int BN_prime_checks_for_size(int);
 
 CUSTOMIZATIONS = """
 #if CRYPTOGRAPHY_IS_BORINGSSL
-static const long Cryptography_HAS_BN_FLAGS = 0;
-
-static const int BN_FLG_CONSTTIME = 0;
-void (*BN_set_flags)(BIGNUM *, int) = NULL;
+static const long Cryptography_HAS_PRIME_CHECKS = 0;
 int (*BN_prime_checks_for_size)(int) = NULL;
 #else
-static const long Cryptography_HAS_BN_FLAGS = 1;
+static const long Cryptography_HAS_PRIME_CHECKS = 1;
 #endif
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -222,10 +222,8 @@ def cryptography_has_pkcs7_funcs() -> typing.List[str]:
     ]
 
 
-def cryptography_has_bn_flags() -> typing.List[str]:
+def cryptography_has_prime_checks() -> typing.List[str]:
     return [
-        "BN_FLG_CONSTTIME",
-        "BN_set_flags",
         "BN_prime_checks_for_size",
     ]
 
@@ -307,7 +305,7 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_300_FIPS": cryptography_has_300_fips,
     "Cryptography_HAS_SSL_COOKIE": cryptography_has_ssl_cookie,
     "Cryptography_HAS_PKCS7_FUNCS": cryptography_has_pkcs7_funcs,
-    "Cryptography_HAS_BN_FLAGS": cryptography_has_bn_flags,
+    "Cryptography_HAS_PRIME_CHECKS": cryptography_has_prime_checks,
     "Cryptography_HAS_EVP_PKEY_DH": cryptography_has_evp_pkey_dh,
     "Cryptography_HAS_300_EVP_CIPHER": cryptography_has_300_evp_cipher,
     "Cryptography_HAS_UNEXPECTED_EOF_WHILE_READING": (


### PR DESCRIPTION
Some of these bindings were in use by pyUmbral, but that project hasn't seen a commit in nearly 2 years, is pinned to `3.x`, and we should keep driving down our bindings consumers and replace them with public APIs where possible.