### PR TITLE
Mark the majority of our Rust types as frozen

### DIFF
--- a/src/rust/src/asn1.rs
+++ b/src/rust/src/asn1.rs
@@ -136,7 +136,7 @@ fn encode_dss_signature(
     Ok(pyo3::types::PyBytes::new(py, &result).to_object(py))
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.asn1")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.asn1")]
 struct TestCertificate {
     #[pyo3(get)]
     not_before_tag: u8,

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -11,17 +11,17 @@ use foreign_types_shared::ForeignTypeRef;
 
 const MIN_MODULUS_SIZE: u32 = 512;
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.dh")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.dh")]
 struct DHPrivateKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Private>,
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.dh")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.dh")]
 struct DHPublicKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Public>,
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.dh")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.dh")]
 struct DHParameters {
     dh: openssl::dh::Dh<openssl::pkey::Params>,
 }

--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -8,6 +8,7 @@ use crate::exceptions;
 use foreign_types_shared::ForeignTypeRef;
 
 #[pyo3::prelude::pyclass(
+    frozen,
     module = "cryptography.hazmat.bindings._rust.openssl.dsa",
     name = "DSAPrivateKey"
 )]
@@ -16,6 +17,7 @@ struct DsaPrivateKey {
 }
 
 #[pyo3::prelude::pyclass(
+    frozen,
     module = "cryptography.hazmat.bindings._rust.openssl.dsa",
     name = "DSAPublicKey"
 )]
@@ -24,6 +26,7 @@ struct DsaPublicKey {
 }
 
 #[pyo3::prelude::pyclass(
+    frozen,
     module = "cryptography.hazmat.bindings._rust.openssl.dsa",
     name = "DSAParameters"
 )]

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -9,14 +9,14 @@ use foreign_types_shared::ForeignTypeRef;
 use pyo3::basic::CompareOp;
 use pyo3::ToPyObject;
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.ec")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.ec")]
 struct ECPrivateKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Private>,
     #[pyo3(get)]
     curve: pyo3::Py<pyo3::PyAny>,
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.ec")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.ec")]
 struct ECPublicKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Public>,
     #[pyo3(get)]

--- a/src/rust/src/backend/ed25519.rs
+++ b/src/rust/src/backend/ed25519.rs
@@ -8,12 +8,12 @@ use crate::error::{CryptographyError, CryptographyResult};
 use crate::exceptions;
 use foreign_types_shared::ForeignTypeRef;
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.ed25519")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.ed25519")]
 struct Ed25519PrivateKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Private>,
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.ed25519")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.ed25519")]
 struct Ed25519PublicKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Public>,
 }

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -8,12 +8,12 @@ use crate::error::{CryptographyError, CryptographyResult};
 use crate::exceptions;
 use foreign_types_shared::ForeignTypeRef;
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.ed448")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.ed448")]
 struct Ed448PrivateKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Private>,
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.ed448")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.ed448")]
 struct Ed448PublicKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Public>,
 }

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -7,12 +7,12 @@ use crate::buf::CffiBuf;
 use crate::error::CryptographyResult;
 use foreign_types_shared::ForeignTypeRef;
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.x25519")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.x25519")]
 struct X25519PrivateKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Private>,
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.x25519")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.x25519")]
 struct X25519PublicKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Public>,
 }

--- a/src/rust/src/backend/x448.rs
+++ b/src/rust/src/backend/x448.rs
@@ -7,12 +7,12 @@ use crate::buf::CffiBuf;
 use crate::error::CryptographyResult;
 use foreign_types_shared::ForeignTypeRef;
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.x448")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.x448")]
 struct X448PrivateKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Private>,
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.x448")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.x448")]
 struct X448PublicKey {
     pkey: openssl::pkey::PKey<openssl::pkey::Public>,
 }

--- a/src/rust/src/exceptions.rs
+++ b/src/rust/src/exceptions.rs
@@ -3,6 +3,7 @@
 // for complete details.
 
 #[pyo3::prelude::pyclass(
+    frozen,
     module = "cryptography.hazmat.bindings._rust.exceptions",
     name = "_Reasons"
 )]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -85,7 +85,7 @@ fn raise_openssl_error() -> crate::error::CryptographyResult<()> {
     Err(openssl::error::ErrorStack::get().into())
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl")]
 struct OpenSSLError {
     e: openssl::error::Error,
 }

--- a/src/rust/src/oid.rs
+++ b/src/rust/src/oid.rs
@@ -6,7 +6,7 @@ use crate::error::CryptographyResult;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust")]
 pub(crate) struct ObjectIdentifier {
     pub(crate) oid: asn1::ObjectIdentifier,
 }

--- a/src/rust/src/pool.rs
+++ b/src/rust/src/pool.rs
@@ -7,14 +7,14 @@ use std::cell::Cell;
 // An object pool that can contain a single object and will dynamically
 // allocate new objects to fulfill requests if the pool'd object is already in
 // use.
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust")]
 pub(crate) struct FixedPool {
     create_fn: pyo3::PyObject,
 
     value: Cell<Option<pyo3::PyObject>>,
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust")]
 struct PoolAcquisition {
     pool: pyo3::Py<FixedPool>,
 

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -33,6 +33,7 @@ self_cell::self_cell!(
     }
 );
 
+// TODO: can't be frozen because extensions takes `&mut self`
 #[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.x509")]
 pub(crate) struct Certificate {
     pub(crate) raw: OwnedCertificate,

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -71,6 +71,7 @@ self_cell::self_cell!(
     }
 );
 
+// TODO: can't be frozen because extensions required `&mut self`.
 #[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.x509")]
 struct CertificateRevocationList {
     owned: Arc<OwnedCertificateRevocationList>,
@@ -490,6 +491,7 @@ impl Clone for OwnedRevokedCertificate {
     }
 }
 
+// TODO: can't be frozen because extensions required `&mut self`.
 #[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.x509")]
 struct RevokedCertificate {
     owned: OwnedRevokedCertificate,

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -22,6 +22,7 @@ self_cell::self_cell!(
     }
 );
 
+// TODO: can't be frozen extensions take `&mut self`
 #[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.x509")]
 struct CertificateSigningRequest {
     raw: OwnedCsr,

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -49,6 +49,7 @@ fn load_der_ocsp_request(
     })
 }
 
+// TODO: can't be frozen because extensions takes `&mut self`
 #[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.ocsp")]
 struct OCSPRequest {
     raw: OwnedOCSPRequest,

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -70,6 +70,7 @@ self_cell::self_cell!(
     }
 );
 
+// TODO: can't be frozen extensions and single_extensions take `&mut self`
 #[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.ocsp")]
 struct OCSPResponse {
     raw: Arc<OwnedOCSPResponse>,
@@ -790,7 +791,7 @@ self_cell::self_cell!(
     }
 );
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.ocsp")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.ocsp")]
 struct OCSPSingleResponse {
     raw: OwnedSingleResponse,
 }

--- a/src/rust/src/x509/sct.rs
+++ b/src/rust/src/x509/sct.rs
@@ -127,7 +127,7 @@ impl TryFrom<u8> for SignatureAlgorithm {
     }
 }
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.x509")]
+#[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.x509")]
 pub(crate) struct Sct {
     log_id: [u8; 32],
     timestamp: u64,


### PR DESCRIPTION
This tells pyo3 that they are immutable, which makes them marginally cheaper. There's a handful of places where types _should_ be immutable, but aren't. For those I added `TODO` comments.