### PR TITLE
support bytes-like consistently across our asym sign/verify APIs

### DIFF
--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -289,7 +289,8 @@ Key interfaces
         Sign one block of data which can be verified later by others using the
         public key.
 
-        :param bytes data: The message string to sign.
+        :param data: The message string to sign.
+        :type data: :term:`bytes-like`
 
         :param algorithm: An instance of
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm` or
@@ -391,9 +392,11 @@ Key interfaces
         Verify one block of data was signed by the private key
         associated with this public key.
 
-        :param bytes signature: The signature to verify.
+        :param signature: The signature to verify.
+        :type signature: :term:`bytes-like`
 
-        :param bytes data: The message string that was signed.
+        :param data: The message string that was signed.
+        :type data: :term:`bytes-like`
 
         :param algorithm: An instance of
             :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm` or

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -569,7 +569,8 @@ Key Interfaces
         Sign one block of data which can be verified later by others using the
         public key.
 
-        :param bytes data: The message string to sign.
+        :param data: The message string to sign.
+        :type data: :term:`bytes-like`
 
         :param signature_algorithm: An instance of
             :class:`EllipticCurveSignatureAlgorithm`, such as :class:`ECDSA`.
@@ -678,12 +679,14 @@ Key Interfaces
         Verify one block of data was signed by the private key associated
         with this public key.
 
-        :param bytes signature: The DER-encoded signature to verify.
+        :param signature: The DER-encoded signature to verify.
             A raw signature may be DER-encoded by splitting it into the ``r``
             and ``s`` components and passing them into
             :func:`~cryptography.hazmat.primitives.asymmetric.utils.encode_dss_signature`.
+        :type signature: :term:`bytes-like`
 
-        :param bytes data: The message string that was signed.
+        :param data: The message string that was signed.
+        :type data: :term:`bytes-like`
 
         :param signature_algorithm: An instance of
             :class:`EllipticCurveSignatureAlgorithm`.

--- a/docs/hazmat/primitives/asymmetric/ed25519.rst
+++ b/docs/hazmat/primitives/asymmetric/ed25519.rst
@@ -67,7 +67,8 @@ Key interfaces
 
     .. method:: sign(data)
 
-        :param bytes data: The data to sign.
+        :param data: The data to sign.
+        :type data: :term:`bytes-like`
 
         :returns bytes: The 64 byte signature.
 
@@ -192,9 +193,11 @@ Key interfaces
 
     .. method:: verify(signature, data)
 
-        :param bytes signature: The signature to verify.
+        :param signature: The signature to verify.
+        :type signature: :term:`bytes-like`
 
-        :param bytes data: The data to verify.
+        :param data: The data to verify.
+        :type data: :term:`bytes-like`
 
         :returns: None
         :raises cryptography.exceptions.InvalidSignature: Raised when the

--- a/docs/hazmat/primitives/asymmetric/ed448.rst
+++ b/docs/hazmat/primitives/asymmetric/ed448.rst
@@ -47,7 +47,8 @@ Key interfaces
 
     .. method:: sign(data)
 
-        :param bytes data: The data to sign.
+        :param data: The data to sign.
+        :type data: :term:`bytes-like`
 
         :returns bytes: The 114 byte signature.
 
@@ -146,9 +147,11 @@ Key interfaces
 
     .. method:: verify(signature, data)
 
-        :param bytes signature: The signature to verify.
+        :param signature: The signature to verify.
+        :type signature: :term:`bytes-like`
 
-        :param bytes data: The data to verify.
+        :param data: The data to verify.
+        :type data: :term:`bytes-like`
 
         :returns: None
         :raises cryptography.exceptions.InvalidSignature: Raised when the

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -64,12 +64,12 @@ impl Ed448PrivateKey {
     fn sign<'p>(
         &self,
         py: pyo3::Python<'p>,
-        data: &[u8],
+        data: CffiBuf<'_>,
     ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
         let mut signer = openssl::sign::Signer::new_without_digest(&self.pkey)?;
         Ok(pyo3::types::PyBytes::new_with(py, signer.len()?, |b| {
             let n = signer
-                .sign_oneshot(b, data)
+                .sign_oneshot(b, data.as_bytes())
                 .map_err(CryptographyError::from)?;
             assert_eq!(n, b.len());
             Ok(())
@@ -116,9 +116,9 @@ impl Ed448PrivateKey {
 
 #[pyo3::prelude::pymethods]
 impl Ed448PublicKey {
-    fn verify(&self, signature: &[u8], data: &[u8]) -> CryptographyResult<()> {
+    fn verify(&self, signature: CffiBuf<'_>, data: CffiBuf<'_>) -> CryptographyResult<()> {
         let valid = openssl::sign::Verifier::new_without_digest(&self.pkey)?
-            .verify_oneshot(signature, data)?;
+            .verify_oneshot(signature.as_bytes(), data.as_bytes())?;
 
         if !valid {
             return Err(CryptographyError::from(

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -522,6 +522,14 @@ class TestDSASignature:
         public_key = private_key.public_key()
         public_key.verify(signature, message, algorithm)
 
+    def test_sign_verify_buffer(self, backend):
+        private_key = DSA_KEY_1024.private_key(backend)
+        message = bytearray(b"one little message")
+        algorithm = hashes.SHA1()
+        signature = private_key.sign(message, algorithm)
+        public_key = private_key.public_key()
+        public_key.verify(bytearray(signature), message, algorithm)
+
     def test_prehashed_sign(self, backend):
         private_key = DSA_KEY_1024.private_key(backend)
         message = b"one little message"

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -516,6 +516,15 @@ class TestECDSAVectors:
         public_key = private_key.public_key()
         public_key.verify(signature, message, algorithm)
 
+    def test_sign_verify_buffers(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+        message = bytearray(b"one little message")
+        algorithm = ec.ECDSA(hashes.SHA1())
+        private_key = ec.generate_private_key(ec.SECP256R1(), backend)
+        signature = private_key.sign(message, algorithm)
+        public_key = private_key.public_key()
+        public_key.verify(bytearray(signature), message, algorithm)
+
     def test_sign_prehashed(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
         message = b"one little message"

--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -117,6 +117,12 @@ class TestEd25519Signing:
         with pytest.raises(InvalidSignature):
             key.public_key().verify(b"0" * 64, b"test data")
 
+    def test_sign_verify_buffer(self, backend):
+        key = Ed25519PrivateKey.generate()
+        data = bytearray(b"test data")
+        signature = key.sign(data)
+        key.public_key().verify(bytearray(signature), data)
+
     def test_generate(self, backend):
         key = Ed25519PrivateKey.generate()
         assert key

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -86,6 +86,12 @@ class TestEd448Signing:
         with pytest.raises(InvalidSignature):
             key.public_key().verify(b"0" * 64, b"test data")
 
+    def test_sign_verify_buffer(self, backend):
+        key = Ed448PrivateKey.generate()
+        data = bytearray(b"test data")
+        signature = key.sign(data)
+        key.public_key().verify(bytearray(signature), data)
+
     def test_generate(self, backend):
         key = Ed448PrivateKey.generate()
         assert key


### PR DESCRIPTION
and update our docs to show it as well