### PR TITLE
Convert PKCS#12 loading to Rust

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/openssl/keys.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/openssl/keys.pyi
@@ -9,10 +9,6 @@ from cryptography.hazmat.primitives.asymmetric.types import (
     PublicKeyTypes,
 )
 
-def private_key_from_ptr(
-    ptr: int,
-    unsafe_skip_rsa_key_validation: bool,
-) -> PrivateKeyTypes: ...
 def load_der_private_key(
     data: bytes,
     password: bytes | None,

--- a/src/cryptography/hazmat/bindings/_rust/pkcs12.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/pkcs12.pyi
@@ -1,0 +1,26 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+import typing
+
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
+from cryptography.hazmat.primitives.serialization.pkcs12 import (
+    PKCS12KeyAndCertificates,
+)
+
+def load_key_and_certificates(
+    data: bytes,
+    password: bytes | None,
+    backend: typing.Any = None,
+) -> tuple[
+    PrivateKeyTypes | None,
+    x509.Certificate | None,
+    list[x509.Certificate],
+]: ...
+def load_pkcs12(
+    data: bytes,
+    password: bytes | None,
+    backend: typing.Any = None,
+) -> PKCS12KeyAndCertificates: ...

--- a/src/cryptography/hazmat/bindings/_rust/pkcs7.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/pkcs7.pyi
@@ -1,3 +1,7 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
 import typing
 
 from cryptography import x509

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import typing
 
 from cryptography import x509
+from cryptography.hazmat.bindings._rust import pkcs12 as rust_pkcs12
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives._serialization import PBES as PBES
 from cryptography.hazmat.primitives.asymmetric import (
@@ -143,28 +144,8 @@ class PKCS12KeyAndCertificates:
         return fmt.format(self.key, self.cert, self.additional_certs)
 
 
-def load_key_and_certificates(
-    data: bytes,
-    password: bytes | None,
-    backend: typing.Any = None,
-) -> tuple[
-    PrivateKeyTypes | None,
-    x509.Certificate | None,
-    list[x509.Certificate],
-]:
-    from cryptography.hazmat.backends.openssl.backend import backend as ossl
-
-    return ossl.load_key_and_certificates_from_pkcs12(data, password)
-
-
-def load_pkcs12(
-    data: bytes,
-    password: bytes | None,
-    backend: typing.Any = None,
-) -> PKCS12KeyAndCertificates:
-    from cryptography.hazmat.backends.openssl.backend import backend as ossl
-
-    return ossl.load_pkcs12(data, password)
+load_key_and_certificates = rust_pkcs12.load_key_and_certificates
+load_pkcs12 = rust_pkcs12.load_pkcs12
 
 
 _PKCS12CATypes = typing.Union[

--- a/src/rust/src/backend/keys.rs
+++ b/src/rust/src/backend/keys.rs
@@ -2,7 +2,6 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use foreign_types_shared::ForeignTypeRef;
 use pyo3::IntoPy;
 
 use crate::backend::utils;
@@ -61,18 +60,7 @@ fn load_pem_private_key(
     private_key_from_pkey(py, &pkey, unsafe_skip_rsa_key_validation)
 }
 
-#[pyo3::prelude::pyfunction]
-fn private_key_from_ptr(
-    py: pyo3::Python<'_>,
-    ptr: usize,
-    unsafe_skip_rsa_key_validation: bool,
-) -> CryptographyResult<pyo3::PyObject> {
-    // SAFETY: Caller is responsible for passing a valid pointer.
-    let pkey = unsafe { openssl::pkey::PKeyRef::from_ptr(ptr as *mut _) };
-    private_key_from_pkey(py, pkey, unsafe_skip_rsa_key_validation)
-}
-
-fn private_key_from_pkey(
+pub(crate) fn private_key_from_pkey(
     py: pyo3::Python<'_>,
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
     unsafe_skip_rsa_key_validation: bool,
@@ -236,15 +224,13 @@ pub(crate) fn create_module(py: pyo3::Python<'_>) -> pyo3::PyResult<&pyo3::prelu
     m.add_function(pyo3::wrap_pyfunction!(load_der_public_key, m)?)?;
     m.add_function(pyo3::wrap_pyfunction!(load_pem_public_key, m)?)?;
 
-    m.add_function(pyo3::wrap_pyfunction!(private_key_from_ptr, m)?)?;
-
     Ok(m)
 }
 
 #[cfg(test)]
 mod tests {
     #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
-    use super::public_key_from_pkey;
+    use super::{private_key_from_pkey, public_key_from_pkey};
 
     #[test]
     #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
@@ -258,6 +244,17 @@ mod tests {
             // Pass a nonsense id for this key to test the unsupported
             // algorithm path.
             assert!(public_key_from_pkey(py, &pkey, openssl::pkey::Id::CMAC).is_err());
+        });
+    }
+
+    #[test]
+    #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
+    fn test_private_key_from_pkey_unknown_key() {
+        pyo3::prepare_freethreaded_python();
+
+        pyo3::Python::with_gil(|py| {
+            let pkey = openssl::pkey::PKey::hmac(&[0; 32]).unwrap();
+            assert!(private_key_from_pkey(py, &pkey, false).is_err());
         });
     }
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -18,6 +18,7 @@ mod error;
 mod exceptions;
 pub(crate) mod oid;
 mod padding;
+mod pkcs12;
 mod pkcs7;
 pub(crate) mod types;
 mod x509;
@@ -82,6 +83,7 @@ fn _rust(py: pyo3::Python<'_>, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> 
 
     m.add_submodule(asn1::create_submodule(py)?)?;
     m.add_submodule(pkcs7::create_submodule(py)?)?;
+    m.add_submodule(pkcs12::create_submodule(py)?)?;
     m.add_submodule(exceptions::create_submodule(py)?)?;
 
     let x509_mod = pyo3::prelude::PyModule::new(py, "x509")?;

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -1,0 +1,150 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use crate::backend::keys;
+use crate::buf::CffiBuf;
+use crate::error::CryptographyResult;
+use crate::{types, x509};
+use pyo3::IntoPy;
+
+fn decode_p12(
+    data: CffiBuf<'_>,
+    password: Option<CffiBuf<'_>>,
+) -> CryptographyResult<openssl::pkcs12::ParsedPkcs12_2> {
+    let p12 = openssl::pkcs12::Pkcs12::from_der(data.as_bytes()).map_err(|_| {
+        pyo3::exceptions::PyValueError::new_err("Could not deserialize PKCS12 data")
+    })?;
+
+    let password = if let Some(p) = password.as_ref() {
+        std::str::from_utf8(p.as_bytes())
+            .map_err(|_| pyo3::exceptions::PyUnicodeDecodeError::new_err(()))?
+    } else {
+        // Treat `password=None` the same as empty string. They're actually
+        // not the same in PKCS#12, but OpenSSL transparently handles them the
+        // same.
+        ""
+    };
+    let parsed = p12
+        .parse2(password)
+        .map_err(|_| pyo3::exceptions::PyValueError::new_err("Invalid password or PKCS12 data"))?;
+
+    Ok(parsed)
+}
+
+#[pyo3::prelude::pyfunction]
+fn load_key_and_certificates<'p>(
+    py: pyo3::Python<'p>,
+    data: CffiBuf<'_>,
+    password: Option<CffiBuf<'_>>,
+    backend: Option<&pyo3::PyAny>,
+) -> CryptographyResult<(
+    pyo3::PyObject,
+    Option<x509::certificate::Certificate>,
+    &'p pyo3::types::PyList,
+)> {
+    let _ = backend;
+
+    let p12 = decode_p12(data, password)?;
+
+    let private_key = if let Some(pkey) = p12.pkey {
+        keys::private_key_from_pkey(py, &pkey, false)?
+    } else {
+        py.None()
+    };
+    let cert = if let Some(ossl_cert) = p12.cert {
+        let cert_der = pyo3::types::PyBytes::new(py, &ossl_cert.to_der()?).into_py(py);
+        Some(x509::certificate::load_der_x509_certificate(
+            py, cert_der, None,
+        )?)
+    } else {
+        None
+    };
+    let additional_certs = pyo3::types::PyList::empty(py);
+    if let Some(ossl_certs) = p12.ca {
+        cfg_if::cfg_if! {
+            if #[cfg(any(
+                CRYPTOGRAPHY_OPENSSL_300_OR_GREATER, CRYPTOGRAPHY_IS_BORINGSSL
+            ))] {
+                let it = ossl_certs.iter();
+            } else {
+                let it = ossl_certs.iter().rev();
+            }
+        };
+
+        for ossl_cert in it {
+            let cert_der = pyo3::types::PyBytes::new(py, &ossl_cert.to_der()?).into_py(py);
+            let cert = x509::certificate::load_der_x509_certificate(py, cert_der, None)?;
+            additional_certs.append(cert.into_py(py))?;
+        }
+    }
+
+    Ok((private_key, cert, additional_certs))
+}
+
+#[pyo3::prelude::pyfunction]
+fn load_pkcs12<'p>(
+    py: pyo3::Python<'p>,
+    data: CffiBuf<'_>,
+    password: Option<CffiBuf<'_>>,
+    backend: Option<&pyo3::PyAny>,
+) -> CryptographyResult<&'p pyo3::PyAny> {
+    let _ = backend;
+
+    let p12 = decode_p12(data, password)?;
+
+    let private_key = if let Some(pkey) = p12.pkey {
+        keys::private_key_from_pkey(py, &pkey, false)?
+    } else {
+        py.None()
+    };
+    let cert = if let Some(ossl_cert) = p12.cert {
+        let cert_der = pyo3::types::PyBytes::new(py, &ossl_cert.to_der()?).into_py(py);
+        let cert = x509::certificate::load_der_x509_certificate(py, cert_der, None)?;
+        let alias = ossl_cert.alias();
+
+        types::PKCS12CERTIFICATE
+            .get(py)?
+            .call1((cert, alias))?
+            .into_py(py)
+    } else {
+        py.None()
+    };
+    let additional_certs = pyo3::types::PyList::empty(py);
+    if let Some(ossl_certs) = p12.ca {
+        cfg_if::cfg_if! {
+            if #[cfg(any(
+                CRYPTOGRAPHY_OPENSSL_300_OR_GREATER, CRYPTOGRAPHY_IS_BORINGSSL
+            ))] {
+                let it = ossl_certs.iter();
+            } else {
+                let it = ossl_certs.iter().rev();
+            }
+        };
+
+        for ossl_cert in it {
+            let cert_der = pyo3::types::PyBytes::new(py, &ossl_cert.to_der()?).into_py(py);
+            let cert = x509::certificate::load_der_x509_certificate(py, cert_der, None)?;
+            let alias = ossl_cert.alias();
+
+            let p12_cert = types::PKCS12CERTIFICATE
+                .get(py)?
+                .call1((cert, alias))?
+                .into_py(py);
+            additional_certs.append(p12_cert)?;
+        }
+    }
+
+    Ok(types::PKCS12KEYANDCERTIFICATES
+        .get(py)?
+        .call1((private_key, cert, additional_certs))?)
+}
+
+pub(crate) fn create_submodule(py: pyo3::Python<'_>) -> pyo3::PyResult<&pyo3::prelude::PyModule> {
+    let submod = pyo3::prelude::PyModule::new(py, "pkcs12")?;
+
+    submod.add_function(pyo3::wrap_pyfunction!(load_key_and_certificates, submod)?)?;
+    submod.add_function(pyo3::wrap_pyfunction!(load_pkcs12, submod)?)?;
+
+    Ok(submod)
+}

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -327,6 +327,15 @@ pub static SMIME_ENCODE: LazyPyImport = LazyPyImport::new(
     &["_smime_encode"],
 );
 
+pub static PKCS12CERTIFICATE: LazyPyImport = LazyPyImport::new(
+    "cryptography.hazmat.primitives.serialization.pkcs12",
+    &["PKCS12Certificate"],
+);
+pub static PKCS12KEYANDCERTIFICATES: LazyPyImport = LazyPyImport::new(
+    "cryptography.hazmat.primitives.serialization.pkcs12",
+    &["PKCS12KeyAndCertificates"],
+);
+
 pub static HASHES_MODULE: LazyPyImport =
     LazyPyImport::new("cryptography.hazmat.primitives.hashes", &[]);
 pub static HASH_ALGORITHM: LazyPyImport =

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -201,15 +201,6 @@ class TestOpenSSLRSA:
 
 
 class TestOpenSSLSerializationWithOpenSSL:
-    def test_unsupported_evp_pkey_type(self):
-        key = backend._lib.EVP_PKEY_new()
-        key = backend._ffi.gc(key, backend._lib.EVP_PKEY_free)
-        with raises_unsupported_algorithm(None):
-            rust_openssl.keys.private_key_from_ptr(
-                int(backend._ffi.cast("uintptr_t", key)),
-                unsafe_skip_rsa_key_validation=False,
-            )
-
     def test_very_long_pem_serialization_password(self):
         password = b"x" * 1025
 

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -91,7 +91,7 @@ class TestPKCS12Loading:
     def test_load_pkcs12_ec_keys_rc2(self, filename, password, backend):
         self._test_load_pkcs12_ec_keys(filename, password, backend)
 
-    def test_load_pkcs12_cert_only(self, backend):
+    def test_load_key_and_cert_cert_only(self, backend):
         cert, _ = _load_ca(backend)
         parsed_key, parsed_cert, parsed_more_certs = load_vectors_from_file(
             os.path.join("pkcs12", "cert-aes256cbc-no-key.p12"),
@@ -104,7 +104,7 @@ class TestPKCS12Loading:
         assert parsed_key is None
         assert parsed_more_certs == [cert]
 
-    def test_load_pkcs12_key_only(self, backend):
+    def test_load_key_and_certificates_key_only(self, backend):
         _, key = _load_ca(backend)
         assert isinstance(key, ec.EllipticCurvePrivateKey)
         parsed_key, parsed_cert, parsed_more_certs = load_vectors_from_file(
@@ -118,6 +118,19 @@ class TestPKCS12Loading:
         assert parsed_key.private_numbers() == key.private_numbers()
         assert parsed_cert is None
         assert parsed_more_certs == []
+
+    def test_load_pkcs12_key_only(self, backend):
+        _, key = _load_ca(backend)
+        assert isinstance(key, ec.EllipticCurvePrivateKey)
+        p12 = load_vectors_from_file(
+            os.path.join("pkcs12", "no-cert-key-aes256cbc.p12"),
+            lambda data: load_pkcs12(data.read(), b"cryptography", backend),
+            mode="rb",
+        )
+        assert isinstance(p12.key, ec.EllipticCurvePrivateKey)
+        assert p12.key.private_numbers() == key.private_numbers()
+        assert p12.cert is None
+        assert p12.additional_certs == []
 
     def test_non_bytes(self, backend):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Missing coverage:
- [x] `load_pkcs12` with invalid DER
- [x] `load_pkcs12` with no additional certs
- [x] `private_key_from_pkey` with unknown key type