### PR TITLE
Support loading SSH keys serialized with 'rsa-sha2-{256,512}' as their key type string

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -68,8 +68,10 @@ _CERT_SUFFIX = b"-cert-v01@openssh.com"
 _SK_SSH_ED25519 = b"sk-ssh-ed25519@openssh.com"
 _SK_SSH_ECDSA_NISTP256 = b"sk-ecdsa-sha2-nistp256@openssh.com"
 
-# These are not key types, only algorithms, so they cannot appear
-# as a public key type
+# These are not key types, only algorithms, so they are not
+# supposed to appear as public key types
+# (per https://datatracker.ietf.org/doc/html/rfc8332#section-3)
+# Some implementations nevertheless use them as public key types.
 _SSH_RSA_SHA256 = b"rsa-sha2-256"
 _SSH_RSA_SHA512 = b"rsa-sha2-512"
 
@@ -634,6 +636,8 @@ class _SSHFormatSKECDSA:
 
 _KEY_FORMATS = {
     _SSH_RSA: _SSHFormatRSA(),
+    _SSH_RSA_SHA256: _SSHFormatRSA(),  # non-standard
+    _SSH_RSA_SHA512: _SSHFormatRSA(),  # non-standard
     _SSH_DSA: _SSHFormatDSA(),
     _SSH_ED25519: _SSHFormatEd25519(),
     _ECDSA_NISTP256: _SSHFormatECDSA(b"nistp256", ec.SECP256R1()),

--- a/tests/hazmat/primitives/test_ssh.py
+++ b/tests/hazmat/primitives/test_ssh.py
@@ -798,17 +798,29 @@ class TestRSASSHSerialization:
         with pytest.raises(ValueError):
             load_ssh_public_key(ssh_key, backend)
 
-    def test_load_ssh_public_key_rsa(self, backend):
-        ssh_key = (
+    @pytest.mark.parametrize(
+        "ssh_key",
+        [
+            # standard representation ('ssh-rsa' as key type)
             b"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDu/XRP1kyK6Cgt36gts9XAk"
             b"FiiuJLW6RU0j3KKVZSs1I7Z3UmU9/9aVh/rZV43WQG8jaR6kkcP4stOR0DEtll"
             b"PDA7ZRBnrfiHpSQYQ874AZaAoIjgkv7DBfsE6gcDQLub0PFjWyrYQUJhtOLQEK"
             b"vY/G0vt2iRL3juawWmCFdTK3W3XvwAdgGk71i6lHt+deOPNEPN2H58E4odrZ2f"
             b"sxn/adpDqfb2sM0kPwQs0aWvrrKGvUaustkivQE4XWiSFnB0oJB/lKK/CKVKuy"
             b"///ImSCGHQRvhwariN2tvZ6CBNSLh3iQgeB0AkyJlng7MXB2qYq/Ci2FUOryCX"
-            b"2MzHvnbv testkey@localhost"
-        )
-
+            b"2MzHvnbv testkey@localhost",
+            # same key with 'rsa-sha2-256' as key type (nonstandard,
+            # contradicts RFC 8332)
+            b"rsa-sha2-256 AAAADHJzYS1zaGEyLTI1NgAAAAMBAAEAAAEBAMO79dE/WTIro"
+            b"KC3fqC2z1cCQWKK4ktbpFTSPcopVlKzUjtndSZT3/1pWH+tlXjdZAbyNpHqSRw"
+            b"/iy05HQMS2WU8MDtlEGet+IelJBhDzvgBloCgiOCS/sMF+wTqBwNAu5vQ8WNbK"
+            b"thBQmG04tAQq9j8bS+3aJEveO5rBaYIV1Mrdbde/AB2AaTvWLqUe3514480Q83"
+            b"YfnwTih2tnZ+zGf9p2kOp9vawzSQ/BCzRpa+usoa9Rq6y2SK9AThdaJIWcHSgk"
+            b"H+Uor8IpUq7L//8iZIIYdBG+HBquI3a29noIE1IuHeJCB4HQCTImWeDsxcHapi"
+            b"r8KLYVQ6vIJfYzMe+du8= testkey@localhost",
+        ],
+    )
+    def test_load_ssh_public_key_rsa(self, ssh_key, backend):
         key = load_ssh_public_key(ssh_key, backend)
 
         assert key is not None


### PR DESCRIPTION
As described in RFC 8332 [1] ("Use of RSA Keys with SHA-256 and SHA-512 in the Secure Shell (SSH) Protocol"):

> Since RSA keys are not dependent on the choice of hash function, the
> new public key algorithms reuse the "ssh-rsa" public key format as
> defined in [RFC4253]:
>
> …
>
> All aspects of the "ssh-rsa" format are kept, including the encoded
> string "ssh-rsa".  This allows existing RSA keys to be used with the
> new public key algorithms, without requiring re-encoding or affecting
> already trusted key fingerprints.

Some real-world SSH servers nevertheless represent their RSA public keys using the string `rsa-sha2-256` or `rsa-sha2-512` instead of `ssh-rsa`, so the library should support LOADING them for robustness.

[1] https://datatracker.ietf.org/doc/html/rfc8332#section-3