### PR TITLE
openssl: Support OpenSSL v3

### DIFF
--- a/src/_cffi_src/openssl/err.py
+++ b/src/_cffi_src/openssl/err.py
@@ -45,4 +45,11 @@ int ERR_GET_REASON(unsigned long);
 """
 
 CUSTOMIZATIONS = """
+#if OPENSSL_VERSION_MAJOR >= 3
+// OpenSSL v3 has dropped this function
+int ERR_GET_FUNC(unsigned long errcode)
+{
+    return 0;
+}
+#endif
 """

--- a/src/_cffi_src/openssl/fips.py
+++ b/src/_cffi_src/openssl/fips.py
@@ -17,7 +17,7 @@ int FIPS_mode(void);
 """
 
 CUSTOMIZATIONS = """
-#if CRYPTOGRAPHY_IS_LIBRESSL
+#if CRYPTOGRAPHY_IS_LIBRESSL || OPENSSL_VERSION_MAJOR >= 3
 static const long Cryptography_HAS_FIPS = 0;
 int (*FIPS_mode_set)(int) = NULL;
 int (*FIPS_mode)(void) = NULL;


### PR DESCRIPTION
Allow build with modern OpenSSL. Some projects may require old cryptography version