### PR TITLE
Raise an exception if a tag is provided 2x:

### DIFF
--- a/src/cryptography/hazmat/primitives/ciphers/base.py
+++ b/src/cryptography/hazmat/primitives/ciphers/base.py
@@ -250,6 +250,11 @@ class _AEADDecryptionContext(_AEADCipherContext, AEADDecryptionContext):
     def finalize_with_tag(self, tag: bytes) -> bytes:
         if self._ctx is None:
             raise AlreadyFinalized("Context was already finalized.")
+        if self._ctx._tag is not None:
+            raise ValueError(
+                "tag provided both in mode and in call with finalize_with_tag:"
+                " tag should only be provided once"
+            )
         data = self._ctx.finalize_with_tag(tag)
         self._tag = self._ctx.tag
         self._ctx = None

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -290,6 +290,21 @@ class TestCipherUpdateInto:
         with pytest.raises(AlreadyFinalized):
             decryptor.finalize_with_tag(encryptor.tag)
 
+    @pytest.mark.supported(
+        only_if=lambda backend: backend.cipher_supported(
+            AES(b"\x00" * 16), modes.GCM(b"0" * 12)
+        ),
+        skip_message="Does not support AES GCM",
+    )
+    def test_finalize_with_tag_duplicate_tag(self, backend):
+        decryptor = ciphers.Cipher(
+            AES(b"\x00" * 16),
+            modes.GCM(b"\x00" * 12, tag=b"\x00" * 16),
+            backend,
+        ).decryptor()
+        with pytest.raises(ValueError):
+            decryptor.finalize_with_tag(b"\x00" * 16)
+
     @pytest.mark.parametrize(
         "params",
         load_vectors_from_file(


### PR DESCRIPTION
Once in GCM() and a second time via finalize_with_tag

refs https://github.com/pyca/cryptography/pull/9859