### PR TITLE
See if wheel dep is required

### DIFF
--- a/.github/requirements/build-requirements.in
+++ b/.github/requirements/build-requirements.in
@@ -1,6 +1,5 @@
 # Must be kept sync with build-system.requires at pyproject.toml
 setuptools>=61.0.0
-wheel
 cffi>=1.12; platform_python_implementation != 'PyPy'
 setuptools-rust>=1.7.0
 

--- a/.github/requirements/build-requirements.txt
+++ b/.github/requirements/build-requirements.txt
@@ -74,10 +74,6 @@ tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via setuptools-rust
-wheel==0.43.0 \
-    --hash=sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85 \
-    --hash=sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81
-    # via -r build-requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==70.1.0 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@
 requires = [
     # First version of setuptools to support pyproject.toml configuration
     "setuptools>=61.0.0",
-    "wheel",
     # Must be kept in sync with `project.dependencies`
     "cffi>=1.12; platform_python_implementation != 'PyPy'",
     "setuptools-rust>=1.7.0",


### PR DESCRIPTION
The setuptools changelog sort of implies its not anymore