### PR TITLE
Apply ruff/flake8-implicit-str-concat rule ISC001

### DIFF
--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
@@ -75,7 +75,7 @@ class _KBKDFDeriver:
 
         if (label or context) and fixed:
             raise ValueError(
-                "When supplying fixed data, " "label and context are ignored."
+                "When supplying fixed data, label and context are ignored."
             )
 
         if rlen is None or not self._valid_byte_length(rlen):

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -869,7 +869,7 @@ class CertificateBuilder:
         # zero.
         if number.bit_length() >= 160:  # As defined in RFC 5280
             raise ValueError(
-                "The serial number should not be more than 159 " "bits."
+                "The serial number should not be more than 159 bits."
             )
         return CertificateBuilder(
             self._issuer_name,
@@ -1047,7 +1047,7 @@ class CertificateRevocationListBuilder:
         last_update = _convert_to_naive_utc_time(last_update)
         if last_update < _EARLIEST_UTC_TIME:
             raise ValueError(
-                "The last update date must be on or after" " 1950 January 1."
+                "The last update date must be on or after 1950 January 1."
             )
         if self._next_update is not None and last_update > self._next_update:
             raise ValueError(
@@ -1071,7 +1071,7 @@ class CertificateRevocationListBuilder:
         next_update = _convert_to_naive_utc_time(next_update)
         if next_update < _EARLIEST_UTC_TIME:
             raise ValueError(
-                "The last update date must be on or after" " 1950 January 1."
+                "The last update date must be on or after 1950 January 1."
             )
         if self._last_update is not None and next_update < self._last_update:
             raise ValueError(
@@ -1172,7 +1172,7 @@ class RevokedCertificateBuilder:
         # zero.
         if number.bit_length() >= 160:  # As defined in RFC 5280
             raise ValueError(
-                "The serial number should not be more than 159 " "bits."
+                "The serial number should not be more than 159 bits."
             )
         return RevokedCertificateBuilder(
             number, self._revocation_date, self._extensions
@@ -1188,7 +1188,7 @@ class RevokedCertificateBuilder:
         time = _convert_to_naive_utc_time(time)
         if time < _EARLIEST_UTC_TIME:
             raise ValueError(
-                "The revocation date must be on or after" " 1950 January 1."
+                "The revocation date must be on or after 1950 January 1."
             )
         return RevokedCertificateBuilder(
             self._serial_number, time, self._extensions

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2721,7 +2721,7 @@ a4090a3a2f602a77ff3bac1417f7e25a683f667b3b91f105016a47afad46a0367b18e2bdf0c
         {
             "curve": "sect233k1",
             "d": int(
-                "1da7422b50e3ff051f2aaaed10acea6cbf6110c517da2f4e" "aca8b5b87",
+                "1da7422b50e3ff051f2aaaed10acea6cbf6110c517da2f4eaca8b5b87",
                 16,
             ),
             "x": int(
@@ -2738,7 +2738,7 @@ a4090a3a2f602a77ff3bac1417f7e25a683f667b3b91f105016a47afad46a0367b18e2bdf0c
         {
             "curve": "sect233k1",
             "d": int(
-                "530951158f7b1586978c196603c12d25607d2cb0557efadb" "23cd0ce8",
+                "530951158f7b1586978c196603c12d25607d2cb0557efadb23cd0ce8",
                 16,
             ),
             "x": int(
@@ -3776,7 +3776,7 @@ f47021022a6c9b45ed791d09d9540eb81ea065fc1959eca365001ee39928c343d75
                 ),
             },
             "Z": int(
-                "b1259ceedfb663d9515089cf727e7024fb3d86cbcec611b4" "ba0b4ab6",
+                "b1259ceedfb663d9515089cf727e7024fb3d86cbcec611b4ba0b4ab6",
                 16,
             ),
             "curve": "secp224r1",
@@ -4015,7 +4015,7 @@ ffdfa60dd7
                 16,
             ),
             "Z": int(
-                "43f23b2c760d686fc99cc008b63aea92f866e224265af60d" "2d8ae540",
+                "43f23b2c760d686fc99cc008b63aea92f866e224265af60d2d8ae540",
                 16,
             ),
             "DKM": int("ad65fa2d12541c3a21f3cd223efb", 16),

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -79,10 +79,10 @@ class TestOCSPRequest:
             ocsp.load_der_ocsp_request,
         )
         assert req.issuer_name_hash == (
-            b"8\xcaF\x8c\x07D\x8d\xf4\x81\x96" b"\xc7mmLpQ\x9e`\xa7\xbd"
+            b"8\xcaF\x8c\x07D\x8d\xf4\x81\x96\xc7mmLpQ\x9e`\xa7\xbd"
         )
         assert req.issuer_key_hash == (
-            b"yu\xbb\x84:\xcb,\xdez\t\xbe1" b"\x1bC\xbc\x1c*MSX"
+            b"yu\xbb\x84:\xcb,\xdez\t\xbe1\x1bC\xbc\x1c*MSX"
         )
         assert isinstance(req.hash_algorithm, hashes.SHA1)
         assert req.serial_number == int(

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -2520,7 +2520,7 @@ class TestRSASubjectAlternativeNameExtension:
         assert ext is not None
         uri = ext.value.get_values_for_type(x509.UniformResourceIdentifier)
         assert uri == [
-            "gopher://xn--80ato2c.cryptography:70/path?q=s#hel" "lo",
+            "gopher://xn--80ato2c.cryptography:70/path?q=s#hello",
             "http://someregulardomain.com",
         ]
 


### PR DESCRIPTION
	ISC001 Implicitly concatenated string literals on one line

This rule is currently disabled because it conflicts with the formatter:
	https://github.com/astral-sh/ruff/issues/8272

These are typically left over by black when unfolding lines (#5324).