### PR TITLE
Keep the original DER for an SPKI around

### DIFF
--- a/src/rust/cryptography-x509/src/certificate.rs
+++ b/src/rust/cryptography-x509/src/certificate.rs
@@ -46,7 +46,7 @@ pub struct TbsCertificate<'a> {
     pub validity: Validity,
     pub subject: name::Name<'a>,
 
-    pub spki: common::SubjectPublicKeyInfo<'a>,
+    pub spki: common::WithTlv<'a, common::SubjectPublicKeyInfo<'a>>,
     #[implicit(1)]
     pub issuer_unique_id: Option<asn1::BitString<'a>>,
     #[implicit(2)]

--- a/src/rust/cryptography-x509/src/csr.rs
+++ b/src/rust/cryptography-x509/src/csr.rs
@@ -18,7 +18,7 @@ pub struct Csr<'a> {
 pub struct CertificationRequestInfo<'a> {
     pub version: u8,
     pub subject: name::Name<'a>,
-    pub spki: common::SubjectPublicKeyInfo<'a>,
+    pub spki: common::WithTlv<'a, common::SubjectPublicKeyInfo<'a>>,
     #[implicit(0, required)]
     pub attributes: Attributes<'a>,
 }

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -67,7 +67,7 @@ impl Certificate {
         // This makes an unnecessary copy. It'd be nice to get rid of it.
         let serialized = pyo3::types::PyBytes::new(
             py,
-            &asn1::write_single(&self.raw.borrow_dependent().tbs_cert.spki)?,
+            self.raw.borrow_dependent().tbs_cert.spki.tlv().full_data(),
         );
         Ok(types::LOAD_DER_PUBLIC_KEY.get(py)?.call1((serialized,))?)
     }

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -48,7 +48,7 @@ impl CertificateSigningRequest {
         // This makes an unnecessary copy. It'd be nice to get rid of it.
         let serialized = pyo3::types::PyBytes::new(
             py,
-            &asn1::write_single(&self.raw.borrow_dependent().csr_info.spki)?,
+            self.raw.borrow_dependent().csr_info.spki.tlv().full_data(),
         );
         Ok(types::LOAD_DER_PUBLIC_KEY.get(py)?.call1((serialized,))?)
     }

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -30,7 +30,7 @@ impl CryptoOps for PyCryptoOps {
     fn public_key(&self, cert: &Certificate<'_>) -> Result<Self::Key, Self::Err> {
         pyo3::Python::with_gil(|py| -> Result<Self::Key, Self::Err> {
             // This makes an unnecessary copy. It'd be nice to get rid of it.
-            let spki_der = pyo3::types::PyBytes::new(py, &asn1::write_single(&cert.tbs_cert.spki)?);
+            let spki_der = pyo3::types::PyBytes::new(py, cert.tbs_cert.spki.tlv().full_data());
 
             Ok(types::LOAD_DER_PUBLIC_KEY
                 .get(py)?


### PR DESCRIPTION
This lets us parse it without needing to re-serialize.

Eventually we can extend this to TBS data itself.