### PR TITLE
X.509: Add WebPKI SPKI AlgorithmIdentifiers

### DIFF
--- a/src/rust/cryptography-x509-validation/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-validation/src/policy/mod.rs
@@ -10,7 +10,7 @@ use asn1::ObjectIdentifier;
 use once_cell::sync::Lazy;
 
 use cryptography_x509::common::{
-    AlgorithmIdentifier, AlgorithmParameters, RsaPssParameters, PSS_SHA256_HASH_ALG,
+    AlgorithmIdentifier, AlgorithmParameters, EcParameters, RsaPssParameters, PSS_SHA256_HASH_ALG,
     PSS_SHA256_MASK_GEN_ALG, PSS_SHA384_HASH_ALG, PSS_SHA384_MASK_GEN_ALG, PSS_SHA512_HASH_ALG,
     PSS_SHA512_MASK_GEN_ALG,
 };
@@ -35,19 +35,19 @@ static SPKI_RSA: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
 // SECP256R1
 static SPKI_SECP256R1: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
     oid: asn1::DefinedByMarker::marker(),
-    params: AlgorithmParameters::EcNamedCurve(EC_SECP256R1),
+    params: AlgorithmParameters::Ec(EcParameters::NamedCurve(EC_SECP256R1)),
 };
 
 // SECP384R1
 static SPKI_SECP384R1: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
     oid: asn1::DefinedByMarker::marker(),
-    params: AlgorithmParameters::EcNamedCurve(EC_SECP384R1),
+    params: AlgorithmParameters::Ec(EcParameters::NamedCurve(EC_SECP384R1)),
 };
 
 // SECP521R1
 static SPKI_SECP521R1: AlgorithmIdentifier<'_> = AlgorithmIdentifier {
     oid: asn1::DefinedByMarker::marker(),
-    params: AlgorithmParameters::EcNamedCurve(EC_SECP521R1),
+    params: AlgorithmParameters::Ec(EcParameters::NamedCurve(EC_SECP521R1)),
 };
 
 /// Permitted algorithms, from CA/B Forum's Baseline Requirements, section 7.1.3.1 (page 96)

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -47,7 +47,7 @@ pub enum AlgorithmParameters<'a> {
 
     // These encodings are only used in SPKI AlgorithmIdentifiers.
     #[defined_by(oid::EC_OID)]
-    EcNamedCurve(asn1::ObjectIdentifier),
+    Ec(EcParameters<'a>),
 
     #[defined_by(oid::RSA_OID)]
     Rsa(Option<asn1::Null>),
@@ -287,6 +287,21 @@ pub const PSS_SHA512_MASK_GEN_ALG: MaskGenAlgorithm<'_> = MaskGenAlgorithm {
     oid: oid::MGF1_OID,
     params: PSS_SHA512_HASH_ALG,
 };
+
+// From RFC 5480 section 2.1.1:
+// ECParameters ::= CHOICE {
+//     namedCurve         OBJECT IDENTIFIER
+//     -- implicitCurve   NULL
+//     -- specifiedCurve  SpecifiedECDomain }
+//
+// Only the namedCurve form may appear in PKIX. Other forms may be found in
+// other PKIs.
+#[derive(asn1::Asn1Read, asn1::Asn1Write, Hash, Clone, PartialEq, Eq, Debug)]
+pub enum EcParameters<'a> {
+    NamedCurve(asn1::ObjectIdentifier),
+    ImplicitCurve(asn1::Null),
+    SpecifiedCurve(asn1::Tlv<'a>),
+}
 
 // From RFC 4055 section 3.1:
 // RSASSA-PSS-params  ::=  SEQUENCE  {

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -45,6 +45,13 @@ pub enum AlgorithmParameters<'a> {
     #[defined_by(oid::ED448_OID)]
     Ed448,
 
+    // These encodings are only used in SPKI AlgorithmIdentifiers.
+    #[defined_by(oid::EC_OID)]
+    EcNamedCurve(asn1::ObjectIdentifier),
+
+    #[defined_by(oid::RSA_OID)]
+    Rsa(Option<asn1::Null>),
+
     // These ECDSA algorithms should have no parameters,
     // but Java 11 (up to at least 11.0.19) encodes them
     // with NULL parameters. The JDK team is looking to

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -300,7 +300,7 @@ pub const PSS_SHA512_MASK_GEN_ALG: MaskGenAlgorithm<'_> = MaskGenAlgorithm {
 pub enum EcParameters<'a> {
     NamedCurve(asn1::ObjectIdentifier),
     ImplicitCurve(asn1::Null),
-    SpecifiedCurve(asn1::Tlv<'a>),
+    SpecifiedCurve(asn1::Sequence<'a>),
 }
 
 // From RFC 4055 section 3.1:

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -45,6 +45,13 @@ pub const INHIBIT_ANY_POLICY_OID: asn1::ObjectIdentifier = asn1::oid!(2, 5, 29, 
 pub const ACCEPTABLE_RESPONSES_OID: asn1::ObjectIdentifier =
     asn1::oid!(1, 3, 6, 1, 5, 5, 7, 48, 1, 4);
 
+// Public key identifiers
+pub const EC_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 2, 1);
+pub const EC_SECP256R1: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 3, 1, 7);
+pub const EC_SECP384R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 34);
+pub const EC_SECP521R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 35);
+pub const RSA_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 1, 1);
+
 // Signing methods
 pub const ECDSA_WITH_SHA224_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 4, 3, 1);
 pub const ECDSA_WITH_SHA256_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 4, 3, 2);


### PR DESCRIPTION
Similar to the AlgorithmIdentifiers listed for signatures (but with different contents).

I've added canonical encoding tests as well, to ensure that the encodings match the ones specified by CABF.

Refs: CABF 7.1.3.1 (Page 96): <https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-v2.0.0.pdf>

