### PR TITLE
Revert "verification: abbreviate two errors slightly (#10575)"

### DIFF
--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -484,7 +484,7 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
         {
             return Err(ValidationError::Other(format!(
                 "Forbidden public key algorithm: {:?}",
-                &child.tbs_cert.spki.algorithm.oid()
+                &child.tbs_cert.spki.algorithm
             )));
         }
 
@@ -500,7 +500,7 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
         {
             return Err(ValidationError::Other(format!(
                 "Forbidden signature algorithm: {:?}",
-                &child.signature_alg.oid()
+                &child.signature_alg
             )));
         }
 


### PR DESCRIPTION
This reverts commit 1db62a1f91a44963521316dd9b18e380a5e12cee.

This was hasty: by rendering only the OID, we make it look like all EC keys are unsupported, not just explicit ones.