### PR TITLE
Don't install cryptography_vectors 2x in local nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -250,11 +250,15 @@ def rust(session: nox.Session) -> None:
 @nox.session
 def local(session):
     pyproject_data = load_pyproject_toml()
+    test_dependencies = pyproject_data["project"]["optional-dependencies"][
+        "test"
+    ]
+    test_dependencies.remove("cryptography_vectors")
     install(
         session,
         *pyproject_data["build-system"]["requires"],
         *pyproject_data["project"]["optional-dependencies"]["pep8test"],
-        *pyproject_data["project"]["optional-dependencies"]["test"],
+        *test_dependencies,
         *pyproject_data["project"]["optional-dependencies"]["ssh"],
         *pyproject_data["project"]["optional-dependencies"]["nox"],
         "flit",


### PR DESCRIPTION
Now that it's a part of the test extras, we were installing it twice, once from PyPI and once from local. Don't do that.