### PR TITLE
policy: `Policy::new` is now `Policy::server`

### DIFF
--- a/src/rust/cryptography-x509-verification/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/extension.rs
@@ -599,7 +599,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::new(
+        let policy = Policy::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
@@ -639,7 +639,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::new(
+        let policy = Policy::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
@@ -673,7 +673,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::new(
+        let policy = Policy::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
@@ -704,7 +704,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::new(
+        let policy = Policy::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
@@ -733,7 +733,7 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::new(
+        let policy = Policy::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -234,9 +234,9 @@ pub struct Policy<'a, B: CryptoOps> {
 }
 
 impl<'a, B: CryptoOps> Policy<'a, B> {
-    /// Create a new policy with defaults for the certificate profile defined in
-    /// the CA/B Forum's Basic Requirements.
-    pub fn new(
+    /// Create a new policy with defaults for the server certificate profile
+    /// defined in the CA/B Forum's Basic Requirements.
+    pub fn server(
         ops: B,
         subject: Subject<'a>,
         time: asn1::DateTime,

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -142,7 +142,7 @@ impl PolicyBuilder {
 
         let policy = OwnedPolicy::try_new(subject_owner, |subject_owner| {
             let subject = build_subject(py, subject_owner)?;
-            Ok::<PyCryptoPolicy<'_>, pyo3::PyErr>(PyCryptoPolicy(Policy::new(
+            Ok::<PyCryptoPolicy<'_>, pyo3::PyErr>(PyCryptoPolicy(Policy::server(
                 PyCryptoOps {},
                 subject,
                 time,


### PR DESCRIPTION
Breakout from https://github.com/pyca/cryptography/pull/10345.