### PR TITLE
validation: flatten error types

### DIFF
--- a/src/rust/cryptography-x509-validation/src/lib.rs
+++ b/src/rust/cryptography-x509-validation/src/lib.rs
@@ -10,3 +10,14 @@ pub mod ops;
 pub mod policy;
 pub mod trust_store;
 pub mod types;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ValidationError {
+    Other(String),
+}
+
+impl From<&str> for ValidationError {
+    fn from(value: &str) -> Self {
+        Self::Other(value.into())
+    }
+}

--- a/src/rust/cryptography-x509-validation/src/lib.rs
+++ b/src/rust/cryptography-x509-validation/src/lib.rs
@@ -11,7 +11,6 @@ pub mod policy;
 pub mod trust_store;
 pub mod types;
 
-#[derive(Debug, PartialEq, Eq)]
 pub enum ValidationError {
     Other(&'static str),
 }

--- a/src/rust/cryptography-x509-validation/src/lib.rs
+++ b/src/rust/cryptography-x509-validation/src/lib.rs
@@ -13,11 +13,5 @@ pub mod types;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ValidationError {
-    Other(String),
-}
-
-impl From<&str> for ValidationError {
-    fn from(value: &str) -> Self {
-        Self::Other(value.into())
-    }
+    Other(&'static str),
 }

--- a/src/rust/cryptography-x509-validation/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-validation/src/policy/extension.rs
@@ -8,9 +8,9 @@ use cryptography_x509::{
     extensions::{Extension, Extensions},
 };
 
-use crate::ops::CryptoOps;
+use crate::{ops::CryptoOps, ValidationError};
 
-use super::{Policy, PolicyError};
+use super::Policy;
 
 // TODO: Remove `dead_code` attributes once we start using these helpers.
 
@@ -40,11 +40,11 @@ impl Criticality {
 
 #[allow(dead_code)]
 type PresentExtensionValidatorCallback<B> =
-    fn(&Policy<'_, B>, &Certificate<'_>, &Extension<'_>) -> Result<(), PolicyError>;
+    fn(&Policy<'_, B>, &Certificate<'_>, &Extension<'_>) -> Result<(), ValidationError>;
 
 #[allow(dead_code)]
 type MaybeExtensionValidatorCallback<B> =
-    fn(&Policy<'_, B>, &Certificate<'_>, Option<&Extension<'_>>) -> Result<(), PolicyError>;
+    fn(&Policy<'_, B>, &Certificate<'_>, Option<&Extension<'_>>) -> Result<(), ValidationError>;
 
 /// Represents different validation states for an extension.
 #[allow(dead_code)]
@@ -117,18 +117,18 @@ impl<B: CryptoOps> ExtensionPolicy<B> {
         policy: &Policy<'_, B>,
         cert: &Certificate<'_>,
         extensions: &Extensions<'_>,
-    ) -> Result<(), PolicyError> {
+    ) -> Result<(), ValidationError> {
         match (&self.validator, extensions.get_extension(&self.oid)) {
             // Extension MUST NOT be present and isn't; OK.
             (ExtensionValidator::NotPresent, None) => Ok(()),
             // Extension MUST NOT be present but is; NOT OK.
-            (ExtensionValidator::NotPresent, Some(_)) => Err(PolicyError::Other(
-                "EE certificate contains prohibited extension",
-            )),
+            (ExtensionValidator::NotPresent, Some(_)) => {
+                Err("EE certificate contains prohibited extension".into())
+            }
             // Extension MUST be present but is not; NOT OK.
-            (ExtensionValidator::Present { .. }, None) => Err(PolicyError::Other(
-                "EE certificate is missing required extension",
-            )),
+            (ExtensionValidator::Present { .. }, None) => {
+                Err("EE certificate is missing required extension".into())
+            }
             // Extension MUST be present and is; check it.
             (
                 ExtensionValidator::Present {
@@ -138,9 +138,7 @@ impl<B: CryptoOps> ExtensionPolicy<B> {
                 Some(extn),
             ) => {
                 if !criticality.permits(extn.critical) {
-                    return Err(PolicyError::Other(
-                        "EE certificate extension has incorrect criticality",
-                    ));
+                    return Err("EE certificate extension has incorrect criticality".into());
                 }
 
                 // If a custom validator is supplied, apply it.
@@ -159,9 +157,7 @@ impl<B: CryptoOps> ExtensionPolicy<B> {
                     .as_ref()
                     .map_or(false, |extn| !criticality.permits(extn.critical))
                 {
-                    return Err(PolicyError::Other(
-                        "EE certificate extension has incorrect criticality",
-                    ));
+                    return Err("EE certificate extension has incorrect criticality".into());
                 }
 
                 // If a custom validator is supplied, apply it.
@@ -176,8 +172,9 @@ mod tests {
     use super::{Criticality, ExtensionPolicy};
     use crate::ops::tests::{cert, v1_cert_pem, NullOps};
     use crate::ops::CryptoOps;
-    use crate::policy::{Policy, PolicyError, Subject};
+    use crate::policy::{Policy, Subject};
     use crate::types::DNSName;
+    use crate::ValidationError;
     use asn1::{ObjectIdentifier, SimpleAsn1Writable};
     use cryptography_x509::certificate::Certificate;
     use cryptography_x509::extensions::{BasicConstraints, Extension, Extensions};
@@ -227,7 +224,7 @@ mod tests {
         _policy: &Policy<'_, B>,
         _cert: &Certificate<'_>,
         _ext: &Extension<'_>,
-    ) -> Result<(), PolicyError> {
+    ) -> Result<(), ValidationError> {
         Ok(())
     }
 
@@ -276,7 +273,7 @@ mod tests {
         _policy: &Policy<'_, B>,
         _cert: &Certificate<'_>,
         _ext: Option<&Extension<'_>>,
-    ) -> Result<(), PolicyError> {
+    ) -> Result<(), ValidationError> {
         Ok(())
     }
 

--- a/src/rust/cryptography-x509-validation/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-validation/src/policy/extension.rs
@@ -122,13 +122,13 @@ impl<B: CryptoOps> ExtensionPolicy<B> {
             // Extension MUST NOT be present and isn't; OK.
             (ExtensionValidator::NotPresent, None) => Ok(()),
             // Extension MUST NOT be present but is; NOT OK.
-            (ExtensionValidator::NotPresent, Some(_)) => {
-                Err("EE certificate contains prohibited extension".into())
-            }
+            (ExtensionValidator::NotPresent, Some(_)) => Err(ValidationError::Other(
+                "EE certificate contains prohibited extension",
+            )),
             // Extension MUST be present but is not; NOT OK.
-            (ExtensionValidator::Present { .. }, None) => {
-                Err("EE certificate is missing required extension".into())
-            }
+            (ExtensionValidator::Present { .. }, None) => Err(ValidationError::Other(
+                "EE certificate is missing required extension",
+            )),
             // Extension MUST be present and is; check it.
             (
                 ExtensionValidator::Present {
@@ -138,7 +138,9 @@ impl<B: CryptoOps> ExtensionPolicy<B> {
                 Some(extn),
             ) => {
                 if !criticality.permits(extn.critical) {
-                    return Err("EE certificate extension has incorrect criticality".into());
+                    return Err(ValidationError::Other(
+                        "EE certificate extension has incorrect criticality",
+                    ));
                 }
 
                 // If a custom validator is supplied, apply it.
@@ -157,7 +159,9 @@ impl<B: CryptoOps> ExtensionPolicy<B> {
                     .as_ref()
                     .map_or(false, |extn| !criticality.permits(extn.critical))
                 {
-                    return Err("EE certificate extension has incorrect criticality".into());
+                    return Err(ValidationError::Other(
+                        "EE certificate extension has incorrect criticality",
+                    ));
                 }
 
                 // If a custom validator is supplied, apply it.

--- a/src/rust/cryptography-x509-validation/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-validation/src/policy/mod.rs
@@ -151,10 +151,6 @@ pub static WEBPKI_PERMITTED_SIGNATURE_ALGORITHMS: Lazy<HashSet<&AlgorithmIdentif
 /// necessary.
 const DEFAULT_MAX_CHAIN_DEPTH: u8 = 8;
 
-pub enum PolicyError {
-    Other(&'static str),
-}
-
 /// Represents a logical certificate "subject," i.e. a principal matching
 /// one of the names listed in a certificate's `subjectAltNames` extension.
 pub enum Subject<'a> {


### PR DESCRIPTION
Breakout from #8873: this removes `PolicyError` in favor of the top-level `ValidationError`, which in turn allows us to get rid of a layer of error types.

(These changes don't look like much here, but they end up saving a few dozen lines in #8873.)