### PR TITLE
Stop building x86-64 macOS wheels, only build universal2

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -196,16 +196,6 @@ jobs:
             # This will change in the future as we change the base Python we
             # build against
             _PYTHON_HOST_PLATFORM: 'macosx-10.9-universal2'
-          - VERSION: '3.11'
-            ABI_VERSION: 'cp37'
-            DOWNLOAD_URL: 'https://www.python.org/ftp/python/3.11.3/python-3.11.3-macos11.pkg'
-            BIN_PATH: '/Library/Frameworks/Python.framework/Versions/3.11/bin/python3'
-            DEPLOYMENT_TARGET: '10.12'
-            # We continue to build a non-universal2 for a bit to see metrics on
-            # download counts (this is a proxy for pip version since universal2
-            # requires a 21.x pip)
-            ARCHFLAGS: '-arch x86_64'
-            _PYTHON_HOST_PLATFORM: 'macosx-10.9-x86_64'
           - VERSION: 'pypy-3.9'
             BIN_PATH: 'pypy3'
             DEPLOYMENT_TARGET: '10.12'


### PR DESCRIPTION
The original motivation for building both universal and x86-64 wheels was for metrics. I can now report that universal2 are about 99% of the wheel downloads for 42.0.5