### PR TITLE
parsing, verification: check RSA key size against WebPKI minimum

### DIFF
--- a/.github/actions/fetch-vectors/action.yml
+++ b/.github/actions/fetch-vectors/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         repository: "C2SP/x509-limbo"
         path: "x509-limbo"
-        # Latest commit on the x509-limbo main branch, as of Jan 30, 2024.
+        # Latest commit on the x509-limbo main branch, as of Jan 31, 2024.
         ref: "481b5d595b00ce55824607e1e8c2f1174539f3f8" # x509-limbo-ref

--- a/.github/actions/fetch-vectors/action.yml
+++ b/.github/actions/fetch-vectors/action.yml
@@ -17,4 +17,4 @@ runs:
         repository: "C2SP/x509-limbo"
         path: "x509-limbo"
         # Latest commit on the x509-limbo main branch, as of Jan 30, 2024.
-        ref: "dd7541dac329f03756f6358ad0c01d32e5677619" # x509-limbo-ref
+        ref: "481b5d595b00ce55824607e1e8c2f1174539f3f8" # x509-limbo-ref

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -125,6 +125,7 @@ name = "cryptography-x509-verification"
 version = "0.1.0"
 dependencies = [
  "asn1",
+ "cryptography-key-parsing",
  "cryptography-x509",
  "once_cell",
  "pem",

--- a/src/rust/cryptography-key-parsing/src/rsa.rs
+++ b/src/rust/cryptography-key-parsing/src/rsa.rs
@@ -5,9 +5,9 @@
 use crate::KeyParsingResult;
 
 #[derive(asn1::Asn1Read)]
-struct Pksc1RsaPublicKey<'a> {
-    n: asn1::BigUint<'a>,
-    e: asn1::BigUint<'a>,
+pub struct Pksc1RsaPublicKey<'a> {
+    pub n: asn1::BigUint<'a>,
+    pub e: asn1::BigUint<'a>,
 }
 
 pub fn parse_pkcs1_public_key(

--- a/src/rust/cryptography-key-parsing/src/rsa.rs
+++ b/src/rust/cryptography-key-parsing/src/rsa.rs
@@ -7,7 +7,7 @@ use crate::KeyParsingResult;
 #[derive(asn1::Asn1Read)]
 pub struct Pksc1RsaPublicKey<'a> {
     pub n: asn1::BigUint<'a>,
-    pub e: asn1::BigUint<'a>,
+    e: asn1::BigUint<'a>,
 }
 
 pub fn parse_pkcs1_public_key(

--- a/src/rust/cryptography-x509-verification/Cargo.toml
+++ b/src/rust/cryptography-x509-verification/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.63.0"
 [dependencies]
 asn1 = { version = "0.16.0", default-features = false }
 cryptography-x509 = { path = "../cryptography-x509" }
+cryptography-key-parsing = { path = "../cryptography-key-parsing" }
 once_cell = "1"
 
 [dev-dependencies]

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -436,19 +436,6 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
 
         self.ca_extension_policy.permits(self, cert, extensions)?;
 
-        // CA/B 6.1.5: Key sizes
-        // NOTE: We don't currently enforce that RSA moduli are divisible by 8,
-        // since other implementations don't bother.
-        let cert_spki = &cert.tbs_cert.spki;
-        if cert_spki.algorithm.is_rsa_key() {
-            let rsa_key: Pksc1RsaPublicKey<'_> =
-                asn1::parse_single(cert_spki.subject_public_key.as_bytes())?;
-
-            if rsa_key.n.as_bytes().len() * 8 < self.minimum_rsa_modulus {
-                return Err(ValidationError::Other("RSA key is too weak".into()));
-            }
-        }
-
         Ok(())
     }
 
@@ -508,6 +495,22 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
                 "Forbidden signature algorithm: {:?}",
                 &child.signature_alg
             )));
+        }
+
+        // CA/B 6.1.5: Key sizes
+        // NOTE: We don't currently enforce that RSA moduli are divisible by 8,
+        // since other implementations don't bother.
+        let issuer_spki = &issuer.certificate().tbs_cert.spki;
+        if matches!(
+            issuer_spki.algorithm.params,
+            AlgorithmParameters::Rsa(_) | AlgorithmParameters::RsaPss(_)
+        ) {
+            let rsa_key: Pksc1RsaPublicKey<'_> =
+                asn1::parse_single(issuer_spki.subject_public_key.as_bytes())?;
+
+            if rsa_key.n.as_bytes().len() * 8 < self.minimum_rsa_modulus {
+                return Err(ValidationError::Other("RSA key is too weak".into()));
+            }
         }
 
         let pk = issuer

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -440,7 +440,7 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
         // NOTE: We don't currently enforce that RSA moduli are divisible by 8,
         // since other implementations don't bother.
         let cert_spki = &cert.tbs_cert.spki;
-        if cert_spki.algorithm.is_rsa() {
+        if cert_spki.algorithm.is_rsa_key() {
             let rsa_key: Pksc1RsaPublicKey<'_> =
                 asn1::parse_single(cert_spki.subject_public_key.as_bytes())?;
 

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -9,6 +9,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use asn1::ObjectIdentifier;
+use cryptography_key_parsing::rsa::Pksc1RsaPublicKey;
 use cryptography_x509::certificate::Certificate;
 use cryptography_x509::common::{
     AlgorithmIdentifier, AlgorithmParameters, EcParameters, RsaPssParameters, Time,
@@ -26,6 +27,9 @@ use crate::ops::CryptoOps;
 use crate::policy::extension::{ca, common, ee, Criticality, ExtensionPolicy, ExtensionValidator};
 use crate::types::{DNSName, DNSPattern, IPAddress};
 use crate::{ValidationError, VerificationCertificate};
+
+// RSA key constraints, as defined in CA/B 6.1.5.
+static WEBPKI_MINIMUM_RSA_MODULUS: usize = 2048;
 
 // SubjectPublicKeyInfo AlgorithmIdentifier constants, as defined in CA/B 7.1.3.1.
 
@@ -213,6 +217,10 @@ pub struct Policy<'a, B: CryptoOps> {
     /// An extended key usage that must appear in EEs validated by this policy.
     pub extended_key_usage: ObjectIdentifier,
 
+    /// The minimum RSA modulus, in bits.
+    /// This is equivalent to the public key size, e.g. 2048 for an RSA-2048 key.
+    pub minimum_rsa_modulus: usize,
+
     /// The set of permitted public key algorithms, identified by their
     /// algorithm identifiers.
     pub permitted_public_key_algorithms: Arc<HashSet<AlgorithmIdentifier<'a>>>,
@@ -240,6 +248,7 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
             subject,
             validation_time: time,
             extended_key_usage: EKU_SERVER_AUTH_OID.clone(),
+            minimum_rsa_modulus: WEBPKI_MINIMUM_RSA_MODULUS,
             permitted_public_key_algorithms: Arc::clone(&*WEBPKI_PERMITTED_SPKI_ALGORITHMS),
             permitted_signature_algorithms: Arc::clone(&*WEBPKI_PERMITTED_SIGNATURE_ALGORITHMS),
             ca_extension_policy: ExtensionPolicy {
@@ -329,6 +338,19 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
     }
 
     fn permits_basic(&self, cert: &Certificate<'_>) -> Result<(), ValidationError> {
+        // CA/B 6.1.5: Key sizes
+        // NOTE: We don't currently enforce that RSA moduli are divisible by 8,
+        // since other implementations don't bother.
+        let cert_spki = &cert.tbs_cert.spki;
+        if cert_spki.algorithm.is_rsa() {
+            let rsa_key: Pksc1RsaPublicKey<'_> =
+                asn1::parse_single(cert_spki.subject_public_key.as_bytes())?;
+
+            if rsa_key.n.as_bytes().len() * 8 < self.minimum_rsa_modulus {
+                return Err(ValidationError::Other("RSA key is too weak".into()));
+            }
+        }
+
         // CA/B 7.1.1:
         // Certificates MUST be of type X.509 v3.
         if cert.tbs_cert.version != 2 {

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -17,10 +17,6 @@ impl AlgorithmIdentifier<'_> {
     pub fn oid(&self) -> &asn1::ObjectIdentifier {
         self.params.item()
     }
-
-    pub fn is_rsa_key(&self) -> bool {
-        matches!(self.params, AlgorithmParameters::Rsa(_))
-    }
 }
 
 #[derive(asn1::Asn1DefinedByRead, asn1::Asn1DefinedByWrite, PartialEq, Eq, Hash, Clone, Debug)]

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -18,7 +18,7 @@ impl AlgorithmIdentifier<'_> {
         self.params.item()
     }
 
-    pub fn is_rsa(&self) -> bool {
+    pub fn is_rsa_key(&self) -> bool {
         matches!(self.params, AlgorithmParameters::Rsa(_))
     }
 }

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -19,21 +19,7 @@ impl AlgorithmIdentifier<'_> {
     }
 
     pub fn is_rsa(&self) -> bool {
-        matches!(
-            self.params,
-            AlgorithmParameters::Rsa(_)
-                | AlgorithmParameters::RsaWithSha1(_)
-                | AlgorithmParameters::RsaWithSha1Alt(_)
-                | AlgorithmParameters::RsaWithSha224(_)
-                | AlgorithmParameters::RsaWithSha256(_)
-                | AlgorithmParameters::RsaWithSha384(_)
-                | AlgorithmParameters::RsaWithSha512(_)
-                | AlgorithmParameters::RsaWithSha3_224(_)
-                | AlgorithmParameters::RsaWithSha3_256(_)
-                | AlgorithmParameters::RsaWithSha3_384(_)
-                | AlgorithmParameters::RsaWithSha3_512(_)
-                | AlgorithmParameters::RsaPss(_)
-        )
+        matches!(self.params, AlgorithmParameters::Rsa(_))
     }
 }
 

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -17,6 +17,24 @@ impl AlgorithmIdentifier<'_> {
     pub fn oid(&self) -> &asn1::ObjectIdentifier {
         self.params.item()
     }
+
+    pub fn is_rsa(&self) -> bool {
+        matches!(
+            self.params,
+            AlgorithmParameters::Rsa(_)
+                | AlgorithmParameters::RsaWithSha1(_)
+                | AlgorithmParameters::RsaWithSha1Alt(_)
+                | AlgorithmParameters::RsaWithSha224(_)
+                | AlgorithmParameters::RsaWithSha256(_)
+                | AlgorithmParameters::RsaWithSha384(_)
+                | AlgorithmParameters::RsaWithSha512(_)
+                | AlgorithmParameters::RsaWithSha3_224(_)
+                | AlgorithmParameters::RsaWithSha3_256(_)
+                | AlgorithmParameters::RsaWithSha3_384(_)
+                | AlgorithmParameters::RsaWithSha3_512(_)
+                | AlgorithmParameters::RsaPss(_)
+        )
+    }
 }
 
 #[derive(asn1::Asn1DefinedByRead, asn1::Asn1DefinedByWrite, PartialEq, Eq, Hash, Clone, Debug)]

--- a/tests/x509/verification/test_limbo.py
+++ b/tests/x509/verification/test_limbo.py
@@ -62,6 +62,9 @@ LIMBO_SKIP_TESTCASES = {
     # forbidden under CABF. This is consistent with what
     # Go's crypto/x509 and Rust's webpki crate do.
     "webpki::aki::root-with-aki-ski-mismatch",
+    # We allow RSA keys that aren't divisible by 8, which is technically
+    # forbidden under CABF. No other implementation checks this either.
+    "webpki::forbidden-rsa-key-not-divisable-by-8",
     # We disallow CAs in the leaf position, which is explicitly forbidden
     # by CABF (but implicitly permitted under RFC 5280). This is consistent
     # with what webpki and rustls do, but inconsistent with Go and OpenSSL.


### PR DESCRIPTION
Depends on https://github.com/C2SP/x509-limbo/pull/184 for coverage.