### PR TITLE
ops: use `Result<..., Self::Err>` for returns

### DIFF
--- a/src/rust/cryptography-x509-validation/src/ops.rs
+++ b/src/rust/cryptography-x509-validation/src/ops.rs
@@ -8,12 +8,15 @@ pub trait CryptoOps {
     /// A public key type for this cryptographic backend.
     type Key;
 
+    /// An error type for this cryptographic backend.
+    type Err;
+
     /// Extracts the public key from the given `Certificate` in
     /// a `Key` format known by the cryptographic backend, or `None`
     /// if the key is malformed.
-    fn public_key(&self, cert: &Certificate<'_>) -> Option<Self::Key>;
+    fn public_key(&self, cert: &Certificate<'_>) -> Result<Self::Key, Self::Err>;
 
     /// Verifies the signature on `Certificate` using the given
     /// `Key`.
-    fn is_signed_by(&self, cert: &Certificate<'_>, key: Self::Key) -> bool;
+    fn is_signed_by(&self, cert: &Certificate<'_>, key: Self::Key) -> Result<(), Self::Err>;
 }


### PR DESCRIPTION
This allows us to pass error states through, rather than swallowing them, which in turn will make these interfaces easier to reuse in a way that gets us coverage.

See https://github.com/pyca/cryptography/pull/9405.