### PR TITLE
Misc oscp pyo3 migrations

### DIFF
--- a/src/rust/src/x509/ocsp.rs
+++ b/src/rust/src/x509/ocsp.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use cryptography_x509::common;
 use cryptography_x509::ocsp_req::CertID;
 use once_cell::sync::Lazy;
-use pyo3::PyNativeType;
+use pyo3::prelude::PyAnyMethods;
 
 use crate::backend::hashes::Hash;
 use crate::error::CryptographyResult;
@@ -76,7 +76,7 @@ pub(crate) fn certid_new<'p>(
     py: pyo3::Python<'p>,
     cert: &'p Certificate,
     issuer: &'p Certificate,
-    hash_algorithm: &'p pyo3::PyAny,
+    hash_algorithm: &pyo3::Bound<'p, pyo3::PyAny>,
 ) -> CryptographyResult<CertID<'p>> {
     let issuer_der = asn1::write_single(&cert.raw.borrow_dependent().tbs_cert.issuer)?;
     let issuer_name_hash = hash_data(py, hash_algorithm, &issuer_der)?;
@@ -123,10 +123,10 @@ pub(crate) fn certid_new_from_hash<'p>(
 
 pub(crate) fn hash_data<'p>(
     py: pyo3::Python<'p>,
-    py_hash_alg: &'p pyo3::PyAny,
+    py_hash_alg: &pyo3::Bound<'p, pyo3::PyAny>,
     data: &[u8],
 ) -> pyo3::PyResult<&'p [u8]> {
-    let mut h = Hash::new(py, &py_hash_alg.as_borrowed(), None)?;
+    let mut h = Hash::new(py, py_hash_alg, None)?;
     h.update_bytes(data)?;
     Ok(h.finalize(py)?.into_gil_ref().as_bytes())
 }

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -8,6 +8,7 @@ use cryptography_x509::{
     oid,
 };
 use pyo3::prelude::{PyAnyMethods, PyListMethods, PyModuleMethods};
+use pyo3::PyNativeType;
 
 use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid, py_uint_to_big_endian_bytes};
 use crate::error::{CryptographyError, CryptographyResult};
@@ -187,7 +188,7 @@ fn create_ocsp_request(
         py_cert = tuple.0;
         py_issuer = tuple.1;
         py_hash = tuple.2;
-        ocsp::certid_new(py, &py_cert, &py_issuer, py_hash)?
+        ocsp::certid_new(py, &py_cert, &py_issuer, &py_hash.as_borrowed())?
     } else {
         let (issuer_name_hash, issuer_key_hash, py_serial, py_hash): (
             &[u8],


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This contains misc migrations for the `ocsp` files and `pkcs7`. One of the changes triggers a pretty big `cargo fmt` change in `pkcs7.rs` making the diff very difficult to read, so I split that change into a second commit.
The only thing that actually changes in the second commit is:

```rust
// pkcs7.rs:165
// before
let digest = asn1::write_single(&x509::ocsp::hash_data(py, py_hash_alg, &data_with_header)?)?;

// after
let digest = asn1::write_single(&x509::ocsp::hash_data(py, &py_hash_alg.as_borrowed(), &data_with_header)?)?;
```
the rest is all formatting.

I suggest reviewing the first commit normally, and then the second to check the above change.

cc @alex @reaperhulk 