### PR TITLE
verification: add RFC822Name

### DIFF
--- a/src/rust/cryptography-x509-verification/src/types.rs
+++ b/src/rust/cryptography-x509-verification/src/types.rs
@@ -347,7 +347,7 @@ impl<'a> RFC822Name<'a> {
     }
 
     pub fn mailbox(&self) -> &str {
-        &(self.0).0.as_str()
+        (self.0).0.as_str()
     }
 
     pub fn domain(&self) -> &DNSName<'_> {

--- a/src/rust/cryptography-x509-verification/src/types.rs
+++ b/src/rust/cryptography-x509-verification/src/types.rs
@@ -318,13 +318,8 @@ impl<'a> RFC822Name<'a> {
     pub fn new(value: &'a str) -> Option<Self> {
         // Mailbox = Local-part "@" Domain
         // Both must be present.
-        let Some((local_part, domain)) = value.split_once('@') else {
-            return None;
-        };
-
-        let Some(local_part) = IA5String::new(local_part) else {
-            return None;
-        };
+        let (local_part, domain) = value.split_once('@')?;
+        let local_part = IA5String::new(local_part)?;
 
         // Local-part = Dot-string / Quoted-string
         // NOTE(ww): We do not support the Quoted-string form, for now.


### PR DESCRIPTION
This is a backing piece for #10345. Once merged, I'll do a follow up PR for `RFC822Constraint` for the Name Constraint side.

Flagging one thing: this implementation doesn't currently bother with the "quoted" form of mailbox names. These are treated as invalid addresses for the time being, and I've added a testcase as a backstop for that behavior so that it doesn't change unexpectedly.

(I can try with the quoted form, but it'll probably make a PR a decent bit bigger and may just be worth a crate that gets it right. They're also uncommon and the relevant RFCs advise against using them for compatibility reasons.)