### PR TITLE
Fixes for ChaCha20 documentation

### DIFF
--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -172,9 +172,12 @@ Algorithms
 
     .. doctest::
 
+        >>> import struct, os
         >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-        >>> nonce = os.urandom(16)
-        >>> algorithm = algorithms.ChaCha20(key, nonce)
+        >>> nonce = os.urandom(8)
+        >>> counter = 0
+        >>> full_nonce = struct.pack("<Q", counter) + nonce
+        >>> algorithm = algorithms.ChaCha20(key, full_nonce)
         >>> cipher = Cipher(algorithm, mode=None)
         >>> encryptor = cipher.encryptor()
         >>> ct = encryptor.update(b"a secret message")

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -157,15 +157,16 @@ Algorithms
         :rfc:`7539`).
     :type nonce: :term:`bytes-like`
 
-        .. note::
+    .. note::
 
-            In :rfc:`7539` the nonce is defined as a 96-bit value that is later
-            concatenated with a block counter (encoded as a 32-bit
-            little-endian). If you have a separate nonce and block counter
-            you will need to concatenate it yourself before passing it. For
-            example, if you have an initial block counter of 2 and a 96-bit
-            nonce the concatenated nonce would be
-            ``struct.pack("<i", 2) + nonce``.
+        In :rfc:`7539` the nonce is defined as a 96-bit value that is later
+        concatenated with a block counter (encoded as a 32-bit
+        little-endian). If you have a separate nonce and block counter
+        you will need to concatenate it yourself before passing it. For
+        example, if you have an initial block counter of 2 and a 96-bit
+        nonce the concatenated nonce would be
+        ``struct.pack("<i", 2) + nonce``.
+
 
     .. doctest::
 

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -140,32 +140,34 @@ Algorithms
         :class:`~cryptography.hazmat.primitives.ciphers.aead.ChaCha20Poly1305`
         does this for you.
 
-    ChaCha20 is a stream cipher used in several IETF protocols. It is
-    standardized in :rfc:`7539`.
+    ChaCha20 is a stream cipher used in several IETF protocols. While it is
+    standardized in :rfc:`7539`, **this implementation is not RFC-compliant**.
+    This implementation uses a ``64`` :term:`bits` counter and a ``64``
+    :term:`bits` nonce as defined in the `original version`_ of the algorithm,
+    rather than the ``32/96`` counter/nonce split defined in :rfc:`7539`.
 
     :param key: The secret key. This must be kept secret. ``256``
         :term:`bits` (32 bytes) in length.
     :type key: :term:`bytes-like`
 
     :param nonce: Should be unique, a :term:`nonce`. It is
-        critical to never reuse a ``nonce`` with a given key.  Any reuse of a
+        critical to never reuse a ``nonce`` with a given key. Any reuse of a
         nonce with the same key compromises the security of every message
         encrypted with that key. The nonce does not need to be kept secret
         and may be included with the ciphertext. This must be ``128``
-        :term:`bits` in length. The 128-bit value is a concatenation of 4-byte
-        little-endian counter and the 12-byte nonce (as described in
-        :rfc:`7539`).
+        :term:`bits` in length. The 128-bit value is a concatenation of the
+        8-byte little-endian counter and the 8-byte nonce.
     :type nonce: :term:`bytes-like`
 
     .. note::
 
-        In :rfc:`7539` the nonce is defined as a 96-bit value that is later
-        concatenated with a block counter (encoded as a 32-bit
-        little-endian). If you have a separate nonce and block counter
-        you will need to concatenate it yourself before passing it. For
-        example, if you have an initial block counter of 2 and a 96-bit
+        In the `original version`_ of the algorithm the nonce is defined as a
+        64-bit value that is later concatenated with a block counter (encoded
+        as a 64-bit little-endian). If you have a separate nonce and block
+        counter you will need to concatenate it yourself before passing it.
+        For example, if you have an initial block counter of 2 and a 64-bit
         nonce the concatenated nonce would be
-        ``struct.pack("<i", 2) + nonce``.
+        ``struct.pack("<Q", 2) + nonce``.
 
 
     .. doctest::
@@ -846,6 +848,7 @@ Exceptions
 .. _`Communications Security Establishment`: https://www.cse-cst.gc.ca
 .. _`encrypt`: https://ssd.eff.org/en/module/what-should-i-know-about-encryption
 .. _`CRYPTREC`: https://www.cryptrec.go.jp/english/
+.. _`original version`: https://en.wikipedia.org/wiki/Salsa20#ChaCha_variant
 .. _`significant patterns in the output`: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Electronic_codebook_(ECB)
 .. _`International Data Encryption Algorithm`: https://en.wikipedia.org/wiki/International_Data_Encryption_Algorithm
 .. _`OpenPGP`: https://www.openpgp.org/


### PR DESCRIPTION
This PR consists of 3 changes (separated by commits). See https://github.com/pyca/cryptography/issues/9017 for more context on the documentation changes.

### 1. Fix hidden documentation
An indentation error causes the following `note` in the ChaCha20 documentation to not be rendered in the HTML output:

https://github.com/pyca/cryptography/blob/2d3354331b88217dd2ffece8a4c16ceb7173d6d4/docs/hazmat/primitives/symmetric-encryption.rst?plain=1#L160-L168

<img width="400" alt="image" src="https://github.com/pyca/cryptography/assets/5762120/e6fa23db-42b6-4c2d-873e-d6d4f20a2bff">


### 2. Fix ChaCha20 docs to refer to the actual implementation
Currently, cryptography uses OpenSSL's ChaCha20 implementation, which is based on the original algorithm designed by Daniel J. Bernstein rather than the later standardized version (RFC 7539).

Since the documentation does not reflect this (it describes the RFC version of the algorithm, rather than the original version we use), this change fixes that.

### 3. Remove random counter from ChaCha20 example docs
This changes the ChaCha20 example in the documentation to use a normal user-defined variable for the counter part of the nonce, rather than a randomized counter.
