### PR TITLE
x509: more extension APIs

### DIFF
--- a/src/rust/cryptography-x509/src/certificate.rs
+++ b/src/rust/cryptography-x509/src/certificate.rs
@@ -35,8 +35,8 @@ pub struct TbsCertificate<'a> {
     pub raw_extensions: Option<extensions::RawExtensions<'a>>,
 }
 
-impl<'a> TbsCertificate<'a> {
-    pub fn extensions(&'a self) -> Result<Extensions<'a>, asn1::ObjectIdentifier> {
+impl TbsCertificate<'_> {
+    pub fn extensions(&self) -> Result<Extensions<'_, '_>, asn1::ObjectIdentifier> {
         Extensions::from_raw_extensions(self.raw_extensions.as_ref())
     }
 }

--- a/src/rust/cryptography-x509/src/certificate.rs
+++ b/src/rust/cryptography-x509/src/certificate.rs
@@ -36,7 +36,7 @@ pub struct TbsCertificate<'a> {
 }
 
 impl TbsCertificate<'_> {
-    pub fn extensions(&self) -> Result<Extensions<'_, '_>, asn1::ObjectIdentifier> {
+    pub fn extensions(&self) -> Result<Extensions<'_>, asn1::ObjectIdentifier> {
         Extensions::from_raw_extensions(self.raw_extensions.as_ref())
     }
 }

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -236,7 +236,6 @@ pub struct BasicConstraints {
 pub type SubjectAlternativeName<'a> = asn1::SequenceOf<'a, name::GeneralName<'a>>;
 pub type ExtendedKeyUsage<'a> = asn1::SequenceOf<'a, asn1::ObjectIdentifier>;
 
-#[derive(Hash, PartialEq, Clone)]
 pub struct KeyUsage<'a>(asn1::BitString<'a>);
 
 impl<'a> asn1::SimpleAsn1Readable<'a> for KeyUsage<'a> {

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -73,6 +73,12 @@ pub struct Extension<'a> {
     pub extn_value: &'a [u8],
 }
 
+impl<'a> Extension<'a> {
+    pub fn value<T: asn1::Asn1Readable<'a>>(&'a self) -> asn1::ParseResult<T> {
+        Ok(asn1::parse_single(self.extn_value)?)
+    }
+}
+
 #[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub struct PolicyConstraints {
     #[implicit(0)]

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -335,9 +335,9 @@ mod tests {
         let extensions = SequenceOfWriter::new(vec![extension]);
 
         let der = asn1::write_single(&extensions).unwrap();
+        let parsed = asn1::parse_single(&der).unwrap();
 
-        let extensions: Extensions =
-            Extensions::from_raw_extensions(Some(&asn1::parse_single(&der).unwrap())).unwrap();
+        let extensions: Extensions = Extensions::from_raw_extensions(Some(&parsed)).unwrap();
 
         let extension_list: Vec<_> = extensions.iter().collect();
         assert_eq!(extension_list.len(), 1);

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -234,6 +234,7 @@ pub struct BasicConstraints {
 }
 
 pub type SubjectAlternativeName<'a> = asn1::SequenceOf<'a, name::GeneralName<'a>>;
+pub type IssuerAlternativeName<'a> = asn1::SequenceOf<'a, name::GeneralName<'a>>;
 pub type ExtendedKeyUsage<'a> = asn1::SequenceOf<'a, asn1::ObjectIdentifier>;
 
 pub struct KeyUsage<'a>(asn1::BitString<'a>);

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -228,6 +228,9 @@ pub struct BasicConstraints {
     pub path_length: Option<u64>,
 }
 
+pub type SubjectAlternativeName<'a> = asn1::SequenceOf<'a, name::GeneralName<'a>>;
+pub type ExtendedKeyUsage<'a> = asn1::SequenceOf<'a, asn1::ObjectIdentifier>;
+
 #[cfg(test)]
 mod tests {
     use asn1::SequenceOfWriter;

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -291,11 +291,9 @@ impl KeyUsage<'_> {
 
 #[cfg(test)]
 mod tests {
-    use asn1::SequenceOfWriter;
-
     use crate::oid::{AUTHORITY_KEY_IDENTIFIER_OID, BASIC_CONSTRAINTS_OID};
 
-    use super::{BasicConstraints, Extension, Extensions};
+    use super::{BasicConstraints, Extension, Extensions, KeyUsage};
 
     #[test]
     fn test_get_extension() {
@@ -308,7 +306,7 @@ mod tests {
             critical: true,
             extn_value: &asn1::write_single(&bc).unwrap(),
         };
-        let extensions = SequenceOfWriter::new(vec![extension]);
+        let extensions = asn1::SequenceOfWriter::new(vec![extension]);
 
         let der = asn1::write_single(&extensions).unwrap();
         let raw = asn1::parse_single(&der).unwrap();
@@ -332,7 +330,7 @@ mod tests {
             critical: true,
             extn_value: &asn1::write_single(&bc).unwrap(),
         };
-        let extensions = SequenceOfWriter::new(vec![extension]);
+        let extensions = asn1::SequenceOfWriter::new(vec![extension]);
 
         let der = asn1::write_single(&extensions).unwrap();
         let parsed = asn1::parse_single(&der).unwrap();
@@ -358,5 +356,25 @@ mod tests {
         let extracted: BasicConstraints = extension.value().unwrap();
         assert_eq!(bc.ca, extracted.ca);
         assert_eq!(bc.path_length, extracted.path_length);
+    }
+
+    #[test]
+    fn test_keyusage() {
+        // let ku: KeyUsage = asn1::parse_single(data)
+        let ku_bits = [0b1111_1111u8, 0b1000_0000u8];
+        let ku_bitstring = asn1::BitString::new(&ku_bits, 7).unwrap();
+        let asn1 = asn1::write_single(&ku_bitstring).unwrap();
+
+        let ku: KeyUsage = asn1::parse_single(&asn1).unwrap();
+        assert!(!ku.zeroed());
+        assert!(ku.digital_signature());
+        assert!(ku.content_comitment());
+        assert!(ku.key_encipherment());
+        assert!(ku.data_encipherment());
+        assert!(ku.key_agreement());
+        assert!(ku.key_cert_sign());
+        assert!(ku.crl_sign());
+        assert!(ku.encipher_only());
+        assert!(ku.decipher_only());
     }
 }

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -299,14 +299,14 @@ mod tests {
 
     #[test]
     fn test_get_extension() {
-        let extension_value = BasicConstraints {
+        let bc = BasicConstraints {
             ca: true,
             path_length: Some(3),
         };
         let extension = Extension {
             extn_id: BASIC_CONSTRAINTS_OID,
             critical: true,
-            extn_value: &asn1::write_single(&extension_value).unwrap(),
+            extn_value: &asn1::write_single(&bc).unwrap(),
         };
         let extensions = SequenceOfWriter::new(vec![extension]);
 
@@ -323,14 +323,14 @@ mod tests {
 
     #[test]
     fn test_extensions_iter() {
-        let extension_value = BasicConstraints {
+        let bc = BasicConstraints {
             ca: true,
             path_length: Some(3),
         };
         let extension = Extension {
             extn_id: BASIC_CONSTRAINTS_OID,
             critical: true,
-            extn_value: &asn1::write_single(&extension_value).unwrap(),
+            extn_value: &asn1::write_single(&bc).unwrap(),
         };
         let extensions = SequenceOfWriter::new(vec![extension]);
 
@@ -341,5 +341,22 @@ mod tests {
 
         let extension_list: Vec<_> = extensions.iter().collect();
         assert_eq!(extension_list.len(), 1);
+    }
+
+    #[test]
+    fn test_extension_value() {
+        let bc = BasicConstraints {
+            ca: true,
+            path_length: Some(3),
+        };
+        let extension = Extension {
+            extn_id: BASIC_CONSTRAINTS_OID,
+            critical: true,
+            extn_value: &asn1::write_single(&bc).unwrap(),
+        };
+
+        let extracted: BasicConstraints = extension.value().unwrap();
+        assert_eq!(bc.ca, extracted.ca);
+        assert_eq!(bc.path_length, extracted.path_length);
     }
 }

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -247,7 +247,7 @@ impl<'a> asn1::SimpleAsn1Readable<'a> for KeyUsage<'a> {
 }
 
 impl KeyUsage<'_> {
-    pub fn zeroed(&self) -> bool {
+    pub fn is_zeroed(&self) -> bool {
         self.0.as_bytes().iter().all(|&b| b == 0)
     }
 
@@ -365,7 +365,7 @@ mod tests {
         let asn1 = asn1::write_single(&ku_bitstring).unwrap();
 
         let ku: KeyUsage = asn1::parse_single(&asn1).unwrap();
-        assert!(!ku.zeroed());
+        assert!(!ku.is_zeroed());
         assert!(ku.digital_signature());
         assert!(ku.content_comitment());
         assert!(ku.key_encipherment());

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -231,6 +231,59 @@ pub struct BasicConstraints {
 pub type SubjectAlternativeName<'a> = asn1::SequenceOf<'a, name::GeneralName<'a>>;
 pub type ExtendedKeyUsage<'a> = asn1::SequenceOf<'a, asn1::ObjectIdentifier>;
 
+#[derive(Hash, PartialEq, Clone)]
+pub struct KeyUsage<'a>(asn1::BitString<'a>);
+
+impl<'a> asn1::SimpleAsn1Readable<'a> for KeyUsage<'a> {
+    const TAG: asn1::Tag = asn1::BitString::TAG;
+
+    fn parse_data(data: &'a [u8]) -> asn1::ParseResult<Self> {
+        asn1::BitString::parse_data(data).map(Self)
+    }
+}
+
+impl KeyUsage<'_> {
+    pub fn zeroed(&self) -> bool {
+        self.0.as_bytes().iter().all(|&b| b == 0)
+    }
+
+    pub fn digital_signature(&self) -> bool {
+        self.0.has_bit_set(0)
+    }
+
+    pub fn content_comitment(&self) -> bool {
+        self.0.has_bit_set(1)
+    }
+
+    pub fn key_encipherment(&self) -> bool {
+        self.0.has_bit_set(2)
+    }
+
+    pub fn data_encipherment(&self) -> bool {
+        self.0.has_bit_set(3)
+    }
+
+    pub fn key_agreement(&self) -> bool {
+        self.0.has_bit_set(4)
+    }
+
+    pub fn key_cert_sign(&self) -> bool {
+        self.0.has_bit_set(5)
+    }
+
+    pub fn crl_sign(&self) -> bool {
+        self.0.has_bit_set(6)
+    }
+
+    pub fn encipher_only(&self) -> bool {
+        self.0.has_bit_set(7)
+    }
+
+    pub fn decipher_only(&self) -> bool {
+        self.0.has_bit_set(8)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use asn1::SequenceOfWriter;

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -18,15 +18,15 @@ pub type RawExtensions<'a> = common::Asn1ReadableOrWritable<
 ///
 /// In particular, an `Extensions` cannot be constructed from a `RawExtensions`
 /// that contains duplicated extensions (by OID).
-pub struct Extensions<'a, 'b>(Option<&'b RawExtensions<'a>>);
+pub struct Extensions<'a>(Option<RawExtensions<'a>>);
 
-impl<'a, 'b> Extensions<'a, 'b> {
+impl<'a> Extensions<'a> {
     /// Create an `Extensions` from the given `RawExtensions`.
     ///
     /// Returns an `Err` variant containing the first duplicated extension's
     /// OID, if there are any duplicates.
     pub fn from_raw_extensions(
-        raw: Option<&'b RawExtensions<'a>>,
+        raw: Option<&RawExtensions<'a>>,
     ) -> Result<Self, asn1::ObjectIdentifier> {
         match raw {
             Some(raw_exts) => {
@@ -38,7 +38,7 @@ impl<'a, 'b> Extensions<'a, 'b> {
                     }
                 }
 
-                Ok(Self(Some(raw_exts)))
+                Ok(Self(Some(raw_exts.clone())))
             }
             None => Ok(Self(None)),
         }
@@ -52,7 +52,7 @@ impl<'a, 'b> Extensions<'a, 'b> {
 
     /// Returns a reference to the underlying extensions.
     pub fn as_raw(&self) -> Option<&RawExtensions<'_>> {
-        self.0
+        self.0.as_ref()
     }
 
     /// Returns an iterator over the underlying extensions.

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -58,7 +58,6 @@ impl<'a, 'b> Extensions<'a, 'b> {
     /// Returns an iterator over the underlying extensions.
     pub fn iter(&self) -> impl Iterator<Item = Extension> {
         self.as_raw()
-            .clone()
             .map(|raw| raw.unwrap_read().clone())
             .into_iter()
             .flatten()
@@ -75,7 +74,7 @@ pub struct Extension<'a> {
 
 impl<'a> Extension<'a> {
     pub fn value<T: asn1::Asn1Readable<'a>>(&'a self) -> asn1::ParseResult<T> {
-        Ok(asn1::parse_single(self.extn_value)?)
+        asn1::parse_single(self.extn_value)
     }
 }
 

--- a/src/rust/src/x509/common.rs
+++ b/src/rust/src/x509/common.rs
@@ -382,7 +382,7 @@ fn ipv6_netmask(num: u128) -> Result<u32, CryptographyError> {
 
 pub(crate) fn parse_and_cache_extensions<
     'p,
-    F: Fn(&asn1::ObjectIdentifier, &[u8]) -> Result<Option<&'p pyo3::PyAny>, CryptographyError>,
+    F: Fn(&Extension<'_>) -> Result<Option<&'p pyo3::PyAny>, CryptographyError>,
 >(
     py: pyo3::Python<'p>,
     cached_extensions: &mut Option<pyo3::PyObject>,
@@ -409,7 +409,7 @@ pub(crate) fn parse_and_cache_extensions<
     for raw_ext in extensions.iter() {
         let oid_obj = oid_to_py_oid(py, &raw_ext.extn_id)?;
 
-        let extn_value = match parse_ext(&raw_ext.extn_id, raw_ext.extn_value)? {
+        let extn_value = match parse_ext(&raw_ext)? {
             Some(e) => e,
             None => x509_module.call_method1(
                 pyo3::intern!(py, "UnrecognizedExtension"),

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -223,12 +223,9 @@ impl CertificateSigningRequest {
                 )
             })?;
 
-        x509::parse_and_cache_extensions(
-            py,
-            &mut self.cached_extensions,
-            &raw_exts,
-            |oid, ext_data| certificate::parse_cert_ext(py, oid.clone(), ext_data),
-        )
+        x509::parse_and_cache_extensions(py, &mut self.cached_extensions, &raw_exts, |ext| {
+            certificate::parse_cert_ext(py, ext)
+        })
     }
 
     #[getter]


### PR DESCRIPTION
More breakout from #8873:

* Brings in extension types/aliases from that PR
* Saves `N` clones in the `RawExtensions` to `Extensions` APIs
* Adds `Extension::value` for extracting inner extension types