### PR TITLE
CHANGELOG: record new X.509 client verification APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ htmlcov/
 .hypothesis/
 target/
 .rust-cov/
+*.lcov
+*.profdata

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,12 @@ Changelog
   They will be removed from the ``cipher`` module in 48.0.0.
 * Added support for deterministic
   :class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDSA` (:rfc:`6979`)
+* Added support for client certificate verification to the
+  :mod:`X.509 path validation <cryptography.x509.verification>` APIs in the
+  form of :class:`~cryptography.x509.verification.ClientVerifier`,
+  :class:`~cryptography.x509.verification.VerifiedClient`, and
+  ``PolicyBuilder``
+  :meth:`~cryptography.x509.verification.PolicyBuilder.build_client_verifier`.
 
 .. _v42-0-5:
 


### PR DESCRIPTION
This also adds two patterns to the `.gitignore` based on in-repo files after generating coverage locally. Happy to remove if you'd prefer.