### PR TITLE
Fix transposed doc, simplify type in trust store test

### DIFF
--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -69,6 +69,20 @@ chain building, etc.
 
         The verifier's trust store.
 
+    .. method:: verify(leaf, intermediates)
+
+        Performs path validation on ``leaf``, returning a valid path
+        if one exists. The path is returned in leaf-first order:
+        the first member is ``leaf``, followed by the intermediates used
+        (if any), followed by a member of the ``store``.
+
+        :param leaf: The leaf :class:`~cryptography.x509.Certificate` to validate
+        :param intermediates: A :class:`list` of intermediate :class:`~cryptography.x509.Certificate` to attempt to use
+
+        :returns: A list containing a valid chain from ``leaf`` to a member of :class:`ServerVerifier.store`.
+
+        :raises VerificationError: If a valid chain cannot be constructed
+
 .. class:: VerificationError
 
     .. versionadded:: 42.0.0
@@ -122,17 +136,3 @@ chain building, etc.
         :param subject: A :class:`Subject` to use in the verifier
 
         :returns: An instance of :class:`ServerVerifier`
-
-    .. method:: verify(leaf, intermediates)
-
-        Performs path validation on ``leaf``, returning a valid path
-        if one exists. The path is returned in leaf-first order:
-        the first member is ``leaf``, followed by the intermediates used
-        (if any), followed by a member of the ``store``.
-
-        :param leaf: The leaf :class:`~cryptography.x509.Certificate` to validate
-        :param intermediates: A :class:`list` of intermediate :class:`~cryptography.x509.Certificate` to attempt to use
-
-        :returns: A list containing a valid chain from ``leaf`` to a member of :class:`ServerVerifier.store`.
-
-        :raises VerificationError: If a valid chain cannot be constructed

--- a/src/rust/cryptography-x509-validation/src/trust_store.rs
+++ b/src/rust/cryptography-x509-validation/src/trust_store.rs
@@ -39,6 +39,6 @@ mod tests {
         let store = Store::new([cert.clone()]);
 
         assert!(store.contains(&cert));
-        assert!(store.iter().collect::<Vec<_>>() == Vec::from([&cert]));
+        assert!(store.iter().collect::<Vec<_>>() == [&cert]);
     }
 }


### PR DESCRIPTION
More breakouts from #8873.

(Sorry about the transposed doc, that was my accident in #9873.)