### PR TITLE
validation/ops: add test-only NullOps

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -30,6 +30,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
@@ -95,7 +101,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-sys",
- "pem",
+ "pem 3.0.2",
  "pyo3",
  "self_cell",
 ]
@@ -114,6 +120,7 @@ dependencies = [
  "asn1",
  "cryptography-x509",
  "once_cell",
+ "pem 1.1.1",
 ]
 
 [[package]]
@@ -231,11 +238,20 @@ dependencies = [
 
 [[package]]
 name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
+name = "pem"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
- "base64",
+ "base64 0.21.4",
 ]
 
 [[package]]

--- a/src/rust/cryptography-x509-validation/Cargo.toml
+++ b/src/rust/cryptography-x509-validation/Cargo.toml
@@ -11,3 +11,6 @@ rust-version = "1.63.0"
 asn1 = { version = "0.15.5", default-features = false }
 cryptography-x509 = { path = "../cryptography-x509" }
 once_cell = "1"
+
+[dev-dependencies]
+pem = "1.1"

--- a/src/rust/cryptography-x509-validation/src/ops.rs
+++ b/src/rust/cryptography-x509-validation/src/ops.rs
@@ -20,3 +20,53 @@ pub trait CryptoOps {
     /// `Key`.
     fn verify_signed_by(&self, cert: &Certificate<'_>, key: Self::Key) -> Result<(), Self::Err>;
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use cryptography_x509::certificate::Certificate;
+
+    use super::CryptoOps;
+
+    pub(crate) struct NullOps {}
+    impl CryptoOps for NullOps {
+        type Key = ();
+        type Err = ();
+
+        fn public_key(&self, _cert: &Certificate<'_>) -> Result<Self::Key, Self::Err> {
+            Ok(())
+        }
+
+        fn verify_signed_by(
+            &self,
+            _cert: &Certificate<'_>,
+            _key: Self::Key,
+        ) -> Result<(), Self::Err> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_nullops() {
+        // Arbitrary relatively small cert (v1_cert.pem from cryptography_vectors).
+        let v1_cert = "
+-----BEGIN CERTIFICATE-----
+MIIBWzCCAQYCARgwDQYJKoZIhvcNAQEEBQAwODELMAkGA1UEBhMCQVUxDDAKBgNV
+BAgTA1FMRDEbMBkGA1UEAxMSU1NMZWF5L3JzYSB0ZXN0IENBMB4XDTk1MDYxOTIz
+MzMxMloXDTk1MDcxNzIzMzMxMlowOjELMAkGA1UEBhMCQVUxDDAKBgNVBAgTA1FM
+RDEdMBsGA1UEAxMUU1NMZWF5L3JzYSB0ZXN0IGNlcnQwXDANBgkqhkiG9w0BAQEF
+AANLADBIAkEAqtt6qS5GTxVxGZYWa0/4u+IwHf7p2LNZbcPBp9/OfIcYAXBQn8hO
+/Re1uwLKXdCjIoaGs4DLdG88rkzfyK5dPQIDAQABMAwGCCqGSIb3DQIFBQADQQAE
+Wc7EcF8po2/ZO6kNCwK/ICH6DobgLekA5lSLr5EvuioZniZp5lFzAw4+YzPQ7XKJ
+zl9HYIMxATFyqSiD9jsx
+-----END CERTIFICATE-----";
+
+        let cert_der = pem::parse(v1_cert.as_bytes()).unwrap().contents;
+        let cert = asn1::parse_single::<Certificate<'_>>(&cert_der).unwrap();
+
+        let ops = NullOps {};
+        assert_eq!(ops.public_key(&cert), Ok(()));
+        assert!(ops
+            .verify_signed_by(&cert, ops.public_key(&cert).unwrap())
+            .is_ok());
+    }
+}


### PR DESCRIPTION
Another breakout from #9405.

This adds a `cfg(test)`-only `NullOps` implementation of `CryptoOps`, which #9405 requires for coverage of some of its API signatures.