### PR TITLE
noxfile, docs: fix posargs handling

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -37,6 +37,13 @@ designed to be run using `pytest`_. ``nox`` automatically invokes ``pytest``:
     62746 passed in 220.43 seconds
 
 
+You can also specify a subset of tests to run as positional arguments:
+
+.. code-block:: console
+
+    $ # run the whole x509 testsuite, plus the fernet tests
+    $ nox -e tests -p py310 -- tests/x509 tests/test_fernet.py
+
 Building documentation
 ----------------------
 

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -42,7 +42,7 @@ You can also specify a subset of tests to run as positional arguments:
 .. code-block:: console
 
     $ # run the whole x509 testsuite, plus the fernet tests
-    $ nox -e tests -p py310 -- tests/x509 tests/test_fernet.py
+    $ nox -e tests -p py310 -- tests/x509/ tests/test_fernet.py
 
 Building documentation
 ----------------------

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,6 +64,11 @@ def tests(session: nox.Session) -> None:
     else:
         cov_args = []
 
+    if session.posargs:
+        tests = session.posargs
+    else:
+        tests = ["tests/"]
+
     session.run(
         "pytest",
         "-n",
@@ -71,8 +76,7 @@ def tests(session: nox.Session) -> None:
         "--dist=worksteal",
         *cov_args,
         "--durations=10",
-        *session.posargs,
-        "tests/",
+        *tests,
     )
 
     if session.name != "tests-nocoverage":


### PR DESCRIPTION
Just tweaks the `nox` build slightly to handle running individual tests (or subdirs), plus documents the ability to do so.