### PR TITLE
Migrate RSA PKCS#1 parsing to pure-Rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -71,6 +71,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptography-key-parsing"
+version = "0.1.0"
+dependencies = [
+ "asn1",
+ "openssl",
+]
+
+[[package]]
 name = "cryptography-openssl"
 version = "0.1.0"
 dependencies = [
@@ -88,6 +96,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "cryptography-cffi",
+ "cryptography-key-parsing",
  "cryptography-openssl",
  "cryptography-x509",
  "cryptography-x509-verification",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -13,6 +13,7 @@ cfg-if = "1"
 pyo3 = { version = "0.20", features = ["abi3"] }
 asn1 = { version = "0.15.5", default-features = false }
 cryptography-cffi = { path = "cryptography-cffi" }
+cryptography-key-parsing = { path = "cryptography-key-parsing" }
 cryptography-x509 = { path = "cryptography-x509" }
 cryptography-x509-verification = { path = "cryptography-x509-verification" }
 cryptography-openssl = { path = "cryptography-openssl" }
@@ -39,6 +40,7 @@ overflow-checks = true
 [workspace]
 members = [
     "cryptography-cffi",
+    "cryptography-key-parsing",
     "cryptography-openssl",
     "cryptography-x509",
     "cryptography-x509-verification",

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cryptography-key-parsing"
+version = "0.1.0"
+authors = ["The cryptography developers <cryptography-dev@python.org>"]
+edition = "2021"
+publish = false
+# This specifies the MSRV
+rust-version = "1.63.0"
+
+[dependencies]
+asn1 = { version = "0.15.5", default-features = false }
+openssl = "0.10.62"

--- a/src/rust/cryptography-key-parsing/src/lib.rs
+++ b/src/rust/cryptography-key-parsing/src/lib.rs
@@ -1,0 +1,39 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+pub mod rsa;
+
+pub enum KeyParsingError {
+    Parse(asn1::ParseError),
+    OpenSSL(openssl::error::ErrorStack),
+}
+
+impl From<asn1::ParseError> for KeyParsingError {
+    fn from(e: asn1::ParseError) -> KeyParsingError {
+        KeyParsingError::Parse(e)
+    }
+}
+
+impl From<openssl::error::ErrorStack> for KeyParsingError {
+    fn from(e: openssl::error::ErrorStack) -> KeyParsingError {
+        KeyParsingError::OpenSSL(e)
+    }
+}
+
+pub type KeyParsingResult<T> = Result<T, KeyParsingError>;
+
+#[cfg(test)]
+mod tests {
+    use super::KeyParsingError;
+
+    #[test]
+    fn test_key_parsing_error_from() {
+        let e = openssl::error::ErrorStack::get();
+
+        assert!(matches!(
+            KeyParsingError::from(e),
+            KeyParsingError::OpenSSL(_)
+        ));
+    }
+}

--- a/src/rust/cryptography-key-parsing/src/rsa.rs
+++ b/src/rust/cryptography-key-parsing/src/rsa.rs
@@ -1,0 +1,23 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use crate::KeyParsingResult;
+
+#[derive(asn1::Asn1Read)]
+struct Pksc1RsaPublicKey<'a> {
+    n: asn1::BigUint<'a>,
+    e: asn1::BigUint<'a>,
+}
+
+pub fn parse_pkcs1_rsa_public_key(
+    data: &[u8],
+) -> KeyParsingResult<openssl::pkey::PKey<openssl::pkey::Public>> {
+    let k = asn1::parse_single::<Pksc1RsaPublicKey>(data)?;
+
+    let n = openssl::bn::BigNum::from_slice(k.n.as_bytes())?;
+    let e = openssl::bn::BigNum::from_slice(k.e.as_bytes())?;
+
+    let rsa = openssl::rsa::Rsa::from_public_components(n, e)?;
+    Ok(openssl::pkey::PKey::from_rsa(rsa)?)
+}

--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -2,11 +2,12 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
 use crate::backend::{hashes, utils};
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{exceptions, types};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 #[pyo3::prelude::pyclass(
     frozen,


### PR DESCRIPTION
We no longer let OpenSSL parse anything.