### PR TITLE
Convert more `utils.rs` APIs to new pyo3 APIs

### DIFF
--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -259,8 +259,8 @@ impl DHPublicKey {
     fn public_bytes<'p>(
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
-        encoding: &pyo3::PyAny,
-        format: &pyo3::PyAny,
+        encoding: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: &pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         if !format.is(types::PUBLIC_FORMAT_SUBJECT_PUBLIC_KEY_INFO.get(py)?) {
             return Err(CryptographyError::from(

--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -7,6 +7,7 @@ use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::exceptions;
 use pyo3::prelude::PyAnyMethods;
+use pyo3::PyNativeType;
 
 #[pyo3::prelude::pyclass(
     frozen,
@@ -71,7 +72,8 @@ impl DsaPrivateKey {
         data: CffiBuf<'_>,
         algorithm: &pyo3::PyAny,
     ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
-        let (data, _) = utils::calculate_digest_and_algorithm(py, data.as_bytes(), algorithm)?;
+        let (data, _) =
+            utils::calculate_digest_and_algorithm(py, data.as_bytes(), &algorithm.as_borrowed())?;
 
         let mut signer = openssl::pkey_ctx::PkeyCtx::new(&self.pkey)?;
         signer.sign_init()?;
@@ -157,7 +159,8 @@ impl DsaPublicKey {
         data: CffiBuf<'_>,
         algorithm: &pyo3::PyAny,
     ) -> CryptographyResult<()> {
-        let (data, _) = utils::calculate_digest_and_algorithm(py, data.as_bytes(), algorithm)?;
+        let (data, _) =
+            utils::calculate_digest_and_algorithm(py, data.as_bytes(), &algorithm.as_borrowed())?;
 
         let mut verifier = openssl::pkey_ctx::PkeyCtx::new(&self.pkey)?;
         verifier.verify_init()?;
@@ -204,8 +207,8 @@ impl DsaPublicKey {
     fn public_bytes<'p>(
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
-        encoding: &pyo3::PyAny,
-        format: &pyo3::PyAny,
+        encoding: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: &pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, false)
     }

--- a/src/rust/src/backend/ed25519.rs
+++ b/src/rust/src/backend/ed25519.rs
@@ -143,8 +143,8 @@ impl Ed25519PublicKey {
     fn public_bytes<'p>(
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
-        encoding: &pyo3::PyAny,
-        format: &pyo3::PyAny,
+        encoding: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: &pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, true)
     }

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -140,8 +140,8 @@ impl Ed448PublicKey {
     fn public_bytes<'p>(
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
-        encoding: &pyo3::PyAny,
-        format: &pyo3::PyAny,
+        encoding: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: &pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, true)
     }

--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -288,11 +288,8 @@ impl RsaPrivateKey {
         padding: &pyo3::Bound<'p, pyo3::PyAny>,
         algorithm: &pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyAny>> {
-        let (data, algorithm) = utils::calculate_digest_and_algorithm(
-            py,
-            data.as_bytes(),
-            algorithm.clone().into_gil_ref(),
-        )?;
+        let (data, algorithm) =
+            utils::calculate_digest_and_algorithm(py, data.as_bytes(), algorithm)?;
 
         let mut ctx = openssl::pkey_ctx::PkeyCtx::new(&self.pkey)?;
         ctx.sign_init().map_err(|_| {
@@ -438,11 +435,8 @@ impl RsaPublicKey {
         padding: &pyo3::Bound<'_, pyo3::PyAny>,
         algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     ) -> CryptographyResult<()> {
-        let (data, algorithm) = utils::calculate_digest_and_algorithm(
-            py,
-            data.as_bytes(),
-            algorithm.clone().into_gil_ref(),
-        )?;
+        let (data, algorithm) =
+            utils::calculate_digest_and_algorithm(py, data.as_bytes(), algorithm)?;
 
         let mut ctx = openssl::pkey_ctx::PkeyCtx::new(&self.pkey)?;
         ctx.verify_init()?;
@@ -534,8 +528,8 @@ impl RsaPublicKey {
     fn public_bytes<'p>(
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
-        encoding: &pyo3::PyAny,
-        format: &pyo3::PyAny,
+        encoding: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: &pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, false)
     }

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -130,8 +130,8 @@ impl X25519PublicKey {
     fn public_bytes<'p>(
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
-        encoding: &pyo3::PyAny,
-        format: &pyo3::PyAny,
+        encoding: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: &pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, false, true)
     }

--- a/src/rust/src/backend/x448.rs
+++ b/src/rust/src/backend/x448.rs
@@ -129,8 +129,8 @@ impl X448PublicKey {
     fn public_bytes<'p>(
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
-        encoding: &pyo3::PyAny,
-        format: &pyo3::PyAny,
+        encoding: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: &pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, false, true)
     }


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

- Converts `pkey_public_bytes()` in `utils.rs`, along with all of the `public_bytes()` methods using it.
- Convert `calculate_digest_and_algorithm()` in `utils.rs`, along with its usages.

I had to add a `.clone()` call to `calculate_digest_and_algorithm()` to be able to return the algorithm as a `Bound<..>` object. There might be a better way of doing it.

cc @alex @reaperhulk 