### PR TITLE
test_limbo: skip non-SERVER cases for now

### DIFF
--- a/.github/actions/fetch-vectors/action.yml
+++ b/.github/actions/fetch-vectors/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         repository: "C2SP/x509-limbo"
         path: "x509-limbo"
-        # Latest commit on the x509-limbo main branch, as of Mar 01, 2024.
-        ref: "a9c42d8d243942e95d9365e39bd45822e5af6981" # x509-limbo-ref
+        # Latest commit on the x509-limbo main branch, as of Mar 05, 2024.
+        ref: "b13ff3276809afc754434808033bd1a48f0157f6" # x509-limbo-ref

--- a/tests/x509/verification/test_limbo.py
+++ b/tests/x509/verification/test_limbo.py
@@ -73,6 +73,9 @@ LIMBO_SKIP_TESTCASES = {
     # with what webpki and rustls do, but inconsistent with Go and OpenSSL.
     "rfc5280::ca-as-leaf",
     "pathlen::validation-ignores-pathlen-in-leaf",
+    # Client testcases are not supported yet.
+    "rfc5280::nc::nc-permits-email-exact",
+    "rfc5280::nc::nc-permits-email-domain",
 }
 
 


### PR DESCRIPTION
Unbreaks https://github.com/pyca/cryptography/pull/10537.