### PR TITLE
verification/policy: make subject optional internally

### DIFF
--- a/src/rust/cryptography-x509-verification/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/extension.rs
@@ -304,7 +304,11 @@ pub(crate) mod ee {
         };
 
         let san: SubjectAlternativeName<'_> = extn.value()?;
-        if !policy.subject.matches(&san) {
+        if !policy
+            .subject
+            .as_ref()
+            .map_or_else(|| false, |sub| sub.matches(&san))
+        {
             return Err(ValidationError::Other(
                 "leaf certificate has no matching subjectAltName".into(),
             ));

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -208,7 +208,7 @@ pub struct Policy<'a, B: CryptoOps> {
 
     /// A subject (i.e. DNS name or other name format) that any EE certificates
     /// validated by this policy must match.
-    pub subject: Subject<'a>,
+    pub subject: Option<Subject<'a>>,
 
     /// The validation time. All certificates validated by this policy must
     /// be valid at this time.
@@ -245,7 +245,7 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
         Self {
             ops,
             max_chain_depth: max_chain_depth.unwrap_or(DEFAULT_MAX_CHAIN_DEPTH),
-            subject,
+            subject: Some(subject),
             validation_time: time,
             extended_key_usage: EKU_SERVER_AUTH_OID.clone(),
             minimum_rsa_modulus: WEBPKI_MINIMUM_RSA_MODULUS,


### PR DESCRIPTION
This is not surfaced in a public API yet; it's purely an internal change to enable a `ClientVerifier` API (which won't take a subject).

See #10276.