### PR TITLE
Support empty string in `Name.from_rfc4514_string()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,8 @@ Changelog
 * Added :attr:`~cryptography.x509.InvalidityDate.invalidity_date_utc`, a
   timezone-aware alternative to the naïve ``datetime`` attribute
   :attr:`~cryptography.x509.InvalidityDate.invalidity_date`.
+* Added support for parsing empty DN string in
+  :meth:`~cryptography.x509.Name.from_rfc4514_string`.
 
 .. _v42-0-7:
 

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -414,6 +414,10 @@ class _RFC4514NameParser:
         we parse it, we need to reverse again to get the RDNs on the
         correct order.
         """
+
+        if not self._has_data():
+            return Name([])
+
         rdns = [self._parse_rdn()]
 
         while self._has_data():

--- a/tests/x509/test_name.py
+++ b/tests/x509/test_name.py
@@ -159,6 +159,7 @@ class TestRFC4514:
                 "2.5.4.10=abc",
                 Name([NameAttribute(NameOID.ORGANIZATION_NAME, "abc")]),
             ),
+            ("", Name([])),
         ]:
             with subtests.test():
                 result = Name.from_rfc4514_string(value)

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -5885,6 +5885,9 @@ class TestNameAttribute:
             {NameOID.COMMON_NAME: "CommonName", NameOID.EMAIL_ADDRESS: "E"}
         ) == ("CommonName=Santa Claus,E=santa@north.pole")
 
+    def test_empty_name(self):
+        assert x509.Name([]).rfc4514_string() == ""
+
     def test_empty_value(self):
         na = x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "")
         assert na.rfc4514_string() == r"ST="


### PR DESCRIPTION
Empty string is a valid result from RFC4514 serialization, and should parse successfully into empty `Name`.

According to https://datatracker.ietf.org/doc/html/rfc4514#section-2.1

> If the RDNSequence is an empty sequence, the result is the empty or zero-length string.
