### PR TITLE
update linkcheck

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,6 +1,9 @@
 name: linkcheck
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - docs/conf.py
+      - .github/workflows/linkcheck.yml
   push:
     branches:
       - main
@@ -13,7 +16,6 @@ env:
 
 jobs:
   docs-linkcheck:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'linkcheck'))
     runs-on: ubuntu-latest
     name: "linkcheck"
     timeout-minutes: 10

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,6 +202,9 @@ linkcheck_ignore = [
     r"https://www.oscca.gov.cn",
     # Cloudflare returns 403s for all non-browser requests
     r"https://speakerdeck.com",
+    # GitHub changed how they do page renders so anchor detection
+    # no longer works in source view
+    r"https://github.com/.*/blob/.*#L\d+",
 ]
 
 autosectionlabel_prefix_document = True


### PR DESCRIPTION
skip github links with anchor tags due to their new page rendering and switch to running linkcheck automatically when we touch conf.py or the linkcheck yaml.