### PR TITLE
rust: update lockfile

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -102,7 +102,6 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "cryptography-x509",
- "pem",
 ]
 
 [[package]]


### PR DESCRIPTION
Removes `pem` from the lockfile.

Per #9296.