### PR TITLE
Add `SSL_OP_LEGACY_SERVER_CONNECT` binding

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -72,6 +72,7 @@ static const long SSL_OP_NO_TICKET;
 static const long SSL_OP_ALL;
 static const long SSL_OP_SINGLE_ECDH_USE;
 static const long SSL_OP_IGNORE_UNEXPECTED_EOF;
+static const long SSL_OP_LEGACY_SERVER_CONNECT;
 static const long SSL_VERIFY_PEER;
 static const long SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 static const long SSL_VERIFY_CLIENT_ONCE;


### PR DESCRIPTION
This is useful to expose in pyOpenSSL so that it can be referenced downstream for `Context.set_options`. (https://github.com/mitmproxy/mitmproxy/pull/6281)