### PR TITLE
Deprecate naive datetime x509 APIs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,14 @@ Changelog
   :meth:`~cryptography.x509.CertificateRevocationList.last_update_utc`.
   These are timezone-aware variants of existing properties that return naïve
   ``datetime`` objects.
+* Deprecated the following properties that return naïve ``datetime`` objects:
+  :meth:`~cryptography.x509.Certificate.not_valid_before`,
+  :meth:`~cryptography.x509.Certificate.not_valid_after`,
+  :meth:`~cryptography.x509.RevokedCertificate.revocation_date`,
+  :meth:`~cryptography.x509.CertificateRevocationList.next_update`,
+  :meth:`~cryptography.x509.CertificateRevocationList.last_update`
+  in favor of the new timezone-aware variants mentioned above.
+
 
 .. _v41-0-4:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -368,6 +368,13 @@ X.509 Certificate Object
 
         :type: :class:`datetime.datetime`
 
+        .. warning::
+
+            This property is deprecated and will be removed in a future
+            version. Please switch to the timezone-aware variant
+            :meth:`~cryptography.x509.Certificate.not_valid_before_utc`.
+
+
         A naïve datetime representing the beginning of the validity period for
         the certificate in UTC. This value is inclusive.
 
@@ -393,6 +400,12 @@ X.509 Certificate Object
     .. attribute:: not_valid_after
 
         :type: :class:`datetime.datetime`
+
+        .. warning::
+
+            This property is deprecated and will be removed in a future
+            version. Please switch to the timezone-aware variant
+            :meth:`~cryptography.x509.Certificate.not_valid_after_utc`.
 
         A naïve datetime representing the end of the validity period for the
         certificate in UTC. This value is inclusive.
@@ -718,6 +731,12 @@ X.509 CRL (Certificate Revocation List) Object
 
         :type: :class:`datetime.datetime`
 
+        .. warning::
+
+            This property is deprecated and will be removed in a future
+            version. Please switch to the timezone-aware variant
+            :meth:`~cryptography.x509.CertificateRevocationList.next_update_utc`.
+
         A naïve datetime representing when the next update to this CRL is
         expected.
 
@@ -743,6 +762,12 @@ X.509 CRL (Certificate Revocation List) Object
     .. attribute:: last_update
 
         :type: :class:`datetime.datetime`
+
+        .. warning::
+
+            This property is deprecated and will be removed in a future
+            version. Please switch to the timezone-aware variant
+            :meth:`~cryptography.x509.CertificateRevocationList.last_update_utc`.
 
         A naïve datetime representing when this CRL was last updated.
 
@@ -1230,6 +1255,12 @@ X.509 Revoked Certificate Object
     .. attribute:: revocation_date
 
         :type: :class:`datetime.datetime`
+
+        .. warning::
+
+            This property is deprecated and will be removed in a future
+            version. Please switch to the timezone-aware variant
+            :meth:`~cryptography.x509.RevokedCertificate.revocation_date_utc`.
 
         A naïve datetime representing the date this certificates was revoked.
 

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -24,6 +24,7 @@ DeprecatedIn36 = CryptographyDeprecationWarning
 DeprecatedIn37 = CryptographyDeprecationWarning
 DeprecatedIn40 = CryptographyDeprecationWarning
 DeprecatedIn41 = CryptographyDeprecationWarning
+DeprecatedIn42 = CryptographyDeprecationWarning
 
 
 def _check_bytes(name: str, value: bytes) -> None:

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -8,6 +8,7 @@ import abc
 import datetime
 import os
 import typing
+import warnings
 
 from cryptography import utils
 from cryptography.hazmat.bindings._rust import x509 as rust_x509
@@ -366,6 +367,12 @@ class _RawRevokedCertificate(RevokedCertificate):
 
     @property
     def revocation_date(self) -> datetime.datetime:
+        warnings.warn(
+            "Properties that return a naïve datetime object have been "
+            "deprecated. Please switch to revocation_date_utc.",
+            utils.DeprecatedIn42,
+            stacklevel=2,
+        )
         return self._revocation_date
 
     @property

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -41,6 +41,8 @@ pub static DEPRECATED_IN_36: LazyPyImport =
     LazyPyImport::new("cryptography.utils", &["DeprecatedIn36"]);
 pub static DEPRECATED_IN_41: LazyPyImport =
     LazyPyImport::new("cryptography.utils", &["DeprecatedIn41"]);
+pub static DEPRECATED_IN_42: LazyPyImport =
+    LazyPyImport::new("cryptography.utils", &["DeprecatedIn42"]);
 
 pub static LOAD_DER_PUBLIC_KEY: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.serialization",

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -196,6 +196,13 @@ impl Certificate {
 
     #[getter]
     fn not_valid_before<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let warning_cls = types::DEPRECATED_IN_42.get(py)?;
+        pyo3::PyErr::warn(
+                py,
+                warning_cls,
+                "Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_before_utc.",
+                1,
+            )?;
         let dt = &self
             .raw
             .borrow_dependent()
@@ -220,6 +227,13 @@ impl Certificate {
 
     #[getter]
     fn not_valid_after<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let warning_cls = types::DEPRECATED_IN_42.get(py)?;
+        pyo3::PyErr::warn(
+                py,
+                warning_cls,
+                "Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc.",
+                1,
+            )?;
         let dt = &self
             .raw
             .borrow_dependent()

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -246,6 +246,13 @@ impl CertificateRevocationList {
 
     #[getter]
     fn next_update<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let warning_cls = types::DEPRECATED_IN_42.get(py)?;
+        pyo3::PyErr::warn(
+                py,
+                warning_cls,
+                "Properties that return a naïve datetime object have been deprecated. Please switch to next_update_utc.",
+                1,
+            )?;
         match &self.owned.borrow_dependent().tbs_cert_list.next_update {
             Some(t) => x509::datetime_to_py(py, t.as_datetime()),
             None => Ok(py.None().into_ref(py)),
@@ -262,6 +269,13 @@ impl CertificateRevocationList {
 
     #[getter]
     fn last_update<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let warning_cls = types::DEPRECATED_IN_42.get(py)?;
+        pyo3::PyErr::warn(
+                py,
+                warning_cls,
+                "Properties that return a naïve datetime object have been deprecated. Please switch to last_update_utc.",
+                1,
+            )?;
         x509::datetime_to_py(
             py,
             self.owned
@@ -507,6 +521,13 @@ impl RevokedCertificate {
 
     #[getter]
     fn revocation_date<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
+        let warning_cls = types::DEPRECATED_IN_42.get(py)?;
+        pyo3::PyErr::warn(
+                py,
+                warning_cls,
+                "Properties that return a naïve datetime object have been deprecated. Please switch to revocation_date_utc.",
+                1,
+            )?;
         x509::datetime_to_py(
             py,
             self.owned.borrow_dependent().revocation_date.as_datetime(),
@@ -604,7 +625,8 @@ fn create_x509_crl(
         let serial_number = py_revoked_cert
             .getattr(pyo3::intern!(py, "serial_number"))?
             .extract()?;
-        let py_revocation_date = py_revoked_cert.getattr(pyo3::intern!(py, "revocation_date"))?;
+        let py_revocation_date =
+            py_revoked_cert.getattr(pyo3::intern!(py, "revocation_date_utc"))?;
         revoked_certs.push(crl::RevokedCertificate {
             user_certificate: asn1::BigUint::new(py_uint_to_big_endian_bytes(py, serial_number)?)
                 .unwrap(),

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -141,12 +141,14 @@ def _check_cert_times(
     not_valid_after: typing.Optional[datetime.datetime],
 ) -> None:
     if not_valid_before:
-        assert cert.not_valid_before == not_valid_before
+        with pytest.warns(utils.DeprecatedIn42):
+            assert cert.not_valid_before == not_valid_before
         assert cert.not_valid_before_utc == not_valid_before.replace(
             tzinfo=datetime.timezone.utc
         )
     if not_valid_after:
-        assert cert.not_valid_after == not_valid_after
+        with pytest.warns(utils.DeprecatedIn42):
+            assert cert.not_valid_after == not_valid_after
         assert cert.not_valid_after_utc == not_valid_after.replace(
             tzinfo=datetime.timezone.utc
         )
@@ -157,11 +159,13 @@ def _check_crl_times(
     last_update: datetime.datetime,
     next_update: datetime.datetime,
 ) -> None:
-    assert crl.last_update == last_update
+    with pytest.warns(utils.DeprecatedIn42):
+        assert crl.last_update == last_update
+        assert crl.next_update == next_update
+
     assert crl.last_update_utc == last_update.replace(
         tzinfo=datetime.timezone.utc
     )
-    assert crl.next_update == next_update
     assert crl.next_update_utc == next_update.replace(
         tzinfo=datetime.timezone.utc
     )
@@ -307,14 +311,15 @@ class TestCertificateRevocationList:
             x509.load_pem_x509_crl,
         )
 
-        assert isinstance(crl.next_update, datetime.datetime)
-        assert isinstance(crl.next_update_utc, datetime.datetime)
-        assert isinstance(crl.last_update, datetime.datetime)
-        assert isinstance(crl.last_update_utc, datetime.datetime)
+        with pytest.warns(utils.DeprecatedIn42):
+            assert isinstance(crl.next_update, datetime.datetime)
+            assert isinstance(crl.last_update, datetime.datetime)
+            assert crl.next_update.isoformat() == "2016-01-01T00:00:00"
+            assert crl.last_update.isoformat() == "2015-01-01T00:00:00"
 
-        assert crl.next_update.isoformat() == "2016-01-01T00:00:00"
+        assert isinstance(crl.next_update_utc, datetime.datetime)
+        assert isinstance(crl.last_update_utc, datetime.datetime)
         assert crl.next_update_utc.isoformat() == "2016-01-01T00:00:00+00:00"
-        assert crl.last_update.isoformat() == "2015-01-01T00:00:00"
         assert crl.last_update_utc.isoformat() == "2015-01-01T00:00:00+00:00"
 
     def test_no_next_update(self, backend):
@@ -322,7 +327,9 @@ class TestCertificateRevocationList:
             os.path.join("x509", "custom", "crl_no_next_update.pem"),
             x509.load_pem_x509_crl,
         )
-        assert crl.next_update is None
+
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl.next_update is None
         assert crl.next_update_utc is None
 
     def test_unrecognized_extension(self, backend):
@@ -376,7 +383,10 @@ class TestCertificateRevocationList:
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
         )[11]
-        assert revoked.revocation_date == datetime.datetime(2015, 1, 1, 0, 0)
+        with pytest.warns(utils.DeprecatedIn42):
+            assert revoked.revocation_date == datetime.datetime(
+                2015, 1, 1, 0, 0
+            )
         assert revoked.revocation_date_utc == datetime.datetime(
             2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc
         )
@@ -603,12 +613,14 @@ class TestRevokedCertificate:
         for i, rev in enumerate(crl):
             assert isinstance(rev, x509.RevokedCertificate)
             assert isinstance(rev.serial_number, int)
-            assert isinstance(rev.revocation_date, datetime.datetime)
+            with pytest.warns(utils.DeprecatedIn42):
+                assert isinstance(rev.revocation_date, datetime.datetime)
             assert isinstance(rev.revocation_date_utc, datetime.datetime)
             assert isinstance(rev.extensions, x509.Extensions)
 
             assert rev.serial_number == i
-            assert rev.revocation_date.isoformat() == "2015-01-01T00:00:00"
+            with pytest.warns(utils.DeprecatedIn42):
+                assert rev.revocation_date.isoformat() == "2015-01-01T00:00:00"
             assert (
                 rev.revocation_date_utc.isoformat()
                 == "2015-01-01T00:00:00+00:00"

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -67,6 +67,9 @@ class TestCertificateRevocationListBuilder:
         crl = builder.sign(private_key, hashes.SHA256(), backend)
         with pytest.warns(utils.DeprecatedIn42):
             assert crl.last_update == utc_last
+        assert crl.last_update_utc == utc_last.replace(
+            tzinfo=datetime.timezone.utc
+        )
 
     def test_last_update_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
@@ -109,6 +112,9 @@ class TestCertificateRevocationListBuilder:
         crl = builder.sign(private_key, hashes.SHA256(), backend)
         with pytest.warns(utils.DeprecatedIn42):
             assert crl.next_update == utc_next
+        assert crl.next_update_utc == utc_next.replace(
+            tzinfo=datetime.timezone.utc
+        )
 
     def test_next_update_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
@@ -222,6 +228,12 @@ class TestCertificateRevocationListBuilder:
         with pytest.warns(utils.DeprecatedIn42):
             assert crl.last_update == last_update
             assert crl.next_update == next_update
+        assert crl.last_update_utc == last_update.replace(
+            tzinfo=datetime.timezone.utc
+        )
+        assert crl.next_update_utc == next_update.replace(
+            tzinfo=datetime.timezone.utc
+        )
 
     @pytest.mark.parametrize(
         "extension",
@@ -579,6 +591,7 @@ class TestCertificateRevocationListBuilder:
         assert crl[0].serial_number == revoked_cert0.serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert crl[0].revocation_date == revoked_cert0.revocation_date
+        assert crl[0].revocation_date_utc == revoked_cert0.revocation_date_utc
         assert len(crl[0].extensions) == 1
         ext = crl[0].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False
@@ -629,6 +642,7 @@ class TestCertificateRevocationListBuilder:
         assert crl[0].serial_number == revoked_cert0.serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert crl[0].revocation_date == revoked_cert0.revocation_date
+        assert crl[0].revocation_date_utc == revoked_cert0.revocation_date_utc
         assert len(crl[0].extensions) == 1
         ext = crl[0].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False
@@ -684,6 +698,7 @@ class TestCertificateRevocationListBuilder:
         assert crl[0].serial_number == revoked_cert0.serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert crl[0].revocation_date == revoked_cert0.revocation_date
+        assert crl[0].revocation_date_utc == revoked_cert0.revocation_date_utc
         assert len(crl[0].extensions) == 1
         ext = crl[0].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False
@@ -739,6 +754,7 @@ class TestCertificateRevocationListBuilder:
         assert crl[0].serial_number == revoked_cert0.serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert crl[0].revocation_date == revoked_cert0.revocation_date
+        assert crl[0].revocation_date_utc == revoked_cert0.revocation_date_utc
         assert len(crl[0].extensions) == 1
         ext = crl[0].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False
@@ -849,13 +865,21 @@ class TestCertificateRevocationListBuilder:
         with pytest.warns(utils.DeprecatedIn42):
             assert crl.last_update == last_update
             assert crl.next_update == next_update
+        assert crl.last_update_utc == last_update.replace(
+            tzinfo=datetime.timezone.utc
+        )
+        assert crl.next_update_utc == next_update.replace(
+            tzinfo=datetime.timezone.utc
+        )
         assert crl[0].serial_number == revoked_cert0.serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert crl[0].revocation_date == revoked_cert0.revocation_date
+        assert crl[0].revocation_date_utc == revoked_cert0.revocation_date_utc
         assert len(crl[0].extensions) == 0
         assert crl[1].serial_number == revoked_cert1.serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert crl[1].revocation_date == revoked_cert1.revocation_date
+        assert crl[1].revocation_date_utc == revoked_cert1.revocation_date_utc
         assert len(crl[1].extensions) == 2
         ext = crl[1].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -7,7 +7,7 @@ import datetime
 
 import pytest
 
-from cryptography import x509
+from cryptography import utils, x509
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
@@ -65,7 +65,8 @@ class TestCertificateRevocationListBuilder:
         )
 
         crl = builder.sign(private_key, hashes.SHA256(), backend)
-        assert crl.last_update == utc_last
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl.last_update == utc_last
 
     def test_last_update_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
@@ -106,7 +107,8 @@ class TestCertificateRevocationListBuilder:
         )
 
         crl = builder.sign(private_key, hashes.SHA256(), backend)
-        assert crl.next_update == utc_next
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl.next_update == utc_next
 
     def test_next_update_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
@@ -217,8 +219,9 @@ class TestCertificateRevocationListBuilder:
 
         crl = builder.sign(private_key, hashes.SHA256(), backend)
         assert len(crl) == 0
-        assert crl.last_update == last_update
-        assert crl.next_update == next_update
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl.last_update == last_update
+            assert crl.next_update == next_update
 
     @pytest.mark.parametrize(
         "extension",
@@ -574,7 +577,8 @@ class TestCertificateRevocationListBuilder:
             == ian
         )
         assert crl[0].serial_number == revoked_cert0.serial_number
-        assert crl[0].revocation_date == revoked_cert0.revocation_date
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl[0].revocation_date == revoked_cert0.revocation_date
         assert len(crl[0].extensions) == 1
         ext = crl[0].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False
@@ -623,7 +627,8 @@ class TestCertificateRevocationListBuilder:
             == ian
         )
         assert crl[0].serial_number == revoked_cert0.serial_number
-        assert crl[0].revocation_date == revoked_cert0.revocation_date
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl[0].revocation_date == revoked_cert0.revocation_date
         assert len(crl[0].extensions) == 1
         ext = crl[0].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False
@@ -677,7 +682,8 @@ class TestCertificateRevocationListBuilder:
             == ian
         )
         assert crl[0].serial_number == revoked_cert0.serial_number
-        assert crl[0].revocation_date == revoked_cert0.revocation_date
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl[0].revocation_date == revoked_cert0.revocation_date
         assert len(crl[0].extensions) == 1
         ext = crl[0].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False
@@ -731,7 +737,8 @@ class TestCertificateRevocationListBuilder:
             == ian
         )
         assert crl[0].serial_number == revoked_cert0.serial_number
-        assert crl[0].revocation_date == revoked_cert0.revocation_date
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl[0].revocation_date == revoked_cert0.revocation_date
         assert len(crl[0].extensions) == 1
         ext = crl[0].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False
@@ -839,13 +846,16 @@ class TestCertificateRevocationListBuilder:
 
         crl = builder.sign(private_key, hashes.SHA256(), backend)
         assert len(crl) == 3
-        assert crl.last_update == last_update
-        assert crl.next_update == next_update
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl.last_update == last_update
+            assert crl.next_update == next_update
         assert crl[0].serial_number == revoked_cert0.serial_number
-        assert crl[0].revocation_date == revoked_cert0.revocation_date
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl[0].revocation_date == revoked_cert0.revocation_date
         assert len(crl[0].extensions) == 0
         assert crl[1].serial_number == revoked_cert1.serial_number
-        assert crl[1].revocation_date == revoked_cert1.revocation_date
+        with pytest.warns(utils.DeprecatedIn42):
+            assert crl[1].revocation_date == revoked_cert1.revocation_date
         assert len(crl[1].extensions) == 2
         ext = crl[1].extensions.get_extension_for_class(x509.InvalidityDate)
         assert ext.critical is False

--- a/tests/x509/test_x509_revokedcertbuilder.py
+++ b/tests/x509/test_x509_revokedcertbuilder.py
@@ -136,6 +136,10 @@ class TestRevokedCertificateBuilder:
         assert revoked_certificate.serial_number == serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert revoked_certificate.revocation_date == revocation_date
+        assert (
+            revoked_certificate.revocation_date_utc
+            == revocation_date.replace(tzinfo=datetime.timezone.utc)
+        )
         assert len(revoked_certificate.extensions) == 0
 
     @pytest.mark.parametrize(
@@ -160,6 +164,10 @@ class TestRevokedCertificateBuilder:
         assert revoked_certificate.serial_number == serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert revoked_certificate.revocation_date == revocation_date
+        assert (
+            revoked_certificate.revocation_date_utc
+            == revocation_date.replace(tzinfo=datetime.timezone.utc)
+        )
         assert len(revoked_certificate.extensions) == 1
         ext = revoked_certificate.extensions.get_extension_for_class(
             type(extension)

--- a/tests/x509/test_x509_revokedcertbuilder.py
+++ b/tests/x509/test_x509_revokedcertbuilder.py
@@ -7,7 +7,7 @@ import datetime
 
 import pytest
 
-from cryptography import x509
+from cryptography import utils, x509
 
 
 class TestRevokedCertificateBuilder:
@@ -68,7 +68,8 @@ class TestRevokedCertificateBuilder:
         )
 
         revoked_certificate = builder.build(backend)
-        assert revoked_certificate.revocation_date == utc_time
+        with pytest.warns(utils.DeprecatedIn42):
+            assert revoked_certificate.revocation_date == utc_time
         assert revoked_certificate.revocation_date_utc == utc_time.replace(
             tzinfo=datetime.timezone.utc
         )
@@ -133,7 +134,8 @@ class TestRevokedCertificateBuilder:
 
         revoked_certificate = builder.build(backend)
         assert revoked_certificate.serial_number == serial_number
-        assert revoked_certificate.revocation_date == revocation_date
+        with pytest.warns(utils.DeprecatedIn42):
+            assert revoked_certificate.revocation_date == revocation_date
         assert len(revoked_certificate.extensions) == 0
 
     @pytest.mark.parametrize(
@@ -156,7 +158,8 @@ class TestRevokedCertificateBuilder:
 
         revoked_certificate = builder.build(backend)
         assert revoked_certificate.serial_number == serial_number
-        assert revoked_certificate.revocation_date == revocation_date
+        with pytest.warns(utils.DeprecatedIn42):
+            assert revoked_certificate.revocation_date == revocation_date
         assert len(revoked_certificate.extensions) == 1
         ext = revoked_certificate.extensions.get_extension_for_class(
             type(extension)


### PR DESCRIPTION
Follow-up to https://github.com/pyca/cryptography/pull/9661, part of https://github.com/pyca/cryptography/issues/9186.

This PR adds deprecation warnings for the following APIs:
- `x509.Certificate.not_valid_before`
- `x509.Certificate.not_valid_after`
- `x509.RevokedCertificate.revocation_date`
- `x509.CertificateRevocationList.next_update`
- `x509.CertificateRevocationList.last_update`

Now that their `_utc` variants exist, we can point users to switch to those instead. This PR adds the warnings, changes the tests so that warnings are expected, and changes the documentation to reflect the change and recommendation to switch.

Fixes https://github.com/pyca/cryptography/issues/9186