### PR TITLE
pypi-publish: tweak OIDC minting endpoint

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -75,7 +75,7 @@ jobs:
           response.raise_for_status()
           token = response.json()["value"]
 
-          response = requests.post(f"https://{os.environ['PYPI_DOMAIN']}/_/oidc/github/mint-token", json={"token": token})
+          response = requests.post(f"https://{os.environ['PYPI_DOMAIN']}/_/oidc/mint-token", json={"token": token})
           response.raise_for_status()
           pypi_token = response.json()["token"]
 


### PR DESCRIPTION
The old URL continues to work, but a new generic one has been added (without any other needed changes). PyPI may eventually remove the old one, so I figured you guys can get a head start as one of the small handful of people using it directly rather than through `gh-action-pypi-publish` 🙂 

Context: https://github.com/pypi/warehouse/pull/15148

