### PR TITLE
support RC2-CBC

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -18,6 +18,7 @@ from cryptography.hazmat.decrepit.ciphers.algorithms import (
     ARC4,
     CAST5,
     IDEA,
+    RC2,
     SEED,
     Blowfish,
     TripleDES,
@@ -66,11 +67,6 @@ from cryptography.hazmat.primitives.serialization.pkcs12 import (
 )
 
 _MemoryBIO = collections.namedtuple("_MemoryBIO", ["bio", "char_ptr"])
-
-
-# Not actually supported, just used as a marker for some serialization tests.
-class _RC2:
-    pass
 
 
 class Backend:
@@ -291,9 +287,8 @@ class Backend:
             self.register_cipher_adapter(
                 ARC4, type(None), GetCipherByName("rc4")
             )
-            # We don't actually support RC2, this is just used by some tests.
             self.register_cipher_adapter(
-                _RC2, type(None), GetCipherByName("rc2")
+                RC2, CBC, GetCipherByName("{cipher.name}-{mode.name}")
             )
 
     def create_symmetric_encryption_ctx(

--- a/src/cryptography/hazmat/decrepit/ciphers/algorithms.py
+++ b/src/cryptography/hazmat/decrepit/ciphers/algorithms.py
@@ -90,3 +90,18 @@ class IDEA(BlockCipherAlgorithm):
     @property
     def key_size(self) -> int:
         return len(self.key) * 8
+
+
+# This class only allows RC2 with a 128-bit key. No support for
+# effective key bits or other key sizes is provided.
+class RC2(BlockCipherAlgorithm):
+    name = "RC2"
+    block_size = 64
+    key_sizes = frozenset([128])
+
+    def __init__(self, key: bytes):
+        self.key = _verify_key_size(self, key)
+
+    @property
+    def key_size(self) -> int:
+        return len(self.key) * 8

--- a/tests/hazmat/primitives/decrepit/test_rc2.py
+++ b/tests/hazmat/primitives/decrepit/test_rc2.py
@@ -1,0 +1,37 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""
+Test using the NIST Test Vectors
+"""
+
+
+import binascii
+import os
+
+import pytest
+
+from cryptography.hazmat.decrepit.ciphers.algorithms import RC2
+from cryptography.hazmat.primitives.ciphers import modes
+
+from ....utils import load_nist_vectors
+from ..utils import generate_encrypt_test
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.cipher_supported(
+        RC2(b"\x00" * 16), modes.CBC(b"\x00" * 8)
+    ),
+    skip_message="Does not support RC2 CBC",
+)
+class TestRC2ModeCBC:
+    test_kat = generate_encrypt_test(
+        load_nist_vectors,
+        os.path.join("ciphers", "RC2"),
+        [
+            "rc2-cbc.txt",
+        ],
+        lambda key, **kwargs: RC2(binascii.unhexlify(key)),
+        lambda iv, **kwargs: modes.CBC(binascii.unhexlify(iv)),
+    )

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -10,7 +10,7 @@ import pytest
 
 from cryptography import x509
 from cryptography.exceptions import UnsupportedAlgorithm
-from cryptography.hazmat.backends.openssl.backend import _RC2
+from cryptography.hazmat.decrepit.ciphers.algorithms import RC2
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import (
     dsa,
@@ -81,7 +81,7 @@ class TestPKCS12Loading:
         ],
     )
     @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(_RC2(), None),
+        only_if=lambda backend: backend.cipher_supported(RC2(b"0" * 16), None),
         skip_message="Does not support RC2",
     )
     def test_load_pkcs12_ec_keys_rc2(self, filename, password, backend):

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -19,6 +19,7 @@ from cryptography.hazmat.primitives.asymmetric import (
     ed25519,
     rsa,
 )
+from cryptography.hazmat.primitives.ciphers.modes import CBC
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     PublicFormat,
@@ -81,7 +82,9 @@ class TestPKCS12Loading:
         ],
     )
     @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(RC2(b"0" * 16), None),
+        only_if=lambda backend: backend.cipher_supported(
+            RC2(b"0" * 16), CBC(b"0" * 8)
+        ),
         skip_message="Does not support RC2",
     )
     def test_load_pkcs12_ec_keys_rc2(self, filename, password, backend):


### PR DESCRIPTION
This PR supports a bad old algorithm to support a scapy use case (and unblock full oxidization of the cipher layer), but does not expose support for effective key bits or any key length other than 128-bit. CBC support only -- no other modes.

I've got mixed feelings about adding documentation for this, so there isn't any right now.