### PR TITLE
pin coverage only on 3.8+

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -29,7 +29,7 @@ click==8.1.6
     # via black
 colorlog==6.7.0
     # via nox
-coverage==7.2.7
+coverage==7.3.0; python_version >= "3.8"
     # via pytest-cov
 distlib==0.3.7
     # via virtualenv


### PR DESCRIPTION
they've dropped 3.7 support