### PR TITLE
Add organizationIdentifier Name OID (2.5.4.97)

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -3076,6 +3076,12 @@ instances. The following common OIDs are available as constants.
 
         Corresponds to the dotted string ``"2.5.4.9"``.
 
+    .. attribute:: ORGANIZATION_IDENTIFIER
+
+        .. versionadded:: 42.0.0
+
+        Corresponds to the dotted string ``"2.5.4.97"``.
+
     .. attribute:: ORGANIZATION_NAME
 
         Corresponds to the dotted string ``"2.5.4.10"``.

--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -60,6 +60,7 @@ class NameOID:
     LOCALITY_NAME = ObjectIdentifier("2.5.4.7")
     STATE_OR_PROVINCE_NAME = ObjectIdentifier("2.5.4.8")
     STREET_ADDRESS = ObjectIdentifier("2.5.4.9")
+    ORGANIZATION_IDENTIFIER = ObjectIdentifier("2.5.4.97")
     ORGANIZATION_NAME = ObjectIdentifier("2.5.4.10")
     ORGANIZATIONAL_UNIT_NAME = ObjectIdentifier("2.5.4.11")
     SERIAL_NUMBER = ObjectIdentifier("2.5.4.5")


### PR DESCRIPTION
Thought that it would be handy to have this in here.

https://oidref.com/2.5.4.97

https://www.alvestrand.no/objectid/submissions/2.5.4.97.html

OpenSSL also has it: https://github.com/openssl/openssl/blob/1d32ec2/crypto/objects/objects.txt#L828.