### PR TITLE
Fix lifetime errors in `asn1.rs` with `gil-refs` disabled

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -70,6 +70,9 @@ dependencies = [
 [[package]]
 name = "cryptography-keepalive"
 version = "0.1.0"
+dependencies = [
+ "pyo3",
+]
 
 [[package]]
 name = "cryptography-key-parsing"

--- a/src/rust/cryptography-keepalive/Cargo.toml
+++ b/src/rust/cryptography-keepalive/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 rust-version = "1.65.0"
 
 [dependencies]
+pyo3 = { version = "0.21.1", features = ["abi3"] }

--- a/src/rust/cryptography-keepalive/src/lib.rs
+++ b/src/rust/cryptography-keepalive/src/lib.rs
@@ -20,8 +20,8 @@ pub unsafe trait StableDeref: Deref {}
 // slice returned by `deref` remains valid.
 unsafe impl<T> StableDeref for Vec<T> {}
 
-// SAFETY: `PyBackedBytes`'s data is on the heap, so as long as it's not mutated, the
-// slice returned by `deref` remains valid.
+// SAFETY: `PyBackedBytes`'s data is on the heap and `bytes` objects in
+// Python are immutable.
 unsafe impl StableDeref for PyBackedBytes {}
 
 #[allow(clippy::new_without_default)]

--- a/src/rust/cryptography-keepalive/src/lib.rs
+++ b/src/rust/cryptography-keepalive/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
 
+use pyo3::pybacked::PyBackedBytes;
 use std::cell::UnsafeCell;
 use std::ops::Deref;
 
@@ -18,6 +19,10 @@ pub unsafe trait StableDeref: Deref {}
 // SAFETY: `Vec`'s data is on the heap, so as long as it's not mutated, the
 // slice returned by `deref` remains valid.
 unsafe impl<T> StableDeref for Vec<T> {}
+
+// SAFETY: `PyBackedBytes`'s data is on the heap, so as long as it's not mutated, the
+// slice returned by `deref` remains valid.
+unsafe impl StableDeref for PyBackedBytes {}
 
 #[allow(clippy::new_without_default)]
 impl<T: StableDeref> KeepAlive<T> {

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -918,12 +918,13 @@ fn create_x509_certificate(
     let py_not_before = builder.getattr(pyo3::intern!(py, "_not_valid_before"))?;
     let py_not_after = builder.getattr(pyo3::intern!(py, "_not_valid_after"))?;
 
+    let serial_bytes = py_uint_to_big_endian_bytes(py, py_serial)?;
     let tbs_cert = cryptography_x509::certificate::TbsCertificate {
         version: builder
             .getattr(pyo3::intern!(py, "_version"))?
             .getattr(pyo3::intern!(py, "value"))?
             .extract()?,
-        serial: asn1::BigInt::new(py_uint_to_big_endian_bytes(py, py_serial)?).unwrap(),
+        serial: asn1::BigInt::new(&serial_bytes).unwrap(),
         signature_alg: sigalg.clone(),
         issuer: x509::common::encode_name(py, &py_issuer_name)?,
         validity: cryptography_x509::certificate::Validity {

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -9,6 +9,7 @@ use crate::error::{CryptographyError, CryptographyResult};
 use crate::x509::{certificate, sct};
 use crate::{types, x509};
 use pyo3::prelude::PyAnyMethods;
+use pyo3::pybacked::PyBackedBytes;
 
 fn encode_general_subtrees<'a>(
     py: pyo3::Python<'a>,
@@ -51,14 +52,11 @@ pub(crate) fn encode_authority_key_identifier<'a>(
     } else {
         None
     };
-    let ka = cryptography_keepalive::KeepAlive::new();
+    let serial_bytes: PyBackedBytes;
     let authority_cert_serial_number =
         if let Some(authority_cert_serial_number) = aki.authority_cert_serial_number {
-            let serial_bytes = ka.add(py_uint_to_big_endian_bytes(
-                py,
-                authority_cert_serial_number,
-            )?);
-            Some(asn1::BigUint::new(serial_bytes).unwrap())
+            serial_bytes = py_uint_to_big_endian_bytes(py, authority_cert_serial_number)?;
+            Some(asn1::BigUint::new(&serial_bytes).unwrap())
         } else {
             None
         };

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -9,7 +9,6 @@ use crate::error::{CryptographyError, CryptographyResult};
 use crate::x509::{certificate, sct};
 use crate::{types, x509};
 use pyo3::prelude::PyAnyMethods;
-use pyo3::pybacked::PyBackedBytes;
 
 fn encode_general_subtrees<'a>(
     py: pyo3::Python<'a>,
@@ -52,7 +51,7 @@ pub(crate) fn encode_authority_key_identifier<'a>(
     } else {
         None
     };
-    let serial_bytes: PyBackedBytes;
+    let serial_bytes;
     let authority_cert_serial_number =
         if let Some(authority_cert_serial_number) = aki.authority_cert_serial_number {
             serial_bytes = py_uint_to_big_endian_bytes(py, authority_cert_serial_number)?;

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -171,6 +171,7 @@ fn create_ocsp_request(
     builder: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<OCSPRequest> {
     let builder_request = builder.getattr(pyo3::intern!(py, "_request"))?;
+    let ka = cryptography_keepalive::KeepAlive::new();
 
     // Declare outside the if-block so the lifetimes are right.
     let (py_cert, py_issuer, py_hash, issuer_name_hash, issuer_key_hash): (
@@ -188,7 +189,8 @@ fn create_ocsp_request(
         (issuer_name_hash, issuer_key_hash, py_serial, py_hash) = builder
             .getattr(pyo3::intern!(py, "_request_hash"))?
             .extract()?;
-        let serial_number = asn1::BigInt::new(py_uint_to_big_endian_bytes(py, py_serial)?).unwrap();
+        let serial_number_bytes = ka.add(py_uint_to_big_endian_bytes(py, py_serial)?);
+        let serial_number = asn1::BigInt::new(serial_number_bytes).unwrap();
         ocsp::certid_new_from_hash(
             py,
             &issuer_name_hash,

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -171,7 +171,8 @@ fn create_ocsp_request(
     builder: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<OCSPRequest> {
     let builder_request = builder.getattr(pyo3::intern!(py, "_request"))?;
-    let ka = cryptography_keepalive::KeepAlive::new();
+    let serial_number_bytes;
+    //let ka = cryptography_keepalive::KeepAlive::new();
 
     // Declare outside the if-block so the lifetimes are right.
     let (py_cert, py_issuer, py_hash, issuer_name_hash, issuer_key_hash): (
@@ -189,8 +190,8 @@ fn create_ocsp_request(
         (issuer_name_hash, issuer_key_hash, py_serial, py_hash) = builder
             .getattr(pyo3::intern!(py, "_request_hash"))?
             .extract()?;
-        let serial_number_bytes = ka.add(py_uint_to_big_endian_bytes(py, py_serial)?);
-        let serial_number = asn1::BigInt::new(serial_number_bytes).unwrap();
+        serial_number_bytes = py_uint_to_big_endian_bytes(py, py_serial)?;
+        let serial_number = asn1::BigInt::new(&serial_number_bytes).unwrap();
         ocsp::certid_new_from_hash(
             py,
             &issuer_name_hash,

--- a/src/rust/src/x509/ocsp_req.rs
+++ b/src/rust/src/x509/ocsp_req.rs
@@ -172,7 +172,6 @@ fn create_ocsp_request(
 ) -> CryptographyResult<OCSPRequest> {
     let builder_request = builder.getattr(pyo3::intern!(py, "_request"))?;
     let serial_number_bytes;
-    //let ka = cryptography_keepalive::KeepAlive::new();
 
     // Declare outside the if-block so the lifetimes are right.
     let (py_cert, py_issuer, py_hash, issuer_name_hash, issuer_key_hash): (


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/10676

This should be merged **after** the [keepalive PR](https://github.com/pyca/cryptography/pull/10764) is merged

Fixes all of the lifetime errors in `asn1.rs`, changing a return type of `py_uint_to_big_endian_bytes` from `&'p [u8]` to `PyBackedBytes`.
It uses the new `keepalive` in the places where the `PyBackedBytes` object is borrowed for longer than its lifetime.

cc @alex @reaperhulk 