### PR TITLE
Make extension handling in x.509 verifier less meta-programmed

### DIFF
--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -2,11 +2,12 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
 use crate::backend::{hashes, utils};
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{exceptions, types};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 #[pyo3::prelude::pyclass(
     frozen,

--- a/tests/x509/verification/test_limbo.py
+++ b/tests/x509/verification/test_limbo.py
@@ -34,6 +34,8 @@ LIMBO_UNSUPPORTED_FEATURES = {
     # incompatible ways. Our validator always tries (by default) to comply
     # closer to CABF, so we skip these.
     "rfc5280-incompatible-with-webpki",
+    # We do not support policy constraints.
+    "has-policy-constraints",
 }
 
 LIMBO_SKIP_TESTCASES = {


### PR DESCRIPTION
We now iterate over the extensions only once.