### PR TITLE
Convert `src/backend/x25519.rs` to new pyo3 APIs

### DIFF
--- a/src/rust/src/backend/mod.rs
+++ b/src/rust/src/backend/mod.rs
@@ -36,7 +36,7 @@ pub(crate) fn add_to_module(module: &pyo3::prelude::PyModule) -> pyo3::PyResult<
     #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
     module.add_submodule(ed448::create_module(module.py())?)?;
 
-    module.add_submodule(x25519::create_module(module.py())?)?;
+    module.add_submodule(x25519::create_module(module.py())?.into_gil_ref())?;
     #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
     module.add_submodule(x448::create_module(module.py())?.into_gil_ref())?;
 

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -5,6 +5,7 @@
 use crate::backend::utils;
 use crate::buf::CffiBuf;
 use crate::error::CryptographyResult;
+use pyo3::prelude::PyModuleMethods;
 
 #[pyo3::prelude::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.x25519")]
 pub(crate) struct X25519PrivateKey {
@@ -66,17 +67,21 @@ impl X25519PrivateKey {
         &self,
         py: pyo3::Python<'p>,
         peer_public_key: &X25519PublicKey,
-    ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let mut deriver = openssl::derive::Deriver::new(&self.pkey)?;
         deriver.set_peer(&peer_public_key.pkey)?;
 
-        Ok(pyo3::types::PyBytes::new_with(py, deriver.len()?, |b| {
-            let n = deriver.derive(b).map_err(|_| {
-                pyo3::exceptions::PyValueError::new_err("Error computing shared key.")
-            })?;
-            assert_eq!(n, b.len());
-            Ok(())
-        })?)
+        Ok(pyo3::types::PyBytes::new_bound_with(
+            py,
+            deriver.len()?,
+            |b| {
+                let n = deriver.derive(b).map_err(|_| {
+                    pyo3::exceptions::PyValueError::new_err("Error computing shared key.")
+                })?;
+                assert_eq!(n, b.len());
+                Ok(())
+            },
+        )?)
     }
 
     fn public_key(&self) -> CryptographyResult<X25519PublicKey> {
@@ -92,9 +97,9 @@ impl X25519PrivateKey {
     fn private_bytes_raw<'p>(
         &self,
         py: pyo3::Python<'p>,
-    ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let raw_bytes = self.pkey.raw_private_key()?;
-        Ok(pyo3::types::PyBytes::new(py, &raw_bytes))
+        Ok(pyo3::types::PyBytes::new_bound(py, &raw_bytes))
     }
 
     fn private_bytes<'p>(
@@ -122,9 +127,9 @@ impl X25519PublicKey {
     fn public_bytes_raw<'p>(
         &self,
         py: pyo3::Python<'p>,
-    ) -> CryptographyResult<&'p pyo3::types::PyBytes> {
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let raw_bytes = self.pkey.raw_public_key()?;
-        Ok(pyo3::types::PyBytes::new(py, &raw_bytes))
+        Ok(pyo3::types::PyBytes::new_bound(py, &raw_bytes))
     }
 
     fn public_bytes<'p>(
@@ -145,11 +150,13 @@ impl X25519PublicKey {
     }
 }
 
-pub(crate) fn create_module(py: pyo3::Python<'_>) -> pyo3::PyResult<&pyo3::prelude::PyModule> {
-    let m = pyo3::prelude::PyModule::new(py, "x25519")?;
-    m.add_function(pyo3::wrap_pyfunction!(generate_key, m)?)?;
-    m.add_function(pyo3::wrap_pyfunction!(from_private_bytes, m)?)?;
-    m.add_function(pyo3::wrap_pyfunction!(from_public_bytes, m)?)?;
+pub(crate) fn create_module(
+    py: pyo3::Python<'_>,
+) -> pyo3::PyResult<pyo3::Bound<'_, pyo3::prelude::PyModule>> {
+    let m = pyo3::prelude::PyModule::new_bound(py, "x25519")?;
+    m.add_function(pyo3::wrap_pyfunction_bound!(generate_key, &m)?)?;
+    m.add_function(pyo3::wrap_pyfunction_bound!(from_private_bytes, &m)?)?;
+    m.add_function(pyo3::wrap_pyfunction_bound!(from_public_bytes, &m)?)?;
 
     m.add_class::<X25519PrivateKey>()?;
     m.add_class::<X25519PublicKey>()?;


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This finishes with all the migration warnings for `src/backend/x25519.rs`

cc @alex @reaperhulk 