### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           - {VERSION: "3.11", NOXSESSION: "tests", OPENSSL: {TYPE: "libressl", VERSION: "3.7.3"}}
           - {VERSION: "3.11", NOXSESSION: "tests", OPENSSL: {TYPE: "libressl", VERSION: "3.8.0"}}
           - {VERSION: "3.11", NOXSESSION: "tests-randomorder"}
-          - {VERSION: "3.12-dev", NOXSESSION: "tests"}
+          - {VERSION: "3.12", NOXSESSION: "tests"}
           # Latest commit on the BoringSSL master branch, as of Aug 26, 2023.
           - {VERSION: "3.11", NOXSESSION: "tests", OPENSSL: {TYPE: "boringssl", VERSION: "792e77c52b5a85bee15a6f644494c10d8db5f7a0"}}
           # Latest commit on the OpenSSL master branch, as of Aug 26, 2023.
@@ -66,6 +66,7 @@ jobs:
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: ci-constraints-requirements.txt
       - name: Setup rust
@@ -223,6 +224,7 @@ jobs:
         PYTHON:
           - {VERSION: "3.7", NOXSESSION: "tests-nocoverage"}
           - {VERSION: "3.11", NOXSESSION: "tests"}
+          - {VERSION: "3.12", NOXSESSION: "tests"}
         exclude:
           # We only test latest Python on arm64. py37 won't work since there's no universal2 binary
           - PYTHON: {VERSION: "3.7", NOXSESSION: "tests-nocoverage"}
@@ -243,6 +245,7 @@ jobs:
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
+          allow-prereleases: true
           architecture: 'x64' # we force this right now so that it will install the universal2 on arm64
           cache: pip
           cache-dependency-path: ci-constraints-requirements.txt
@@ -291,6 +294,7 @@ jobs:
         PYTHON:
           - {VERSION: "3.7", NOXSESSION: "tests-nocoverage"}
           - {VERSION: "3.11", NOXSESSION: "tests"}
+          - {VERSION: "3.12", NOXSESSION: "tests"}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -302,6 +306,7 @@ jobs:
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
+          allow-prereleases: true
           architecture: ${{ matrix.WINDOWS.ARCH }}
           cache: pip
           cache-dependency-path: ci-constraints-requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Security :: Cryptography",


### PR DESCRIPTION
The [Python 3.12 release candidate is out!](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.