### PR TITLE
Add support for ChaCha20 with LibreSSL

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -26,6 +26,7 @@ ffi = build_ffi_for_binding(
         "asn1",
         "bignum",
         "bio",
+        "chacha",
         "cmac",
         "crypto",
         "dh",

--- a/src/_cffi_src/openssl/chacha.py
+++ b/src/_cffi_src/openssl/chacha.py
@@ -1,0 +1,40 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+INCLUDES = """
+#if CRYPTOGRAPHY_IS_LIBRESSL
+#include <openssl/chacha.h>
+#endif"""
+
+TYPES = """
+static const long Cryptography_HAS_CHACHA20_API;
+"""
+
+FUNCTIONS = """
+void Cryptography_CRYPTO_chacha_20(uint8_t *, const uint8_t *, size_t,
+                                   const uint8_t[32], const uint8_t[8],
+                                   uint64_t);
+"""
+
+CUSTOMIZATIONS = """
+#if CRYPTOGRAPHY_IS_LIBRESSL
+static const long Cryptography_HAS_CHACHA20_API = 1;
+#else
+static const long Cryptography_HAS_CHACHA20_API = 0;
+#endif
+
+#if CRYPTOGRAPHY_IS_LIBRESSL
+void Cryptography_CRYPTO_chacha_20(uint8_t *out, const uint8_t *in,
+                                   size_t in_len, const uint8_t key[32],
+                                   const uint8_t nonce[8], uint64_t counter) {
+    CRYPTO_chacha_20(out, in, in_len, key, nonce, counter);
+}
+#else
+void (*Cryptography_CRYPTO_chacha_20)(uint8_t *, const uint8_t *, size_t,
+                                      const uint8_t[32], const uint8_t[8],
+                                      uint64_t) = NULL;
+#endif
+"""


### PR DESCRIPTION
This PR adds support for ChaCha20 with LibreSSL. Since cryptography's ChaCha20 uses OpenSSL's implementation (which uses a 64 bit counter + 64 bit nonce), and LibreSSL does the same, it is straightforward to use LibreSSL's API.

The only complication is that the current `_CipherContext` implementation assumes that the underlying cipher can be accessed through the `EVP_CIPHER` API. This is not the case for LibreSSL's ChaCha20, which has a separate [CRYPTO_chacha_20()](https://man.openbsd.org/ChaCha.3) API for it.

In order to solve that, this PR makes `_CipherContext` an abstract class with two implementations, `_CipherContextEVP` (which is the previous `_CipherContext`) and `_CipherContextChaCha`, which is a simple context that is used only for the LibreSSL+ChaCha20 combination.

This means all of the code that uses `_CipherContext` remains the same, and we only have a single branching point isolated in the `create_cipher_context()` function, which selects the correct context depending on the cipher+backend.

It also leaves the option open in the future if we want to add BoringSSL's ChaCha20, since we can reuse the same `_CipherContextChaCha` for it (the API is almost the same, and we can deal with the differences in a C wrapper)

