### PR TITLE
Introduce a keepalive abstraction

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -68,6 +68,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptography-keepalive"
+version = "0.1.0"
+
+[[package]]
 name = "cryptography-key-parsing"
 version = "0.1.0"
 dependencies = [
@@ -96,6 +100,7 @@ dependencies = [
  "asn1",
  "cfg-if",
  "cryptography-cffi",
+ "cryptography-keepalive",
  "cryptography-key-parsing",
  "cryptography-openssl",
  "cryptography-x509",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -13,6 +13,7 @@ cfg-if = "1"
 pyo3 = { version = "0.21.1", features = ["abi3", "gil-refs"] }
 asn1 = { version = "0.16.1", default-features = false }
 cryptography-cffi = { path = "cryptography-cffi" }
+cryptography-keepalive = { path = "cryptography-keepalive" }
 cryptography-key-parsing = { path = "cryptography-key-parsing" }
 cryptography-x509 = { path = "cryptography-x509" }
 cryptography-x509-verification = { path = "cryptography-x509-verification" }
@@ -37,6 +38,7 @@ overflow-checks = true
 [workspace]
 members = [
     "cryptography-cffi",
+    "cryptography-keepalive",
     "cryptography-key-parsing",
     "cryptography-openssl",
     "cryptography-x509",

--- a/src/rust/cryptography-keepalive/Cargo.toml
+++ b/src/rust/cryptography-keepalive/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cryptography-keepalive"
+version = "0.1.0"
+authors = ["The cryptography developers <cryptography-dev@python.org>"]
+edition = "2021"
+publish = false
+# This specifies the MSRV
+rust-version = "1.65.0"
+
+[dependencies]

--- a/src/rust/cryptography-keepalive/src/lib.rs
+++ b/src/rust/cryptography-keepalive/src/lib.rs
@@ -1,0 +1,40 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+#![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
+
+use std::cell::UnsafeCell;
+use std::ops::Deref;
+
+pub struct KeepAlive<T: StableDeref> {
+    values: UnsafeCell<Vec<T>>,
+}
+
+/// # Safety
+/// Implementors of this trait must ensure that the value returned by
+/// `deref()` must remain valid, even if `self` is moved.
+pub unsafe trait StableDeref: Deref {}
+// SAFETY: `Vec`'s data is on the heap, so as long as it's not mutated, the
+// slice returned by `deref` remains valid.
+unsafe impl<T> StableDeref for Vec<T> {}
+
+#[allow(clippy::new_without_default)]
+impl<T: StableDeref> KeepAlive<T> {
+    pub fn new() -> Self {
+        KeepAlive {
+            values: UnsafeCell::new(vec![]),
+        }
+    }
+
+    pub fn add(&self, v: T) -> &T::Target {
+        // SAFETY: We only ever append to `self.values`, which, when combined
+        // with the invariants of `StableDeref`, means that the result of
+        // `deref()` will always be valid for the lifetime of `&self`.
+        unsafe {
+            let values = &mut *self.values.get();
+            values.push(v);
+            values.last().unwrap().deref()
+        }
+    }
+}


### PR DESCRIPTION
This effectively emulates what pyo3's old GIL pool was doing, but we'll use it in a far more targetted manner.