### PR TITLE
x509: construct `IPAddress` and `IPRange` types

### DIFF
--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -453,12 +453,14 @@ mod tests {
             \x00\x00\x00\x00\x00\x00\x00\x01\
             \xf0\x00\x00\x00\x00\x00\x00\x00\
             \x00\x00\x00\x00\x00\x00\x00\x00";
+        let bad = b"\xff\xff\xff";
 
         assert_eq!(IPRange::from_bytes(ipv4_bad), None);
         assert_eq!(IPRange::from_bytes(ipv4_bad_many_bits), None);
         assert_eq!(IPRange::from_bytes(ipv4_bad_octet), None);
         assert_eq!(IPRange::from_bytes(ipv6_bad), None);
         assert_ne!(IPRange::from_bytes(ipv6_good), None);
+        assert_eq!(IPRange::from_bytes(bad), None);
 
         // 192.168.1.1/16
         let ipv4_with_extra = b"\xc0\xa8\x01\x01\xff\xff\x00\x00";

--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -383,4 +383,18 @@ mod tests {
 
         assert!(range.matches(&IPAddress::from_str("192.168.0.50").unwrap()));
     }
+
+    #[test]
+    fn test_iprange_bad_masks() {
+        // 192.168.1.1, mask 255.254.255.0
+        let bad_mask_one_bit = b"\xc0\xa8\x01\x01\xff\xfe\xff\x00";
+        // 192.168.1.1, mask 255.252.255.0
+        let bad_mask_many_bits = b"\xc0\xa8\x01\x01\xff\xfc\xff\x00";
+        // 192.168.1.1, mask 0.255.255.0
+        let bad_mask_octet = b"\xc0\xa8\x01\x01\x00\xff\xff\xff";
+
+        assert_eq!(IPRange::from_bytes(bad_mask_one_bit), None);
+        assert_eq!(IPRange::from_bytes(bad_mask_many_bits), None);
+        assert_eq!(IPRange::from_bytes(bad_mask_octet), None);
+    }
 }

--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -198,8 +198,8 @@ impl IPAddress {
     }
 }
 
-impl From<std::net::IpAddr> for IPAddress {
-    fn from(addr: std::net::IpAddr) -> Self {
+impl From<IpAddr> for IPAddress {
+    fn from(addr: IpAddr) -> Self {
         Self(addr)
     }
 }

--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -134,12 +134,12 @@ impl IPAddress {
     pub fn from_bytes(b: &[u8]) -> Option<Self> {
         match b.len() {
             4 => {
-                let b: Option<[u8; 4]> = b.try_into().ok();
-                b.map(std::net::IpAddr::from).map(Self::from_std)
+                let b: [u8; 4] = b.try_into().ok()?;
+                Some(Self::from_std(std::net::IpAddr::from(b)))
             }
             16 => {
-                let b: Option<[u8; 16]> = b.try_into().ok();
-                b.map(std::net::IpAddr::from).map(Self::from_std)
+                let b: [u8; 16] = b.try_into().ok()?;
+                Some(Self::from_std(std::net::IpAddr::from(b)))
             }
             _ => None,
         }

--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -195,23 +195,17 @@ pub struct IPRange {
 /// TODO
 impl IPRange {
     pub fn from_bytes(b: &[u8]) -> Option<Self> {
-        match b.len() {
-            8 => {
-                let prefix = IPAddress::from_bytes(&b[4..])?.as_prefix()?;
-                Some(IPRange {
-                    address: IPAddress::from_bytes(&b[..4])?.mask(prefix),
-                    prefix,
-                })
-            }
-            32 => {
-                let prefix = IPAddress::from_bytes(&b[16..])?.as_prefix()?;
-                Some(IPRange {
-                    address: IPAddress::from_bytes(&b[..16])?.mask(prefix),
-                    prefix,
-                })
-            }
-            _ => None,
-        }
+        let slice_idx = match b.len() {
+            8 => 4,
+            32 => 16,
+            _ => return None,
+        };
+
+        let prefix = IPAddress::from_bytes(&b[slice_idx..])?.as_prefix()?;
+        Some(IPRange {
+            address: IPAddress::from_bytes(&b[..slice_idx])?.mask(prefix),
+            prefix,
+        })
     }
 
     /// TODO

--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -363,19 +363,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ipaddress_from_std() {
-        let ipv4_addr = "192.0.2.1".parse().unwrap();
-        let ipv6_addr = "2001:db8::1".parse().unwrap();
-
-        if let IPAddress::V6(_) = IPAddress::from_std(ipv4_addr) {
-            panic!("expected IPAddress::V4, got IPAddress::V6");
-        }
-        if let IPAddress::V4(_) = IPAddress::from_std(ipv6_addr) {
-            panic!("expected IPAddress::V6, got IPAddress::V4");
-        }
-    }
-
-    #[test]
     fn test_ipaddress_from_str() {
         assert_ne!(IPAddress::from_str("192.168.1.1"), None)
     }

--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -118,7 +118,9 @@ pub enum IPAddress {
     V6(std::net::Ipv6Addr),
 }
 
-/// TODO
+/// An `IPAddress` represents an IP address as defined in [RFC 5280 4.2.1.6].
+///
+/// [RFC 5280 4.2.1.6]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 impl IPAddress {
     pub fn from_std(addr: std::net::IpAddr) -> Self {
         match addr {
@@ -131,6 +133,11 @@ impl IPAddress {
         std::net::IpAddr::from_str(s).ok().map(Self::from_std)
     }
 
+    /// Constructs an `IPAddress` from a slice. The provided data must be
+    /// 4 (IPv4) or 16 (IPv6) bytes in "network byte order", as specified by
+    /// [RFC 5280].
+    ///
+    /// [https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6]
     pub fn from_bytes(b: &[u8]) -> Option<Self> {
         match b.len() {
             4 => {
@@ -145,9 +152,9 @@ impl IPAddress {
         }
     }
 
-    /// Parses the octets of an IP address as a mask. If the mask is well-formed,
-    /// i.e. has only one contiguous block of 1 bits starting from the MSB, a prefix
-    /// is returned.
+    /// Parses the octets of the `IPAddress` as a mask. If it is well-formed,
+    /// i.e., has only one contiguous block of set bits starting from the most
+    /// significant bit, a prefix is returned.
     pub fn as_prefix(&self) -> Option<u8> {
         match self {
             Self::V4(a) => {
@@ -171,7 +178,13 @@ impl IPAddress {
         }
     }
 
-    /// TODO
+    /// Returns a new `IPAddress` with the first `prefix` bits of the `IPAddress`.
+    ///
+    /// ```rust
+    /// # use cryptography_x509_validation::types::IPAddress;
+    /// let ip = IPAddress::from_str("192.0.2.1").unwrap();
+    /// assert_eq!(ip.mask(24), IPAddress::from_str("192.0.2.0").unwrap());
+    /// ```
     pub fn mask(&self, prefix: u8) -> Self {
         match self {
             Self::V4(a) => {

--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -130,7 +130,7 @@ impl IPAddress {
     /// 4 (IPv4) or 16 (IPv6) bytes in "network byte order", as specified by
     /// [RFC 5280].
     ///
-    /// [https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6]
+    /// [RFC 5280]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
     pub fn from_bytes(b: &[u8]) -> Option<Self> {
         match b.len() {
             4 => {

--- a/src/rust/cryptography-x509-validation/src/types.rs
+++ b/src/rust/cryptography-x509-validation/src/types.rs
@@ -175,11 +175,7 @@ impl IPAddress {
     pub fn mask(&self, prefix: u8) -> Self {
         match self {
             Self::V4(a) => {
-                if prefix >= 32 {
-                    return *self;
-                }
-
-                let prefix = (32 - prefix).into();
+                let prefix = 32u8.checked_sub(prefix).unwrap_or(0).into();
                 let masked = u32::from_be_bytes(a.octets())
                     & u32::MAX
                         .checked_shr(prefix)
@@ -189,11 +185,7 @@ impl IPAddress {
                 Self::from_bytes(&masked.to_be_bytes()).unwrap()
             }
             Self::V6(a) => {
-                if prefix >= 128 {
-                    return *self;
-                }
-
-                let prefix = (128 - prefix).into();
+                let prefix = 128u8.checked_sub(prefix).unwrap_or(0).into();
                 let masked = u128::from_be_bytes(a.octets())
                     & u128::MAX
                         .checked_shr(prefix)


### PR DESCRIPTION
This contains two more types for `cryptography_x509_validation`:

1. `IPAddress` is a thin wrapper around `std::net::IpAddr` with helpers for masking and conversion to prefixes.
2. `IPRange` represents a CIDR range. Its `from_bytes` can parse IPs from [RFC 5280's `iPAddress` fields].

[RFC 5280's `iPAddress` fields]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10