### PR TITLE
support RSA PSS for CRLs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,12 +18,16 @@ Changelog
   values, as documented in the 41.0.2 release notes.
 * Updated the minimum supported Rust version (MSRV) to 1.63.0, from 1.56.0.
 * Support :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` for
-  X.509 certificate signing requests with the keyword-only argument
-  ``rsa_padding`` on
-  :meth:`~cryptography.x509.CertificateSigningRequestBuilder.sign`.
+  X.509 certificate signing requests and certificate revocation lists with the
+  keyword-only argument ``rsa_padding`` on the ``sign`` methods for
+  :class:`~cryptography.x509.CertificateSigningRequestBuilder` and
+  :class:`~cryptography.x509.CertificateRevocationListBuilder`.
 * Added support for obtaining X.509 certificate signing request signature
   algorithm parameters (including PSS) via
   :meth:`~cryptography.x509.CertificateSigningRequest.signature_algorithm_parameters`.
+* Added support for obtaining X.509 certificate revocation list signature
+  algorithm parameters (including PSS) via
+  :meth:`~cryptography.x509.CertificateRevocationList.signature_algorithm_parameters`.
 * Added `mgf` property to
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`.
 * Added `algorithm` and `mgf` properties to

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -716,6 +716,27 @@ X.509 CRL (Certificate Revocation List) Object
             >>> crl.signature_algorithm_oid
             <ObjectIdentifier(oid=1.2.840.113549.1.1.11, name=sha256WithRSAEncryption)>
 
+    .. attribute:: signature_algorithm_parameters
+
+        .. versionadded:: 42.0.0
+
+        Returns the parameters of the signature algorithm used to sign the
+        certificate revocation list. For RSA signatures it will return either a
+        :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15` or
+        :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` object.
+
+        For ECDSA signatures it will
+        return an :class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDSA`.
+
+        For EdDSA and DSA signatures it will return ``None``.
+
+        These objects can be used to verify the CRL signature.
+
+        :returns: None,
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`, or
+            :class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDSA`
+
     .. attribute:: issuer
 
         :type: :class:`Name`
@@ -1212,7 +1233,7 @@ X.509 Certificate Revocation List Builder
             obtained from an existing CRL or created with
             :class:`~cryptography.x509.RevokedCertificateBuilder`.
 
-    .. method:: sign(private_key, algorithm)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None)
 
         Sign this CRL using the CA's private key.
 
@@ -1230,6 +1251,22 @@ X.509 Certificate Revocation List Builder
             and an instance of a
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
             otherwise.
+
+        :param rsa_padding:
+
+            .. versionadded:: 42.0.0
+
+            This is a keyword-only argument. If ``private_key`` is an
+            ``RSAPrivateKey`` then this can be set to either
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15` or
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` to sign
+            with those respective paddings. If this is ``None`` then RSA
+            keys will default to ``PKCS1v15`` padding. All other key types **must**
+            not pass a value other than ``None``.
+
+        :type rsa_padding: ``None``,
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
+            or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
 
         :returns: :class:`~cryptography.x509.CertificateRevocationList`
 

--- a/src/cryptography/hazmat/bindings/_rust/x509.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/x509.pyi
@@ -24,18 +24,19 @@ def create_x509_certificate(
     builder: x509.CertificateBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
-    padding: PKCS1v15 | PSS | None,
+    rsa_padding: PKCS1v15 | PSS | None,
 ) -> x509.Certificate: ...
 def create_x509_csr(
     builder: x509.CertificateSigningRequestBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
-    padding: PKCS1v15 | PSS | None,
+    rsa_padding: PKCS1v15 | PSS | None,
 ) -> x509.CertificateSigningRequest: ...
 def create_x509_crl(
     builder: x509.CertificateRevocationListBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
+    rsa_padding: PKCS1v15 | PSS | None,
 ) -> x509.CertificateRevocationList: ...
 def create_server_verifier(
     name: x509.verification.Subject,


### PR DESCRIPTION
adds rsa_padding kwarg to CertificateRevocationListBuilder::sign and also adds CertificateRevocationList::signature_algorithm_parameters

fixes #10006 