### PR TITLE
Fix DH Key exchange incompatibility

### DIFF
--- a/docs/development/test-vectors.rst
+++ b/docs/development/test-vectors.rst
@@ -205,6 +205,10 @@ Key exchange
   ``vectors/cryptography_vectors/asymmetric/DH/dhpub.der`` contains
   are the above parameters and keys in DER format.
 
+  ``vectors/cryptography_vectors/asymmetric/DH/dhpub_v41_0_7.pem`` contains
+  a Diffie-Hellman public key created with version 41.0.7 of this
+  package.
+
 * ``vectors/cryptography_vectors/asymmetric/DH/dhp_rfc5114_2.pem``,
   ``vectors/cryptography_vectors/asymmetric/DH/dhkey_rfc5114_2.pem`` and
   ``vectors/cryptography_vectors/asymmetric/DH/dhpub_rfc5114_2.pem`` contains

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -77,11 +77,7 @@ fn pkey_from_dh<T: openssl::pkey::HasParams>(
         if #[cfg(CRYPTOGRAPHY_IS_LIBRESSL)] {
             Ok(openssl::pkey::PKey::from_dh(dh)?)
         } else {
-            if dh.prime_q().is_some() {
-                Ok(openssl::pkey::PKey::from_dhx(dh)?)
-            } else {
-                Ok(openssl::pkey::PKey::from_dh(dh)?)
-            }
+            Ok(openssl::pkey::PKey::from_dh(dh)?)
         }
     }
 }

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -12,6 +12,7 @@ use pyo3::prelude::{PyAnyMethods, PyModuleMethods};
 
 const MIN_MODULUS_SIZE: u32 = 512;
 
+#[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 pub(crate) enum AllowDHX {
     True,

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -77,7 +77,7 @@ pub(crate) fn public_key_from_pkey(
 }
 
 #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
-#[allow(dead_code)]
+#[allow(unused_variables)]
 fn pkey_from_dh<T: openssl::pkey::HasParams>(
     dh: openssl::dh::Dh<T>,
     allow_dhx: AllowDHX,

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -12,7 +12,6 @@ use pyo3::prelude::{PyAnyMethods, PyModuleMethods};
 
 const MIN_MODULUS_SIZE: u32 = 512;
 
-#[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
 #[derive(Debug, PartialEq)]
 pub(crate) enum AllowDHX {
     True,
@@ -77,6 +76,7 @@ pub(crate) fn public_key_from_pkey(
 }
 
 #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
+#[allow(dead_code)]
 fn pkey_from_dh<T: openssl::pkey::HasParams>(
     dh: openssl::dh::Dh<T>,
     allow_dhx: AllowDHX,

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -12,6 +12,7 @@ use pyo3::prelude::{PyAnyMethods, PyModuleMethods};
 
 const MIN_MODULUS_SIZE: u32 = 512;
 
+#[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
 #[derive(Debug, PartialEq)]
 pub(crate) enum AllowDHX {
     True,

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -7,6 +7,7 @@ import binascii
 import copy
 import itertools
 import os
+import textwrap
 import typing
 
 import pytest
@@ -472,6 +473,39 @@ class TestDH:
         key2 = copy.copy(key1)
 
         assert key1 == key2
+
+    def test_old_public_key_exchange(self, backend):
+        # This is a public key generated on cryptograpy version 41.0.7
+        key_data = textwrap.dedent(
+            """\
+        -----BEGIN PUBLIC KEY-----
+        MIICJTCCARcGCSqGSIb3DQEDATCCAQgCggEBAP//////////yQ/aoiFowjTExmKL
+        gNwc0SkCTgiKZ8x0Agu+pjsTmyJRSgh5jjQE3e+VGbPNOkMbMCsKbfJfFDdP4TVt
+        bVHCReSFtXZiXn7G9ExC6aY37WsL/1y29Aa37e44a/taiZ+lrp8kEXxLH+ZJKGZR
+        7ORbPcIAfLihY78FmNpINhxV05ppFj+o/STPX4NlXSPco62WHGLzViCFUrue1SkH
+        cJaWbWcMNU5KvJgE8XRsCMoYIXwykF5GLjbOO+OedywYDoY DmyeDouwHoo+1xV3w
+        b0xSyd4ry/aVWBcYOZVJfOqVauUV0iYYmPoFEBVyjlqKrKpo//////////8CAQID
+        ggEGAAKCAQEAoely6vSHw+/Q3zGYLaJj7eeQkfd25K8SvtC+FMY9D7jwS4g71pyr
+        U3FJ98Fi45Wdksh+d4u7U089trF5Xbgui29bZ0HcQZtfHEEz0Mh69tkipCm2/QIj
+        6eDlo6sPk9hhhvgg4MMGiWKhCtHrub3x1FHdmf7KjOhrGeb5apiudo7blGFzGhZ3
+        NFnbff+ArVNd+rdVmSoZn0aMhXRConlDu/44IYe5/24VLl7G+BzZlIZO4P2M83fd
+        mBOvR13cmYssQjEFTbaZVQvQHa3t0+aywfdCgsXGmTTK6QDCBP8D+vf1bmhEswzs
+        oYn1GLtJ3VyYyMBPDBomd2ctchZgTzsX1w==
+        -----END PUBLIC KEY-----
+        """
+        ).encode()
+
+        public_key = serialization.load_pem_public_key(key_data, backend)
+
+        assert isinstance(public_key, dh.DHPublicKey)
+
+        params = public_key.parameters()
+
+        private_key = params.generate_private_key()
+
+        # test that we can do a key exchange with a public key
+        # generated with an older version
+        private_key.exchange(public_key)
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -7,7 +7,6 @@ import binascii
 import copy
 import itertools
 import os
-import textwrap
 import typing
 
 import pytest
@@ -475,27 +474,13 @@ class TestDH:
         assert key1 == key2
 
     def test_old_public_key_exchange(self, backend):
-        # This is a public key generated on cryptograpy version 41.0.7
-        key_data = textwrap.dedent(
-            """\
-        -----BEGIN PUBLIC KEY-----
-        MIICJTCCARcGCSqGSIb3DQEDATCCAQgCggEBAP//////////yQ/aoiFowjTExmKL
-        gNwc0SkCTgiKZ8x0Agu+pjsTmyJRSgh5jjQE3e+VGbPNOkMbMCsKbfJfFDdP4TVt
-        bVHCReSFtXZiXn7G9ExC6aY37WsL/1y29Aa37e44a/taiZ+lrp8kEXxLH+ZJKGZR
-        7ORbPcIAfLihY78FmNpINhxV05ppFj+o/STPX4NlXSPco62WHGLzViCFUrue1SkH
-        cJaWbWcMNU5KvJgE8XRsCMoYIXwykF5GLjbOO+OedywYDoY DmyeDouwHoo+1xV3w
-        b0xSyd4ry/aVWBcYOZVJfOqVauUV0iYYmPoFEBVyjlqKrKpo//////////8CAQID
-        ggEGAAKCAQEAoely6vSHw+/Q3zGYLaJj7eeQkfd25K8SvtC+FMY9D7jwS4g71pyr
-        U3FJ98Fi45Wdksh+d4u7U089trF5Xbgui29bZ0HcQZtfHEEz0Mh69tkipCm2/QIj
-        6eDlo6sPk9hhhvgg4MMGiWKhCtHrub3x1FHdmf7KjOhrGeb5apiudo7blGFzGhZ3
-        NFnbff+ArVNd+rdVmSoZn0aMhXRConlDu/44IYe5/24VLl7G+BzZlIZO4P2M83fd
-        mBOvR13cmYssQjEFTbaZVQvQHa3t0+aywfdCgsXGmTTK6QDCBP8D+vf1bmhEswzs
-        oYn1GLtJ3VyYyMBPDBomd2ctchZgTzsX1w==
-        -----END PUBLIC KEY-----
-        """
-        ).encode()
+        vector = load_vectors_from_file(
+            os.path.join("asymmetric", "DH", "dhpub_v41_0_7.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
 
-        public_key = serialization.load_pem_public_key(key_data, backend)
+        public_key = serialization.load_pem_public_key(vector, backend)
 
         assert isinstance(public_key, dh.DHPublicKey)
 

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -7,6 +7,7 @@ import binascii
 import copy
 import itertools
 import os
+import sys
 import typing
 
 import pytest
@@ -486,7 +487,9 @@ class TestDH:
 
         params = public_key.parameters()
 
+        print("XXXXXX: test p1", file=sys.stderr)
         private_key = params.generate_private_key()
+        print("XXXXXX: test p2", file=sys.stderr)
 
         # test that we can do a key exchange with a public key
         # generated with an older version

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -7,7 +7,6 @@ import binascii
 import copy
 import itertools
 import os
-import sys
 import typing
 
 import pytest

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -487,9 +487,7 @@ class TestDH:
 
         params = public_key.parameters()
 
-        print("XXXXXX: test p1", file=sys.stderr)
         private_key = params.generate_private_key()
-        print("XXXXXX: test p2", file=sys.stderr)
 
         # test that we can do a key exchange with a public key
         # generated with an older version

--- a/vectors/cryptography_vectors/asymmetric/DH/dhpub_v41_0_7.pem
+++ b/vectors/cryptography_vectors/asymmetric/DH/dhpub_v41_0_7.pem
@@ -1,0 +1,15 @@
+# A public key generated with cryptograpy 41.0.7
+-----BEGIN PUBLIC KEY-----
+MIICJTCCARcGCSqGSIb3DQEDATCCAQgCggEBAP//////////yQ/aoiFowjTExmKL
+gNwc0SkCTgiKZ8x0Agu+pjsTmyJRSgh5jjQE3e+VGbPNOkMbMCsKbfJfFDdP4TVt
+bVHCReSFtXZiXn7G9ExC6aY37WsL/1y29Aa37e44a/taiZ+lrp8kEXxLH+ZJKGZR
+7ORbPcIAfLihY78FmNpINhxV05ppFj+o/STPX4NlXSPco62WHGLzViCFUrue1SkH
+cJaWbWcMNU5KvJgE8XRsCMoYIXwykF5GLjbOO+OedywYDoY DmyeDouwHoo+1xV3w
+b0xSyd4ry/aVWBcYOZVJfOqVauUV0iYYmPoFEBVyjlqKrKpo//////////8CAQID
+ggEGAAKCAQEAoely6vSHw+/Q3zGYLaJj7eeQkfd25K8SvtC+FMY9D7jwS4g71pyr
+U3FJ98Fi45Wdksh+d4u7U089trF5Xbgui29bZ0HcQZtfHEEz0Mh69tkipCm2/QIj
+6eDlo6sPk9hhhvgg4MMGiWKhCtHrub3x1FHdmf7KjOhrGeb5apiudo7blGFzGhZ3
+NFnbff+ArVNd+rdVmSoZn0aMhXRConlDu/44IYe5/24VLl7G+BzZlIZO4P2M83fd
+mBOvR13cmYssQjEFTbaZVQvQHa3t0+aywfdCgsXGmTTK6QDCBP8D+vf1bmhEswzs
+oYn1GLtJ3VyYyMBPDBomd2ctchZgTzsX1w==
+-----END PUBLIC KEY-----


### PR DESCRIPTION
A change in key types for DH keys was introduced in 42.0.0 such that DH key exchange with older versions (e.g. 41.0.7) no longer works.  This affects key exchange with other OpenSSL servers as well.

This commit reverts the code that attempts to differentiate between DH and DHX key exchanges.

Fixes issue #10790 