### PR TITLE
Convert module-related code to new pyo3 APIs

### DIFF
--- a/src/rust/src/backend/mod.rs
+++ b/src/rust/src/backend/mod.rs
@@ -2,6 +2,8 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use pyo3::prelude::PyModuleMethods;
+
 pub(crate) mod aead;
 pub(crate) mod cipher_registry;
 pub(crate) mod ciphers;
@@ -23,29 +25,31 @@ pub(crate) mod x25519;
 #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
 pub(crate) mod x448;
 
-pub(crate) fn add_to_module(module: &pyo3::prelude::PyModule) -> pyo3::PyResult<()> {
-    module.add_submodule(aead::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(ciphers::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(cmac::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(dh::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(dsa::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(ec::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(keys::create_module(module.py())?.into_gil_ref())?;
+pub(crate) fn add_to_module(
+    module: &pyo3::Bound<'_, pyo3::prelude::PyModule>,
+) -> pyo3::PyResult<()> {
+    module.add_submodule(&aead::create_module(module.py())?)?;
+    module.add_submodule(&ciphers::create_module(module.py())?)?;
+    module.add_submodule(&cmac::create_module(module.py())?)?;
+    module.add_submodule(&dh::create_module(module.py())?)?;
+    module.add_submodule(&dsa::create_module(module.py())?)?;
+    module.add_submodule(&ec::create_module(module.py())?)?;
+    module.add_submodule(&keys::create_module(module.py())?)?;
 
-    module.add_submodule(ed25519::create_module(module.py())?.into_gil_ref())?;
+    module.add_submodule(&ed25519::create_module(module.py())?)?;
     #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
-    module.add_submodule(ed448::create_module(module.py())?.into_gil_ref())?;
+    module.add_submodule(&ed448::create_module(module.py())?)?;
 
-    module.add_submodule(x25519::create_module(module.py())?.into_gil_ref())?;
+    module.add_submodule(&x25519::create_module(module.py())?)?;
     #[cfg(all(not(CRYPTOGRAPHY_IS_LIBRESSL), not(CRYPTOGRAPHY_IS_BORINGSSL)))]
-    module.add_submodule(x448::create_module(module.py())?.into_gil_ref())?;
+    module.add_submodule(&x448::create_module(module.py())?)?;
 
-    module.add_submodule(poly1305::create_module(module.py())?.into_gil_ref())?;
+    module.add_submodule(&poly1305::create_module(module.py())?)?;
 
-    module.add_submodule(hashes::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(hmac::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(kdf::create_module(module.py())?.into_gil_ref())?;
-    module.add_submodule(rsa::create_module(module.py())?.into_gil_ref())?;
+    module.add_submodule(&hashes::create_module(module.py())?)?;
+    module.add_submodule(&hmac::create_module(module.py())?)?;
+    module.add_submodule(&kdf::create_module(module.py())?)?;
+    module.add_submodule(&rsa::create_module(module.py())?)?;
 
     Ok(())
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -91,15 +91,21 @@ fn enable_fips(providers: &mut LoadedProviders) -> CryptographyResult<()> {
 }
 
 #[pyo3::prelude::pymodule]
-fn _rust(py: pyo3::Python<'_>, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> {
-    m.add_function(pyo3::wrap_pyfunction!(padding::check_pkcs7_padding, m)?)?;
-    m.add_function(pyo3::wrap_pyfunction!(padding::check_ansix923_padding, m)?)?;
+fn _rust(py: pyo3::Python<'_>, m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()> {
+    m.add_function(pyo3::wrap_pyfunction_bound!(
+        padding::check_pkcs7_padding,
+        m
+    )?)?;
+    m.add_function(pyo3::wrap_pyfunction_bound!(
+        padding::check_ansix923_padding,
+        m
+    )?)?;
     m.add_class::<oid::ObjectIdentifier>()?;
 
-    m.add_submodule(asn1::create_submodule(py)?.into_gil_ref())?;
-    m.add_submodule(pkcs7::create_submodule(py)?.into_gil_ref())?;
-    m.add_submodule(pkcs12::create_submodule(py)?.into_gil_ref())?;
-    m.add_submodule(exceptions::create_submodule(py)?.into_gil_ref())?;
+    m.add_submodule(&asn1::create_submodule(py)?)?;
+    m.add_submodule(&pkcs7::create_submodule(py)?)?;
+    m.add_submodule(&pkcs12::create_submodule(py)?)?;
+    m.add_submodule(&exceptions::create_submodule(py)?)?;
 
     let x509_mod = pyo3::prelude::PyModule::new_bound(py, "x509")?;
     crate::x509::certificate::add_to_module(&x509_mod)?;
@@ -108,14 +114,14 @@ fn _rust(py: pyo3::Python<'_>, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> 
     crate::x509::csr::add_to_module(&x509_mod)?;
     crate::x509::sct::add_to_module(&x509_mod)?;
     crate::x509::verify::add_to_module(&x509_mod)?;
-    m.add_submodule(x509_mod.into_gil_ref())?;
+    m.add_submodule(&x509_mod)?;
 
-    let ocsp_mod = pyo3::prelude::PyModule::new(py, "ocsp")?;
-    crate::x509::ocsp_req::add_to_module(ocsp_mod)?;
-    crate::x509::ocsp_resp::add_to_module(ocsp_mod)?;
-    m.add_submodule(ocsp_mod)?;
+    let ocsp_mod = pyo3::prelude::PyModule::new_bound(py, "ocsp")?;
+    crate::x509::ocsp_req::add_to_module(&ocsp_mod)?;
+    crate::x509::ocsp_resp::add_to_module(&ocsp_mod)?;
+    m.add_submodule(&ocsp_mod)?;
 
-    m.add_submodule(cryptography_cffi::create_module(py)?.into_gil_ref())?;
+    m.add_submodule(&cryptography_cffi::create_module(py)?)?;
 
     let openssl_mod = pyo3::prelude::PyModule::new_bound(py, "openssl")?;
     openssl_mod.add(
@@ -161,8 +167,8 @@ fn _rust(py: pyo3::Python<'_>, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> 
     )?)?;
     openssl_mod.add_function(pyo3::wrap_pyfunction_bound!(is_fips_enabled, &openssl_mod)?)?;
     openssl_mod.add_class::<error::OpenSSLError>()?;
-    crate::backend::add_to_module(openssl_mod.clone().into_gil_ref())?;
-    m.add_submodule(openssl_mod.into_gil_ref())?;
+    crate::backend::add_to_module(&openssl_mod)?;
+    m.add_submodule(&openssl_mod)?;
 
     Ok(())
 }

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -7,7 +7,7 @@ use cryptography_x509::{
     ocsp_req::{self, OCSPRequest as RawOCSPRequest},
     oid,
 };
-use pyo3::prelude::{PyAnyMethods, PyListMethods};
+use pyo3::prelude::{PyAnyMethods, PyListMethods, PyModuleMethods};
 
 use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid, py_uint_to_big_endian_bytes};
 use crate::error::{CryptographyError, CryptographyResult};
@@ -234,9 +234,11 @@ fn create_ocsp_request(
     load_der_ocsp_request(py, pyo3::types::PyBytes::new_bound(py, &data).unbind())
 }
 
-pub(crate) fn add_to_module(module: &pyo3::prelude::PyModule) -> pyo3::PyResult<()> {
-    module.add_function(pyo3::wrap_pyfunction!(load_der_ocsp_request, module)?)?;
-    module.add_function(pyo3::wrap_pyfunction!(create_ocsp_request, module)?)?;
+pub(crate) fn add_to_module(
+    module: &pyo3::Bound<'_, pyo3::prelude::PyModule>,
+) -> pyo3::PyResult<()> {
+    module.add_function(pyo3::wrap_pyfunction_bound!(load_der_ocsp_request, module)?)?;
+    module.add_function(pyo3::wrap_pyfunction_bound!(create_ocsp_request, module)?)?;
 
     Ok(())
 }

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -10,7 +10,7 @@ use cryptography_x509::{
     ocsp_resp::{self, OCSPResponse as RawOCSPResponse, SingleResponse as RawSingleResponse},
     oid,
 };
-use pyo3::prelude::{PyAnyMethods, PyListMethods};
+use pyo3::prelude::{PyAnyMethods, PyListMethods, PyModuleMethods};
 use pyo3::PyNativeType;
 
 use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid};
@@ -760,9 +760,14 @@ fn create_ocsp_response(
     load_der_ocsp_response(py, pyo3::types::PyBytes::new_bound(py, &data).unbind())
 }
 
-pub(crate) fn add_to_module(module: &pyo3::prelude::PyModule) -> pyo3::PyResult<()> {
-    module.add_function(pyo3::wrap_pyfunction!(load_der_ocsp_response, module)?)?;
-    module.add_function(pyo3::wrap_pyfunction!(create_ocsp_response, module)?)?;
+pub(crate) fn add_to_module(
+    module: &pyo3::Bound<'_, pyo3::prelude::PyModule>,
+) -> pyo3::PyResult<()> {
+    module.add_function(pyo3::wrap_pyfunction_bound!(
+        load_der_ocsp_response,
+        module
+    )?)?;
+    module.add_function(pyo3::wrap_pyfunction_bound!(create_ocsp_response, module)?)?;
 
     Ok(())
 }


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This finishes with all of the migration warnings for `src/lib.rs`, and removes a bunch of `into_gil_refs()` added as part of the migration.

cc @alex @reaperhulk 