### PR TITLE
Fix ASN.1 issues in PKCS#7 and S/MIME signing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Changelog
   and :class:`~cryptography.hazmat.primitives.ciphers.algorithms.ARC4` into
   :doc:`/hazmat/decrepit/index` and deprecated them in the ``cipher`` module.
   They will be removed from the ``cipher`` module in 48.0.0.
+* Fixed ASN.1 encoding for PKCS7/SMIME signed messages. The fields ``SMIMECapabilities``
+  and ``SignatureAlgorithmIdentifier`` should now be correctly encoded according to the
+  definitions in :rfc:`2633` :rfc:`3370`.
 
 .. _v42-0-3:
 

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -269,13 +269,13 @@ fn compute_pkcs7_signature_algorithm<'p>(
     rsa_padding: &'p pyo3::PyAny,
 ) -> pyo3::PyResult<common::AlgorithmIdentifier<'static>> {
     let key_type = x509::sign::identify_key_type(py, private_key)?;
-    let has_pss_padding = !rsa_padding.is_none() && rsa_padding.is_instance(types::PSS.get(py)?)?;
+    let has_pss_padding = rsa_padding.is_instance(types::PSS.get(py)?)?;
     // For RSA signatures (with no PSS padding), the OID is always the same no matter the
     // digest algorithm. See RFC 3370 (section 3.2).
     if key_type == x509::sign::KeyType::Rsa && !has_pss_padding {
         Ok(common::AlgorithmIdentifier {
             oid: asn1::DefinedByMarker::marker(),
-            params: common::AlgorithmParameters::Rsa(None),
+            params: common::AlgorithmParameters::Rsa(Some(())),
         })
     } else {
         x509::sign::compute_signature_algorithm(py, private_key, hash_algorithm, rsa_padding)

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -205,7 +205,7 @@ fn sign_and_serialize<'p>(
             },
             digest_algorithm: digest_alg,
             authenticated_attributes: authenticated_attrs,
-            digest_encryption_algorithm: x509::sign::compute_signature_algorithm(
+            digest_encryption_algorithm: compute_pkcs7_signature_algorithm(
                 py,
                 py_private_key,
                 py_hash_alg,
@@ -259,6 +259,26 @@ fn sign_and_serialize<'p>(
     } else {
         // Handles the DER, PEM, and error cases
         encode_der_data(py, "PKCS7".to_string(), ci_bytes, encoding)
+    }
+}
+
+fn compute_pkcs7_signature_algorithm<'p>(
+    py: pyo3::Python<'p>,
+    private_key: &'p pyo3::PyAny,
+    hash_algorithm: &'p pyo3::PyAny,
+    rsa_padding: &'p pyo3::PyAny,
+) -> pyo3::PyResult<common::AlgorithmIdentifier<'static>> {
+    let key_type = x509::sign::identify_key_type(py, private_key)?;
+    let has_pss_padding = !rsa_padding.is_none() && rsa_padding.is_instance(types::PSS.get(py)?)?;
+    // For RSA signatures (with no PSS padding), the OID is always the same no matter the
+    // digest algorithm. See RFC 3370 (section 3.2).
+    if key_type == x509::sign::KeyType::Rsa && !has_pss_padding {
+        Ok(common::AlgorithmIdentifier {
+            oid: asn1::DefinedByMarker::marker(),
+            params: common::AlgorithmParameters::Rsa(None),
+        })
+    } else {
+        x509::sign::compute_signature_algorithm(py, private_key, hash_algorithm, rsa_padding)
     }
 }
 

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -104,9 +104,9 @@ fn sign_and_serialize<'p>(
         // Subset of values OpenSSL provides:
         // https://github.com/openssl/openssl/blob/667a8501f0b6e5705fd611d5bb3ca24848b07154/crypto/pkcs7/pk7_smime.c#L150
         // removing all the ones that are bad cryptography
-        AES_256_CBC_OID,
-        AES_192_CBC_OID,
-        AES_128_CBC_OID,
+        &asn1::SequenceOfWriter::new([AES_256_CBC_OID]),
+        &asn1::SequenceOfWriter::new([AES_192_CBC_OID]),
+        &asn1::SequenceOfWriter::new([AES_128_CBC_OID]),
     ]))?;
 
     let py_signers: Vec<(

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -48,7 +48,10 @@ enum HashType {
     Sha3_512,
 }
 
-fn identify_key_type(py: pyo3::Python<'_>, private_key: &pyo3::PyAny) -> pyo3::PyResult<KeyType> {
+pub(crate) fn identify_key_type(
+    py: pyo3::Python<'_>,
+    private_key: &pyo3::PyAny,
+) -> pyo3::PyResult<KeyType> {
     if private_key.is_instance(types::RSA_PRIVATE_KEY.get(py)?)? {
         Ok(KeyType::Rsa)
     } else if private_key.is_instance(types::DSA_PRIVATE_KEY.get(py)?)? {


### PR DESCRIPTION
This PR fixes two issues with the ASN.1 generated when signing using PKCS#7:

## First issue
The [current implementation](https://github.com/pyca/cryptography/blob/bfcdfbefb32c5a9786ef66d4eb0777f70ae5943b/src/rust/src/pkcs7.rs#L103-L109) defines the SMIMECapabilities attribute so that its value is a SEQUENCE of all the algorithm OIDs that are supported. This is what the ASN.1 currently looks like for a signed message using `cryptography`:
```asn.1
  U.P.SEQUENCE {
     U.P.OBJECTIDENTIFIER 1.2.840.113549.1.9.15 (S/MIME capabilities)
     U.P.SET {
        U.P.SEQUENCE {
           U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.42 (aes256-CBC-PAD)
           U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.22 (aes192-CBC-PAD)
           U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.2 (aes128-CBC-PAD)
        }
     }
  }
```

However, the S/MIME v3 spec (RFC 2633) specifies that each algorithm should be specified in its own SEQUENCE:

```asn.1
SMIMECapabilities ::= SEQUENCE OF SMIMECapability

SMIMECapability ::= SEQUENCE {
   capabilityID OBJECT IDENTIFIER,
   parameters ANY DEFINED BY capabilityID OPTIONAL }
```

([RFC 2633, Appendix A](https://datatracker.ietf.org/doc/html/rfc2633#appendix-A))

The spec matches what OpenSSL outputs (using `openssl smime -sign`):
```asn.1
  U.P.SEQUENCE {
     U.P.OBJECTIDENTIFIER 1.2.840.113549.1.9.15 (S/MIME capabilities)
     U.P.SET {
        U.P.SEQUENCE {
           U.P.SEQUENCE {
              U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.42 (aes256-CBC-PAD)
           }
           U.P.SEQUENCE {
              U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.22 (aes192-CBC-PAD)
           }
           U.P.SEQUENCE {
              U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.2 (aes128-CBC-PAD)
           }
           U.P.SEQUENCE {
              U.P.OBJECTIDENTIFIER 1.2.840.113549.3.7 (id_des_EDE3_CBC)
           }
          .....
```         


This PR changes the implementation so that each algorithm is inside its own SEQUENCE. After the changes in this PR, the ASN.1 output looks like:
```asn.1
  U.P.SEQUENCE {
     U.P.OBJECTIDENTIFIER 1.2.840.113549.1.9.15 (S/MIME capabilities)
     U.P.SET {
        U.P.SEQUENCE {
           U.P.SEQUENCE {
              U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.42 (aes256-CBC-PAD)
           }
           U.P.SEQUENCE {
              U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.22 (aes192-CBC-PAD)
           }
           U.P.SEQUENCE {
              U.P.OBJECTIDENTIFIER 2.16.840.1.101.3.4.1.2 (aes128-CBC-PAD)
           }
        }
     }
  }
```

## Second issue
There is an issue with the RSA OID used for signing PKCS#7/SMIME, in the `SignatureAlgorithmIdentifier` field.
    
The current implementation computes the algorithm identifier used in the `digest_encryption_algorithm` PKCS#7 field
(or `SignatureAlgorithmIdentifier` in S/MIME) based on both the algorithm used to sign (e.g. RSA) and the digest algorithm (e.g. SHA512).
    
This is correct for ECDSA signatures, where the OIDs used include the digest algorithm (e.g: `ecdsa-with-SHA512`). However, due to historical reasons, when signing with RSA the OID specified should be the one
corresponding to just RSA (`"1.2.840.113549.1.1.1" rsaEncryption`), rather than OIDs which also include the digest algorithm (such as `"1.2.840.113549.1.1.13" sha512WithRSAEncryption`).

This means that the logic to compute the algorithm identifier is the same except when signing with RSA, in which case the OID will always be `rsaEncryption`. This is consistent with the OpenSSL implementation, and the RFCs that define PKCS#7 and S/MIME.

See [RFC 3851 (section 2.2)](https://www.rfc-editor.org/rfc/rfc3851#section-2.2), and [RFC 3370 (section 3.2)](https://www.rfc-editor.org/rfc/rfc3370#section-3.2) for more details.