### PR TITLE
Add support for ChaCha20 in LibreSSL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,9 @@ Changelog
   :meth:`~cryptography.x509.CertificateRevocationList.next_update`,
   :meth:`~cryptography.x509.CertificateRevocationList.last_update`
   in favor of the new timezone-aware variants mentioned above.
-
+* Added support for
+  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.ChaCha20`
+  on LibreSSL.
 
 .. _v41-0-4:
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -264,8 +264,14 @@ class Backend:
         self.register_cipher_adapter(
             TripleDES, ECB, GetCipherByName("des-ede3")
         )
+        # ChaCha20 uses the Short Name "chacha20" in OpenSSL, but in LibreSSL
+        # it uses "chacha"
         self.register_cipher_adapter(
-            ChaCha20, type(None), GetCipherByName("chacha20")
+            ChaCha20,
+            type(None),
+            GetCipherByName(
+                "chacha" if self._lib.CRYPTOGRAPHY_IS_LIBRESSL else "chacha20"
+            ),
         )
         self.register_cipher_adapter(AES, XTS, _get_xts_cipher)
         for mode_cls in [ECB, CBC, OFB, CFB, CTR]:


### PR DESCRIPTION
Replaces https://github.com/pyca/cryptography/pull/9209, since LibreSSL does have support for the EVP API for ChaCha20.