### PR TITLE
smaller mmap in tests to fit in a 32-bit ssize_t

### DIFF
--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -38,7 +38,11 @@ def _aead_supported(cls):
 
 
 def large_mmap():
-    return mmap.mmap(-1, 2**32, prot=mmap.PROT_READ)
+    # We need this large but not larger than fits in a 32-bit int. This way
+    # a 32-bit platform can return this mmap successfully but we'll raise
+    # OverFlowError in the tests because the underlying type for the
+    # function signature is a signed int
+    return mmap.mmap(-1, 2**31, prot=mmap.PROT_READ)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
this still triggers the overflows we expect in the tests and should also work on 32-bit systems

fixes #10364 