### PR TITLE
Set mac_iter to OpenSSL's default

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -410,6 +410,7 @@ class Backend:
             nid_cert = -1
             nid_key = -1
             pkcs12_iter = 0
+            # mac_iter of 0 uses OpenSSL's default value
             mac_iter = 0
             mac_alg = self._ffi.NULL
         elif isinstance(
@@ -426,10 +427,7 @@ class Backend:
                 nid_key = self._lib.NID_pbe_WithSHA1And3_Key_TripleDES_CBC
             # At least we can set this higher than OpenSSL's default
             pkcs12_iter = 20000
-            # mac_iter chosen for compatibility reasons, see:
-            # https://www.openssl.org/docs/man1.1.1/man3/PKCS12_create.html
-            # Did we mention how lousy PKCS12 encryption is?
-            mac_iter = 1
+            mac_iter = 0
             # MAC algorithm can only be set on OpenSSL 3.0.0+
             mac_alg = self._ffi.NULL
             password = encryption_algorithm.password
@@ -446,8 +444,7 @@ class Backend:
             nid_key = 0
             # Use the default iters we use in best available
             pkcs12_iter = 20000
-            # See the Best Available comment for why this is 1
-            mac_iter = 1
+            mac_iter = 0
             password = encryption_algorithm.password
             keycertalg = encryption_algorithm._key_cert_algorithm
             if keycertalg is PBES.PBESv1SHA1And3KeyTripleDESCBC:


### PR DESCRIPTION
On OpenSSL 3, it uses 2048 iterations for mac_iter by default. We've been doing this with NoEncryption for two years, so I guess it's fine now and the comment is out of date.