### PR TITLE
Convert `src/backend/hashes.rs` to new pyo3 APIs

### DIFF
--- a/src/rust/src/backend/hashes.rs
+++ b/src/rust/src/backend/hashes.rs
@@ -2,6 +2,8 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use pyo3::prelude::{PyAnyMethods, PyModuleMethods};
+use pyo3::IntoPy;
 use std::borrow::Cow;
 
 use crate::buf::CffiBuf;
@@ -39,9 +41,9 @@ impl Hash {
 
 pub(crate) fn message_digest_from_algorithm(
     py: pyo3::Python<'_>,
-    algorithm: &pyo3::PyAny,
+    algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<openssl::hash::MessageDigest> {
-    if !algorithm.is_instance(types::HASH_ALGORITHM.get(py)?)? {
+    if !algorithm.is_instance(&types::HASH_ALGORITHM.get_bound(py)?)? {
         return Err(CryptographyError::from(
             pyo3::exceptions::PyTypeError::new_err("Expected instance of hashes.HashAlgorithm."),
         ));
@@ -83,8 +85,8 @@ impl Hash {
     #[pyo3(signature = (algorithm, backend=None))]
     pub(crate) fn new(
         py: pyo3::Python<'_>,
-        algorithm: &pyo3::PyAny,
-        backend: Option<pyo3::Bound<'_, pyo3::PyAny>>,
+        algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
+        backend: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
     ) -> CryptographyResult<Hash> {
         let _ = backend;
 
@@ -92,7 +94,7 @@ impl Hash {
         let ctx = openssl::hash::Hasher::new(md)?;
 
         Ok(Hash {
-            algorithm: algorithm.into(),
+            algorithm: algorithm.clone().into_py(py),
             ctx: Some(ctx),
         })
     }
@@ -104,17 +106,17 @@ impl Hash {
     pub(crate) fn finalize<'p>(
         &mut self,
         py: pyo3::Python<'p>,
-    ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         #[cfg(not(any(CRYPTOGRAPHY_IS_LIBRESSL, CRYPTOGRAPHY_IS_BORINGSSL)))]
         {
             let algorithm = self.algorithm.clone_ref(py);
-            let algorithm = algorithm.as_ref(py);
-            if algorithm.is_instance(types::EXTENDABLE_OUTPUT_FUNCTION.get(py)?)? {
+            let algorithm = algorithm.bind(py);
+            if algorithm.is_instance(&types::EXTENDABLE_OUTPUT_FUNCTION.get_bound(py)?)? {
                 let ctx = self.get_mut_ctx()?;
                 let digest_size = algorithm
                     .getattr(pyo3::intern!(py, "digest_size"))?
                     .extract::<usize>()?;
-                let result = pyo3::types::PyBytes::new_with(py, digest_size, |b| {
+                let result = pyo3::types::PyBytes::new_bound_with(py, digest_size, |b| {
                     ctx.finish_xof(b).unwrap();
                     Ok(())
                 })?;
@@ -125,7 +127,7 @@ impl Hash {
 
         let data = self.get_mut_ctx()?.finish()?;
         self.ctx = None;
-        Ok(pyo3::types::PyBytes::new(py, &data))
+        Ok(pyo3::types::PyBytes::new_bound(py, &data))
     }
 
     fn copy(&self, py: pyo3::Python<'_>) -> CryptographyResult<Hash> {
@@ -136,8 +138,10 @@ impl Hash {
     }
 }
 
-pub(crate) fn create_module(py: pyo3::Python<'_>) -> pyo3::PyResult<&pyo3::prelude::PyModule> {
-    let m = pyo3::prelude::PyModule::new(py, "hashes")?;
+pub(crate) fn create_module(
+    py: pyo3::Python<'_>,
+) -> pyo3::PyResult<pyo3::Bound<'_, pyo3::prelude::PyModule>> {
+    let m = pyo3::prelude::PyModule::new_bound(py, "hashes")?;
     m.add_class::<Hash>()?;
 
     Ok(m)

--- a/src/rust/src/backend/hmac.rs
+++ b/src/rust/src/backend/hmac.rs
@@ -6,6 +6,7 @@ use crate::backend::hashes::{already_finalized_error, message_digest_from_algori
 use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::exceptions;
+use pyo3::PyNativeType;
 
 #[pyo3::prelude::pyclass(
     module = "cryptography.hazmat.bindings._rust.openssl.hmac",
@@ -23,7 +24,7 @@ impl Hmac {
         key: &[u8],
         algorithm: &pyo3::PyAny,
     ) -> CryptographyResult<Hmac> {
-        let md = message_digest_from_algorithm(py, algorithm)?;
+        let md = message_digest_from_algorithm(py, &algorithm.as_borrowed())?;
         let ctx = cryptography_openssl::hmac::Hmac::new(key, md).map_err(|_| {
             exceptions::UnsupportedAlgorithm::new_err((
                 "Digest is not supported for HMAC",

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -10,7 +10,7 @@ use crate::error::CryptographyResult;
 fn derive_pbkdf2_hmac<'p>(
     py: pyo3::Python<'p>,
     key_material: CffiBuf<'_>,
-    algorithm: &pyo3::PyAny,
+    algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     salt: &[u8],
     iterations: usize,
     length: usize,

--- a/src/rust/src/backend/mod.rs
+++ b/src/rust/src/backend/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn add_to_module(module: &pyo3::prelude::PyModule) -> pyo3::PyResult<
 
     module.add_submodule(poly1305::create_module(module.py())?)?;
 
-    module.add_submodule(hashes::create_module(module.py())?)?;
+    module.add_submodule(hashes::create_module(module.py())?.into_gil_ref())?;
     module.add_submodule(hmac::create_module(module.py())?)?;
     module.add_submodule(kdf::create_module(module.py())?)?;
     module.add_submodule(rsa::create_module(module.py())?.into_gil_ref())?;

--- a/src/rust/src/backend/utils.rs
+++ b/src/rust/src/backend/utils.rs
@@ -6,7 +6,7 @@ use crate::backend::hashes::Hash;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::{error, types};
 use pyo3::prelude::PyAnyMethods;
-use pyo3::ToPyObject;
+use pyo3::{PyNativeType, ToPyObject};
 
 pub(crate) fn py_int_to_bn(
     py: pyo3::Python<'_>,
@@ -362,9 +362,9 @@ pub(crate) fn calculate_digest_and_algorithm<'p>(
     } else {
         // Potential optimization: rather than allocate a PyBytes in
         // `h.finalize()`, have a way to get the `DigestBytes` directly.
-        let mut h = Hash::new(py, algorithm, None)?;
+        let mut h = Hash::new(py, &algorithm.as_borrowed(), None)?;
         h.update_bytes(data)?;
-        data = h.finalize(py)?.as_bytes();
+        data = h.finalize(py)?.into_gil_ref().as_bytes();
     }
 
     if data.len() != algorithm.getattr("digest_size")?.extract()? {

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -17,7 +17,7 @@ use cryptography_x509::extensions::{
 use cryptography_x509::extensions::{Extension, SubjectAlternativeName};
 use cryptography_x509::{common, oid};
 use cryptography_x509_verification::ops::CryptoOps;
-use pyo3::{IntoPy, ToPyObject};
+use pyo3::{IntoPy, PyNativeType, ToPyObject};
 
 use crate::asn1::{
     big_byte_slice_to_py_int, encode_der_data, oid_to_py_oid, py_uint_to_big_endian_bytes,
@@ -90,9 +90,9 @@ impl Certificate {
     ) -> CryptographyResult<&'p pyo3::PyAny> {
         let serialized = asn1::write_single(&self.raw.borrow_dependent())?;
 
-        let mut h = hashes::Hash::new(py, algorithm, None)?;
+        let mut h = hashes::Hash::new(py, &algorithm.as_borrowed(), None)?;
         h.update_bytes(&serialized)?;
-        Ok(h.finalize(py)?)
+        Ok(h.finalize(py)?.into_gil_ref())
     }
 
     fn public_bytes<'p>(

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -13,7 +13,7 @@ use cryptography_x509::{
     },
     name, oid,
 };
-use pyo3::{IntoPy, ToPyObject};
+use pyo3::{IntoPy, PyNativeType, ToPyObject};
 
 use crate::asn1::{
     big_byte_slice_to_py_int, encode_der_data, oid_to_py_oid, py_uint_to_big_endian_bytes,
@@ -178,9 +178,9 @@ impl CertificateRevocationList {
     ) -> pyo3::PyResult<&'p pyo3::PyAny> {
         let data = self.public_bytes_der()?;
 
-        let mut h = Hash::new(py, algorithm, None)?;
+        let mut h = Hash::new(py, &algorithm.as_borrowed(), None)?;
         h.update_bytes(&data)?;
-        Ok(h.finalize(py)?)
+        Ok(h.finalize(py)?.into_gil_ref())
     }
 
     #[getter]

--- a/src/rust/src/x509/ocsp.rs
+++ b/src/rust/src/x509/ocsp.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use cryptography_x509::common;
 use cryptography_x509::ocsp_req::CertID;
 use once_cell::sync::Lazy;
+use pyo3::PyNativeType;
 
 use crate::backend::hashes::Hash;
 use crate::error::CryptographyResult;
@@ -125,7 +126,7 @@ pub(crate) fn hash_data<'p>(
     py_hash_alg: &'p pyo3::PyAny,
     data: &[u8],
 ) -> pyo3::PyResult<&'p [u8]> {
-    let mut h = Hash::new(py, py_hash_alg, None)?;
+    let mut h = Hash::new(py, &py_hash_alg.as_borrowed(), None)?;
     h.update_bytes(data)?;
-    Ok(h.finalize(py)?.as_bytes())
+    Ok(h.finalize(py)?.into_gil_ref().as_bytes())
 }


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676. This fixes all of the warnings in `src/backend/hashes.rs`.

Most of the changes are trivial, but there are a couple where I added a `clone()` call that should be manually reviewed:

- In `hashes.rs:97`:
```rust
algorithm: algorithm.clone().into_py(py),
```

- In `rsa.rs:294`:
```rust
algorithm.clone().into_gil_ref(),
```

- In `rsa.rs:444`:
```rust
algorithm.clone().into_gil_ref(),
```

cc @alex @reaperhulk 