### PR TITLE
Convert more APIs in `certificate.rs` to new pyo3 APIs

### DIFF
--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -213,7 +213,7 @@ impl CertificateSigningRequest {
             })?;
 
         x509::parse_and_cache_extensions(py, &self.cached_extensions, &raw_exts, |ext| {
-            certificate::parse_cert_ext(py, ext)
+            certificate::parse_cert_ext(py, ext).map(|x| x.map(|y| y.into_gil_ref()))
         })
     }
 

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -107,7 +107,8 @@ pub(crate) fn encode_distribution_points<'p>(
             None
         };
         let reasons = if let Some(py_reasons) = py_dp.reasons {
-            let reasons = certificate::encode_distribution_point_reasons(py, py_reasons)?;
+            let reasons =
+                certificate::encode_distribution_point_reasons(py, &py_reasons.as_borrowed())?;
             Some(common::Asn1ReadableOrWritable::new_write(reasons))
         } else {
             None
@@ -308,7 +309,8 @@ fn encode_issuing_distribution_point(
         .is_truthy()?
     {
         let py_reasons = ext.getattr(pyo3::intern!(py, "only_some_reasons"))?;
-        let reasons = certificate::encode_distribution_point_reasons(ext.py(), py_reasons)?;
+        let reasons =
+            certificate::encode_distribution_point_reasons(ext.py(), &py_reasons.as_borrowed())?;
         Some(common::Asn1ReadableOrWritable::new_write(reasons))
     } else {
         None


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

Goes through all the `certificate.rs` APIs, converting parameter and return types from GIL references to `Bound`.

cc @alex @reaperhulk 