### PR TITLE
Add timezone-aware API variants for x509

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,14 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`.
 * Added `algorithm` and `mgf` properties to
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.OAEP`.
+* Added the following properties that return timezone-aware ``datetime`` objects:
+  :meth:`~cryptography.x509.Certificate.not_valid_before_utc`,
+  :meth:`~cryptography.x509.Certificate.not_valid_after_utc`,
+  :meth:`~cryptography.x509.RevokedCertificate.revocation_date_utc`,
+  :meth:`~cryptography.x509.CertificateRevocationList.next_update_utc`,
+  :meth:`~cryptography.x509.CertificateRevocationList.last_update_utc`.
+  These are timezone-aware variants of existing properties that return naïve
+  ``datetime`` objects.
 
 .. _v41-0-4:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -376,6 +376,20 @@ X.509 Certificate Object
             >>> cert.not_valid_before
             datetime.datetime(2010, 1, 1, 8, 30)
 
+    .. attribute:: not_valid_before_utc
+
+        .. versionadded:: 42.0.0
+
+        :type: :class:`datetime.datetime`
+
+        A timezone-aware datetime representing the beginning of the validity
+        period for the certificate in UTC. This value is inclusive.
+
+        .. doctest::
+
+            >>> cert.not_valid_before_utc
+            datetime.datetime(2010, 1, 1, 8, 30, tzinfo=datetime.timezone.utc)
+
     .. attribute:: not_valid_after
 
         :type: :class:`datetime.datetime`
@@ -387,6 +401,20 @@ X.509 Certificate Object
 
             >>> cert.not_valid_after
             datetime.datetime(2030, 12, 31, 8, 30)
+
+    .. attribute:: not_valid_after_utc
+
+        .. versionadded:: 42.0.0
+
+        :type: :class:`datetime.datetime`
+
+        A timezone-aware datetime representing the end of the validity period
+        for the certificate in UTC. This value is inclusive.
+
+        .. doctest::
+
+            >>> cert.not_valid_after_utc
+            datetime.datetime(2030, 12, 31, 8, 30, tzinfo=datetime.timezone.utc)
 
     .. attribute:: issuer
 
@@ -698,6 +726,20 @@ X.509 CRL (Certificate Revocation List) Object
             >>> crl.next_update
             datetime.datetime(2016, 1, 1, 0, 0)
 
+    .. attribute:: next_update_utc
+
+        .. versionadded:: 42.0.0
+
+        :type: :class:`datetime.datetime`
+
+        A timezone-aware datetime representing when the next update to this
+        CRL is expected.
+
+        .. doctest::
+
+            >>> crl.next_update_utc
+            datetime.datetime(2016, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+
     .. attribute:: last_update
 
         :type: :class:`datetime.datetime`
@@ -708,6 +750,19 @@ X.509 CRL (Certificate Revocation List) Object
 
             >>> crl.last_update
             datetime.datetime(2015, 1, 1, 0, 0)
+
+    .. attribute:: last_update_utc
+
+        .. versionadded:: 42.0.0
+
+        :type: :class:`datetime.datetime`
+
+        A timezone-aware datetime representing when this CRL was last updated.
+
+        .. doctest::
+
+            >>> crl.last_update_utc
+            datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 
     .. attribute:: extensions
 
@@ -1182,6 +1237,20 @@ X.509 Revoked Certificate Object
 
             >>> revoked_certificate.revocation_date
             datetime.datetime(2015, 1, 1, 0, 0)
+
+    .. attribute:: revocation_date_utc
+
+        .. versionadded:: 42.0.0
+
+        :type: :class:`datetime.datetime`
+
+        A timezone-aware datetime representing the date this certificates was
+        revoked.
+
+        .. doctest::
+
+            >>> revoked_certificate.revocation_date_utc
+            datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 
     .. attribute:: extensions
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -195,9 +195,23 @@ class Certificate(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
+    def not_valid_before_utc(self) -> datetime.datetime:
+        """
+        Not before time (represented as a non-naive UTC datetime)
+        """
+
+    @property
+    @abc.abstractmethod
     def not_valid_after(self) -> datetime.datetime:
         """
         Not after time (represented as UTC datetime)
+        """
+
+    @property
+    @abc.abstractmethod
+    def not_valid_after_utc(self) -> datetime.datetime:
+        """
+        Not after time (represented as a non-naive UTC datetime)
         """
 
     @property
@@ -317,6 +331,14 @@ class RevokedCertificate(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
+    def revocation_date_utc(self) -> datetime.datetime:
+        """
+        Returns the date of when this certificate was revoked as a non-naive
+        UTC datetime.
+        """
+
+    @property
+    @abc.abstractmethod
     def extensions(self) -> Extensions:
         """
         Returns an Extensions object containing a list of Revoked extensions.
@@ -345,6 +367,10 @@ class _RawRevokedCertificate(RevokedCertificate):
     @property
     def revocation_date(self) -> datetime.datetime:
         return self._revocation_date
+
+    @property
+    def revocation_date_utc(self) -> datetime.datetime:
+        return self._revocation_date.replace(tzinfo=datetime.timezone.utc)
 
     @property
     def extensions(self) -> Extensions:
@@ -406,9 +432,25 @@ class CertificateRevocationList(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
+    def next_update_utc(self) -> datetime.datetime | None:
+        """
+        Returns the date of next update for this CRL as a non-naive UTC
+        datetime.
+        """
+
+    @property
+    @abc.abstractmethod
     def last_update(self) -> datetime.datetime:
         """
         Returns the date of last update for this CRL.
+        """
+
+    @property
+    @abc.abstractmethod
+    def last_update_utc(self) -> datetime.datetime:
+        """
+        Returns the date of last update for this CRL as a non-naive UTC
+        datetime.
         """
 
     @property

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -207,6 +207,18 @@ impl Certificate {
     }
 
     #[getter]
+    fn not_valid_before_utc<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let dt = &self
+            .raw
+            .borrow_dependent()
+            .tbs_cert
+            .validity
+            .not_before
+            .as_datetime();
+        x509::datetime_to_py_utc(py, dt)
+    }
+
+    #[getter]
     fn not_valid_after<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
         let dt = &self
             .raw
@@ -216,6 +228,18 @@ impl Certificate {
             .not_after
             .as_datetime();
         x509::datetime_to_py(py, dt)
+    }
+
+    #[getter]
+    fn not_valid_after_utc<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let dt = &self
+            .raw
+            .borrow_dependent()
+            .tbs_cert
+            .validity
+            .not_after
+            .as_datetime();
+        x509::datetime_to_py_utc(py, dt)
     }
 
     #[getter]

--- a/src/rust/src/x509/common.rs
+++ b/src/rust/src/x509/common.rs
@@ -484,6 +484,23 @@ pub(crate) fn datetime_to_py<'p>(
     ))
 }
 
+pub(crate) fn datetime_to_py_utc<'p>(
+    py: pyo3::Python<'p>,
+    dt: &asn1::DateTime,
+) -> pyo3::PyResult<&'p pyo3::PyAny> {
+    let timezone = types::DATETIME_TIMEZONE_UTC.get(py)?;
+    types::DATETIME_DATETIME.get(py)?.call1((
+        dt.year(),
+        dt.month(),
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+        dt.second(),
+        0,
+        timezone,
+    ))
+}
+
 pub(crate) fn py_to_datetime(
     py: pyo3::Python<'_>,
     val: &pyo3::PyAny,

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -253,8 +253,28 @@ impl CertificateRevocationList {
     }
 
     #[getter]
+    fn next_update_utc<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        match &self.owned.borrow_dependent().tbs_cert_list.next_update {
+            Some(t) => x509::datetime_to_py_utc(py, t.as_datetime()),
+            None => Ok(py.None().into_ref(py)),
+        }
+    }
+
+    #[getter]
     fn last_update<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
         x509::datetime_to_py(
+            py,
+            self.owned
+                .borrow_dependent()
+                .tbs_cert_list
+                .this_update
+                .as_datetime(),
+        )
+    }
+
+    #[getter]
+    fn last_update_utc<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        x509::datetime_to_py_utc(
             py,
             self.owned
                 .borrow_dependent()
@@ -488,6 +508,14 @@ impl RevokedCertificate {
     #[getter]
     fn revocation_date<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
         x509::datetime_to_py(
+            py,
+            self.owned.borrow_dependent().revocation_date.as_datetime(),
+        )
+    }
+
+    #[getter]
+    fn revocation_date_utc<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        x509::datetime_to_py_utc(
             py,
             self.owned.borrow_dependent().revocation_date.as_datetime(),
         )

--- a/src/rust/src/x509/mod.rs
+++ b/src/rust/src/x509/mod.rs
@@ -15,6 +15,6 @@ pub(crate) mod sign;
 pub(crate) mod verify;
 
 pub(crate) use common::{
-    datetime_to_py, find_in_pem, parse_and_cache_extensions, parse_general_name,
-    parse_general_names, parse_name, parse_rdn, py_to_datetime,
+    datetime_to_py, datetime_to_py_utc, find_in_pem, parse_and_cache_extensions,
+    parse_general_name, parse_general_names, parse_name, parse_rdn, py_to_datetime,
 };

--- a/tests/x509/test_x509_revokedcertbuilder.py
+++ b/tests/x509/test_x509_revokedcertbuilder.py
@@ -69,6 +69,9 @@ class TestRevokedCertificateBuilder:
 
         revoked_certificate = builder.build(backend)
         assert revoked_certificate.revocation_date == utc_time
+        assert revoked_certificate.revocation_date_utc == utc_time.replace(
+            tzinfo=datetime.timezone.utc
+        )
 
     def test_revocation_date_invalid(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
This PRs adds timezone-aware variants for the following properties:
- `x509.Certificate.not_valid_before` and `x509.Certificate.not_valid_after`
- `x509.RevokedCertificate.revocation_date`
- `x509.CertificateRevocationList.last_update` and `x509.CertificateRevocationList.next_update`

The variants have the same name with `_utc` appended (i.e: `not_valid_before` -> `not_valid_before_utc`).
These variants return a `datetime.datetime` object with the timezone set to UTC. Since `cryptography` already internally converted these datetimes to UTC, we only need to return the same object with the timezone set.

This is part of https://github.com/pyca/cryptography/issues/9186: providing the timezone-aware variants is the step before deprecating the naive APIs.