### PR TITLE
raise an exception instead of returning an empty list for pkcs7 cert …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+.. _v41-0-8:
+
+41.0.8 - 2024-02-07
+~~~~~~~~~~~~~~~~~~~
+
+* **BACKWARDS INCOMPATIBLE:** Loading a PKCS7 with no content field using
+  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_pem_pkcs7_certificates`
+  or
+  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_der_pkcs7_certificates`
+  will now raise a ``ValueError`` rather than return an empty list.
+
 .. _v41-0-7:
 
 41.0.7 - 2023-11-27

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -1890,12 +1890,15 @@ class Backend:
                 _Reasons.UNSUPPORTED_SERIALIZATION,
             )
 
-        certs: list[x509.Certificate] = []
         if p7.d.sign == self._ffi.NULL:
-            return certs
+            raise ValueError(
+                "The provided PKCS7 has no certificate data, but a cert "
+                "loading method was called."
+            )
 
         sk_x509 = p7.d.sign.cert
         num = self._lib.sk_X509_num(sk_x509)
+        certs: list[x509.Certificate] = []
         for i in range(num):
             x509 = self._lib.sk_X509_value(sk_x509, i)
             self.openssl_assert(x509 != self._ffi.NULL)

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -92,8 +92,8 @@ class TestPKCS7Loading:
     def test_load_pkcs7_empty_certificates(self, backend):
         der = b"\x30\x0B\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x07\x02"
 
-        certificates = pkcs7.load_der_pkcs7_certificates(der)
-        assert certificates == []
+        with pytest.raises(ValueError):
+            pkcs7.load_der_pkcs7_certificates(der)
 
 
 # We have no public verification API and won't be adding one until we get


### PR DESCRIPTION
…loading (#9947)

* raise an exception instead of returning an empty list

as davidben points out in #9926 we are calling a specific load certificates function and an empty value doesn't necessarily mean empty because PKCS7 contains multitudes. erroring is more correct.

---------

I know this change is backward incompatible but it synchronizes the behavior of the fix for CVE-2023-49083. Versions 41.0.x are not vulnerable anymore but version 42 has better implementation that raises ValueError.

The concern of backward compatibility is just between the latest 41.0.x releases because:
* 41.0.5 - is vulnerable, segfaults
* 41.0.6 and 41.0.7 - is fixed, returns empty list
* 41.0.8 - is fixed, raises ValueError (if this is merged and released)

What do you think about it?