### PR TITLE
Revert "cryptography-cffi: substitute include path from target sysroot in cross builds (#9105)"

### DIFF
--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -49,7 +49,7 @@ fn main() {
     println!("cargo:rustc-cfg=python_implementation=\"{}\"", python_impl);
     let python_include = run_python_script(
         &python,
-        "import sysconfig; print(sysconfig.get_config_var('INCLUDEPY'), end='')",
+        "import sysconfig; print(sysconfig.get_path('include'), end='')",
     )
     .unwrap();
     let openssl_include =


### PR DESCRIPTION
The original code was right all along: it uses the official API for obtaining header locations, and it is on the build environment to ensure python supplies that in cross-build scenarios (another option is to apply a custom patch, however any such patch is not eligible for upstream submission due to its specificity).

Further info: https://github.com/pyca/cryptography/pull/9129