### PR TITLE
Add support for ChaCha20 with LibreSSL

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -26,6 +26,7 @@ ffi = build_ffi_for_binding(
         "asn1",
         "bignum",
         "bio",
+        "chacha",
         "cmac",
         "crypto",
         "dh",

--- a/src/_cffi_src/openssl/chacha.py
+++ b/src/_cffi_src/openssl/chacha.py
@@ -1,0 +1,42 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+INCLUDES = """
+#if CRYPTOGRAPHY_IS_LIBRESSL
+#include <openssl/chacha.h>
+#endif"""
+
+TYPES = """
+static const long Cryptography_HAS_CHACHA20_API;
+"""
+
+FUNCTIONS = """
+/* Signature is different between LibreSSL and BoringSSL, so expose via
+   different symbol name */
+void Cryptography_CRYPTO_chacha_20(uint8_t *, const uint8_t *, size_t,
+                                   const uint8_t[32], const uint8_t[8],
+                                   uint64_t);
+"""
+
+CUSTOMIZATIONS = """
+#if CRYPTOGRAPHY_IS_LIBRESSL
+static const long Cryptography_HAS_CHACHA20_API = 1;
+#else
+static const long Cryptography_HAS_CHACHA20_API = 0;
+#endif
+
+#if CRYPTOGRAPHY_IS_LIBRESSL
+void Cryptography_CRYPTO_chacha_20(uint8_t *out, const uint8_t *in,
+                                   size_t in_len, const uint8_t key[32],
+                                   const uint8_t nonce[8], uint64_t counter) {
+    CRYPTO_chacha_20(out, in, in_len, key, nonce, counter);
+}
+#else
+void (*Cryptography_CRYPTO_chacha_20)(uint8_t *, const uint8_t *, size_t,
+                                      const uint8_t[32], const uint8_t[8],
+                                      uint64_t) = NULL;
+#endif
+"""

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -12,7 +12,10 @@ import typing
 from cryptography import utils, x509
 from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.backends.openssl import aead
-from cryptography.hazmat.backends.openssl.ciphers import _CipherContext
+from cryptography.hazmat.backends.openssl.ciphers import (
+    _CipherContext,
+    create_cipher_context,
+)
 from cryptography.hazmat.backends.openssl.cmac import _CMACContext
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.bindings.openssl import binding
@@ -221,6 +224,10 @@ class Backend:
         return self.hash_supported(algorithm)
 
     def cipher_supported(self, cipher: CipherAlgorithm, mode: Mode) -> bool:
+        # ChaCha20 is supported in LibreSSL by a different API than OpenSSL,
+        # so checking for the corresponding EVP_CIPHER is not useful
+        if self._lib.CRYPTOGRAPHY_IS_LIBRESSL and isinstance(cipher, ChaCha20):
+            return True
         if self._fips_enabled:
             # FIPS mode requires AES. TripleDES is disallowed/deprecated in
             # FIPS 140-3.
@@ -312,12 +319,12 @@ class Backend:
     def create_symmetric_encryption_ctx(
         self, cipher: CipherAlgorithm, mode: Mode
     ) -> _CipherContext:
-        return _CipherContext(self, cipher, mode, _CipherContext._ENCRYPT)
+        return create_cipher_context(self, cipher, mode, encrypt=True)
 
     def create_symmetric_decryption_ctx(
         self, cipher: CipherAlgorithm, mode: Mode
     ) -> _CipherContext:
-        return _CipherContext(self, cipher, mode, _CipherContext._DECRYPT)
+        return create_cipher_context(self, cipher, mode, encrypt=False)
 
     def pbkdf2_hmac_supported(self, algorithm: hashes.HashAlgorithm) -> bool:
         return self.hmac_supported(algorithm)

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.backends.openssl.backend import backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers import Cipher
-from cryptography.hazmat.primitives.ciphers.algorithms import AES
+from cryptography.hazmat.primitives.ciphers.algorithms import AES, ChaCha20
 from cryptography.hazmat.primitives.ciphers.modes import CBC
 
 from ...doubles import (
@@ -406,3 +406,25 @@ class TestOpenSSLDHSerialization:
         )
         with pytest.raises(ValueError):
             loader_func(key_bytes, backend)
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.cipher_supported(
+        ChaCha20(b"\x00" * 32, b"\x00" * 16), None
+    )
+    and backend._lib.CRYPTOGRAPHY_IS_LIBRESSL,
+    skip_message="Does not support non-EVP ChaCha20 cipher",
+)
+class TestChaCha20CipherContext:
+    def test_unsupported_api(self):
+        from cryptography.hazmat.backends.openssl.ciphers import (
+            _CipherContextChaCha,
+        )
+
+        ctx = _CipherContextChaCha(
+            backend, ChaCha20(b"\x00" * 32, b"\x00" * 16)
+        )
+        with pytest.raises(NotImplementedError):
+            ctx.authenticate_additional_data(b"data")
+        with pytest.raises(NotImplementedError):
+            ctx.finalize_with_tag(b"tag")


### PR DESCRIPTION
This PR adds support for ChaCha20 with LibreSSL. Since cryptography's ChaCha20 uses OpenSSL's implementation (which uses a 64 bit counter + 64 bit nonce), and LibreSSL does the same, it is straightforward to use LibreSSL's API.

The only complication is that the current `_CipherContext` implementation assumes that the underlying cipher can be accessed through the `EVP_CIPHER` API. This is not the case for LibreSSL's ChaCha20, which has a separate [CRYPTO_chacha_20()](https://man.openbsd.org/ChaCha.3) API for it.

In order to solve that, this PR makes `_CipherContext` an abstract class with two implementations, `_CipherContextEVP` (which is the previous `_CipherContext`) and `_CipherContextChaCha`, which is a simple context that is used only for the LibreSSL+ChaCha20 combination.

This means all of the code that uses `_CipherContext` remains the same, and we only have a single branching point isolated in the `create_cipher_context()` function, which selects the correct context depending on the cipher+backend.

It also leaves the option open in the future if we want to add BoringSSL's ChaCha20, since we can reuse the same `_CipherContextChaCha` for it (the API is almost the same, and we can deal with the differences in a C wrapper)