### PR TITLE
Remove unused X509_STORE_set_get_issuer bindings

### DIFF
--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -19,8 +19,6 @@ typedef STACK_OF(X509_OBJECT) Cryptography_STACK_OF_X509_OBJECT;
 """
 
 TYPES = """
-static const long Cryptography_HAS_X509_STORE_CTX_GET_ISSUER;
-
 typedef ... Cryptography_STACK_OF_ASN1_OBJECT;
 typedef ... Cryptography_STACK_OF_X509_OBJECT;
 
@@ -174,16 +172,7 @@ int sk_X509_OBJECT_num(Cryptography_STACK_OF_X509_OBJECT *);
 Cryptography_STACK_OF_X509_OBJECT *X509_STORE_get0_objects(X509_STORE *);
 
 X509 *X509_STORE_CTX_get0_cert(X509_STORE_CTX *);
-void X509_STORE_set_get_issuer(X509_STORE *, X509_STORE_CTX_get_issuer_fn);
 """
 
 CUSTOMIZATIONS = """
-#if CRYPTOGRAPHY_IS_LIBRESSL
-static const long Cryptography_HAS_X509_STORE_CTX_GET_ISSUER = 0;
-typedef void *X509_STORE_CTX_get_issuer_fn;
-void (*X509_STORE_set_get_issuer)(X509_STORE *,
-                                  X509_STORE_CTX_get_issuer_fn) = NULL;
-#else
-static const long Cryptography_HAS_X509_STORE_CTX_GET_ISSUER = 1;
-#endif
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -40,12 +40,6 @@ def cryptography_has_mem_functions() -> list[str]:
     ]
 
 
-def cryptography_has_x509_store_ctx_get_issuer() -> list[str]:
-    return [
-        "X509_STORE_set_get_issuer",
-    ]
-
-
 def cryptography_has_ed448() -> list[str]:
     return [
         "EVP_PKEY_ED448",
@@ -227,9 +221,6 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_TLS_ST": cryptography_has_tls_st,
     "Cryptography_HAS_EVP_PKEY_DHX": cryptography_has_evp_pkey_dhx,
     "Cryptography_HAS_MEM_FUNCTIONS": cryptography_has_mem_functions,
-    "Cryptography_HAS_X509_STORE_CTX_GET_ISSUER": (
-        cryptography_has_x509_store_ctx_get_issuer
-    ),
     "Cryptography_HAS_ED448": cryptography_has_ed448,
     "Cryptography_HAS_SIGALGS": cryptography_has_ssl_sigalgs,
     "Cryptography_HAS_PSK": cryptography_has_psk,


### PR DESCRIPTION
This was added in https://github.com/pyca/cryptography/pull/3546 for AIA chasing, but it doesn't seem to have ever been used. Moreover, I'm not sure this is safe for use with AIA chasing anyway. This callback replaces the built-in lookup within an X509_STORE, but certificates from an X509_STORE are "trusted" certificates:

https://github.com/openssl/openssl/blob/openssl-3.2.0/crypto/x509/x509_vfy.c#L3184-L3198

While this does not automatically make it a trust anchor, it makes it eligible for being a trust anchor. Trust anchors are determined by some combination of out-of-band metadata (X509_add1_trust_object) and a "compatibility" step of whether the certificate is self-signed:

https://man.openbsd.org/X509_check_trust.3

This means, if an application uses this callback to implement AIA fetching, in most configurations, if the (should be untrusted) AIA fetch returned any self-signed certificate, it would automatically be treated as a trust anchor!

Remove this binding before someone inadvertently does this.