### PR TITLE
Add `poly1305` implementation for BoringSSL and LibreSSL

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1256,7 +1256,13 @@ class Backend:
     def poly1305_supported(self) -> bool:
         if self._fips_enabled:
             return False
-        return self._lib.Cryptography_HAS_POLY1305 == 1
+        elif (
+            self._lib.CRYPTOGRAPHY_IS_BORINGSSL
+            or self._lib.CRYPTOGRAPHY_IS_LIBRESSL
+        ):
+            return True
+        else:
+            return self._lib.Cryptography_HAS_POLY1305 == 1
 
     def pkcs7_supported(self) -> bool:
         return not self._lib.CRYPTOGRAPHY_IS_BORINGSSL

--- a/src/rust/cryptography-openssl/Cargo.toml
+++ b/src/rust/cryptography-openssl/Cargo.toml
@@ -9,6 +9,6 @@ rust-version = "1.63.0"
 
 [dependencies]
 openssl = "0.10.57"
-ffi = { package = "openssl-sys", version = "0.9.85" }
+ffi = { package = "openssl-sys", version = "0.9.91" }
 foreign-types = "0.3"
 foreign-types-shared = "0.1"

--- a/src/rust/cryptography-openssl/src/lib.rs
+++ b/src/rust/cryptography-openssl/src/lib.rs
@@ -4,6 +4,8 @@
 
 pub mod fips;
 pub mod hmac;
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_LIBRESSL))]
+pub mod poly1305;
 
 pub type OpenSSLResult<T> = Result<T, openssl::error::ErrorStack>;
 

--- a/src/rust/cryptography-openssl/src/poly1305.rs
+++ b/src/rust/cryptography-openssl/src/poly1305.rs
@@ -1,0 +1,40 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use std::mem::MaybeUninit;
+
+pub struct Poly1305State {
+    // The state data must be allocated in the heap so that its address does not change. This is
+    // because BoringSSL APIs that take a `poly1305_state*` ignore all the data before an aligned
+    // address. Since a stack-allocated struct would change address on every copy, BoringSSL would
+    // interpret each copy differently, causing unexpected behavior.
+    context: Box<ffi::poly1305_state>,
+}
+
+impl Poly1305State {
+    pub fn new(key: &[u8]) -> Poly1305State {
+        #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
+        let mut ctx: Box<ffi::poly1305_state> = Box::new([0; 512usize]);
+        #[cfg(CRYPTOGRAPHY_IS_LIBRESSL)]
+        let mut ctx: Box<ffi::poly1305_state> = Box::new(ffi::poly1305_state {
+            aligner: 0,
+            opaque: [0; 136usize],
+        });
+
+        unsafe {
+            ffi::CRYPTO_poly1305_init(ctx.as_mut(), key.as_ptr());
+        }
+        Poly1305State { context: ctx }
+    }
+
+    pub fn update(&mut self, data: &[u8]) -> () {
+        unsafe {
+            ffi::CRYPTO_poly1305_update(self.context.as_mut(), data.as_ptr(), data.len());
+        };
+    }
+
+    pub fn finalize(&mut self, output: &mut [u8]) -> () {
+        unsafe { ffi::CRYPTO_poly1305_finish(self.context.as_mut(), output.as_mut_ptr()) };
+    }
+}

--- a/src/rust/src/backend/poly1305.rs
+++ b/src/rust/src/backend/poly1305.rs
@@ -7,26 +7,78 @@ use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::exceptions;
 
-#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.poly1305")]
-struct Poly1305 {
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_LIBRESSL))]
+struct Poly1305Boring {
+    context: Option<Box<openssl_sys::poly1305_state>>,
+}
+
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_LIBRESSL))]
+impl Poly1305Boring {
+    fn new(key: CffiBuf<'_>) -> CryptographyResult<Poly1305Boring> {
+        if key.as_bytes().len() != 32 {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err("A poly1305 key is 32 bytes long"),
+            ));
+        }
+        #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
+        let mut ctx: Box<openssl_sys::poly1305_state> = Box::new([0; 512usize]);
+        #[cfg(CRYPTOGRAPHY_IS_LIBRESSL)]
+        let mut ctx: Box<openssl_sys::poly1305_state> = Box::new(openssl_sys::poly1305_state {
+            aligner: 0,
+            opaque: [0; 136usize],
+        });
+
+        unsafe {
+            openssl_sys::CRYPTO_poly1305_init(ctx.as_mut(), key.as_bytes().as_ptr());
+        }
+        Ok(Poly1305Boring { context: Some(ctx) })
+    }
+
+    fn get_mut_context(&mut self) -> CryptographyResult<&mut openssl_sys::poly1305_state> {
+        if let Some(ctx) = self.context.as_mut() {
+            return Ok(ctx);
+        };
+        Err(already_finalized_error())
+    }
+
+    fn update(&mut self, data: CffiBuf<'_>) -> CryptographyResult<()> {
+        let buf = data.as_bytes();
+        let ctx = self.get_mut_context()?;
+        unsafe {
+            openssl_sys::CRYPTO_poly1305_update(ctx, buf.as_ptr(), buf.len());
+        };
+        Ok(())
+    }
+    fn finalize<'p>(
+        &mut self,
+        py: pyo3::Python<'p>,
+    ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
+        let ctx = self.get_mut_context()?;
+        let result = pyo3::types::PyBytes::new_with(py, 16usize, |b| {
+            unsafe { openssl_sys::CRYPTO_poly1305_finish(ctx, b.as_mut_ptr()) };
+            Ok(())
+        })?;
+        self.context = None;
+        Ok(result)
+    }
+}
+
+#[cfg(not(any(CRYPTOGRAPHY_IS_LIBRESSL, CRYPTOGRAPHY_IS_BORINGSSL)))]
+struct Poly1305Open {
     signer: Option<openssl::sign::Signer<'static>>,
 }
 
-impl Poly1305 {
+#[cfg(not(any(CRYPTOGRAPHY_IS_LIBRESSL, CRYPTOGRAPHY_IS_BORINGSSL)))]
+impl Poly1305Open {
     fn get_mut_signer(&mut self) -> CryptographyResult<&mut openssl::sign::Signer<'static>> {
         if let Some(signer) = self.signer.as_mut() {
             return Ok(signer);
         };
         Err(already_finalized_error())
     }
-}
 
-#[pyo3::pymethods]
-impl Poly1305 {
-    #[new]
-    fn new(key: CffiBuf<'_>) -> CryptographyResult<Poly1305> {
-        #[cfg(any(CRYPTOGRAPHY_IS_LIBRESSL, CRYPTOGRAPHY_IS_BORINGSSL))]
-        {
+    fn new(key: CffiBuf<'_>) -> CryptographyResult<Poly1305Open> {
+        if cryptography_openssl::fips::is_enabled() {
             return Err(CryptographyError::from(
                 exceptions::UnsupportedAlgorithm::new_err((
                     "poly1305 is not supported by this version of OpenSSL.",
@@ -35,33 +87,60 @@ impl Poly1305 {
             ));
         }
 
-        #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
-        {
-            if cryptography_openssl::fips::is_enabled() {
-                return Err(CryptographyError::from(
-                    exceptions::UnsupportedAlgorithm::new_err((
-                        "poly1305 is not supported by this version of OpenSSL.",
-                        exceptions::Reasons::UNSUPPORTED_MAC,
-                    )),
-                ));
-            }
+        let pkey = openssl::pkey::PKey::private_key_from_raw_bytes(
+            key.as_bytes(),
+            openssl::pkey::Id::POLY1305,
+        )
+        .map_err(|_| pyo3::exceptions::PyValueError::new_err("A poly1305 key is 32 bytes long"))?;
 
-            let pkey = openssl::pkey::PKey::private_key_from_raw_bytes(
-                key.as_bytes(),
-                openssl::pkey::Id::POLY1305,
-            )
-            .map_err(|_| {
-                pyo3::exceptions::PyValueError::new_err("A poly1305 key is 32 bytes long")
-            })?;
+        Ok(Poly1305Open {
+            signer: Some(
+                openssl::sign::Signer::new_without_digest(&pkey).map_err(|_| {
+                    pyo3::exceptions::PyValueError::new_err("A poly1305 key is 32 bytes long")
+                })?,
+            ),
+        })
+    }
+    fn update(&mut self, data: CffiBuf<'_>) -> CryptographyResult<()> {
+        let buf = data.as_bytes();
+        self.get_mut_signer()?.update(buf)?;
+        Ok(())
+    }
+    fn finalize<'p>(
+        &mut self,
+        py: pyo3::Python<'p>,
+    ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
+        let signer = self.get_mut_signer()?;
+        let result = pyo3::types::PyBytes::new_with(py, signer.len()?, |b| {
+            let n = signer.sign(b).unwrap();
+            assert_eq!(n, b.len());
+            Ok(())
+        })?;
+        self.signer = None;
+        Ok(result)
+    }
+}
 
-            Ok(Poly1305 {
-                signer: Some(
-                    openssl::sign::Signer::new_without_digest(&pkey).map_err(|_| {
-                        pyo3::exceptions::PyValueError::new_err("A poly1305 key is 32 bytes long")
-                    })?,
-                ),
-            })
-        }
+#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.poly1305")]
+struct Poly1305 {
+    #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_LIBRESSL))]
+    backend: Poly1305Boring,
+    #[cfg(not(any(CRYPTOGRAPHY_IS_LIBRESSL, CRYPTOGRAPHY_IS_BORINGSSL)))]
+    backend: Poly1305Open,
+}
+
+#[pyo3::pymethods]
+impl Poly1305 {
+    #[new]
+    fn new(key: CffiBuf<'_>) -> CryptographyResult<Poly1305> {
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_LIBRESSL))]
+        return Ok(Poly1305 {
+            backend: Poly1305Boring::new(key)?,
+        });
+        #[cfg(not(any(CRYPTOGRAPHY_IS_LIBRESSL, CRYPTOGRAPHY_IS_BORINGSSL)))]
+        return Ok(Poly1305 {
+            backend: Poly1305Open::new(key)?,
+        });
     }
 
     #[staticmethod]
@@ -88,22 +167,14 @@ impl Poly1305 {
     }
 
     fn update(&mut self, data: CffiBuf<'_>) -> CryptographyResult<()> {
-        self.get_mut_signer()?.update(data.as_bytes())?;
-        Ok(())
+        self.backend.update(data)
     }
 
     fn finalize<'p>(
         &mut self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
-        let signer = self.get_mut_signer()?;
-        let result = pyo3::types::PyBytes::new_with(py, signer.len()?, |b| {
-            let n = signer.sign(b).unwrap();
-            assert_eq!(n, b.len());
-            Ok(())
-        })?;
-        self.signer = None;
-        Ok(result)
+        self.backend.finalize(py)
     }
 
     fn verify(&mut self, py: pyo3::Python<'_>, signature: &[u8]) -> CryptographyResult<()> {


### PR DESCRIPTION
Currently, we support `poly1305` only with OpenSSL. This PR adds support for Boring and Libre.

The current Rust implementation uses the OpenSSL API `EVP_DigestUpdate`. Since Boring and Libre implement a [different API](https://github.com/google/boringssl/blob/master/include/openssl/poly1305.h) for `poly1305`, this PR changes the implementation so that `Poly1305` is now a struct that has two possible backends:

```rust
#[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.poly1305")]
struct Poly1305 {
    #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_LIBRESSL))]
    backend: Poly1305Boring,
    #[cfg(not(any(CRYPTOGRAPHY_IS_LIBRESSL, CRYPTOGRAPHY_IS_BORINGSSL)))]
    backend: Poly1305Open,
}
```

The `Poly1305Open` backend is the same as the current `Poly1305` implementation, whereas the `Poly1305Boring` backend is the new implementation that uses the Libre/Boring Rust bindings exposed through [`openssl-sys 0.9.91`](https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/CHANGELOG.md#v0991---2023-08-06)

This fixes https://github.com/pyca/cryptography/issues/8959