### PR TITLE
Stop explicitly enabling RSA blinding

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import threading
 import typing
 
 from cryptography.exceptions import (
@@ -400,9 +399,6 @@ class _RSAPrivateKey(RSAPrivateKey):
         self._backend = backend
         self._rsa_cdata = rsa_cdata
         self._evp_pkey = evp_pkey
-        # Used for lazy blinding
-        self._blinded = False
-        self._blinding_lock = threading.Lock()
 
         n = self._backend._ffi.new("BIGNUM **")
         self._backend._lib.RSA_get0_key(
@@ -414,31 +410,11 @@ class _RSAPrivateKey(RSAPrivateKey):
         self._backend.openssl_assert(n[0] != self._backend._ffi.NULL)
         self._key_size = self._backend._lib.BN_num_bits(n[0])
 
-    def _enable_blinding(self) -> None:
-        # If you call blind on an already blinded RSA key OpenSSL will turn
-        # it off and back on, which is a performance hit we want to avoid.
-        if not self._blinded:
-            with self._blinding_lock:
-                self._non_threadsafe_enable_blinding()
-
-    def _non_threadsafe_enable_blinding(self) -> None:
-        # This is only a separate function to allow for testing to cover both
-        # branches. It should never be invoked except through _enable_blinding.
-        # Check if it's not True again in case another thread raced past the
-        # first non-locked check.
-        if not self._blinded:
-            res = self._backend._lib.RSA_blinding_on(
-                self._rsa_cdata, self._backend._ffi.NULL
-            )
-            self._backend.openssl_assert(res == 1)
-            self._blinded = True
-
     @property
     def key_size(self) -> int:
         return self._key_size
 
     def decrypt(self, ciphertext: bytes, padding: AsymmetricPadding) -> bytes:
-        self._enable_blinding()
         key_size_bytes = (self.key_size + 7) // 8
         if key_size_bytes != len(ciphertext):
             raise ValueError("Ciphertext length must be equal to key size.")
@@ -508,7 +484,6 @@ class _RSAPrivateKey(RSAPrivateKey):
         padding: AsymmetricPadding,
         algorithm: typing.Union[asym_utils.Prehashed, hashes.HashAlgorithm],
     ) -> bytes:
-        self._enable_blinding()
         data, algorithm = _calculate_digest_and_algorithm(data, algorithm)
         return _rsa_sig_sign(self._backend, padding, algorithm, self, data)
 


### PR DESCRIPTION
It is on by default in OpenSSL, going back at least as far 1.1.1d, and probably much farther.