### PR TITLE
#9969 Expose SSL_session_reused.

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -142,6 +142,7 @@ FUNCTIONS = """
 const char *SSL_state_string_long(const SSL *);
 SSL_SESSION *SSL_get1_session(SSL *);
 int SSL_set_session(SSL *, SSL_SESSION *);
+int SSL_session_reused(const SSL *ssl);
 SSL *SSL_new(SSL_CTX *);
 void SSL_free(SSL *);
 int SSL_set_fd(SSL *, int);

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -142,7 +142,7 @@ FUNCTIONS = """
 const char *SSL_state_string_long(const SSL *);
 SSL_SESSION *SSL_get1_session(SSL *);
 int SSL_set_session(SSL *, SSL_SESSION *);
-int SSL_session_reused(const SSL *ssl);
+int SSL_session_reused(const SSL *);
 SSL *SSL_new(SSL_CTX *);
 void SSL_free(SSL *);
 int SSL_set_fd(SSL *, int);

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -112,16 +112,3 @@ class TestOpenSSL:
         assert error.reason == b.lib.EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH
         if not b.lib.CRYPTOGRAPHY_IS_BORINGSSL:
             assert b"data not multiple of block length" in error.reason_text
-
-    def test_ssl_session_reused_new(self):
-        """
-        The SSL_session_reused API is available
-        and return 0 for a new connection.
-        """
-        b = Binding()
-        ctx = b.lib.SSL_CTX_new(b.lib.TLS_method())
-        ctx = b.ffi.gc(ctx, b.lib.SSL_CTX_free)
-        ssl = b.lib.SSL_new(ctx)
-        ssl = b.ffi.gc(ssl, b.lib.SSL_free)
-
-        assert b.lib.SSL_session_reused(ssl) == 0

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -113,9 +113,10 @@ class TestOpenSSL:
         if not b.lib.CRYPTOGRAPHY_IS_BORINGSSL:
             assert b"data not multiple of block length" in error.reason_text
 
-    def test_SSL_session_reused_new(self):
+    def test_ssl_session_reused_new(self):
         """
-        The API is available and return 0 for a new connection.
+        The SSL_session_reused API is available
+        and return 0 for a new connection.
         """
         b = Binding()
         ctx = b.lib.SSL_CTX_new(b.lib.TLS_method())

--- a/tests/hazmat/bindings/test_openssl.py
+++ b/tests/hazmat/bindings/test_openssl.py
@@ -112,3 +112,15 @@ class TestOpenSSL:
         assert error.reason == b.lib.EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH
         if not b.lib.CRYPTOGRAPHY_IS_BORINGSSL:
             assert b"data not multiple of block length" in error.reason_text
+
+    def test_SSL_session_reused_new(self):
+        """
+        The API is available and return 0 for a new connection.
+        """
+        b = Binding()
+        ctx = b.lib.SSL_CTX_new(b.lib.TLS_method())
+        ctx = b.ffi.gc(ctx, b.lib.SSL_CTX_free)
+        ssl = b.lib.SSL_new(ctx)
+        ssl = b.ffi.gc(ssl, b.lib.SSL_free)
+
+        assert b.lib.SSL_session_reused(ssl) == 0


### PR DESCRIPTION
Fixes #9969 

This (re)adds the `SSL_session_reused` API.

I think that this API is criticial.

First, this complements the already supported `int SSL_set_session(SSL *, SSL_SESSION *);
` to allow you to verify that after the handshake the session was reused.

Second, when implementing an FTPS server, this API is the only way to make sure you don't end up with hijacked FTP data connection.

I only added a simple tests to check that the API is there.

Let me know if more tests are required.

Thanks