### PR TITLE
rebuild if the OPENSSL_DIR has changed

### DIFF
--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -25,6 +25,9 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?
     let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
+    if let Ok(dir) = env::var("OPENSSL_DIR") {
+        println!("cargo:rerun-if-changed={}", dir);
+    };
     println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
     println!("cargo:rerun-if-changed=../../_cffi_src/");
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");


### PR DESCRIPTION
This probably needs to be done in other crates too? And what if `OPENSSL_DIR` isn't set?