### PR TITLE
Fix docstring for _SSHFormatSKECDSA.load_public

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -620,7 +620,7 @@ class _SSHFormatSKECDSA:
     def load_public(
         self, data: memoryview
     ) -> tuple[ec.EllipticCurvePublicKey, memoryview]:
-        """Make Ed25519 public key from data."""
+        """Make ECDSA public key from data."""
         public_key, data = _lookup_kformat(_ECDSA_NISTP256).load_public(data)
         _, data = load_application(data)
         return public_key, data


### PR DESCRIPTION
Correct a small mistake from copy-pasting the docstring of `_SSHFormatSKEd25519.load_public` as noted in
https://github.com/pyca/cryptography/commit/51a6dd28ccbb7587fff9e951299b17aac39ee5cc#r143361696.