### PR TITLE
Remove the requirement for VerificationCertificate to be Clone

### DIFF
--- a/src/rust/cryptography-x509-verification/src/ops.rs
+++ b/src/rust/cryptography-x509-verification/src/ops.rs
@@ -39,11 +39,6 @@ impl<B: CryptoOps> PartialEq for VerificationCertificate<'_, B> {
     }
 }
 impl<B: CryptoOps> Eq for VerificationCertificate<'_, B> {}
-impl<B: CryptoOps> Clone for VerificationCertificate<'_, B> {
-    fn clone(&self) -> Self {
-        VerificationCertificate::new(self.cert.clone(), self.extra.clone())
-    }
-}
 
 pub trait CryptoOps {
     /// A public key type for this cryptographic backend.
@@ -53,7 +48,7 @@ pub trait CryptoOps {
     type Err;
 
     /// Extra data that's passed around with the certificate.
-    type CertificateExtra: Clone;
+    type CertificateExtra;
 
     /// Extracts the public key from the given `Certificate` in
     /// a `Key` format known by the cryptographic backend, or `None`

--- a/src/rust/cryptography-x509-verification/src/trust_store.rs
+++ b/src/rust/cryptography-x509-verification/src/trust_store.rs
@@ -22,7 +22,7 @@ impl<'a, B: CryptoOps> Store<'a, B> {
             by_subject
                 .entry(cert.certificate().tbs_cert.subject.clone())
                 .or_default()
-                .push(cert.clone());
+                .push(cert);
         }
         Store { by_subject }
     }
@@ -51,9 +51,10 @@ mod tests {
     #[test]
     fn test_store() {
         let cert_pem = v1_cert_pem();
-        let cert = VerificationCertificate::new(cert(&cert_pem), ());
-        let store = Store::<'_, PublicKeyErrorOps>::new([cert.clone()]);
+        let cert1 = VerificationCertificate::new(cert(&cert_pem), ());
+        let cert2 = VerificationCertificate::new(cert(&cert_pem), ());
+        let store = Store::<'_, PublicKeyErrorOps>::new([cert1]);
 
-        assert!(store.contains(&cert));
+        assert!(store.contains(&cert2));
     }
 }

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -260,17 +260,25 @@ impl PyClientVerifier {
         let policy = self.as_policy();
         let store = self.store.get();
 
-        let chain = cryptography_x509_verification::verify(
-            &VerificationCertificate::new(
-                leaf.get().raw.borrow_dependent().clone(),
-                leaf.clone_ref(py),
-            ),
-            intermediates.iter().map(|i| {
+        let intermediates = intermediates
+            .iter()
+            .map(|i| {
                 VerificationCertificate::new(
                     i.get().raw.borrow_dependent().clone(),
                     i.clone_ref(py),
                 )
-            }),
+            })
+            .collect::<Vec<_>>();
+        let intermediate_refs = intermediates.iter().collect::<Vec<_>>();
+
+        let v = VerificationCertificate::new(
+            leaf.get().raw.borrow_dependent().clone(),
+            leaf.clone_ref(py),
+        );
+
+        let chain = cryptography_x509_verification::verify(
+            &v,
+            &intermediate_refs,
             policy,
             store.raw.borrow_dependent(),
         )
@@ -344,17 +352,25 @@ impl PyServerVerifier {
         let policy = self.as_policy();
         let store = self.store.get();
 
-        let chain = cryptography_x509_verification::verify(
-            &VerificationCertificate::new(
-                leaf.get().raw.borrow_dependent().clone(),
-                leaf.clone_ref(py),
-            ),
-            intermediates.iter().map(|i| {
+        let intermediates = intermediates
+            .iter()
+            .map(|i| {
                 VerificationCertificate::new(
                     i.get().raw.borrow_dependent().clone(),
                     i.clone_ref(py),
                 )
-            }),
+            })
+            .collect::<Vec<_>>();
+        let intermediate_refs = intermediates.iter().collect::<Vec<_>>();
+
+        let v = VerificationCertificate::new(
+            leaf.get().raw.borrow_dependent().clone(),
+            leaf.clone_ref(py),
+        );
+
+        let chain = cryptography_x509_verification::verify(
+            &v,
+            &intermediate_refs,
             policy,
             store.raw.borrow_dependent(),
         )


### PR DESCRIPTION
This is done by passing around references, rather than owned copies. Necessary for the pyo3 0.22 upgrade.