### PR TITLE
Migrate more `x509/extensions.rs` APIs to new pyo3 APIs (and other migrations)

### DIFF
--- a/src/rust/src/asn1.rs
+++ b/src/rust/src/asn1.rs
@@ -97,7 +97,7 @@ pub(crate) fn encode_der_data<'p>(
     py: pyo3::Python<'p>,
     pem_tag: String,
     data: Vec<u8>,
-    encoding: &'p pyo3::PyAny,
+    encoding: &pyo3::Bound<'p, pyo3::PyAny>,
 ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
     if encoding.is(&types::ENCODING_DER.get_bound(py)?) {
         Ok(pyo3::types::PyBytes::new_bound(py, &data))

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -369,7 +369,7 @@ impl DHParameters {
         } else {
             "X9.42 DH PARAMETERS"
         };
-        encode_der_data(py, tag.to_string(), data, encoding.into_gil_ref())
+        encode_der_data(py, tag.to_string(), data, &encoding)
     }
 }
 

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -77,12 +77,7 @@ fn serialize_certificates<'p>(
     };
     let content_info_bytes = asn1::write_single(&content_info)?;
 
-    encode_der_data(
-        py,
-        "PKCS7".to_string(),
-        content_info_bytes,
-        encoding.clone().into_gil_ref(),
-    )
+    encode_der_data(py, "PKCS7".to_string(), content_info_bytes, encoding)
 }
 
 #[pyo3::prelude::pyfunction]
@@ -273,12 +268,7 @@ fn sign_and_serialize<'p>(
             .extract()?)
     } else {
         // Handles the DER, PEM, and error cases
-        encode_der_data(
-            py,
-            "PKCS7".to_string(),
-            ci_bytes,
-            encoding.clone().into_gil_ref(),
-        )
+        encode_der_data(py, "PKCS7".to_string(), ci_bytes, encoding)
     }
 }
 

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -960,10 +960,7 @@ fn create_x509_certificate(
         subject_unique_id: None,
         raw_extensions: x509::common::encode_extensions(
             py,
-            builder
-                .getattr(pyo3::intern!(py, "_extensions"))?
-                .clone()
-                .into_gil_ref(),
+            &builder.getattr(pyo3::intern!(py, "_extensions"))?,
             extensions::encode_extension,
         )?,
     };

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -103,14 +103,11 @@ impl Certificate {
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let result = asn1::write_single(self.raw.borrow_dependent())?;
 
-        Ok(encode_der_data(
-            py,
-            "CERTIFICATE".to_string(),
-            result,
-            encoding.clone().into_gil_ref(),
-        )?
-        .as_borrowed()
-        .to_owned())
+        Ok(
+            encode_der_data(py, "CERTIFICATE".to_string(), result, encoding)?
+                .as_borrowed()
+                .to_owned(),
+        )
     }
 
     #[getter]

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -103,11 +103,7 @@ impl Certificate {
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let result = asn1::write_single(self.raw.borrow_dependent())?;
 
-        Ok(
-            encode_der_data(py, "CERTIFICATE".to_string(), result, encoding)?
-                .as_borrowed()
-                .to_owned(),
-        )
+        encode_der_data(py, "CERTIFICATE".to_string(), result, encoding)
     }
 
     #[getter]

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -672,10 +672,7 @@ fn create_x509_crl(
             )?,
             raw_crl_entry_extensions: x509::common::encode_extensions(
                 py,
-                py_revoked_cert
-                    .getattr(pyo3::intern!(py, "extensions"))?
-                    .clone()
-                    .into_gil_ref(),
+                &py_revoked_cert.getattr(pyo3::intern!(py, "extensions"))?,
                 extensions::encode_extension,
             )?,
         });
@@ -702,10 +699,7 @@ fn create_x509_crl(
         },
         raw_crl_extensions: x509::common::encode_extensions(
             py,
-            builder
-                .getattr(pyo3::intern!(py, "_extensions"))?
-                .clone()
-                .into_gil_ref(),
+            &builder.getattr(pyo3::intern!(py, "_extensions"))?,
             extensions::encode_extension,
         )?,
     };

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -239,7 +239,7 @@ impl CertificateRevocationList {
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let result = asn1::write_single(&self.owned.borrow_dependent())?;
 
-        encode_der_data(py, "X509 CRL".to_string(), result, encoding.into_gil_ref())
+        encode_der_data(py, "X509 CRL".to_string(), result, &encoding)
     }
 
     #[getter]

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -312,9 +312,7 @@ fn create_x509_csr(
     let ext_bytes;
     if let Some(exts) = x509::common::encode_extensions(
         py,
-        builder
-            .getattr(pyo3::intern!(py, "_extensions"))?
-            .into_gil_ref(),
+        &builder.getattr(pyo3::intern!(py, "_extensions"))?,
         x509::extensions::encode_extension,
     )? {
         ext_bytes = asn1::write_single(&exts)?;

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -123,12 +123,7 @@ impl CertificateSigningRequest {
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let result = asn1::write_single(self.raw.borrow_dependent())?;
 
-        encode_der_data(
-            py,
-            "CERTIFICATE REQUEST".to_string(),
-            result,
-            encoding.clone().into_gil_ref(),
-        )
+        encode_der_data(py, "CERTIFICATE REQUEST".to_string(), result, encoding)
     }
 
     fn get_attribute_for_oid<'p>(

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -210,10 +210,7 @@ fn create_ocsp_request(
 
     let extensions = x509::common::encode_extensions(
         py,
-        builder
-            .getattr(pyo3::intern!(py, "_extensions"))?
-            .clone()
-            .into_gil_ref(),
+        &builder.getattr(pyo3::intern!(py, "_extensions"))?,
         extensions::encode_extension,
     )?;
     let reqs = [ocsp_req::Request {

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -696,10 +696,7 @@ fn create_ocsp_response(
             )),
             raw_response_extensions: x509::common::encode_extensions(
                 py,
-                builder
-                    .getattr(pyo3::intern!(py, "_extensions"))?
-                    .clone()
-                    .into_gil_ref(),
+                &builder.getattr(pyo3::intern!(py, "_extensions"))?,
                 extensions::encode_extension,
             )?,
         };


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This one does not fix any warnings, but it does remove multiple `into_gil_ref()` calls and migrates several functions to use `Bound` parameters.


cc @alex @reaperhulk 