### PR TITLE
Revert "Silence new clippy false-positive"

### DIFF
--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -120,9 +120,6 @@ impl CertificateRevocationList {
         self.len()
     }
 
-    // Silenced due to false-positives
-    // https://github.com/rust-lang/rust-clippy/issues/12135
-    #[allow(clippy::useless_asref)]
     fn __iter__(&self) -> CRLIterator {
         CRLIterator {
             contents: OwnedCRLIteratorData::try_new(Arc::clone(&self.owned), |v| {


### PR DESCRIPTION
Reverts pyca/cryptography#10168

In theory this has been properly fixed upstream