### PR TITLE
name: devolve `NameReadable` variant

### DIFF
--- a/src/rust/cryptography-x509/src/name.rs
+++ b/src/rust/cryptography-x509/src/name.rs
@@ -4,9 +4,11 @@
 
 use crate::common;
 
+pub type NameReadable<'a> = asn1::SequenceOf<'a, asn1::SetOf<'a, common::AttributeTypeValue<'a>>>;
+
 pub type Name<'a> = common::Asn1ReadableOrWritable<
     'a,
-    asn1::SequenceOf<'a, asn1::SetOf<'a, common::AttributeTypeValue<'a>>>,
+    NameReadable<'a>,
     asn1::SequenceOfWriter<
         'a,
         asn1::SetOfWriter<'a, common::AttributeTypeValue<'a>, Vec<common::AttributeTypeValue<'a>>>,


### PR DESCRIPTION
Breakout from #9254.