### PR TITLE
Support for ECDSA deterministic signing (RFC 6979)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Changelog
   and :class:`~cryptography.hazmat.primitives.ciphers.algorithms.ARC4` into
   :doc:`/hazmat/decrepit/index` and deprecated them in the ``cipher`` module.
   They will be removed from the ``cipher`` module in 48.0.0.
+* Added support for deterministic ECDSA (:rfc:`6979`)
 
 .. _v42-0-5:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,8 @@ Changelog
   and :class:`~cryptography.hazmat.primitives.ciphers.algorithms.ARC4` into
   :doc:`/hazmat/decrepit/index` and deprecated them in the ``cipher`` module.
   They will be removed from the ``cipher`` module in 48.0.0.
-* Added support for deterministic ECDSA (:rfc:`6979`)
+* Added support for deterministic
+  :class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDSA` (:rfc:`6979`)
 
 .. _v42-0-5:
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -49,7 +49,10 @@ Elliptic Curve Signature Algorithms
 
     :param bool deterministic_signing: A boolean flag defaulting to ``False``
         that specifies whether the signing procedure should be deterministic
-        or not, as defined in :rfc:`6979`.
+        or not, as defined in :rfc:`6979`. This only impacts the signing
+        process, verification is not affected (the verification process
+        is the same for both deterministic and non-deterministic signed
+        messages).
 
         .. versionadded:: 43.0.0
 

--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -47,6 +47,16 @@ Elliptic Curve Signature Algorithms
     :param algorithm: An instance of
         :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`.
 
+    :param bool deterministic_signing: A boolean flag defaulting to ``False``
+        that specifies whether the signing procedure should be deterministic
+        or not, as defined in :rfc:`6979`.
+
+        .. versionadded:: 43.0.0
+
+    :raises cryptography.exceptions.UnsupportedAlgorithm: If
+        ``deterministic_signing`` is set to ``True`` and the version of
+        OpenSSL does not support ECDSA with deterministic signing.
+
     .. doctest::
 
         >>> from cryptography.hazmat.primitives import hashes

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -358,6 +358,12 @@ class Backend:
             and not rust_openssl.CRYPTOGRAPHY_IS_BORINGSSL
         )
 
+    def ecdsa_deterministic_supported(self) -> bool:
+        return (
+            rust_openssl.CRYPTOGRAPHY_OPENSSL_320_OR_GREATER
+            and not self._fips_enabled
+        )
+
     def _zero_data(self, data, length: int) -> None:
         # We clear things this way because at the moment we're not
         # sure of a better way that can guarantee it overwrites the

--- a/src/rust/cryptography-openssl/Cargo.toml
+++ b/src/rust/cryptography-openssl/Cargo.toml
@@ -10,6 +10,6 @@ rust-version = "1.65.0"
 [dependencies]
 cfg-if = "1"
 openssl = "0.10.64"
-ffi = { package = "openssl-sys", version = "0.9.100" }
+ffi = { package = "openssl-sys", version = "0.9.101" }
 foreign-types = "0.3"
 foreign-types-shared = "0.1"

--- a/src/rust/cryptography-openssl/Cargo.toml
+++ b/src/rust/cryptography-openssl/Cargo.toml
@@ -10,6 +10,6 @@ rust-version = "1.65.0"
 [dependencies]
 cfg-if = "1"
 openssl = "0.10.64"
-ffi = { package = "openssl-sys", version = "0.9.99" }
+ffi = { package = "openssl-sys", version = "0.9.100" }
 foreign-types = "0.3"
 foreign-types-shared = "0.1"

--- a/src/rust/cryptography-openssl/build.rs
+++ b/src/rust/cryptography-openssl/build.rs
@@ -12,6 +12,9 @@ fn main() {
         if version >= 0x3_00_00_00_0 {
             println!("cargo:rustc-cfg=CRYPTOGRAPHY_OPENSSL_300_OR_GREATER");
         }
+        if version >= 0x3_02_00_00_0 {
+            println!("cargo:rustc-cfg=CRYPTOGRAPHY_OPENSSL_320_OR_GREATER");
+        }
     }
 
     if env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER").is_ok() {

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -273,7 +273,7 @@ impl ECPrivateKey {
                 )),
             ));
         }
-        let (data, _algo) = utils::calculate_digest_and_algorithm(
+        let (data, algo) = utils::calculate_digest_and_algorithm(
             py,
             data.as_bytes(),
             signature_algorithm.getattr(pyo3::intern!(py, "algorithm"))?,
@@ -287,7 +287,7 @@ impl ECPrivateKey {
         cfg_if::cfg_if! {
             if #[cfg(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER)]{
                 if deterministic {
-                    let hash_function_name = _algo
+                    let hash_function_name = algo
                         .getattr(pyo3::intern!(py, "name"))?
                         .extract::<&str>()?;
                     let hash_function = openssl::md::Md::fetch(None, hash_function_name, None)?;
@@ -299,6 +299,7 @@ impl ECPrivateKey {
                     signer.set_nonce_type(openssl::pkey_ctx::NonceType::RANDOM_K)?;
                 }
             } else {
+                let _ = algo;
                 assert!(!deterministic);
             }
         }

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -300,7 +300,12 @@ impl ECPrivateKey {
                 }
             } else {
                 let _ = algo;
-                assert!(!deterministic);
+                return Err(CryptographyError::from(
+                    exceptions::UnsupportedAlgorithm::new_err((
+                        "ECDSA with deterministic signature (RFC 6979) is not supported by this version of OpenSSL.",
+                        exceptions::Reasons::UNSUPPORTED_PUBLIC_KEY_ALGORITHM,
+                    )),
+                ));
             }
         }
 

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -281,11 +281,11 @@ impl ECPrivateKey {
 
         let mut signer = openssl::pkey_ctx::PkeyCtx::new(&self.pkey)?;
         signer.sign_init()?;
-        let deterministic: bool = signature_algorithm
-            .getattr(pyo3::intern!(py, "deterministic_signing"))?
-            .extract()?;
         cfg_if::cfg_if! {
             if #[cfg(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER)]{
+                let deterministic: bool = signature_algorithm
+                    .getattr(pyo3::intern!(py, "deterministic_signing"))?
+                    .extract()?;
                 if deterministic {
                     let hash_function_name = algo
                         .getattr(pyo3::intern!(py, "name"))?

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -300,12 +300,6 @@ impl ECPrivateKey {
                 }
             } else {
                 let _ = algo;
-                return Err(CryptographyError::from(
-                    exceptions::UnsupportedAlgorithm::new_err((
-                        "ECDSA with deterministic signature (RFC 6979) is not supported by this version of OpenSSL.",
-                        exceptions::Reasons::UNSUPPORTED_PUBLIC_KEY_ALGORITHM,
-                    )),
-                ));
             }
         }
 

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -274,7 +274,7 @@ impl ECPrivateKey {
             ));
         }
 
-        let (data, _) = utils::calculate_digest_and_algorithm(
+        let (data, _algo) = utils::calculate_digest_and_algorithm(
             py,
             data.as_bytes(),
             signature_algorithm.getattr(pyo3::intern!(py, "algorithm"))?,
@@ -282,6 +282,27 @@ impl ECPrivateKey {
 
         let mut signer = openssl::pkey_ctx::PkeyCtx::new(&self.pkey)?;
         signer.sign_init()?;
+        let deterministic: bool = signature_algorithm
+            .getattr(pyo3::intern!(py, "deterministic_signing"))?
+            .extract()?;
+        cfg_if::cfg_if! {
+            if #[cfg(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER)]{
+                match deterministic {
+                    true => {
+                        let hash_function_name = _algo.getattr(pyo3::intern!(py, "name"))?.extract::<&str>()?;
+                        let hash_function = openssl::md::Md::fetch(None, hash_function_name, None)?;
+                        // Setting a deterministic nonce type requires to explicitly set the hash function.
+                        // See https://github.com/openssl/openssl/issues/23205
+                        signer.set_signature_md(&hash_function)?;
+                        signer.set_nonce_type(openssl::pkey_ctx::NonceType::DETERMINISTIC_K)?;
+                        },
+                    false => signer.set_nonce_type(openssl::pkey_ctx::NonceType::RANDOM_K)?,
+                };
+            } else {
+                assert!(!deterministic);
+            }
+        }
+
         // TODO: This does an extra allocation and copy. This can't easily use
         // `PyBytes::new_with` because the exact length of the signature isn't
         // easily known a priori (if `r` or `s` has a leading 0, the signature

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -513,7 +513,7 @@ class TestECDSAVectors:
                         signature, vector["message"], ec.ECDSA(hash_type())
                     )
 
-    def test_unsupported_deterministic_nonce(self, backend, subtests):
+    def test_unsupported_deterministic_nonce(self, backend):
         if backend.ecdsa_deterministic_supported():
             pytest.skip(
                 f"ECDSA deterministic signing is supported by this"
@@ -529,14 +529,12 @@ class TestECDSAVectors:
                 f" backend {backend}"
             )
 
-        supported_hash_algorithms: typing.Dict[
-            str, typing.Type[hashes.HashAlgorithm]
-        ] = {
-            "SHA1": hashes.SHA1,
-            "SHA224": hashes.SHA224,
-            "SHA256": hashes.SHA256,
-            "SHA384": hashes.SHA384,
-            "SHA512": hashes.SHA512,
+        supported_hash_algorithms = {
+            "SHA1": hashes.SHA1(),
+            "SHA224": hashes.SHA224(),
+            "SHA256": hashes.SHA256(),
+            "SHA384": hashes.SHA384(),
+            "SHA512": hashes.SHA512(),
         }
         vectors = load_vectors_from_file(
             os.path.join(
@@ -551,10 +549,9 @@ class TestECDSAVectors:
             key = bytes("\n".join(vector["key"]), "utf-8")
             if "digest_sign" in vector:
                 algorithm = vector["digest_sign"]
-                assert algorithm in supported_hash_algorithms
                 hash_algorithm = supported_hash_algorithms[algorithm]
                 algorithm = ec.ECDSA(
-                    hash_algorithm(),
+                    hash_algorithm,
                     deterministic_signing=vector["deterministic_nonce"],
                 )
                 private_key = serialization.load_pem_private_key(
@@ -568,7 +565,7 @@ class TestECDSAVectors:
                 algorithm = vector["digest_verify"]
                 assert algorithm in supported_hash_algorithms
                 hash_algorithm = supported_hash_algorithms[algorithm]
-                algorithm = ec.ECDSA(hash_algorithm())
+                algorithm = ec.ECDSA(hash_algorithm)
                 public_key = serialization.load_pem_public_key(key)
                 assert isinstance(public_key, EllipticCurvePublicKey)
                 if vector["verify_error"]:

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -543,8 +543,8 @@ class TestECDSAVectors:
             load_rfc6979_vectors,
         )
 
-        with subtests.test():
-            for vector in vectors:
+        for vector in vectors:
+            with subtests.test():
                 input = bytes(vector["input"], "utf-8")
                 output = bytes.fromhex(vector["output"])
                 key = bytes("\n".join(vector["key"]), "utf-8")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -701,6 +701,57 @@ def load_kasvs_ecdh_vectors(vector_data):
     return vectors
 
 
+def load_rfc6979_vectors(vector_data):
+    """
+    Loads data out of the ECDSA and DSA RFC6979 vector files.
+    """
+    vectors = []
+    keys: typing.Dict[str, typing.List[str]] = dict()
+    reading_key = False
+    current_key_name = None
+
+    data: typing.Dict[str, object] = dict()
+    for line in vector_data:
+        line = line.strip()
+
+        if reading_key and current_key_name:
+            keys[current_key_name].append(line)
+            if line.startswith("-----END"):
+                reading_key = False
+                current_key_name = None
+
+        if line.startswith("PrivateKey=") or line.startswith("PublicKey="):
+            reading_key = True
+            current_key_name = line.split("=")[1].strip()
+            keys[current_key_name] = []
+        elif line.startswith("DigestSign = "):
+            data["digest_sign"] = line.split("=")[1].strip()
+            data["deterministic_nonce"] = False
+        elif line.startswith("DigestVerify = "):
+            data["digest_verify"] = line.split("=")[1].strip()
+            data["verify_error"] = False
+        elif line.startswith("Key = "):
+            key_name = line.split("=")[1].strip()
+            assert key_name in keys
+            data["key"] = keys[key_name]
+        elif line.startswith("NonceType = "):
+            nonce_type = line.split("=")[1].strip()
+            data["deterministic_nonce"] = nonce_type == "deterministic"
+        elif line.startswith("Input = "):
+            data["input"] = line.split("=")[1].strip(' "')
+        elif line.startswith("Output = "):
+            data["output"] = line.split("=")[1].strip()
+        elif line.startswith("Result = "):
+            data["verify_error"] = line.split("=")[1].strip() == "VERIFY_ERROR"
+
+        elif not line:
+            if data:
+                vectors.append(data)
+                data = dict()
+
+    return vectors
+
+
 def load_x963_vectors(vector_data):
     """
     Loads data out of the X9.63 vector data

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -747,7 +747,7 @@ def load_rfc6979_vectors(vector_data):
         elif not line:
             if data:
                 vectors.append(data)
-                data = dict()
+                data = {}
 
     return vectors
 


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/9795. Now that the Rust bindings needed are in place (https://github.com/sfackler/rust-openssl/pull/2144), this PR adds support for ECDSA deterministic signing (RFC 6979), a new feature in `OpenSSL >= 3.2.0`.

The way to enable it is by passing a new boolean parameter `deterministic_signing` to `ec.ECDSA()`:
``` python
signature = private_key.sign(
    data,
    ec.ECDSA(hashes.SHA256(), deterministic_signing=True)
)
```
- When using anything other than OpenSSL >= 3.2.0, this will raise an `UnsupportedAlgorithm` exception. It will also raise if [FIPS is enabled](https://github.com/openssl/openssl/blob/da1c088f599af3755aaeed1c447a39621ef12e1f/crypto/ec/ecdsa_ossl.c#L183-L190).
- The new `deterministic_signing` parameter defaults to `False`, so that old code that does not specify it maintains the same behavior.
