### PR TITLE
verification: remove an error variant

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -265,6 +265,7 @@ def local(session):
         *test_dependencies,
         *pyproject_data["project"]["optional-dependencies"]["ssh"],
         *pyproject_data["project"]["optional-dependencies"]["nox"],
+        "-e",
         "./vectors/",
         verbose=False,
     )

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -436,29 +436,3 @@ impl<'a, 'chain: 'a, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
         Ok(chain)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use asn1::ParseError;
-    use cryptography_x509::oid::SUBJECT_ALTERNATIVE_NAME_OID;
-
-    use crate::ValidationError;
-
-    #[test]
-    fn test_validationerror_display() {
-        let err = ValidationError::Malformed(ParseError::new(asn1::ParseErrorKind::InvalidLength));
-        assert_eq!(err.to_string(), "ASN.1 parsing error: invalid length");
-
-        let err = ValidationError::ExtensionError {
-            oid: SUBJECT_ALTERNATIVE_NAME_OID,
-            reason: "duplicate extension",
-        };
-        assert_eq!(
-            err.to_string(),
-            "invalid extension: duplicate extension: 2.5.29.17"
-        );
-
-        let err = ValidationError::FatalError("oops");
-        assert_eq!(err.to_string(), "fatal error: oops");
-    }
-}

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -440,9 +440,7 @@ impl<'a, 'chain: 'a, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
 #[cfg(test)]
 mod tests {
     use asn1::ParseError;
-    use cryptography_x509::{
-        extensions::DuplicateExtensionsError, oid::SUBJECT_ALTERNATIVE_NAME_OID,
-    };
+    use cryptography_x509::oid::SUBJECT_ALTERNATIVE_NAME_OID;
 
     use crate::ValidationError;
 
@@ -451,12 +449,13 @@ mod tests {
         let err = ValidationError::Malformed(ParseError::new(asn1::ParseErrorKind::InvalidLength));
         assert_eq!(err.to_string(), "ASN.1 parsing error: invalid length");
 
-        let err = ValidationError::DuplicateExtension(DuplicateExtensionsError(
-            SUBJECT_ALTERNATIVE_NAME_OID,
-        ));
+        let err = ValidationError::ExtensionError {
+            oid: SUBJECT_ALTERNATIVE_NAME_OID,
+            reason: "duplicate extension",
+        };
         assert_eq!(
             err.to_string(),
-            "malformed certificate: duplicate extension: 2.5.29.17"
+            "invalid extension: duplicate extension: 2.5.29.17"
         );
 
         let err = ValidationError::FatalError("oops");

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -436,3 +436,29 @@ impl<'a, 'chain: 'a, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
         Ok(chain)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use asn1::ParseError;
+    use cryptography_x509::oid::SUBJECT_ALTERNATIVE_NAME_OID;
+
+    use crate::ValidationError;
+
+    #[test]
+    fn test_validationerror_display() {
+        let err = ValidationError::Malformed(ParseError::new(asn1::ParseErrorKind::InvalidLength));
+        assert_eq!(err.to_string(), "ASN.1 parsing error: invalid length");
+
+        let err = ValidationError::ExtensionError {
+            oid: SUBJECT_ALTERNATIVE_NAME_OID,
+            reason: "duplicate extension",
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid extension: 2.5.29.17: duplicate extension"
+        );
+
+        let err = ValidationError::FatalError("oops");
+        assert_eq!(err.to_string(), "fatal error: oops");
+    }
+}

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -8,7 +8,6 @@ use crate::common;
 use crate::crl;
 use crate::name;
 
-#[derive(Debug)]
 pub struct DuplicateExtensionsError(pub asn1::ObjectIdentifier);
 
 pub type RawExtensions<'a> = common::Asn1ReadableOrWritable<

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -295,6 +295,7 @@ impl PyClientVerifier {
         let leaf_san = &chain[0]
             .certificate()
             .extensions()
+            .ok()
             .unwrap()
             .get_extension(&SUBJECT_ALTERNATIVE_NAME_OID)
             .unwrap();


### PR DESCRIPTION
`DuplicateExtension` is well-covered under the `ExtensionError` variant, so this removes it. NFC otherwise.

