### PR TITLE
Convert `src/backend/poly1305.rs` to new pyo3 APIs

### DIFF
--- a/src/rust/src/backend/mod.rs
+++ b/src/rust/src/backend/mod.rs
@@ -40,7 +40,7 @@ pub(crate) fn add_to_module(module: &pyo3::prelude::PyModule) -> pyo3::PyResult<
     #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
     module.add_submodule(x448::create_module(module.py())?.into_gil_ref())?;
 
-    module.add_submodule(poly1305::create_module(module.py())?)?;
+    module.add_submodule(poly1305::create_module(module.py())?.into_gil_ref())?;
 
     module.add_submodule(hashes::create_module(module.py())?.into_gil_ref())?;
     module.add_submodule(hmac::create_module(module.py())?)?;


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This finishes with all the migration warnings for `src/backend/poly1305.rs`

cc @alex @reaperhulk 