### PR TITLE
Remove explicit enablement of sparse registry from wheel builder

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -19,9 +19,6 @@ on:
       - pyproject.toml
       - vectors/pyproject.toml
 
-env:
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-
 jobs:
   sdist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Its on by default in rust starting with 1.70.

Note: I'm not removing it from ci.yml until our MSRV is 1.70, as there are older builders. However, wheel-builder.yml always builds with the latest rustc, so it can safely be removed.