### PR TITLE
we'll ship 3.2.0 for 42

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -17,5 +17,5 @@ runs:
       shell: bash
     - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8  # v2.7.1
       with:
-        key: ${{ steps.normalized-key.outputs.key }}
+        key: ${{ steps.normalized-key.outputs.key }}-1
         workspaces: "./src/rust/ -> target"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changelog
   will now raise a ``ValueError`` rather than return an empty list.
 * Parsing SSH certificates no longer permits malformed critical options with
   values, as documented in the 41.0.2 release notes.
+* Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.2.0.
 * Updated the minimum supported Rust version (MSRV) to 1.63.0, from 1.56.0.
 * We now publish both ``py37`` and ``py39`` ``abi3`` wheels. This should
   resolve some errors relating to initializing a module multiple times per


### PR DESCRIPTION
but we won't be merging the infra PR until we know we don't need to do another 41.0.x