### PR TITLE
verification: add missing max_chain_depth kwargs

### DIFF
--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -57,6 +57,12 @@ chain building, etc.
 
         The verifier's validation time.
 
+    .. attribute:: max_chain_depth
+
+        :type: :class:`int`
+
+        The verifier's maximum intermediate CA chain depth.
+
     .. attribute:: store
 
         :type: :class:`Store`

--- a/src/cryptography/x509/verification.py
+++ b/src/cryptography/x509/verification.py
@@ -38,7 +38,11 @@ class PolicyBuilder:
         if self._time is not None:
             raise ValueError("The validation time may only be set once.")
 
-        return PolicyBuilder(time=new_time, store=self._store)
+        return PolicyBuilder(
+            time=new_time,
+            store=self._store,
+            max_chain_depth=self._max_chain_depth,
+        )
 
     def store(self, new_store: Store) -> PolicyBuilder:
         """
@@ -48,7 +52,11 @@ class PolicyBuilder:
         if self._store is not None:
             raise ValueError("The trust store may only be set once.")
 
-        return PolicyBuilder(time=self._time, store=new_store)
+        return PolicyBuilder(
+            time=self._time,
+            store=new_store,
+            max_chain_depth=self._max_chain_depth,
+        )
 
     def max_chain_depth(self, new_max_chain_depth: int) -> PolicyBuilder:
         """


### PR DESCRIPTION
Missed these on the original PR.

Also, adds a doc element for `ServerVerifier.max_chain_depth`.