### PR TITLE
Add top-level permissions to pypi

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,6 +18,9 @@ on:
 env:
   PUBLISH_REQUIREMENTS_PATH: .github/requirements/publish-requirements.txt
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
which are then overridden by the one job. the various bots like this better