### PR TITLE
Remove gil-refs feature from cryptography-cffi

### DIFF
--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version = "1.65.0"
 
 [dependencies]
-pyo3 = { version = "0.21.1", features = ["abi3", "gil-refs"] }
+pyo3 = { version = "0.21.1", features = ["abi3"] }
 openssl-sys = "0.9.102"
 
 [build-dependencies]


### PR DESCRIPTION
It doesn't need it