### PR TITLE
Fix more misspellings

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -94,7 +94,7 @@ Glossary
         A bytes-like object contains binary data and supports the
         `buffer protocol`_. This includes ``bytes``, ``bytearray``, and
         ``memoryview`` objects. It is :term:`unsafe` to pass a mutable object
-        (e.g., a ``bytearray`` or other implementor of the buffer protocol)
+        (e.g., a ``bytearray`` or other implementer of the buffer protocol)
         and to `mutate it concurrently`_ with the operation it has been
         provided for.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -62,7 +62,6 @@ hazmat
 Homebrew
 hostname
 hostnames
-implementor
 incrementing
 indistinguishability
 initialisms

--- a/src/rust/cryptography-keepalive/src/lib.rs
+++ b/src/rust/cryptography-keepalive/src/lib.rs
@@ -13,7 +13,7 @@ pub struct KeepAlive<T: StableDeref> {
 }
 
 /// # Safety
-/// Implementors of this trait must ensure that the value returned by
+/// Implementers of this trait must ensure that the value returned by
 /// `deref()` must remain valid, even if `self` is moved.
 pub unsafe trait StableDeref: Deref {}
 // SAFETY: `Vec`'s data is on the heap, so as long as it's not mutated, the

--- a/src/rust/src/backend/cipher_registry.rs
+++ b/src/rust/src/backend/cipher_registry.rs
@@ -262,7 +262,7 @@ fn get_cipher_registry(
         m.add(&chacha20, none_type.as_any(), None, Cipher::chacha20())?;
 
         // Don't register legacy ciphers if they're unavailable. In theory
-        // this should't be necessary but OpenSSL 3 will return an EVP_CIPHER
+        // this shouldn't be necessary but OpenSSL 3 will return an EVP_CIPHER
         // even when the cipher is unavailable.
         if cfg!(not(CRYPTOGRAPHY_OPENSSL_300_OR_GREATER))
             || types::LEGACY_PROVIDER_LOADED.get(py)?.is_truthy()?


### PR DESCRIPTION
_Implementor_ is not exactly a misspelling, but:
* From [Garner's Modern English Usage (4 ed.)](https://www.oxfordreference.com/display/10.1093/acref/9780190491482.001.0001/acref-9780190491482-e-4046):
  > Although the variant spelling ✳implementor predominated for much of the late 20th century, today implementer is considered standard.
* The Google Ngram Viewer shows a [ratio of almost 10:1 in 2019](https://books.google.com/ngrams/graph?content=implementor%2Cimplementer&year_start=1900&year_end=2019&corpus=en-2019).