### PR TITLE
rust: add PyCryptoOps

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "cryptography-cffi",
  "cryptography-openssl",
  "cryptography-x509",
+ "cryptography-x509-validation",
  "foreign-types-shared",
  "once_cell",
  "openssl",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,6 +14,7 @@ pyo3 = { version = "0.19", features = ["abi3-py37"] }
 asn1 = { version = "0.15.5", default-features = false }
 cryptography-cffi = { path = "cryptography-cffi" }
 cryptography-x509 = { path = "cryptography-x509" }
+cryptography-x509-validation = { path = "cryptography-x509-validation" }
 cryptography-openssl = { path = "cryptography-openssl" }
 pem = { version = "3", default-features = false }
 openssl = "0.10.57"

--- a/src/rust/cryptography-x509-validation/src/ops.rs
+++ b/src/rust/cryptography-x509-validation/src/ops.rs
@@ -18,5 +18,5 @@ pub trait CryptoOps {
 
     /// Verifies the signature on `Certificate` using the given
     /// `Key`.
-    fn is_signed_by(&self, cert: &Certificate<'_>, key: Self::Key) -> Result<(), Self::Err>;
+    fn verify_signed_by(&self, cert: &Certificate<'_>, key: Self::Key) -> Result<(), Self::Err>;
 }

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -290,7 +290,7 @@ impl Certificate {
 
         let ops = PyCryptoOps {};
         let issuer_key = ops.public_key(issuer.raw.borrow_dependent())?;
-        ops.is_signed_by(self.raw.borrow_dependent(), issuer_key)
+        ops.verify_signed_by(self.raw.borrow_dependent(), issuer_key)
     }
 }
 

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -7,6 +7,7 @@ use crate::asn1::{
 };
 use crate::backend::hashes;
 use crate::error::{CryptographyError, CryptographyResult};
+use crate::x509::verify::PyCryptoOps;
 use crate::x509::{extensions, sct, sign};
 use crate::{exceptions, types, x509};
 use cryptography_x509::certificate::Certificate as RawCertificate;
@@ -20,6 +21,7 @@ use cryptography_x509::extensions::{
 };
 use cryptography_x509::extensions::{Extension, SubjectAlternativeName};
 use cryptography_x509::{common, oid};
+use cryptography_x509_validation::ops::CryptoOps;
 use pyo3::{IntoPy, ToPyObject};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -267,7 +269,6 @@ impl Certificate {
 
     fn verify_directly_issued_by(
         &self,
-        py: pyo3::Python<'_>,
         issuer: pyo3::PyRef<'_, Certificate>,
     ) -> CryptographyResult<()> {
         if self.raw.borrow_dependent().tbs_cert.signature_alg
@@ -286,13 +287,10 @@ impl Certificate {
                 ),
             ));
         };
-        sign::verify_signature_with_signature_algorithm(
-            py,
-            issuer.public_key(py)?,
-            &self.raw.borrow_dependent().signature_alg,
-            self.raw.borrow_dependent().signature.as_bytes(),
-            &asn1::write_single(&self.raw.borrow_dependent().tbs_cert)?,
-        )
+
+        let ops = PyCryptoOps {};
+        let issuer_key = ops.public_key(issuer.raw.borrow_dependent())?;
+        ops.is_signed_by(self.raw.borrow_dependent(), issuer_key)
     }
 }
 

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -30,7 +30,7 @@ impl CryptoOps for PyCryptoOps {
         })
     }
 
-    fn is_signed_by(&self, cert: &Certificate<'_>, key: Self::Key) -> Result<(), Self::Err> {
+    fn verify_signed_by(&self, cert: &Certificate<'_>, key: Self::Key) -> Result<(), Self::Err> {
         pyo3::Python::with_gil(|py| -> CryptographyResult<()> {
             sign::verify_signature_with_signature_algorithm(
                 py,


### PR DESCRIPTION
Reimplements `verify_directly_issued_by` in terms of `PyCryptoOps`, for free coverage.

Breakout from #9405.