### PR TITLE
src, tests: add max_chain_depth to validation API

### DIFF
--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -89,6 +89,20 @@ chain building, etc.
 
         :returns: A new instance of :class:`PolicyBuilder`
 
+    .. method:: max_chain_depth(new_max_chain_depth)
+
+        Sets the verifier's maximum chain building depth.
+
+        This depth behaves tracks the length of the intermediate CA
+        chain: a maximum depth of zero means that the leaf must be directly
+        issued by a member of the store, a depth of one means no more than
+        one intermediate CA, and so forth. Note that self-issued intermediates
+        don't count against the chain depth, per RFC 5280.
+
+        :param new_max_chain_depth: The maximum depth to allow in the verifier
+
+        :returns: A new instance of :class:`PolicyBuilder`
+
     .. method:: build_server_verifier(subject)
 
         Builds a verifier for verifying server certificates.

--- a/src/cryptography/hazmat/bindings/_rust/x509.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/x509.pyi
@@ -41,6 +41,7 @@ def create_server_verifier(
     name: x509.verification.Subject,
     store: Store,
     time: datetime.datetime | None,
+    max_chain_depth: int | None,
 ) -> x509.verification.ServerVerifier: ...
 
 class Sct: ...
@@ -56,6 +57,8 @@ class ServerVerifier:
     def validation_time(self) -> datetime.datetime: ...
     @property
     def store(self) -> Store: ...
+    @property
+    def max_chain_depth(self) -> int: ...
     def verify(
         self,
         leaf: x509.Certificate,

--- a/src/cryptography/x509/verification.py
+++ b/src/cryptography/x509/verification.py
@@ -25,9 +25,11 @@ class PolicyBuilder:
         *,
         time: datetime.datetime | None = None,
         store: Store | None = None,
+        max_chain_depth: int | None = None,
     ):
         self._time = time
         self._store = store
+        self._max_chain_depth = max_chain_depth
 
     def time(self, new_time: datetime.datetime) -> PolicyBuilder:
         """
@@ -48,6 +50,20 @@ class PolicyBuilder:
 
         return PolicyBuilder(time=self._time, store=new_store)
 
+    def max_chain_depth(self, new_max_chain_depth: int) -> PolicyBuilder:
+        """
+        Sets the maximum chain depth.
+        """
+
+        if self._max_chain_depth is not None:
+            raise ValueError("The maximum chain depth may only be set once.")
+
+        return PolicyBuilder(
+            time=self._time,
+            store=self._store,
+            max_chain_depth=new_max_chain_depth,
+        )
+
     def build_server_verifier(self, subject: Subject) -> ServerVerifier:
         """
         Builds a verifier for verifying server certificates.
@@ -60,4 +76,5 @@ class PolicyBuilder:
             subject,
             self._store,
             self._time,
+            self._max_chain_depth,
         )

--- a/src/rust/cryptography-x509-validation/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-validation/src/policy/extension.rs
@@ -236,7 +236,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(ops, None, epoch(), None);
 
         // Test a policy that stipulates that a given extension MUST be present.
         let extension_policy = ExtensionPolicy::present(
@@ -280,7 +280,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(ops, None, epoch(), None);
 
         // Test a policy that stipulates that a given extension CAN be present.
         let extension_policy = ExtensionPolicy::maybe_present(
@@ -316,7 +316,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(ops, None, epoch(), None);
 
         // Test a policy that stipulates that a given extension MUST NOT be present.
         let extension_policy = ExtensionPolicy::not_present(BASIC_CONSTRAINTS_OID);
@@ -348,7 +348,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(ops, None, epoch(), None);
 
         // Test a present policy that stipulates that a given extension MUST be critical.
         let extension_policy = ExtensionPolicy::present(
@@ -376,7 +376,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = NullOps {};
-        let policy = Policy::new(ops, None, epoch());
+        let policy = Policy::new(ops, None, epoch(), None);
 
         // Test a maybe present policy that stipulates that a given extension MUST be critical.
         let extension_policy = ExtensionPolicy::maybe_present(

--- a/src/rust/cryptography-x509-validation/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-validation/src/policy/mod.rs
@@ -230,10 +230,15 @@ pub struct Policy<'a, B: CryptoOps> {
 impl<'a, B: CryptoOps> Policy<'a, B> {
     /// Create a new policy with defaults for the certificate profile defined in
     /// the CA/B Forum's Basic Requirements.
-    pub fn new(ops: B, subject: Option<Subject<'a>>, time: asn1::DateTime) -> Self {
+    pub fn new(
+        ops: B,
+        subject: Option<Subject<'a>>,
+        time: asn1::DateTime,
+        max_chain_depth: Option<u8>,
+    ) -> Self {
         Self {
             _ops: ops,
-            max_chain_depth: 8,
+            max_chain_depth: max_chain_depth.unwrap_or(8),
             subject,
             validation_time: time,
             extended_key_usage: EKU_SERVER_AUTH_OID.clone(),
@@ -383,7 +388,7 @@ mod tests {
     #[test]
     fn test_policy_critical_extensions() {
         let time = asn1::DateTime::new(2023, 9, 12, 1, 1, 1).unwrap();
-        let policy = Policy::new(NullOps {}, None, time);
+        let policy = Policy::new(NullOps {}, None, time, None);
 
         assert_eq!(
             policy.critical_ca_extensions,

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -8,6 +8,7 @@ use cryptography_x509_validation::{
     policy::{Policy, Subject},
     types::{DNSName, IPAddress},
 };
+use pyo3::IntoPy;
 
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::types;
@@ -93,6 +94,11 @@ impl PyServerVerifier {
         datetime_to_py(py, &self.as_policy().validation_time)
     }
 
+    #[getter]
+    fn max_chain_depth(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject> {
+        Ok(self.as_policy().max_chain_depth.into_py(py))
+    }
+
     fn verify<'p>(
         &self,
         _py: pyo3::Python<'p>,
@@ -155,10 +161,15 @@ fn create_server_verifier(
     subject: pyo3::Py<pyo3::PyAny>,
     store: pyo3::Py<PyStore>,
     time: Option<&pyo3::PyAny>,
+    max_chain_depth: Option<&pyo3::types::PyInt>,
 ) -> pyo3::PyResult<PyServerVerifier> {
     let time = match time {
         Some(time) => py_to_datetime(py, time)?,
         None => datetime_now(py)?,
+    };
+    let max_chain_depth: Option<u8> = match max_chain_depth {
+        Some(max_chain_depth) => max_chain_depth.extract()?,
+        None => None,
     };
 
     let subject_owner = build_subject_owner(py, &subject)?;
@@ -168,6 +179,7 @@ fn create_server_verifier(
             PyCryptoOps {},
             subject,
             time,
+            max_chain_depth,
         )))
     })?;
 

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -161,15 +161,11 @@ fn create_server_verifier(
     subject: pyo3::Py<pyo3::PyAny>,
     store: pyo3::Py<PyStore>,
     time: Option<&pyo3::PyAny>,
-    max_chain_depth: Option<&pyo3::types::PyInt>,
+    max_chain_depth: Option<u8>,
 ) -> pyo3::PyResult<PyServerVerifier> {
     let time = match time {
         Some(time) => py_to_datetime(py, time)?,
         None => datetime_now(py)?,
-    };
-    let max_chain_depth: Option<u8> = match max_chain_depth {
-        Some(max_chain_depth) => max_chain_depth.extract()?,
-        None => None,
     };
 
     let subject_owner = build_subject_owner(py, &subject)?;

--- a/tests/x509/test_verification.py
+++ b/tests/x509/test_verification.py
@@ -35,6 +35,10 @@ class TestPolicyBuilder:
         with pytest.raises(ValueError):
             PolicyBuilder().store(dummy_store()).store(dummy_store())
 
+    def test_max_chain_depth_already_set(self):
+        with pytest.raises(ValueError):
+            PolicyBuilder().max_chain_depth(8).max_chain_depth(9)
+
     def test_ipaddress_subject(self):
         policy = (
             PolicyBuilder()
@@ -71,15 +75,18 @@ class TestPolicyBuilder:
     def test_builder_pattern(self):
         now = datetime.datetime.now().replace(microsecond=0)
         store = dummy_store()
+        max_chain_depth = 16
 
         builder = PolicyBuilder()
         builder = builder.time(now)
         builder = builder.store(store)
+        builder = builder.max_chain_depth(max_chain_depth)
 
         verifier = builder.build_server_verifier(DNSName("cryptography.io"))
         assert verifier.subject == DNSName("cryptography.io")
         assert verifier.validation_time == now
         assert verifier.store == store
+        assert verifier.max_chain_depth == max_chain_depth
 
     def test_build_server_verifier_missing_store(self):
         with pytest.raises(


### PR DESCRIPTION
This adds `max_chain_depth` to the Python API, and plumbs it through to the equivalent (previously invariant) setting on the Rust API. It's needed to get the last bit of coverage on #8873, since we'd otherwise be unable to exercise the corresponding Limbo testcases from Python.

Breakout from #8873.