### PR TITLE
fix the release script (#10233)

### DIFF
--- a/release.py
+++ b/release.py
@@ -22,7 +22,6 @@ def cli():
 
 
 @cli.command()
-@click.argument("version")
 def release() -> None:
     base_dir = pathlib.Path(__file__).parent
     with (base_dir / "pyproject.toml").open("rb") as f:


### PR DESCRIPTION
we removed version as an arg, but didn't remove it from the click decorator