### PR TITLE
Allow clippy::result_large_err

### DIFF
--- a/src/rust/cryptography-key-parsing/src/lib.rs
+++ b/src/rust/cryptography-key-parsing/src/lib.rs
@@ -2,6 +2,10 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
+#![allow(unknown_lints, clippy::result_large_err)]
+
 pub mod rsa;
 pub mod spki;
 

--- a/src/rust/cryptography-key-parsing/src/rsa.rs
+++ b/src/rust/cryptography-key-parsing/src/rsa.rs
@@ -13,7 +13,7 @@ pub struct Pksc1RsaPublicKey<'a> {
 pub fn parse_pkcs1_public_key(
     data: &[u8],
 ) -> KeyParsingResult<openssl::pkey::PKey<openssl::pkey::Public>> {
-    let k = asn1::parse_single::<Pksc1RsaPublicKey>(data)?;
+    let k = asn1::parse_single::<Pksc1RsaPublicKey<'_>>(data)?;
 
     let n = openssl::bn::BigNum::from_slice(k.n.as_bytes())?;
     let e = openssl::bn::BigNum::from_slice(k.e.as_bytes())?;

--- a/src/rust/cryptography-key-parsing/src/spki.rs
+++ b/src/rust/cryptography-key-parsing/src/spki.rs
@@ -9,7 +9,7 @@ use crate::{KeyParsingError, KeyParsingResult};
 pub fn parse_public_key(
     data: &[u8],
 ) -> KeyParsingResult<openssl::pkey::PKey<openssl::pkey::Public>> {
-    let k = asn1::parse_single::<SubjectPublicKeyInfo>(data)?;
+    let k = asn1::parse_single::<SubjectPublicKeyInfo<'_>>(data)?;
 
     match k.algorithm.params {
         AlgorithmParameters::Ec(ec_params) => match ec_params {

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
+#![allow(unknown_lints, clippy::result_large_err)]
 
 pub mod certificate;
 pub mod ops;

--- a/src/rust/cryptography-x509/src/lib.rs
+++ b/src/rust/cryptography-x509/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
+#![allow(unknown_lints, clippy::result_large_err)]
 
 pub mod certificate;
 pub mod common;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -3,7 +3,7 @@
 // for complete details.
 
 #![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
-#![allow(unknown_lints, non_local_definitions)]
+#![allow(unknown_lints, non_local_definitions, clippy::result_large_err)]
 
 #[cfg(CRYPTOGRAPHY_OPENSSL_300_OR_GREATER)]
 use crate::error::CryptographyResult;


### PR DESCRIPTION
This is triggered by the latest rust-asn1 (see #10530)