### PR TITLE
Update development docs

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -20,9 +20,8 @@ installed with ``pip``.
 OpenSSL on macOS
 ~~~~~~~~~~~~~~~~
 
-You must have installed `OpenSSL`_ (via `Homebrew`_ , `MacPorts`_, or a custom
-build) and must configure the build `as documented here`_ before calling
-``nox`` or else pip will fail to compile.
+You must have installed `OpenSSL`_ (via `Homebrew`_ , `MacPorts`_) before
+invoking ``nox`` or else pip will fail to compile.
 
 Running tests
 -------------
@@ -44,22 +43,6 @@ You can also specify a subset of tests to run as positional arguments:
     $ # run the whole x509 testsuite, plus the fernet tests
     $ nox -e tests -p py310 -- tests/x509/ tests/test_fernet.py
 
-Building documentation
-----------------------
-
-``cryptography`` documentation is stored in the ``docs/`` directory. It is
-written in `reStructured Text`_ and rendered using `Sphinx`_.
-
-Use `nox`_ to build the documentation. For example:
-
-.. code-block:: console
-
-    $ nox -e docs
-    ...
-    nox > Session docs was successful.
-
-The HTML documentation index can now be found at
-``docs/_build/html/index.html``.
 
 .. _`Homebrew`: https://brew.sh
 .. _`MacPorts`: https://www.macports.org
@@ -68,6 +51,4 @@ The HTML documentation index can now be found at
 .. _`nox`: https://pypi.org/project/nox/
 .. _`virtualenv`: https://pypi.org/project/virtualenv/
 .. _`pip`: https://pypi.org/project/pip/
-.. _`sphinx`: https://pypi.org/project/Sphinx/
-.. _`reStructured Text`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _`as documented here`: https://docs.rs/openssl/latest/openssl/#automatic


### PR DESCRIPTION
- No special configuration is required for brew or macports OpenSSL anymore
- There's no point in documenting building local docs, it's basically never necessary