### PR TITLE
verification/policy: tweak key checks

### DIFF
--- a/.github/actions/fetch-vectors/action.yml
+++ b/.github/actions/fetch-vectors/action.yml
@@ -17,4 +17,4 @@ runs:
         repository: "C2SP/x509-limbo"
         path: "x509-limbo"
         # Latest commit on the x509-limbo main branch, as of Jan 31, 2024.
-        ref: "481b5d595b00ce55824607e1e8c2f1174539f3f8" # x509-limbo-ref
+        ref: "e7b8885bb20e532392e1f7c4be0d54c39b17c58b" # x509-limbo-ref

--- a/tests/x509/verification/test_limbo.py
+++ b/tests/x509/verification/test_limbo.py
@@ -27,7 +27,10 @@ LIMBO_UNSUPPORTED_FEATURES = {
     # Our support for custom EKUs is limited, and we (like most impls.) don't
     # handle all EKU conditions under CABF.
     "pedantic-webpki-eku",
-    # Similarly: contains tests that fail based on a strict reading of RFC 5280
+    # Most CABF validators do not enforce the CABF key requirements on
+    # subscriber keys (i.e., in the leaf certificate).
+    "pedantic-webpki-subscriber-key",
+    # Tests that fail based on a strict reading of RFC 5280
     # but are widely ignored by validators.
     "pedantic-rfc5280",
     # In rare circumstances, CABF relaxes RFC 5280's prescriptions in
@@ -64,7 +67,7 @@ LIMBO_SKIP_TESTCASES = {
     "webpki::aki::root-with-aki-ski-mismatch",
     # We allow RSA keys that aren't divisible by 8, which is technically
     # forbidden under CABF. No other implementation checks this either.
-    "webpki::forbidden-rsa-key-not-divisable-by-8",
+    "webpki::forbidden-rsa-not-divisable-by-8-in-root",
     # We disallow CAs in the leaf position, which is explicitly forbidden
     # by CABF (but implicitly permitted under RFC 5280). This is consistent
     # with what webpki and rustls do, but inconsistent with Go and OpenSSL.


### PR DESCRIPTION
This changes the `valid_issuer` logic slightly, to the following:

1. The issuer's SPKI is checked instead of the child's, since all issuing certificates must confirm to CABF (previously, this would allow a root with a non-CABF-allowed key when used in `root -> EE` configuration)
2. The subject's signature is still checked, and I've added a note explaining why we check the subject's signature rather than the issuer's

With these changes, I've confirmed that the existing tests pass as expected (and additionally, the new tests in the limbo PR below also newly pass).

Needs https://github.com/C2SP/x509-limbo/pull/185.