### PR TITLE
restoring SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER constant

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -108,6 +108,7 @@ static const long SSL_CB_HANDSHAKE_START;
 static const long SSL_CB_HANDSHAKE_DONE;
 static const long SSL_MODE_RELEASE_BUFFERS;
 static const long SSL_MODE_ENABLE_PARTIAL_WRITE;
+static const long SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER;
 static const long SSL_MODE_AUTO_RETRY;
 static const long TLS_ST_BEFORE;
 static const long TLS_ST_OK;


### PR DESCRIPTION
This constant was removed in https://github.com/pyca/cryptography/commit/895de04c7318edf0ecb5d55c4758598ff6d79724 but it is still needed to deal with an issue in PyOpenSSL described here https://github.com/cherrypy/cheroot/issues/245 and PR https://github.com/pyca/pyopenssl/pull/1242.