### PR TITLE
Add support for `AES-GCM-SIV` using `OpenSSL>=3.2.0`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,9 @@ Changelog
 * In the next release (43.0.0) of cryptography, loading an X.509 certificate
   with a negative serial number will raise an exception. This has been
   deprecated since 36.0.0.
+* Added support for
+  :class:`~cryptography.hazmat.primitives.ciphers.aead.AESGCMSIV` when using
+  OpenSSL 3.2.0+.
 
 .. _v41-0-7:
 

--- a/docs/hazmat/primitives/aead.rst
+++ b/docs/hazmat/primitives/aead.rst
@@ -164,6 +164,79 @@ also support providing integrity for associated data which is not encrypted.
             when the ciphertext has been changed, but will also occur when the
             key, nonce, or associated data are wrong.
 
+.. class:: AESGCMSIV(key)
+
+    .. versionadded:: 42.0.0
+
+    The AES-GCM-SIV construction is defined in :rfc:`8452` and is composed of
+    the :class:`~cryptography.hazmat.primitives.ciphers.algorithms.AES` block
+    cipher utilizing Galois Counter Mode (GCM) and a synthetic initialization
+    vector (SIV).
+
+    :param key: A 128, 192, or 256-bit key. This **must** be kept secret.
+    :type key: :term:`bytes-like`
+
+    :raises cryptography.exceptions.UnsupportedAlgorithm: If the version of
+        OpenSSL does not support AES-GCM-SIV.
+
+    .. doctest::
+
+        >>> import os
+        >>> from cryptography.hazmat.primitives.ciphers.aead import AESGCMSIV
+        >>> data = b"a secret message"
+        >>> aad = b"authenticated but unencrypted data"
+        >>> key = AESGCMSIV.generate_key(bit_length=128)
+        >>> aesgcmsiv = AESGCMSIV(key)
+        >>> nonce = os.urandom(12)
+        >>> ct = aesgcmsiv.encrypt(nonce, data, aad)
+        >>> aesgcmsiv.decrypt(nonce, ct, aad)
+        b'a secret message'
+
+    .. classmethod:: generate_key(bit_length)
+
+        Securely generates a random AES-GCM-SIV key.
+
+        :param bit_length: The bit length of the key to generate. Must be
+            128, 192, or 256.
+
+        :returns bytes: The generated key.
+
+    .. method:: encrypt(nonce, data, associated_data)
+
+        Encrypts and authenticates the ``data`` provided as well as
+        authenticating the ``associated_data``.  The output of this can be
+        passed directly to the ``decrypt`` method.
+
+        :param nonce: A 12-byte value.
+        :type nonce: :term:`bytes-like`
+        :param data: The data to encrypt.
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data that should be
+            authenticated with the key, but is not encrypted. Can be ``None``.
+        :type associated_data: :term:`bytes-like`
+        :returns bytes: The ciphertext bytes with the 16 byte tag appended.
+        :raises OverflowError: If ``data`` or ``associated_data`` is larger
+            than 2\ :sup:`32` - 1 bytes.
+
+    .. method:: decrypt(nonce, data, associated_data)
+
+        Decrypts the ``data`` and authenticates the ``associated_data``. If you
+        called encrypt with ``associated_data`` you must pass the same
+        ``associated_data`` in decrypt or the integrity check will fail.
+
+        :param nonce: A 12-byte value.
+        :type nonce: :term:`bytes-like`
+        :param data: The data to decrypt (with tag appended).
+        :type data: :term:`bytes-like`
+        :param associated_data: Additional data to authenticate. Can be
+            ``None`` if none was passed during encryption.
+        :type associated_data: :term:`bytes-like`
+        :returns bytes: The original plaintext.
+        :raises cryptography.exceptions.InvalidTag: If the authentication tag
+            doesn't validate this exception will be raised. This will occur
+            when the ciphertext has been changed, but will also occur when the
+            key, nonce, or associated data are wrong.
+
 .. class:: AESOCB3(key)
 
     .. versionadded:: 36.0.0

--- a/src/cryptography/hazmat/bindings/_rust/openssl/aead.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/openssl/aead.pyi
@@ -33,3 +33,20 @@ class AESOCB3:
         data: bytes,
         associated_data: bytes | None,
     ) -> bytes: ...
+
+class AESGCMSIV:
+    def __init__(self, key: bytes) -> None: ...
+    @staticmethod
+    def generate_key(key_size: int) -> bytes: ...
+    def encrypt(
+        self,
+        nonce: bytes,
+        data: bytes,
+        associated_data: bytes | None,
+    ) -> bytes: ...
+    def decrypt(
+        self,
+        nonce: bytes,
+        data: bytes,
+        associated_data: bytes | None,
+    ) -> bytes: ...

--- a/src/cryptography/hazmat/primitives/ciphers/aead.py
+++ b/src/cryptography/hazmat/primitives/ciphers/aead.py
@@ -16,12 +16,14 @@ __all__ = [
     "ChaCha20Poly1305",
     "AESCCM",
     "AESGCM",
+    "AESGCMSIV",
     "AESOCB3",
     "AESSIV",
 ]
 
 AESSIV = rust_openssl.aead.AESSIV
 AESOCB3 = rust_openssl.aead.AESOCB3
+AESGCMSIV = rust_openssl.aead.AESGCMSIV
 
 
 class ChaCha20Poly1305:

--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -12,6 +12,9 @@ fn main() {
         if version >= 0x3_00_00_00_0 {
             println!("cargo:rustc-cfg=CRYPTOGRAPHY_OPENSSL_300_OR_GREATER");
         }
+        if version >= 0x3_02_00_00_0 {
+            println!("cargo:rustc-cfg=CRYPTOGRAPHY_OPENSSL_320_OR_GREATER");
+        }
     }
 
     if let Ok(version) = env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER") {


### PR DESCRIPTION
OpenSSL 3.2.0 has added support for AES-GCM-SIV ([issue](https://github.com/openssl/openssl/issues/16721), [PR](https://github.com/openssl/openssl/pull/18693)). It is defined in [RFC 8452](https://datatracker.ietf.org/doc/html/rfc8452).

This PR adds support for it through the Rust bindings. The implementation is based on already existing AEADs, but adapted to the specifics of AES-GCM-SIV.

The test vectors are from OpenSSL ([source](https://github.com/openssl/openssl/blob/a2b1ab6100d5f0fb50b61d241471eea087415632/test/recipes/30-test_evp_data/evpciph_aes_gcm_siv.txt))

This PR is part of https://github.com/pyca/cryptography/issues/9795.