### PR TITLE
Revert "pin python version for downstream tests due to twisted/python bug"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
           - mitmproxy
           - scapy
         PYTHON:
-          - '3.12.3'
+          - '3.12'
     name: "Downstream tests for ${{ matrix.DOWNSTREAM }}"
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Reverts pyca/cryptography#11121