### PR TITLE
verification: abbreviate two errors slightly

### DIFF
--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -484,7 +484,7 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
         {
             return Err(ValidationError::Other(format!(
                 "Forbidden public key algorithm: {:?}",
-                &child.tbs_cert.spki.algorithm
+                &child.tbs_cert.spki.algorithm.oid()
             )));
         }
 
@@ -500,7 +500,7 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
         {
             return Err(ValidationError::Other(format!(
                 "Forbidden signature algorithm: {:?}",
-                &child.signature_alg
+                &child.signature_alg.oid()
             )));
         }
 


### PR DESCRIPTION
This is a tiny QoL thing, noticed in https://github.com/C2SP/x509-limbo/pull/173: rather than dumping out the entire `AlgorithmIdentifier` (which can be huge, e.g. due to an explicit curve encoding), we can render just the identifier's OID).

