### PR TITLE
Revert "Bump cc from 1.0.83 to 1.0.85 in /src/rust (#10386)"

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -48,9 +48,12 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "cc"
-version = "1.0.85"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b918671670962b48bc23753aef0c51d072dca6f52f01f800854ada6ddb7f7d3"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -12,4 +12,4 @@ pyo3 = { version = "0.20", features = ["abi3"] }
 openssl-sys = "0.9.99"
 
 [build-dependencies]
-cc = "1.0.85"
+cc = "1.0.83"


### PR DESCRIPTION
This reverts commit c835401c4aaaef17d421a5b8fb1136cfe8a681b6.

1.0.85 (and 84) were yanked.