### PR TITLE
Start converting `src/x509/verify.rs` to new pyo3 APIs

### DIFF
--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -379,7 +379,7 @@ fn build_subject_owner(
             .call0()?
             .downcast::<pyo3::types::PyBytes>()?
             .clone();
-        Ok(SubjectOwner::IPAddress(value.clone().unbind()))
+        Ok(SubjectOwner::IPAddress(value.unbind()))
     } else {
         Err(pyo3::exceptions::PyTypeError::new_err(
             "unsupported subject type",

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -371,15 +371,15 @@ fn build_subject_owner(
     if subject.is_instance(&types::DNS_NAME.get_bound(py)?)? {
         let value = subject
             .getattr(pyo3::intern!(py, "value"))?
-            .downcast::<pyo3::types::PyString>()?;
-
+            .downcast::<pyo3::types::PyString>()?
+            .clone();
         Ok(SubjectOwner::DNSName(value.to_str()?.to_owned()))
     } else if subject.is_instance(&types::IP_ADDRESS.get_bound(py)?)? {
         let value = subject
             .getattr(pyo3::intern!(py, "_packed"))?
             .call0()?
-            .downcast::<pyo3::types::PyBytes>()?;
-
+            .downcast::<pyo3::types::PyBytes>()?
+            .clone();
         Ok(SubjectOwner::IPAddress(value.clone().unbind()))
     } else {
         Err(pyo3::exceptions::PyTypeError::new_err(

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -371,6 +371,8 @@ fn build_subject_owner(
     if subject.is_instance(&types::DNS_NAME.get_bound(py)?)? {
         let value = subject
             .getattr(pyo3::intern!(py, "value"))?
+            // TODO: switch this to borrowing the string (using Bound::to_str) once our
+            // minimum Python version is 3.10
             .extract::<String>()?;
         Ok(SubjectOwner::DNSName(value))
     } else if subject.is_instance(&types::IP_ADDRESS.get_bound(py)?)? {

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -11,7 +11,7 @@ use cryptography_x509_verification::{
     trust_store::Store,
     types::{DNSName, IPAddress},
 };
-use pyo3::prelude::{PyAnyMethods, PyListMethods, PyStringMethods};
+use pyo3::prelude::{PyAnyMethods, PyListMethods};
 
 use crate::backend::keys;
 use crate::error::{CryptographyError, CryptographyResult};
@@ -371,9 +371,8 @@ fn build_subject_owner(
     if subject.is_instance(&types::DNS_NAME.get_bound(py)?)? {
         let value = subject
             .getattr(pyo3::intern!(py, "value"))?
-            .downcast::<pyo3::types::PyString>()?
-            .clone();
-        Ok(SubjectOwner::DNSName(value.to_str()?.to_owned()))
+            .extract::<String>()?;
+        Ok(SubjectOwner::DNSName(value))
     } else if subject.is_instance(&types::IP_ADDRESS.get_bound(py)?)? {
         let value = subject
             .getattr(pyo3::intern!(py, "_packed"))?


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This fixes all **except one** of the migration warnings for `src/x509/verify.rs`. The remaining warning should be fixed by the changes on `verify.rs` on this PR: [link](https://github.com/pyca/cryptography/pull/10734/files#diff-6207df575875d8f1ffd6b2a7999a84061967780e6936ec7a25ad7386ea4d6e83)

cc @alex @reaperhulk 