### PR TITLE
Added warning about SHA1 being used for response signing in ocsp.rst

### DIFF
--- a/docs/x509/ocsp.rst
+++ b/docs/x509/ocsp.rst
@@ -343,7 +343,7 @@ Creating Responses
             otherwise. Please note that
             :class:`~cryptography.hazmat.primitives.hashes.SHA1`
             can not be used here, regardless of if it was used for
-            :meth: `~cryptography.x509.ocsp.OCSPResponseBuilder.add_response`
+            :meth:`~cryptography.x509.ocsp.OCSPResponseBuilder.add_response`
             or not.
 
         :returns: A new :class:`~cryptography.x509.ocsp.OCSPResponse`.

--- a/docs/x509/ocsp.rst
+++ b/docs/x509/ocsp.rst
@@ -340,7 +340,7 @@ Creating Responses
             :class:`~cryptography.hazmat.primitives.asymmetric.ed448.Ed448PrivateKey`
             and an instance of a
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
-            otherwise. This should not be the same algorithim used to add
+            otherwise. This should not be the same algorithm used to add
             a certificate to the response, as
             :class:`~cryptography.hazmat.primitives.hashes.SHA1` can't be used
             for signing, despite its compatibility requirement for certain 

--- a/docs/x509/ocsp.rst
+++ b/docs/x509/ocsp.rst
@@ -343,7 +343,7 @@ Creating Responses
             otherwise. This should not be the same algorithim used to add
             a certificate to the response, as
             :class:`~cryptography.hazmat.primitives.hashes.SHA1` can't be used
-            for signing, despite its compatbility requirement for certain 
+            for signing, despite its compatibility requirement for certain 
             applications.
 
         :returns: A new :class:`~cryptography.x509.ocsp.OCSPResponse`.

--- a/docs/x509/ocsp.rst
+++ b/docs/x509/ocsp.rst
@@ -340,7 +340,11 @@ Creating Responses
             :class:`~cryptography.hazmat.primitives.asymmetric.ed448.Ed448PrivateKey`
             and an instance of a
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
-            otherwise.
+            otherwise. This should not be the same algorithim used to add
+            a certificate to the response, as
+            :class:`~cryptography.hazmat.primitives.hashes.SHA1` can't be used
+            for signing, despite its compatbility requirement for certain 
+            applications.
 
         :returns: A new :class:`~cryptography.x509.ocsp.OCSPResponse`.
 

--- a/docs/x509/ocsp.rst
+++ b/docs/x509/ocsp.rst
@@ -340,11 +340,11 @@ Creating Responses
             :class:`~cryptography.hazmat.primitives.asymmetric.ed448.Ed448PrivateKey`
             and an instance of a
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
-            otherwise. This should not be the same algorithm used to add
-            a certificate to the response, as
-            :class:`~cryptography.hazmat.primitives.hashes.SHA1` can't be used
-            for signing, despite its compatibility requirement for certain 
-            applications.
+            otherwise. Please note that
+            :class:`~cryptography.hazmat.primitives.hashes.SHA1`
+            can not be used here, regardless of if it was used for
+            :meth: `~cryptography.x509.ocsp.OCSPResponseBuilder.add_response`
+            or not.
 
         :returns: A new :class:`~cryptography.x509.ocsp.OCSPResponse`.
 


### PR DESCRIPTION
While SHA1 can't be used for signing requests/responses, it can still be used for adding certificates to the request/response. I am guessing this is allowable due to the fact that we're signing with a stronger algorithm (SHA256), preventing modification of digest made with a weaker algorithm (SHA1)

Despite this, there is not enough clarity to indicate this, as someone may see the SHA1 algorithm being used in the "add_response" function and thinking "Oh! We can use SHA1 here", despite that not being the case. This commits adds the needed clarity. 