### PR TITLE
Convert more of `src/pkcs7.rs` to new pyo3 APIs

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -97,7 +97,7 @@ fn _rust(py: pyo3::Python<'_>, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> 
     m.add_class::<oid::ObjectIdentifier>()?;
 
     m.add_submodule(asn1::create_submodule(py)?.into_gil_ref())?;
-    m.add_submodule(pkcs7::create_submodule(py)?)?;
+    m.add_submodule(pkcs7::create_submodule(py)?.into_gil_ref())?;
     m.add_submodule(pkcs12::create_submodule(py)?.into_gil_ref())?;
     m.add_submodule(exceptions::create_submodule(py)?.into_gil_ref())?;
 


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This fixes all **except one** of the migration warnings for `src/pkcs7.rs`. The remaining warning is:

```
error: use of deprecated associated function `pyo3::types::PyBytes::new`: `PyBytes::new` will be replaced by `PyBytes::new_bound` in a future PyO3 version
   --> src/pkcs7.rs:168:54
    |
168 |             let digest_bytes = pyo3::types::PyBytes::new(py, &digest);
    |       
```
which, when fixed, causes the following compilation error:

```rust
error[E0597]: `digest_bytes` does not live long enough
   --> src/pkcs7.rs:172:40
    |
168 |             let digest_bytes = pyo3::types::PyBytes::new_bound(py, &digest);
    |                 ------------ binding `digest_bytes` declared here
...
172 |                     asn1::parse_single(digest_bytes.as_bytes()).unwrap(),
    |                                        ^^^^^^^^^^^^ borrowed value does not live long enough
...
194 |         };
    |         - `digest_bytes` dropped here while still borrowed

```
cc @alex @reaperhulk 