### PR TITLE
Begin migrating PKCS#12 serialization to Rust

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/pkcs12.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/pkcs12.pyi
@@ -33,3 +33,8 @@ def load_pkcs12(
     password: bytes | None,
     backend: typing.Any = None,
 ) -> PKCS12KeyAndCertificates: ...
+def serialize_key_and_certificates(
+    name: bytes | None,
+    cert: x509.Certificate | None,
+    cas: typing.Iterable[x509.Certificate | PKCS12Certificate] | None,
+) -> bytes: ...

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -167,6 +167,11 @@ def serialize_key_and_certificates(
     if key is None and cert is None and not cas:
         raise ValueError("You must supply at least one of key, cert, or cas")
 
+    if key is None and isinstance(
+        encryption_algorithm, serialization.NoEncryption
+    ):
+        return rust_pkcs12.serialize_key_and_certificates(name, cert, cas)
+
     from cryptography.hazmat.backends.openssl.backend import backend
 
     return backend.serialize_key_and_certificates_to_pkcs12(

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -414,6 +414,25 @@ impl<'a> asn1::SimpleAsn1Writable for UnvalidatedVisibleString<'a> {
     }
 }
 
+/// A BMPString ASN.1 element, where it is stored as a UTF-8 string in memory.
+pub struct Utf8StoredBMPString<'a>(pub &'a str);
+
+impl<'a> Utf8StoredBMPString<'a> {
+    pub fn new(s: &'a str) -> Self {
+        Utf8StoredBMPString(s)
+    }
+}
+
+impl<'a> asn1::SimpleAsn1Writable for Utf8StoredBMPString<'a> {
+    const TAG: asn1::Tag = asn1::BMPString::TAG;
+    fn write_data(&self, writer: &mut asn1::WriteBuf) -> asn1::WriteResult {
+        for ch in self.0.encode_utf16() {
+            writer.push_slice(&ch.to_be_bytes())?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone)]
 pub struct WithTlv<'a, T> {
     tlv: asn1::Tlv<'a>,

--- a/src/rust/cryptography-x509/src/pkcs12.rs
+++ b/src/rust/cryptography-x509/src/pkcs12.rs
@@ -2,6 +2,7 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use crate::common::Utf8StoredBMPString;
 use crate::pkcs7;
 
 pub const CERT_BAG_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 12, 10, 1, 3);
@@ -9,60 +10,60 @@ pub const KEY_BAG_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1,
 pub const X509_CERTIFICATE_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 22, 1);
 pub const FRIENDLY_NAME_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 20);
 
-// #[derive(asn1::Asn1Write)]
+#[derive(asn1::Asn1Write)]
 pub struct Pfx<'a> {
     pub version: u8,
     pub auth_safe: pkcs7::ContentInfo<'a>,
     pub mac_data: Option<MacData<'a>>,
 }
 
-// #[derive(asn1::Asn1Write)]
+#[derive(asn1::Asn1Write)]
 pub struct MacData<'a> {
     pub mac: pkcs7::DigestInfo<'a>,
     pub salt: &'a [u8],
-    // #[default(1u64)]
+    #[default(1u64)]
     pub iterations: u64,
 }
 
-// #[derive(asn1::Asn1Write)]
+#[derive(asn1::Asn1Write)]
 pub struct SafeBag<'a> {
     pub _bag_id: asn1::DefinedByMarker<asn1::ObjectIdentifier>,
-    // #[defined_by(_bag_id)]
+    #[defined_by(_bag_id)]
     pub bag_value: asn1::Explicit<BagValue<'a>, 0>,
-    // pub attributes: Option<asn1::SetOfWriter<'a, Attribute<'a>>>,
+    pub attributes: Option<asn1::SetOfWriter<'a, Attribute<'a>, Vec<Attribute<'a>>>>,
 }
 
-// #[derive(asn1::Asn1Write)]
+#[derive(asn1::Asn1Write)]
 pub struct Attribute<'a> {
     pub _attr_id: asn1::DefinedByMarker<asn1::ObjectIdentifier>,
-    // #[defined_by(_attr_id)]
+    #[defined_by(_attr_id)]
     pub attr_values: AttributeSet<'a>,
 }
 
-// #[derive(asn1::Asn1DefinedByWrite)]
+#[derive(asn1::Asn1DefinedByWrite)]
 pub enum AttributeSet<'a> {
-    // #[defined_by(FRIENDLY_NAME_OID)]
-    FriendlyName(asn1::SetOfWriter<'a, asn1::BMPString<'a>>),
+    #[defined_by(FRIENDLY_NAME_OID)]
+    FriendlyName(asn1::SetOfWriter<'a, Utf8StoredBMPString<'a>, [Utf8StoredBMPString<'a>; 1]>),
 }
 
-// #[derive(asn1::Asn1DefinedByWrite)]
+#[derive(asn1::Asn1DefinedByWrite)]
 pub enum BagValue<'a> {
-    // #[defined_by(CERT_BAG_OID)]
+    #[defined_by(CERT_BAG_OID)]
     CertBag(CertBag<'a>),
 
-    // #[defined_by(KEY_BAG_OID)]
+    #[defined_by(KEY_BAG_OID)]
     KeyBag(asn1::Tlv<'a>),
 }
 
-// #[derive(asn1::Asn1Write)]
+#[derive(asn1::Asn1Write)]
 pub struct CertBag<'a> {
     pub _cert_id: asn1::DefinedByMarker<asn1::ObjectIdentifier>,
-    // #[defined_by(_cert_id)]
+    #[defined_by(_cert_id)]
     pub cert_value: asn1::Explicit<CertType<'a>, 0>,
 }
 
-// #[derive(asn1::Asn1DefinedByWrite)]
+#[derive(asn1::Asn1DefinedByWrite)]
 pub enum CertType<'a> {
-    // #[defined_by(X509_CERTIFICATE_OID)]
+    #[defined_by(X509_CERTIFICATE_OID)]
     X509(asn1::OctetStringEncoded<crate::certificate::Certificate<'a>>),
 }

--- a/src/rust/cryptography-x509/src/pkcs7.rs
+++ b/src/rust/cryptography-x509/src/pkcs7.rs
@@ -59,7 +59,7 @@ pub struct IssuerAndSerialNumber<'a> {
     pub serial_number: asn1::BigInt<'a>,
 }
 
-// #[derive(asn1::Asn1Write)]
+#[derive(asn1::Asn1Write)]
 pub struct DigestInfo<'a> {
     pub algorithm: common::AlgorithmIdentifier<'a>,
     pub digest: &'a [u8],

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -345,6 +345,8 @@ pub static EXTENDABLE_OUTPUT_FUNCTION: LazyPyImport = LazyPyImport::new(
 );
 pub static SHA1: LazyPyImport =
     LazyPyImport::new("cryptography.hazmat.primitives.hashes", &["SHA1"]);
+pub static SHA256: LazyPyImport =
+    LazyPyImport::new("cryptography.hazmat.primitives.hashes", &["SHA256"]);
 
 pub static PREHASHED: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.asymmetric.utils",

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -544,9 +544,6 @@ class TestPKCS12Creation:
         assert parsed_more_certs == [cert]
 
     def test_invalid_utf8_friendly_name(self, backend):
-        if rust_openssl.CRYPTOGRAPHY_IS_LIBRESSL:
-            pytest.skip("Temporarily doesn't work on LibreSSL")
-
         cert, _ = _load_ca(backend)
         with pytest.raises(ValueError):
             serialize_key_and_certificates(


### PR DESCRIPTION
For now, only handle unencrypted cert-only PKCS#12.