### PR TITLE
Format all the imports with

### DIFF
--- a/src/rust/cryptography-openssl/src/cmac.rs
+++ b/src/rust/cryptography-openssl/src/cmac.rs
@@ -2,10 +2,12 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::ptr;
+
+use foreign_types_shared::{ForeignType, ForeignTypeRef};
+
 use crate::hmac::DigestBytes;
 use crate::{cvt, cvt_p, OpenSSLResult};
-use foreign_types_shared::{ForeignType, ForeignTypeRef};
-use std::ptr;
 
 foreign_types::foreign_type! {
     type CType = ffi::CMAC_CTX;

--- a/src/rust/cryptography-openssl/src/hmac.rs
+++ b/src/rust/cryptography-openssl/src/hmac.rs
@@ -2,9 +2,11 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::{cvt, cvt_p, OpenSSLResult};
-use foreign_types_shared::{ForeignType, ForeignTypeRef};
 use std::ptr;
+
+use foreign_types_shared::{ForeignType, ForeignTypeRef};
+
+use crate::{cvt, cvt_p, OpenSSLResult};
 
 foreign_types::foreign_type! {
     type CType = ffi::HMAC_CTX;

--- a/src/rust/cryptography-x509-verification/src/certificate.rs
+++ b/src/rust/cryptography-x509-verification/src/certificate.rs
@@ -12,11 +12,10 @@ pub(crate) fn cert_is_self_issued(cert: &Certificate<'_>) -> bool {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use super::cert_is_self_issued;
     use crate::certificate::Certificate;
     use crate::ops::tests::{cert, v1_cert_pem};
     use crate::ops::CryptoOps;
-
-    use super::cert_is_self_issued;
 
     #[test]
     fn test_certificate_v1() {

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -14,6 +14,13 @@ pub mod types;
 use std::collections::HashSet;
 use std::vec;
 
+use cryptography_x509::extensions::{DuplicateExtensionsError, Extensions};
+use cryptography_x509::{
+    extensions::{NameConstraints, SubjectAlternativeName},
+    name::GeneralName,
+    oid::{NAME_CONSTRAINTS_OID, SUBJECT_ALTERNATIVE_NAME_OID},
+};
+
 use crate::certificate::cert_is_self_issued;
 use crate::ops::{CryptoOps, VerificationCertificate};
 use crate::policy::Policy;
@@ -21,12 +28,6 @@ use crate::trust_store::Store;
 use crate::types::DNSName;
 use crate::types::{DNSConstraint, IPAddress, IPConstraint};
 use crate::ApplyNameConstraintStatus::{Applied, Skipped};
-use cryptography_x509::extensions::{DuplicateExtensionsError, Extensions};
-use cryptography_x509::{
-    extensions::{NameConstraints, SubjectAlternativeName},
-    name::GeneralName,
-    oid::{NAME_CONSTRAINTS_OID, SUBJECT_ALTERNATIVE_NAME_OID},
-};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ValidationError {

--- a/src/rust/cryptography-x509-verification/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/extension.rs
@@ -446,16 +446,17 @@ pub(crate) mod common {
 
 #[cfg(test)]
 mod tests {
+    use asn1::{ObjectIdentifier, SimpleAsn1Writable};
+    use cryptography_x509::certificate::Certificate;
+    use cryptography_x509::extensions::{BasicConstraints, Extension, Extensions};
+    use cryptography_x509::oid::BASIC_CONSTRAINTS_OID;
+
     use super::{Criticality, ExtensionPolicy};
     use crate::certificate::tests::PublicKeyErrorOps;
     use crate::ops::tests::{cert, v1_cert_pem};
     use crate::ops::CryptoOps;
     use crate::policy::{Policy, Subject, ValidationError};
     use crate::types::DNSName;
-    use asn1::{ObjectIdentifier, SimpleAsn1Writable};
-    use cryptography_x509::certificate::Certificate;
-    use cryptography_x509::extensions::{BasicConstraints, Extension, Extensions};
-    use cryptography_x509::oid::BASIC_CONSTRAINTS_OID;
 
     #[test]
     fn test_criticality_variants() {

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -9,8 +9,6 @@ use std::ops::Range;
 
 use asn1::ObjectIdentifier;
 use cryptography_x509::certificate::Certificate;
-use once_cell::sync::Lazy;
-
 use cryptography_x509::common::{
     AlgorithmIdentifier, AlgorithmParameters, EcParameters, RsaPssParameters, Time,
     PSS_SHA256_HASH_ALG, PSS_SHA256_MASK_GEN_ALG, PSS_SHA384_HASH_ALG, PSS_SHA384_MASK_GEN_ALG,
@@ -24,6 +22,7 @@ use cryptography_x509::oid::{
     KEY_USAGE_OID, NAME_CONSTRAINTS_OID, POLICY_CONSTRAINTS_OID, SUBJECT_ALTERNATIVE_NAME_OID,
     SUBJECT_DIRECTORY_ATTRIBUTES_OID, SUBJECT_KEY_IDENTIFIER_OID,
 };
+use once_cell::sync::Lazy;
 
 use crate::ops::CryptoOps;
 use crate::policy::extension::{ca, common, ee, Criticality, ExtensionPolicy};
@@ -580,18 +579,17 @@ mod tests {
         name::{GeneralName, UnvalidatedIA5String},
     };
 
+    use super::{
+        permits_validity_date, ECDSA_SHA256, ECDSA_SHA384, ECDSA_SHA512, RSASSA_PKCS1V15_SHA256,
+        RSASSA_PKCS1V15_SHA384, RSASSA_PKCS1V15_SHA512, RSASSA_PSS_SHA256, RSASSA_PSS_SHA384,
+        RSASSA_PSS_SHA512, WEBPKI_PERMITTED_SIGNATURE_ALGORITHMS,
+    };
     use crate::{
         policy::{
             Subject, SPKI_RSA, SPKI_SECP256R1, SPKI_SECP384R1, SPKI_SECP521R1,
             WEBPKI_PERMITTED_SPKI_ALGORITHMS,
         },
         types::{DNSName, IPAddress},
-    };
-
-    use super::{
-        permits_validity_date, ECDSA_SHA256, ECDSA_SHA384, ECDSA_SHA512, RSASSA_PKCS1V15_SHA256,
-        RSASSA_PKCS1V15_SHA384, RSASSA_PKCS1V15_SHA512, RSASSA_PSS_SHA256, RSASSA_PSS_SHA384,
-        RSASSA_PSS_SHA512, WEBPKI_PERMITTED_SIGNATURE_ALGORITHMS,
     };
 
     #[test]

--- a/src/rust/cryptography-x509-verification/src/trust_store.rs
+++ b/src/rust/cryptography-x509-verification/src/trust_store.rs
@@ -4,9 +4,10 @@
 
 use std::collections::{HashMap, HashSet};
 
+use cryptography_x509::name::Name;
+
 use crate::CryptoOps;
 use crate::VerificationCertificate;
-use cryptography_x509::name::Name;
 
 /// A `Store` represents the core state needed for X.509 path validation.
 pub struct Store<'a, B: CryptoOps> {

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -2,8 +2,9 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::oid;
 use asn1::Asn1DefinedByWritable;
+
+use crate::oid;
 
 #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Hash, Clone, Eq, Debug)]
 pub struct AlgorithmIdentifier<'a> {
@@ -408,8 +409,9 @@ impl<T: std::hash::Hash> std::hash::Hash for WithTlv<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Asn1ReadableOrWritable, RawTlv, UnvalidatedVisibleString, WithTlv};
     use asn1::Asn1Readable;
+
+    use super::{Asn1ReadableOrWritable, RawTlv, UnvalidatedVisibleString, WithTlv};
 
     #[test]
     #[should_panic]

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -288,9 +288,8 @@ impl KeyUsage<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::oid::{AUTHORITY_KEY_IDENTIFIER_OID, BASIC_CONSTRAINTS_OID};
-
     use super::{BasicConstraints, Extension, Extensions, KeyUsage};
+    use crate::oid::{AUTHORITY_KEY_IDENTIFIER_OID, BASIC_CONSTRAINTS_OID};
 
     #[test]
     fn test_get_extension() {

--- a/src/rust/src/asn1.rs
+++ b/src/rust/src/asn1.rs
@@ -2,14 +2,15 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::error::{CryptographyError, CryptographyResult};
-use crate::types;
 use asn1::SimpleAsn1Readable;
 use cryptography_x509::certificate::Certificate;
 use cryptography_x509::common::{DssSignature, SubjectPublicKeyInfo, Time};
 use cryptography_x509::name::Name;
 use pyo3::types::IntoPyDict;
 use pyo3::ToPyObject;
+
+use crate::error::{CryptographyError, CryptographyResult};
+use crate::types;
 
 pub(crate) fn py_oid_to_oid(py_oid: &pyo3::PyAny) -> pyo3::PyResult<asn1::ObjectIdentifier> {
     Ok(py_oid

--- a/src/rust/src/backend/cipher_registry.rs
+++ b/src/rust/src/backend/cipher_registry.rs
@@ -2,10 +2,12 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::collections::HashMap;
+
+use openssl::cipher::Cipher;
+
 use crate::error::CryptographyResult;
 use crate::types;
-use openssl::cipher::Cipher;
-use std::collections::HashMap;
 
 struct RegistryKey {
     algorithm: pyo3::PyObject,

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -2,11 +2,12 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use cryptography_x509::common;
+
 use crate::asn1::encode_der_data;
 use crate::backend::utils;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{types, x509};
-use cryptography_x509::common;
 
 const MIN_MODULUS_SIZE: u32 = 512;
 

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -2,12 +2,14 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use pyo3::ToPyObject;
+
 use crate::backend::utils;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{exceptions, types};
-use pyo3::ToPyObject;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 #[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.ec")]
 pub(crate) struct ECPrivateKey {

--- a/src/rust/src/backend/hashes.rs
+++ b/src/rust/src/backend/hashes.rs
@@ -2,10 +2,11 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::borrow::Cow;
+
 use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{exceptions, types};
-use std::borrow::Cow;
 
 #[pyo3::prelude::pyclass(module = "cryptography.hazmat.bindings._rust.openssl.hashes")]
 pub(crate) struct Hash {

--- a/src/rust/src/backend/keys.rs
+++ b/src/rust/src/backend/keys.rs
@@ -2,11 +2,12 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use foreign_types_shared::ForeignTypeRef;
+use pyo3::IntoPy;
+
 use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{error, exceptions, types};
-use foreign_types_shared::ForeignTypeRef;
-use pyo3::IntoPy;
 
 #[pyo3::prelude::pyfunction]
 fn private_key_from_ptr(

--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -2,8 +2,9 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::types;
 use std::{ptr, slice};
+
+use crate::types;
 
 pub(crate) struct CffiBuf<'p> {
     _pyobj: &'p pyo3::PyAny,

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -2,8 +2,9 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::exceptions;
 use pyo3::ToPyObject;
+
+use crate::exceptions;
 
 pub enum CryptographyError {
     Asn1Parse(asn1::ParseError),

--- a/src/rust/src/oid.rs
+++ b/src/rust/src/oid.rs
@@ -2,10 +2,11 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::error::CryptographyResult;
-use crate::types;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+
+use crate::error::CryptographyResult;
+use crate::types;
 
 #[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust")]
 pub(crate) struct ObjectIdentifier {

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -2,16 +2,18 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use cryptography_x509::csr::Attribute;
+use cryptography_x509::{common, oid, pkcs7};
+use once_cell::sync::Lazy;
+
 use crate::asn1::encode_der_data;
 use crate::buf::CffiBuf;
 use crate::error::CryptographyResult;
 use crate::{types, x509};
-use cryptography_x509::csr::Attribute;
-use cryptography_x509::{common, oid, pkcs7};
-use once_cell::sync::Lazy;
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::ops::Deref;
 
 const PKCS7_CONTENT_TYPE_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 3);
 const PKCS7_MESSAGE_DIGEST_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 4);
@@ -299,9 +301,10 @@ pub(crate) fn create_submodule(py: pyo3::Python<'_>) -> pyo3::PyResult<&pyo3::pr
 
 #[cfg(test)]
 mod tests {
-    use super::smime_canonicalize;
     use std::borrow::Cow;
     use std::ops::Deref;
+
+    use super::smime_canonicalize;
 
     #[test]
     fn test_smime_canonicalize() {

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -2,14 +2,9 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::asn1::{
-    big_byte_slice_to_py_int, encode_der_data, oid_to_py_oid, py_uint_to_big_endian_bytes,
-};
-use crate::backend::{hashes, keys};
-use crate::error::{CryptographyError, CryptographyResult};
-use crate::x509::verify::PyCryptoOps;
-use crate::x509::{extensions, sct, sign};
-use crate::{exceptions, types, x509};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
 use cryptography_x509::certificate::Certificate as RawCertificate;
 use cryptography_x509::common::{AlgorithmParameters, Asn1ReadableOrWritable};
 use cryptography_x509::extensions::{
@@ -23,8 +18,15 @@ use cryptography_x509::extensions::{Extension, SubjectAlternativeName};
 use cryptography_x509::{common, oid};
 use cryptography_x509_verification::ops::CryptoOps;
 use pyo3::{IntoPy, ToPyObject};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+
+use crate::asn1::{
+    big_byte_slice_to_py_int, encode_der_data, oid_to_py_oid, py_uint_to_big_endian_bytes,
+};
+use crate::backend::{hashes, keys};
+use crate::error::{CryptographyError, CryptographyResult};
+use crate::x509::verify::PyCryptoOps;
+use crate::x509::{extensions, sct, sign};
+use crate::{exceptions, types, x509};
 
 self_cell::self_cell!(
     pub(crate) struct OwnedCertificate {

--- a/src/rust/src/x509/common.rs
+++ b/src/rust/src/x509/common.rs
@@ -2,9 +2,6 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::asn1::{oid_to_py_oid, py_oid_to_oid};
-use crate::error::{CryptographyError, CryptographyResult};
-use crate::{exceptions, types, x509};
 use cryptography_x509::common::{Asn1ReadableOrWritable, AttributeTypeValue, RawTlv};
 use cryptography_x509::extensions::{
     AccessDescription, DuplicateExtensionsError, Extension, Extensions, RawExtensions,
@@ -12,6 +9,10 @@ use cryptography_x509::extensions::{
 use cryptography_x509::name::{GeneralName, Name, NameReadable, OtherName, UnvalidatedIA5String};
 use pyo3::types::IntoPyDict;
 use pyo3::{IntoPy, ToPyObject};
+
+use crate::asn1::{oid_to_py_oid, py_oid_to_oid};
+use crate::error::{CryptographyError, CryptographyResult};
+use crate::{exceptions, types, x509};
 
 /// Parse all sections in a PEM file and return the first matching section.
 /// If no matching sections are found, return an error.

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -2,13 +2,8 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::asn1::{
-    big_byte_slice_to_py_int, encode_der_data, oid_to_py_oid, py_uint_to_big_endian_bytes,
-};
-use crate::backend::hashes::Hash;
-use crate::error::{CryptographyError, CryptographyResult};
-use crate::x509::{certificate, extensions, sign};
-use crate::{exceptions, types, x509};
+use std::sync::Arc;
+
 use cryptography_x509::extensions::{Extension, IssuerAlternativeName};
 use cryptography_x509::{
     common,
@@ -19,7 +14,14 @@ use cryptography_x509::{
     name, oid,
 };
 use pyo3::{IntoPy, ToPyObject};
-use std::sync::Arc;
+
+use crate::asn1::{
+    big_byte_slice_to_py_int, encode_der_data, oid_to_py_oid, py_uint_to_big_endian_bytes,
+};
+use crate::backend::hashes::Hash;
+use crate::error::{CryptographyError, CryptographyResult};
+use crate::x509::{certificate, extensions, sign};
+use crate::{exceptions, types, x509};
 
 #[pyo3::prelude::pyfunction]
 fn load_der_x509_crl(

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -2,17 +2,19 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use asn1::SimpleAsn1Readable;
+use cryptography_x509::csr::{check_attribute_length, Attribute, CertificationRequestInfo, Csr};
+use cryptography_x509::{common, oid};
+use pyo3::IntoPy;
+
 use crate::asn1::{encode_der_data, oid_to_py_oid, py_oid_to_oid};
 use crate::backend::keys;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::x509::{certificate, sign};
 use crate::{exceptions, types, x509};
-use asn1::SimpleAsn1Readable;
-use cryptography_x509::csr::{check_attribute_length, Attribute, CertificationRequestInfo, Csr};
-use cryptography_x509::{common, oid};
-use pyo3::IntoPy;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 self_cell::self_cell!(
     struct OwnedCsr {

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -2,11 +2,12 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use cryptography_x509::{common, crl, extensions, oid};
+
 use crate::asn1::{py_oid_to_oid, py_uint_to_big_endian_bytes};
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::x509::{certificate, sct};
 use crate::{types, x509};
-use cryptography_x509::{common, crl, extensions, oid};
 
 fn encode_general_subtrees<'a>(
     py: pyo3::Python<'a>,

--- a/src/rust/src/x509/ocsp.rs
+++ b/src/rust/src/x509/ocsp.rs
@@ -2,14 +2,16 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::collections::HashMap;
+
+use cryptography_x509::common;
+use cryptography_x509::ocsp_req::CertID;
+use once_cell::sync::Lazy;
+
 use crate::backend::hashes::Hash;
 use crate::error::CryptographyResult;
 use crate::x509;
 use crate::x509::certificate::Certificate;
-use cryptography_x509::common;
-use cryptography_x509::ocsp_req::CertID;
-use once_cell::sync::Lazy;
-use std::collections::HashMap;
 
 pub(crate) static ALGORITHM_PARAMETERS_TO_HASH: Lazy<
     HashMap<common::AlgorithmParameters<'_>, &str>,

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -2,16 +2,17 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid, py_uint_to_big_endian_bytes};
-use crate::error::{CryptographyError, CryptographyResult};
-use crate::x509::{extensions, ocsp};
-use crate::{exceptions, types, x509};
 use cryptography_x509::{
     common,
     ocsp_req::{self, OCSPRequest as RawOCSPRequest},
     oid,
 };
 use pyo3::IntoPy;
+
+use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid, py_uint_to_big_endian_bytes};
+use crate::error::{CryptographyError, CryptographyResult};
+use crate::x509::{extensions, ocsp};
+use crate::{exceptions, types, x509};
 
 self_cell::self_cell!(
     struct OwnedOCSPRequest {

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -2,10 +2,8 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid};
-use crate::error::{CryptographyError, CryptographyResult};
-use crate::x509::{certificate, crl, extensions, ocsp, py_to_datetime, sct};
-use crate::{exceptions, types, x509};
+use std::sync::Arc;
+
 use cryptography_x509::ocsp_resp::SingleResponse;
 use cryptography_x509::{
     common,
@@ -13,7 +11,11 @@ use cryptography_x509::{
     oid,
 };
 use pyo3::IntoPy;
-use std::sync::Arc;
+
+use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid};
+use crate::error::{CryptographyError, CryptographyResult};
+use crate::x509::{certificate, crl, extensions, ocsp, py_to_datetime, sct};
+use crate::{exceptions, types, x509};
 
 const BASIC_RESPONSE_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 6, 1, 5, 5, 7, 48, 1, 1);
 

--- a/src/rust/src/x509/sct.rs
+++ b/src/rust/src/x509/sct.rs
@@ -2,11 +2,13 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::error::CryptographyError;
-use crate::types;
-use pyo3::ToPyObject;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+
+use pyo3::ToPyObject;
+
+use crate::error::CryptographyError;
+use crate::types;
 
 struct TLSReader<'a> {
     data: &'a [u8],

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -2,12 +2,14 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::collections::HashMap;
+
+use cryptography_x509::{common, oid};
+use once_cell::sync::Lazy;
+
 use crate::asn1::oid_to_py_oid;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{exceptions, types};
-use cryptography_x509::{common, oid};
-use once_cell::sync::Lazy;
-use std::collections::HashMap;
 
 // This is similar to a hashmap in ocsp.rs but contains more hash algorithms
 // that aren't allowable in OCSP
@@ -515,11 +517,12 @@ pub(crate) fn identify_signature_algorithm_parameters<'p>(
 
 #[cfg(test)]
 mod tests {
+    use cryptography_x509::{common, oid};
+
     use super::{
         identify_alg_params_for_hash_type, identify_key_type_for_algorithm_params, HashType,
         KeyType,
     };
-    use cryptography_x509::{common, oid};
 
     #[test]
     fn test_identify_key_type_for_algorithm_params() {


### PR DESCRIPTION
https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#group_imports using a value of `StdExternalCrate`

This option isn't stable, so we can't enforce it in CI, which is annoying.