### PR TITLE
explicitly support bytes-like for signature/data in RSA sign/verify

### DIFF
--- a/docs/hazmat/primitives/asymmetric/rsa.rst
+++ b/docs/hazmat/primitives/asymmetric/rsa.rst
@@ -620,7 +620,8 @@ Key interfaces
         Sign one block of data which can be verified later by others using the
         public key.
 
-        :param bytes data: The message string to sign.
+        :param data: The message string to sign.
+        :type data: :term:`bytes-like`
 
         :param padding: An instance of
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`.
@@ -739,9 +740,11 @@ Key interfaces
         Verify one block of data was signed by the private key
         associated with this public key.
 
-        :param bytes signature: The signature to verify.
+        :param signature: The signature to verify.
+        :type signature: :term:`bytes-like`
 
-        :param bytes data: The message string that was signed.
+        :param data: The message string that was signed.
+        :type data: :term:`bytes-like`
 
         :param padding: An instance of
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`.

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -763,9 +763,15 @@ class TestRSASignature:
         )
         private_key.sign(b"no failure", padding.PKCS1v15(), hashes.SHA512())
 
-    def test_sign(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    @pytest.mark.parametrize(
+        "message",
+        [
+            b"one little message",
+            bytearray(b"one little message"),
+        ],
+    )
+    def test_sign(self, rsa_key_2048: rsa.RSAPrivateKey, message, backend):
         private_key = rsa_key_2048
-        message = b"one little message"
         pkcs = padding.PKCS1v15()
         algorithm = hashes.SHA256()
         signature = private_key.sign(message, pkcs, algorithm)
@@ -1375,9 +1381,15 @@ class TestRSAVerification:
                 hashes.SHA1(),
             )
 
-    def test_verify(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    @pytest.mark.parametrize(
+        "message",
+        [
+            b"one little message",
+            bytearray(b"one little message"),
+        ],
+    )
+    def test_verify(self, rsa_key_2048: rsa.RSAPrivateKey, message, backend):
         private_key = rsa_key_2048
-        message = b"one little message"
         pkcs = padding.PKCS1v15()
         algorithm = hashes.SHA256()
         signature = private_key.sign(message, pkcs, algorithm)


### PR DESCRIPTION
this was never documented but previously worked in <42. we now also document that this is supported to confuse ourselves less.