### PR TITLE
raise an exception instead of returning an empty list for pkcs7 cert loading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changelog
   :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_pem_pkcs7_certificates`
   or
   :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_der_pkcs7_certificates`
-  will now raise an exception rather than return an empty list.
+  will now raise a ``ValueError`` rather than return an empty list.
 * Parsing SSH certificates no longer permits malformed critical options with
   values, as documented in the 41.0.2 release notes.
 * Updated the minimum supported Rust version (MSRV) to 1.63.0, from 1.56.0.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Changelog
 .. note:: This version is not yet released and is under active development.
 
 * **BACKWARDS INCOMPATIBLE:** Dropped support for LibreSSL < 3.7.
+* **BACKWARDS INCOMPATIBLE:** Loading a PKCS7 with no content field using
+  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_pem_pkcs7_certificates`
+  or
+  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_der_pkcs7_certificates`
+  will now raise an exception rather than return an empty list.
 * Parsing SSH certificates no longer permits malformed critical options with
   values, as documented in the 41.0.2 release notes.
 * Updated the minimum supported Rust version (MSRV) to 1.63.0, from 1.56.0.

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1111,12 +1111,15 @@ class Backend:
                 _Reasons.UNSUPPORTED_SERIALIZATION,
             )
 
-        certs: list[x509.Certificate] = []
         if p7.d.sign == self._ffi.NULL:
-            return certs
+            raise ValueError(
+                "The provided PKCS7 has no certificate data, but a cert "
+                "loading method was called."
+            )
 
         sk_x509 = p7.d.sign.cert
         num = self._lib.sk_X509_num(sk_x509)
+        certs: list[x509.Certificate] = []
         for i in range(num):
             x509 = self._lib.sk_X509_value(sk_x509, i)
             self.openssl_assert(x509 != self._ffi.NULL)

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -92,8 +92,8 @@ class TestPKCS7Loading:
     def test_load_pkcs7_empty_certificates(self):
         der = b"\x30\x0B\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x07\x02"
 
-        certificates = pkcs7.load_der_pkcs7_certificates(der)
-        assert certificates == []
+        with pytest.raises(ValueError):
+            pkcs7.load_der_pkcs7_certificates(der)
 
 
 # We have no public verification API and won't be adding one until we get


### PR DESCRIPTION
as davidben points out in #9926 we are calling a load certificates function and an empty value doesn't necessarily mean empty because PKCS7 contains multitudes. erroring is more correct.