### PR TITLE
x509/verification: add an API usage example

### DIFF
--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -12,6 +12,23 @@ or chain building.
     While usable, these APIs should be considered experimental and not yet
     subject to our backwards compatibility policy.
 
+Example usage, with `certifi <https://pypi.org/project/certifi/>`_ providing
+the root of trust:
+
+.. code-block:: python
+
+    from cryptography.x509 import Certificate, DNSName, load_pem_x509_certificates
+    from cryptography.x509.verification import PolicyBuilder, Store
+    import certifi
+
+    with open(certifi.where()) as pems:
+        store = Store(load_pem_x509_certificates(pems.read()))
+
+    builder = PolicyBuilder().store(store)
+    verifier = builder().build_server_verifier(DNSName("cryptography.io"))
+
+    verifier.verify(peer, untrusted_intermediates)
+
 .. class:: Store(certs)
 
     .. versionadded:: 42.0.0

--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -21,13 +21,13 @@ the root of trust:
     from cryptography.x509.verification import PolicyBuilder, Store
     import certifi
 
-    with open(certifi.where()) as pems:
+    with open(certifi.where(), "rb") as pems:
         store = Store(load_pem_x509_certificates(pems.read()))
 
     builder = PolicyBuilder().store(store)
     verifier = builder().build_server_verifier(DNSName("cryptography.io"))
 
-    verifier.verify(peer, untrusted_intermediates)
+    chain = verifier.verify(peer, untrusted_intermediates)
 
 .. class:: Store(certs)
 


### PR DESCRIPTION
This is a pretty minimal example as-is, pushing it up to get something started.

See https://github.com/pyca/cryptography/issues/10034.