### PR TITLE
Migrate SPKI parsing from OpenSSL to Rust

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -75,7 +75,10 @@ name = "cryptography-key-parsing"
 version = "0.1.0"
 dependencies = [
  "asn1",
+ "cfg-if",
+ "cryptography-x509",
  "openssl",
+ "openssl-sys",
 ]
 
 [[package]]

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -9,4 +9,7 @@ rust-version = "1.63.0"
 
 [dependencies]
 asn1 = { version = "0.15.5", default-features = false }
+cfg-if = "1"
 openssl = "0.10.63"
+openssl-sys = "0.9.99"
+cryptography-x509 = { path = "../cryptography-x509" }

--- a/src/rust/cryptography-key-parsing/build.rs
+++ b/src/rust/cryptography-key-parsing/build.rs
@@ -1,0 +1,15 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use std::env;
+
+fn main() {
+    if env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER").is_ok() {
+        println!("cargo:rustc-cfg=CRYPTOGRAPHY_IS_LIBRESSL");
+    }
+
+    if env::var("DEP_OPENSSL_BORINGSSL").is_ok() {
+        println!("cargo:rustc-cfg=CRYPTOGRAPHY_IS_BORINGSSL");
+    }
+}

--- a/src/rust/cryptography-key-parsing/src/lib.rs
+++ b/src/rust/cryptography-key-parsing/src/lib.rs
@@ -3,8 +3,13 @@
 // for complete details.
 
 pub mod rsa;
+pub mod spki;
 
 pub enum KeyParsingError {
+    InvalidKey,
+    ExplicitCurveUnsupported,
+    UnsupportedKeyType(asn1::ObjectIdentifier),
+    UnsupportedEllipticCurve(asn1::ObjectIdentifier),
     Parse(asn1::ParseError),
     OpenSSL(openssl::error::ErrorStack),
 }

--- a/src/rust/cryptography-key-parsing/src/rsa.rs
+++ b/src/rust/cryptography-key-parsing/src/rsa.rs
@@ -10,7 +10,7 @@ struct Pksc1RsaPublicKey<'a> {
     e: asn1::BigUint<'a>,
 }
 
-pub fn parse_pkcs1_rsa_public_key(
+pub fn parse_pkcs1_public_key(
     data: &[u8],
 ) -> KeyParsingResult<openssl::pkey::PKey<openssl::pkey::Public>> {
     let k = asn1::parse_single::<Pksc1RsaPublicKey>(data)?;

--- a/src/rust/cryptography-key-parsing/src/spki.rs
+++ b/src/rust/cryptography-key-parsing/src/spki.rs
@@ -1,0 +1,142 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use cryptography_x509::common::{AlgorithmParameters, EcParameters, SubjectPublicKeyInfo};
+
+use crate::{KeyParsingError, KeyParsingResult};
+
+pub fn parse_public_key(
+    data: &[u8],
+) -> KeyParsingResult<openssl::pkey::PKey<openssl::pkey::Public>> {
+    let k = asn1::parse_single::<SubjectPublicKeyInfo>(data)?;
+
+    match k.algorithm.params {
+        AlgorithmParameters::Ec(ec_params) => match ec_params {
+            EcParameters::NamedCurve(curve_oid) => {
+                let curve_nid = match curve_oid {
+                    cryptography_x509::oid::EC_SECP192R1 => openssl::nid::Nid::X9_62_PRIME192V1,
+                    cryptography_x509::oid::EC_SECP224R1 => openssl::nid::Nid::SECP224R1,
+                    cryptography_x509::oid::EC_SECP256R1 => openssl::nid::Nid::X9_62_PRIME256V1,
+                    cryptography_x509::oid::EC_SECP384R1 => openssl::nid::Nid::SECP384R1,
+                    cryptography_x509::oid::EC_SECP521R1 => openssl::nid::Nid::SECP521R1,
+
+                    cryptography_x509::oid::EC_SECP256K1 => openssl::nid::Nid::SECP256K1,
+
+                    cryptography_x509::oid::EC_SECT233R1 => openssl::nid::Nid::SECT233R1,
+                    cryptography_x509::oid::EC_SECT283R1 => openssl::nid::Nid::SECT283R1,
+                    cryptography_x509::oid::EC_SECT409R1 => openssl::nid::Nid::SECT409R1,
+                    cryptography_x509::oid::EC_SECT571R1 => openssl::nid::Nid::SECT571R1,
+
+                    cryptography_x509::oid::EC_SECT163R2 => openssl::nid::Nid::SECT163R2,
+
+                    cryptography_x509::oid::EC_SECT163K1 => openssl::nid::Nid::SECT163K1,
+                    cryptography_x509::oid::EC_SECT233K1 => openssl::nid::Nid::SECT233K1,
+                    cryptography_x509::oid::EC_SECT283K1 => openssl::nid::Nid::SECT283K1,
+                    cryptography_x509::oid::EC_SECT409K1 => openssl::nid::Nid::SECT409K1,
+                    cryptography_x509::oid::EC_SECT571K1 => openssl::nid::Nid::SECT571K1,
+
+                    #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
+                    cryptography_x509::oid::EC_BRAINPOOLP256R1 => {
+                        openssl::nid::Nid::BRAINPOOL_P256R1
+                    }
+                    #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
+                    cryptography_x509::oid::EC_BRAINPOOLP384R1 => {
+                        openssl::nid::Nid::BRAINPOOL_P384R1
+                    }
+                    #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
+                    cryptography_x509::oid::EC_BRAINPOOLP512R1 => {
+                        openssl::nid::Nid::BRAINPOOL_P512R1
+                    }
+
+                    _ => return Err(KeyParsingError::UnsupportedEllipticCurve(curve_oid)),
+                };
+
+                let group = openssl::ec::EcGroup::from_curve_name(curve_nid)
+                    .map_err(|_| KeyParsingError::UnsupportedEllipticCurve(curve_oid))?;
+                let mut bn_ctx = openssl::bn::BigNumContext::new()?;
+                let ec_point = openssl::ec::EcPoint::from_bytes(
+                    &group,
+                    k.subject_public_key.as_bytes(),
+                    &mut bn_ctx,
+                )
+                .map_err(|_| KeyParsingError::InvalidKey)?;
+                let ec_key = openssl::ec::EcKey::from_public_key(&group, &ec_point)?;
+                Ok(openssl::pkey::PKey::from_ec_key(ec_key)?)
+            }
+            EcParameters::ImplicitCurve(_) | EcParameters::SpecifiedCurve(_) => {
+                Err(KeyParsingError::ExplicitCurveUnsupported)
+            }
+        },
+        AlgorithmParameters::Ed25519 => Ok(openssl::pkey::PKey::public_key_from_raw_bytes(
+            k.subject_public_key.as_bytes(),
+            openssl::pkey::Id::ED25519,
+        )?),
+        #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
+        AlgorithmParameters::Ed448 => Ok(openssl::pkey::PKey::public_key_from_raw_bytes(
+            k.subject_public_key.as_bytes(),
+            openssl::pkey::Id::ED448,
+        )?),
+        AlgorithmParameters::X25519 => Ok(openssl::pkey::PKey::public_key_from_raw_bytes(
+            k.subject_public_key.as_bytes(),
+            openssl::pkey::Id::X25519,
+        )?),
+        #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
+        AlgorithmParameters::X448 => Ok(openssl::pkey::PKey::public_key_from_raw_bytes(
+            k.subject_public_key.as_bytes(),
+            openssl::pkey::Id::X448,
+        )?),
+        AlgorithmParameters::Rsa(_) | AlgorithmParameters::RsaPss(_) => {
+            // RSA-PSS keys are treated the same as bare RSA keys.
+            crate::rsa::parse_pkcs1_public_key(k.subject_public_key.as_bytes())
+        }
+        AlgorithmParameters::Dsa(dsa_params) => {
+            let p = openssl::bn::BigNum::from_slice(dsa_params.p.as_bytes())?;
+            let q = openssl::bn::BigNum::from_slice(dsa_params.q.as_bytes())?;
+            let g = openssl::bn::BigNum::from_slice(dsa_params.g.as_bytes())?;
+
+            let pub_key_int =
+                asn1::parse_single::<asn1::BigUint<'_>>(k.subject_public_key.as_bytes())?;
+            let pub_key = openssl::bn::BigNum::from_slice(pub_key_int.as_bytes())?;
+
+            let dsa = openssl::dsa::Dsa::from_public_components(p, q, g, pub_key)?;
+            Ok(openssl::pkey::PKey::from_dsa(dsa)?)
+        }
+        #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
+        AlgorithmParameters::Dh(dh_params) => {
+            let p = openssl::bn::BigNum::from_slice(dh_params.p.as_bytes())?;
+            let q = openssl::bn::BigNum::from_slice(dh_params.q.as_bytes())?;
+            let g = openssl::bn::BigNum::from_slice(dh_params.g.as_bytes())?;
+            let dh = openssl::dh::Dh::from_pqg(p, Some(q), g)?;
+
+            let pub_key_int =
+                asn1::parse_single::<asn1::BigUint<'_>>(k.subject_public_key.as_bytes())?;
+            let pub_key = openssl::bn::BigNum::from_slice(pub_key_int.as_bytes())?;
+            let dh = dh.set_public_key(pub_key)?;
+
+            cfg_if::cfg_if! {
+                if #[cfg(CRYPTOGRAPHY_IS_LIBRESSL)] {
+                    Ok(openssl::pkey::PKey::from_dh(dh)?)
+                } else {
+                    Ok(openssl::pkey::PKey::from_dhx(dh)?)
+                }
+            }
+        }
+        #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
+        AlgorithmParameters::DhKeyAgreement(dh_params) => {
+            let p = openssl::bn::BigNum::from_slice(dh_params.p.as_bytes())?;
+            let g = openssl::bn::BigNum::from_slice(dh_params.g.as_bytes())?;
+            let dh = openssl::dh::Dh::from_pqg(p, None, g)?;
+
+            let pub_key_int =
+                asn1::parse_single::<asn1::BigUint<'_>>(k.subject_public_key.as_bytes())?;
+            let pub_key = openssl::bn::BigNum::from_slice(pub_key_int.as_bytes())?;
+            let dh = dh.set_public_key(pub_key)?;
+
+            Ok(openssl::pkey::PKey::from_dh(dh)?)
+        }
+        _ => Err(KeyParsingError::UnsupportedKeyType(
+            k.algorithm.oid().clone(),
+        )),
+    }
+}

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -47,9 +47,32 @@ pub const ACCEPTABLE_RESPONSES_OID: asn1::ObjectIdentifier =
 
 // Public key identifiers
 pub const EC_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 2, 1);
+
+pub const EC_SECP192R1: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 3, 1, 1);
+pub const EC_SECP224R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 33);
 pub const EC_SECP256R1: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 3, 1, 7);
 pub const EC_SECP384R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 34);
 pub const EC_SECP521R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 35);
+
+pub const EC_SECP256K1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 10);
+
+pub const EC_SECT233R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 27);
+pub const EC_SECT283R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 17);
+pub const EC_SECT409R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 37);
+pub const EC_SECT571R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 39);
+
+pub const EC_SECT163R2: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 15);
+
+pub const EC_SECT163K1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 1);
+pub const EC_SECT233K1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 26);
+pub const EC_SECT283K1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 16);
+pub const EC_SECT409K1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 36);
+pub const EC_SECT571K1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 38);
+
+pub const EC_BRAINPOOLP256R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3, 2, 8, 1, 1, 7);
+pub const EC_BRAINPOOLP384R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3, 2, 8, 1, 1, 11);
+pub const EC_BRAINPOOLP512R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3, 2, 8, 1, 1, 13);
+
 pub const RSA_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 1, 1);
 
 // Signing methods
@@ -81,10 +104,17 @@ pub const RSA_WITH_SHA3_384_OID: asn1::ObjectIdentifier =
 pub const RSA_WITH_SHA3_512_OID: asn1::ObjectIdentifier =
     asn1::oid!(2, 16, 840, 1, 101, 3, 4, 3, 16);
 
+pub const DSA_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10040, 4, 1);
 pub const DSA_WITH_SHA224_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 3, 1);
 pub const DSA_WITH_SHA256_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 3, 2);
 pub const DSA_WITH_SHA384_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 3, 3);
 pub const DSA_WITH_SHA512_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 3, 4);
+
+pub const DH_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10046, 2, 1);
+pub const DH_KEY_AGREEMENT_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 3, 1);
+
+pub const X25519_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 101, 110);
+pub const X448_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 101, 111);
 
 pub const ED25519_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 101, 112);
 pub const ED448_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 101, 113);

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -152,9 +152,7 @@ pub(crate) fn public_key_from_pkey(
     py: pyo3::Python<'_>,
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Public>,
 ) -> CryptographyResult<ECPublicKey> {
-    let ec = pkey.ec_key().map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("Unable to load EC key: {e}"))
-    })?;
+    let ec = pkey.ec_key()?;
     let curve = py_curve_from_curve(py, ec.group())?;
     check_key_infinity(&ec)?;
     Ok(ECPublicKey {

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -57,6 +57,25 @@ impl From<cryptography_key_parsing::KeyParsingError> for CryptographyError {
         match e {
             cryptography_key_parsing::KeyParsingError::Parse(e) => CryptographyError::KeyParsing(e),
             cryptography_key_parsing::KeyParsingError::OpenSSL(e) => CryptographyError::OpenSSL(e),
+            cryptography_key_parsing::KeyParsingError::InvalidKey => {
+                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err("Invalid key"))
+            }
+            cryptography_key_parsing::KeyParsingError::ExplicitCurveUnsupported => {
+                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
+                    "ECDSA keys with explicit parameters are unsupported at this time",
+                ))
+            }
+            cryptography_key_parsing::KeyParsingError::UnsupportedKeyType(oid) => {
+                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Unknown key type: {oid}"
+                )))
+            }
+            cryptography_key_parsing::KeyParsingError::UnsupportedEllipticCurve(oid) => {
+                CryptographyError::Py(exceptions::UnsupportedAlgorithm::new_err((
+                    format!("Curve {oid} is not supported"),
+                    exceptions::Reasons::UNSUPPORTED_ELLIPTIC_CURVE,
+                )))
+            }
         }
     }
 }

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -308,23 +308,3 @@ class TestOpenSSLDHSerialization:
         )
         with pytest.raises(ValueError):
             loader_func(key_bytes, None, backend)
-
-    @pytest.mark.parametrize(
-        ("key_path", "loader_func"),
-        [
-            (
-                os.path.join("asymmetric", "DH", "dhpub_rfc5114_2.pem"),
-                serialization.load_pem_public_key,
-            ),
-            (
-                os.path.join("asymmetric", "DH", "dhpub_rfc5114_2.der"),
-                serialization.load_der_public_key,
-            ),
-        ],
-    )
-    def test_public_load_dhx_unsupported(self, key_path, loader_func, backend):
-        key_bytes = load_vectors_from_file(
-            key_path, lambda pemfile: pemfile.read(), mode="rb"
-        )
-        with pytest.raises(ValueError):
-            loader_func(key_bytes, backend)

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -1758,22 +1758,6 @@ class TestSubjectKeyIdentifierExtension:
         with pytest.raises(ValueError, match="Invalid public key encoding"):
             _key_identifier_from_public_key(pretend_key)
 
-    def test_no_optional_params_allowed_from_public_key(self, backend):
-        data = load_vectors_from_file(
-            filename=os.path.join(
-                "asymmetric",
-                "DER_Serialization",
-                "dsa_public_key_no_params.der",
-            ),
-            loader=lambda data: data.read(),
-            mode="rb",
-        )
-        pretend_key = pretend.stub(public_bytes=lambda x, y: data)
-        key_identifier = _key_identifier_from_public_key(pretend_key)
-        assert key_identifier == binascii.unhexlify(
-            b"24c0133a6a492f2c48a18c7648e515db5ac76749"
-        )
-
     def test_from_ec_public_key(self, backend):
         _skip_curve_unsupported(backend, ec.SECP384R1())
         cert = _load_cert(


### PR DESCRIPTION
TODO:

- [x] Handle unsupported key types
- [x] Handle un-named EC keys
- [x] Figure out how to handle DHX stuff (`DH_set_flags(dh, DH_FLAG_TYPE_DHX)`)
- [x] More EC curves?
- [x] rust-openssl release
- [x] Figure out the RHEL issue
- [x] Missing EC coverage
  - [x] Private key with explicit curve parameters
  - [x] Private key with an unsupported curve
  - [x] Loading keys with obscure curves:
    - [x] SECT163K1
    - [x] SECT233K1
    - [x] SECT163R2
    - [x] SECT233R1
