### PR TITLE
Convert `src/backend/hmac.rs` to new pyo3 APIs

### DIFF
--- a/src/rust/src/backend/mod.rs
+++ b/src/rust/src/backend/mod.rs
@@ -43,7 +43,7 @@ pub(crate) fn add_to_module(module: &pyo3::prelude::PyModule) -> pyo3::PyResult<
     module.add_submodule(poly1305::create_module(module.py())?)?;
 
     module.add_submodule(hashes::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(hmac::create_module(module.py())?)?;
+    module.add_submodule(hmac::create_module(module.py())?.into_gil_ref())?;
     module.add_submodule(kdf::create_module(module.py())?.into_gil_ref())?;
     module.add_submodule(rsa::create_module(module.py())?.into_gil_ref())?;
 


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This finishes with all the migration warnings for `src/backend/hmac.rs`

cc @alex @reaperhulk 