### PR TITLE
Start converting `src/backend/rsa.rs` to the new pyo3 APIs

### DIFF
--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -125,13 +125,13 @@ fn dh_parameters_from_numbers(
     py: pyo3::Python<'_>,
     numbers: &DHParameterNumbers,
 ) -> CryptographyResult<openssl::dh::Dh<openssl::pkey::Params>> {
-    let p = utils::py_int_to_bn(py, numbers.p.as_ref(py))?;
+    let p = utils::py_int_to_bn(py, numbers.p.bind(py))?;
     let q = numbers
         .q
         .as_ref()
-        .map(|v| utils::py_int_to_bn(py, v.as_ref(py)))
+        .map(|v| utils::py_int_to_bn(py, v.bind(py)))
         .transpose()?;
-    let g = utils::py_int_to_bn(py, numbers.g.as_ref(py))?;
+    let g = utils::py_int_to_bn(py, numbers.g.bind(py))?;
 
     Ok(openssl::dh::Dh::from_pqg(p, q, g)?)
 }
@@ -222,7 +222,7 @@ impl DHPrivateKey {
     }
 
     fn private_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -257,7 +257,7 @@ impl DHPublicKey {
     }
 
     fn public_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -418,8 +418,8 @@ impl DHPrivateNumbers {
 
         let dh = dh_parameters_from_numbers(py, self.public_numbers.get().parameter_numbers.get())?;
 
-        let pub_key = utils::py_int_to_bn(py, self.public_numbers.get().y.as_ref(py))?;
-        let priv_key = utils::py_int_to_bn(py, self.x.as_ref(py))?;
+        let pub_key = utils::py_int_to_bn(py, self.public_numbers.get().y.bind(py))?;
+        let priv_key = utils::py_int_to_bn(py, self.x.bind(py))?;
 
         let dh = dh.set_key(pub_key, priv_key)?;
         if !dh.check_key()? {
@@ -470,7 +470,7 @@ impl DHPublicNumbers {
 
         let dh = dh_parameters_from_numbers(py, self.parameter_numbers.get())?;
 
-        let pub_key = utils::py_int_to_bn(py, self.y.as_ref(py))?;
+        let pub_key = utils::py_int_to_bn(py, self.y.bind(py))?;
 
         let pkey = pkey_from_dh(dh.set_public_key(pub_key)?)?;
 

--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -129,7 +129,7 @@ impl DsaPrivateKey {
     }
 
     fn private_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -202,7 +202,7 @@ impl DsaPublicKey {
     }
 
     fn public_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -371,11 +371,11 @@ impl DsaPrivateNumbers {
         check_dsa_private_numbers(py, self)?;
 
         let dsa = openssl::dsa::Dsa::from_private_components(
-            utils::py_int_to_bn(py, parameter_numbers.p.as_ref(py))?,
-            utils::py_int_to_bn(py, parameter_numbers.q.as_ref(py))?,
-            utils::py_int_to_bn(py, parameter_numbers.g.as_ref(py))?,
-            utils::py_int_to_bn(py, self.x.as_ref(py))?,
-            utils::py_int_to_bn(py, public_numbers.y.as_ref(py))?,
+            utils::py_int_to_bn(py, parameter_numbers.p.bind(py))?,
+            utils::py_int_to_bn(py, parameter_numbers.q.bind(py))?,
+            utils::py_int_to_bn(py, parameter_numbers.g.bind(py))?,
+            utils::py_int_to_bn(py, self.x.bind(py))?,
+            utils::py_int_to_bn(py, public_numbers.y.bind(py))?,
         )
         .unwrap();
         let pkey = openssl::pkey::PKey::from_dsa(dsa)?;
@@ -420,10 +420,10 @@ impl DsaPublicNumbers {
         check_dsa_parameters(py, parameter_numbers)?;
 
         let dsa = openssl::dsa::Dsa::from_public_components(
-            utils::py_int_to_bn(py, parameter_numbers.p.as_ref(py))?,
-            utils::py_int_to_bn(py, parameter_numbers.q.as_ref(py))?,
-            utils::py_int_to_bn(py, parameter_numbers.g.as_ref(py))?,
-            utils::py_int_to_bn(py, self.y.as_ref(py))?,
+            utils::py_int_to_bn(py, parameter_numbers.p.bind(py))?,
+            utils::py_int_to_bn(py, parameter_numbers.q.bind(py))?,
+            utils::py_int_to_bn(py, parameter_numbers.g.bind(py))?,
+            utils::py_int_to_bn(py, self.y.bind(py))?,
         )
         .unwrap();
         let pkey = openssl::pkey::PKey::from_dsa(dsa)?;
@@ -472,9 +472,9 @@ impl DsaParameterNumbers {
         check_dsa_parameters(py, self)?;
 
         let dsa = openssl::dsa::Dsa::from_pqg(
-            utils::py_int_to_bn(py, self.p.as_ref(py))?,
-            utils::py_int_to_bn(py, self.q.as_ref(py))?,
-            utils::py_int_to_bn(py, self.g.as_ref(py))?,
+            utils::py_int_to_bn(py, self.p.bind(py))?,
+            utils::py_int_to_bn(py, self.q.bind(py))?,
+            utils::py_int_to_bn(py, self.g.bind(py))?,
         )
         .unwrap();
         Ok(DsaParameters { dsa })

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -175,7 +175,7 @@ fn generate_private_key(
 #[pyo3::prelude::pyfunction]
 fn derive_private_key(
     py: pyo3::Python<'_>,
-    py_private_value: &pyo3::types::PyLong,
+    py_private_value: &pyo3::Bound<'_, pyo3::types::PyLong>,
     py_curve: &pyo3::PyAny,
 ) -> CryptographyResult<ECPrivateKey> {
     let curve = curve_from_py_curve(py, py_curve, false)?;
@@ -353,7 +353,7 @@ impl ECPrivateKey {
     }
 
     fn private_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -435,7 +435,7 @@ impl ECPublicKey {
     }
 
     fn public_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -484,8 +484,8 @@ fn public_key_from_numbers(
         ));
     }
 
-    let x = utils::py_int_to_bn(py, numbers.x.as_ref(py))?;
-    let y = utils::py_int_to_bn(py, numbers.y.as_ref(py))?;
+    let x = utils::py_int_to_bn(py, numbers.x.bind(py))?;
+    let y = utils::py_int_to_bn(py, numbers.y.bind(py))?;
 
     let mut point = openssl::ec::EcPoint::new(curve)?;
     let mut bn_ctx = openssl::bn::BigNumContext::new()?;
@@ -522,7 +522,7 @@ impl EllipticCurvePrivateNumbers {
 
         let curve = curve_from_py_curve(py, self.public_numbers.get().curve.as_ref(py), false)?;
         let public_key = public_key_from_numbers(py, self.public_numbers.get(), &curve)?;
-        let private_value = utils::py_int_to_bn(py, self.private_value.as_ref(py))?;
+        let private_value = utils::py_int_to_bn(py, self.private_value.bind(py))?;
 
         let mut bn_ctx = openssl::bn::BigNumContext::new()?;
         let mut expected_pub = openssl::ec::EcPoint::new(&curve)?;

--- a/src/rust/src/backend/ed25519.rs
+++ b/src/rust/src/backend/ed25519.rs
@@ -97,7 +97,7 @@ impl Ed25519PrivateKey {
     }
 
     fn private_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -141,7 +141,7 @@ impl Ed25519PublicKey {
     }
 
     fn public_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -95,7 +95,7 @@ impl Ed448PrivateKey {
     }
 
     fn private_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -138,7 +138,7 @@ impl Ed448PublicKey {
     }
 
     fn public_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,

--- a/src/rust/src/backend/mod.rs
+++ b/src/rust/src/backend/mod.rs
@@ -45,7 +45,7 @@ pub(crate) fn add_to_module(module: &pyo3::prelude::PyModule) -> pyo3::PyResult<
     module.add_submodule(hashes::create_module(module.py())?)?;
     module.add_submodule(hmac::create_module(module.py())?)?;
     module.add_submodule(kdf::create_module(module.py())?)?;
-    module.add_submodule(rsa::create_module(module.py())?)?;
+    module.add_submodule(rsa::create_module(module.py())?.into_gil_ref())?;
 
     Ok(())
 }

--- a/src/rust/src/backend/utils.rs
+++ b/src/rust/src/backend/utils.rs
@@ -10,7 +10,7 @@ use pyo3::ToPyObject;
 
 pub(crate) fn py_int_to_bn(
     py: pyo3::Python<'_>,
-    v: &pyo3::PyAny,
+    v: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<openssl::bn::BigNum> {
     let n = v
         .call_method0(pyo3::intern!(py, "bit_length"))?
@@ -44,7 +44,7 @@ pub(crate) fn bn_to_big_endian_bytes(b: &openssl::bn::BigNumRef) -> Cryptography
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn pkey_private_bytes<'p>(
     py: pyo3::Python<'p>,
-    key_obj: &pyo3::PyAny,
+    key_obj: &pyo3::Bound<'p, pyo3::PyAny>,
     pkey: &openssl::pkey::PKey<openssl::pkey::Private>,
     encoding: &pyo3::PyAny,
     format: &pyo3::PyAny,
@@ -238,7 +238,7 @@ pub(crate) fn pkey_private_bytes<'p>(
 
 pub(crate) fn pkey_public_bytes<'p>(
     py: pyo3::Python<'p>,
-    key_obj: &pyo3::PyAny,
+    key_obj: &pyo3::Bound<'p, pyo3::PyAny>,
     pkey: &openssl::pkey::PKey<openssl::pkey::Public>,
     encoding: &pyo3::PyAny,
     format: &pyo3::PyAny,

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -98,7 +98,7 @@ impl X25519PrivateKey {
     }
 
     fn private_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -128,7 +128,7 @@ impl X25519PublicKey {
     }
 
     fn public_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,

--- a/src/rust/src/backend/x448.rs
+++ b/src/rust/src/backend/x448.rs
@@ -97,7 +97,7 @@ impl X448PrivateKey {
     }
 
     fn private_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,
@@ -127,7 +127,7 @@ impl X448PublicKey {
     }
 
     fn public_bytes<'p>(
-        slf: &pyo3::PyCell<Self>,
+        slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: &pyo3::PyAny,
         format: &pyo3::PyAny,


### PR DESCRIPTION
Using @alex's [branch](https://github.com/pyca/cryptography/pull/10678) as a base, this PR starts to migrate `src/backend/rsa.rs` to the new PyO3 Bound API. A bunch of other modules also end up modified due to having to change `utils.rs`.

This is part of https://github.com/pyca/cryptography/issues/10676

(This should only be merged after https://github.com/pyca/cryptography/pull/10678)