### PR TITLE
fixed #9838 -- handle hashes with algorithm identifiers that have no …

### DIFF
--- a/src/rust/src/x509/ocsp.rs
+++ b/src/rust/src/x509/ocsp.rs
@@ -15,10 +15,15 @@ pub(crate) static ALGORITHM_PARAMETERS_TO_HASH: Lazy<
     HashMap<common::AlgorithmParameters<'_>, &str>,
 > = Lazy::new(|| {
     let mut h = HashMap::new();
+    h.insert(common::AlgorithmParameters::Sha1(None), "SHA1");
     h.insert(common::AlgorithmParameters::Sha1(Some(())), "SHA1");
+    h.insert(common::AlgorithmParameters::Sha224(None), "SHA224");
     h.insert(common::AlgorithmParameters::Sha224(Some(())), "SHA224");
+    h.insert(common::AlgorithmParameters::Sha256(None), "SHA256");
     h.insert(common::AlgorithmParameters::Sha256(Some(())), "SHA256");
+    h.insert(common::AlgorithmParameters::Sha384(None), "SHA384");
     h.insert(common::AlgorithmParameters::Sha384(Some(())), "SHA384");
+    h.insert(common::AlgorithmParameters::Sha512(None), "SHA512");
     h.insert(common::AlgorithmParameters::Sha512(Some(())), "SHA512");
     h
 });


### PR DESCRIPTION
…parameters in OCSP