### PR TITLE
extensions: drop unnecessary self lifetime bound

### DIFF
--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -75,7 +75,7 @@ pub struct Extension<'a> {
 }
 
 impl<'a> Extension<'a> {
-    pub fn value<T: asn1::Asn1Readable<'a>>(&'a self) -> asn1::ParseResult<T> {
+    pub fn value<T: asn1::Asn1Readable<'a>>(&self) -> asn1::ParseResult<T> {
         asn1::parse_single(self.extn_value)
     }
 }


### PR DESCRIPTION
Noticed this while reviewing https://github.com/trail-of-forks/cryptography/pull/4 -- `'a` isn't meant to bind the `&self` reference, so having it here unnecessarily constrains the actual returned value's lifetime.