### PR TITLE
#9975 Add info to setup the dev env for TDD.

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -50,13 +50,13 @@ Running tests for TDD
 
 .. warning::
 
-    When not using `nox`, it's easy to screw up the build system,
+    When not using ``nox``, it's easy to screw up the build system,
     Failing to rebuild any extension module will get you confusing
     and inconsistent results.
-    When in doubt, fallback to using `nox`.
+    When in doubt, fallback to using ``nox``.
 
 For TDD you might want to speed up the test run cycle.
-After activating your virtualenv, install the dev requirements
+After activating your ``virtualenv``, install the development requirements
 and then install the project in edit mode.
 
 .. code-block:: console

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -17,12 +17,31 @@ installed with ``pip``.
     $ # Specify your Python version here.
     $ nox -e tests -p py310
 
+
+Rust dependencies on Linux
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here are the notes for Ubuntu.
+I hope they help and you can adapt them to your OS.
+Make sure to have the following packages installed, for OpenSSL development::
+
+    apt install pkgconf libssl-dev
+
+The easies way to get a working `rust` dev environment is via https://rustup.rs
+and have it installed in your home directory.
+
+After `rustup` is installed, you can install the optional rust dev tools::
+
+    rustup component add llvm-tools
+
+
 OpenSSL on macOS
 ~~~~~~~~~~~~~~~~
 
 You must have installed `OpenSSL`_ (via `Homebrew`_ , `MacPorts`_, or a custom
 build) and must configure the build `as documented here`_ before calling
 ``nox`` or else pip will fail to compile.
+
 
 Running tests
 -------------
@@ -43,6 +62,27 @@ You can also specify a subset of tests to run as positional arguments:
 
     $ # run the whole x509 testsuite, plus the fernet tests
     $ nox -e tests -p py310 -- tests/x509/ tests/test_fernet.py
+
+For TDD you might want to speed up the test run cycle.
+After activating your virtualenv, install the dev requirements
+and then install the project in edit mode.
+
+.. code-block:: console
+
+    $ pip install -e vectors/
+    $ pip install -e .[ssh,test,test-randomorder]
+
+If you are changing the OpenSSL bindings from `src/_cffi_src` you will need
+to rebuild the rust OpenSSL bindings.
+The easiest method is to just reinstall in edit mode.
+
+.. code-block:: console
+
+    $ # Re-build the binding and other extensions.
+    $ pip install -e .
+    $ # Then re-run the tests.
+    $ pytest tests/hazmat/bindings/
+
 
 Building documentation
 ----------------------

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -4,6 +4,7 @@ Getting started
 Development dependencies
 ------------------------
 
+Start by reading the installation documentation.
 Working on ``cryptography`` requires the installation of a small number of
 development dependencies in addition to the dependencies for
 :doc:`/installation`. These are handled by the use of ``nox``, which can be
@@ -17,31 +18,12 @@ installed with ``pip``.
     $ # Specify your Python version here.
     $ nox -e tests -p py310
 
-
-Rust dependencies on Linux
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Here are the notes for Ubuntu.
-I hope they help and you can adapt them to your OS.
-Make sure to have the following packages installed, for OpenSSL development::
-
-    apt install pkgconf libssl-dev
-
-The easies way to get a working `rust` dev environment is via https://rustup.rs
-and have it installed in your home directory.
-
-After `rustup` is installed, you can install the optional rust dev tools::
-
-    rustup component add llvm-tools
-
-
 OpenSSL on macOS
 ~~~~~~~~~~~~~~~~
 
 You must have installed `OpenSSL`_ (via `Homebrew`_ , `MacPorts`_, or a custom
 build) and must configure the build `as documented here`_ before calling
 ``nox`` or else pip will fail to compile.
-
 
 Running tests
 -------------
@@ -62,6 +44,17 @@ You can also specify a subset of tests to run as positional arguments:
 
     $ # run the whole x509 testsuite, plus the fernet tests
     $ nox -e tests -p py310 -- tests/x509/ tests/test_fernet.py
+
+
+Running tests for TDD
+~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+    When not using `nox`, it's easy to screw up the build system,
+    Failing to rebuild any extension module will get you confusing
+    and inconsistent results.
+    When in doubt, fallback to using `nox`.
 
 For TDD you might want to speed up the test run cycle.
 After activating your virtualenv, install the dev requirements

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -98,10 +98,11 @@ for the OpenSSL and ``libffi`` libraries available on your system.
 On all Linux distributions you will need to have :ref:`Rust installed and
 available<installation:Rust>`.
 
-The easies way to get a working `rust` is via `rustup <https://rustup.rs>`_
+The easiest way to get a working `rust` is via `rustup <https://rustup.rs>`_
 and have it installed in your home directory.
 
-After `rustup` is installed, you can install the optional rust dev tools::
+After `rustup` is installed, you can install the optional rust
+development tools::
 
     rustup component add llvm-tools
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -98,6 +98,14 @@ for the OpenSSL and ``libffi`` libraries available on your system.
 On all Linux distributions you will need to have :ref:`Rust installed and
 available<installation:Rust>`.
 
+The easies way to get a working `rust` is via `rustup <https://rustup.rs>`_
+and have it installed in your home directory.
+
+After `rustup` is installed, you can install the optional rust dev tools::
+
+    rustup component add llvm-tools
+
+
 Alpine
 ~~~~~~
 


### PR DESCRIPTION
Fixes #9975 

These are some notes that I took while trying to get my first patch 

I think that it helps to mention rustup, so that people will not have to mess with `rust` package from their OS... the Ubuntu one is not great.

Also, doing TDD via nox, is very slow. So I added a few notes about running in edit mode.