### PR TITLE
add X509V3_EXT_ERROR_UNKNOWN binding

### DIFF
--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -41,6 +41,8 @@ typedef struct {
     } d;
     ...;
 } GENERAL_NAME;
+
+static const long X509V3_EXT_ERROR_UNKNOWN;
 """
 
 


### PR DESCRIPTION
As a prerequisite to fixing https://github.com/pyca/pyopenssl/issues/1238 add binding as requested in https://github.com/pyca/pyopenssl/pull/1239#issuecomment-1706507699.