### PR TITLE
Backport fix for CVE-2023-23931 - Don't allow update_into mutate immutable objects

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/ciphers.py
+++ b/src/cryptography/hazmat/backends/openssl/ciphers.py
@@ -157,7 +157,7 @@ class _CipherContext:
         data_processed = 0
         total_out = 0
         outlen = self._backend._ffi.new("int *")
-        baseoutbuf = self._backend._ffi.from_buffer(buf)
+        baseoutbuf = self._backend._ffi.from_buffer(buf, require_writable=True)
         baseinbuf = self._backend._ffi.from_buffer(data)
 
         while data_processed != total_data_len:

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -318,6 +318,14 @@ class TestCipherUpdateInto:
         with pytest.raises(ValueError):
             encryptor.update_into(b"testing", buf)
 
+    def test_update_into_immutable(self, backend):
+        key = b"\x00" * 16
+        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        encryptor = c.encryptor()
+        buf = b"\x00" * 32
+        with pytest.raises((TypeError, BufferError)):
+            encryptor.update_into(b"testing", buf)
+
     @pytest.mark.supported(
         only_if=lambda backend: backend.cipher_supported(
             AES(b"\x00" * 16), modes.GCM(b"\x00" * 12)


### PR DESCRIPTION
This is a Backport from 39.0.1 for a fix of the CVE-2023-23931

- Don't allow update_into to mutate immutable objects
