### PR TITLE
sign: bound-ify sig_alg APIs

### DIFF
--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -28,6 +28,21 @@ impl LazyPyImport {
             })
             .map(|p| p.as_ref(py))
     }
+
+    pub fn get_bound<'p>(
+        &'p self,
+        py: pyo3::Python<'p>,
+    ) -> pyo3::PyResult<pyo3::Bound<'p, pyo3::PyAny>> {
+        let p = self.value.get_or_try_init(py, || {
+            let mut obj = py.import(self.module)?.as_ref();
+            for name in self.names {
+                obj = obj.getattr(*name)?;
+            }
+            obj.extract()
+        })?;
+
+        Ok(p.clone().into_bound(py))
+    }
 }
 
 pub static DATETIME_DATETIME: LazyPyImport = LazyPyImport::new("datetime", &["datetime"]);

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -18,15 +18,7 @@ impl LazyPyImport {
     }
 
     pub fn get<'p>(&'p self, py: pyo3::Python<'p>) -> pyo3::PyResult<&'p pyo3::PyAny> {
-        self.value
-            .get_or_try_init(py, || {
-                let mut obj = py.import(self.module)?.as_ref();
-                for name in self.names {
-                    obj = obj.getattr(*name)?;
-                }
-                obj.extract()
-            })
-            .map(|p| p.as_ref(py))
+        Ok(self.get_bound(py)?.into_gil_ref())
     }
 
     pub fn get_bound<'p>(

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -257,7 +257,7 @@ impl Certificate {
     fn signature_hash_algorithm<'p>(
         &self,
         py: pyo3::Python<'p>,
-    ) -> Result<&'p pyo3::PyAny, CryptographyError> {
+    ) -> Result<pyo3::Bound<'p, pyo3::PyAny>, CryptographyError> {
         sign::identify_signature_hash_algorithm(py, &self.raw.borrow_dependent().signature_alg)
     }
 
@@ -270,7 +270,7 @@ impl Certificate {
     fn signature_algorithm_parameters<'p>(
         &'p self,
         py: pyo3::Python<'p>,
-    ) -> CryptographyResult<&'p pyo3::PyAny> {
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
         sign::identify_signature_algorithm_parameters(
             py,
             &self.raw.borrow_dependent().signature_alg,

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -207,7 +207,7 @@ impl CertificateRevocationList {
     fn signature_algorithm_parameters<'p>(
         &'p self,
         py: pyo3::Python<'p>,
-    ) -> CryptographyResult<&'p pyo3::PyAny> {
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
         sign::identify_signature_algorithm_parameters(
             py,
             &self.owned.borrow_dependent().signature_algorithm,

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -91,7 +91,7 @@ impl CertificateSigningRequest {
     fn signature_hash_algorithm<'p>(
         &self,
         py: pyo3::Python<'p>,
-    ) -> Result<&'p pyo3::PyAny, CryptographyError> {
+    ) -> Result<pyo3::Bound<'p, pyo3::PyAny>, CryptographyError> {
         sign::identify_signature_hash_algorithm(py, &self.raw.borrow_dependent().signature_alg)
     }
 
@@ -104,7 +104,7 @@ impl CertificateSigningRequest {
     fn signature_algorithm_parameters<'p>(
         &'p self,
         py: pyo3::Python<'p>,
-    ) -> CryptographyResult<&'p pyo3::PyAny> {
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
         sign::identify_signature_algorithm_parameters(
             py,
             &self.raw.borrow_dependent().signature_alg,

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 
 use cryptography_x509::{common, oid};
 use once_cell::sync::Lazy;
+use pyo3::prelude::PyAnyMethods;
+use pyo3::ToPyObject;
 
 use crate::asn1::oid_to_py_oid;
 use crate::error::{CryptographyError, CryptographyResult};
@@ -442,20 +444,22 @@ fn hash_oid_py_hash(
 pub(crate) fn identify_signature_hash_algorithm<'p>(
     py: pyo3::Python<'p>,
     signature_algorithm: &common::AlgorithmIdentifier<'_>,
-) -> CryptographyResult<&'p pyo3::PyAny> {
+) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
     let sig_oids_to_hash = types::SIG_OIDS_TO_HASH.get(py)?;
     match &signature_algorithm.params {
         common::AlgorithmParameters::RsaPss(opt_pss) => {
             let pss = opt_pss.as_ref().ok_or_else(|| {
                 pyo3::exceptions::PyValueError::new_err("Invalid RSA PSS parameters")
             })?;
-            hash_oid_py_hash(py, pss.hash_algorithm.oid().clone())
+            Ok(hash_oid_py_hash(py, pss.hash_algorithm.oid().clone())?
+                .to_object(py)
+                .into_bound(py))
         }
         _ => {
             let py_sig_alg_oid = oid_to_py_oid(py, signature_algorithm.oid())?;
             let hash_alg = sig_oids_to_hash.get_item(py_sig_alg_oid);
             match hash_alg {
-                Ok(data) => Ok(data),
+                Ok(data) => Ok(data.to_object(py).into_bound(py)),
                 Err(_) => Err(CryptographyError::from(
                     exceptions::UnsupportedAlgorithm::new_err(format!(
                         "Signature algorithm OID: {} not recognized",
@@ -470,7 +474,7 @@ pub(crate) fn identify_signature_hash_algorithm<'p>(
 pub(crate) fn identify_signature_algorithm_parameters<'p>(
     py: pyo3::Python<'p>,
     signature_algorithm: &common::AlgorithmIdentifier<'_>,
-) -> CryptographyResult<&'p pyo3::PyAny> {
+) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
     match &signature_algorithm.params {
         common::AlgorithmParameters::RsaPss(opt_pss) => {
             let pss = opt_pss.as_ref().ok_or_else(|| {
@@ -487,7 +491,7 @@ pub(crate) fn identify_signature_algorithm_parameters<'p>(
             let py_mask_gen_hash_alg =
                 hash_oid_py_hash(py, pss.mask_gen_algorithm.params.oid().clone())?;
             let py_mgf = types::MGF1.get(py)?.call1((py_mask_gen_hash_alg,))?;
-            Ok(types::PSS.get(py)?.call1((py_mgf, pss.salt_length))?)
+            Ok(types::PSS.get_bound(py)?.call1((py_mgf, pss.salt_length))?)
         }
         common::AlgorithmParameters::RsaWithSha1(_)
         | common::AlgorithmParameters::RsaWithSha1Alt(_)
@@ -499,7 +503,7 @@ pub(crate) fn identify_signature_algorithm_parameters<'p>(
         | common::AlgorithmParameters::RsaWithSha3_256(_)
         | common::AlgorithmParameters::RsaWithSha3_384(_)
         | common::AlgorithmParameters::RsaWithSha3_512(_) => {
-            Ok(types::PKCS1V15.get(py)?.call0()?)
+            Ok(types::PKCS1V15.get_bound(py)?.call0()?)
         }
         common::AlgorithmParameters::EcDsaWithSha224(_)
         | common::AlgorithmParameters::EcDsaWithSha256(_)
@@ -512,9 +516,11 @@ pub(crate) fn identify_signature_algorithm_parameters<'p>(
             let signature_hash_algorithm =
                 identify_signature_hash_algorithm(py, signature_algorithm)?;
 
-            Ok(types::ECDSA.get(py)?.call1((signature_hash_algorithm,))?)
+            Ok(types::ECDSA
+                .get_bound(py)?
+                .call1((signature_hash_algorithm,))?)
         }
-        _ => Ok(py.None().into_ref(py)),
+        _ => Ok(py.None().into_bound(py)),
     }
 }
 


### PR DESCRIPTION
See #10676.

This unfortunately taints a few certificate, CRL, etc. APIs in the process. 

However, each is a singular top-level API, so the diff isn't too bad.