### PR TITLE
Remove linkcheck ignore for secg.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,8 +195,6 @@ linkcheck_timeout = 5
 linkcheck_ignore = [
     # Insecure renegotiation settings
     r"https://info.isl.ntt.co.jp/crypt/eng/camellia/",
-    # Inconsistent small DH params they seem incapable of fixing
-    r"https://www.secg.org/sec1-v2.pdf",
     # Cloudflare returns 403s for all non-browser requests
     r"https://speakerdeck.com",
     r"https://\w+.stackexchange.com",


### PR DESCRIPTION
They appear to have gotten rid of FF DH KEX entirely