### PR TITLE
Bump vectors

### DIFF
--- a/.github/actions/fetch-vectors/action.yml
+++ b/.github/actions/fetch-vectors/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         repository: "C2SP/x509-limbo"
         path: "x509-limbo"
-        # Latest commit on the x509-limbo main branch, as of Jul 16, 2024.
-        ref: "8815322a268ad32918d21c44805e8cb37c9fd7b2" # x509-limbo-ref
+        # Latest commit on the x509-limbo main branch, as of Jul 17, 2024.
+        ref: "fb3e03cd0e686ed06a6a118e372df709f480d6a4" # x509-limbo-ref

--- a/tests/x509/verification/test_limbo.py
+++ b/tests/x509/verification/test_limbo.py
@@ -139,6 +139,7 @@ def _limbo_testcase(id_, testcase):
             verifier = builder.build_server_verifier(peer_name)
         except ValueError:
             assert not should_pass
+            return
     else:
         assert testcase["extended_key_usage"] == ["clientAuth"]
         verifier = builder.build_client_verifier()

--- a/tests/x509/verification/test_limbo.py
+++ b/tests/x509/verification/test_limbo.py
@@ -133,7 +133,13 @@ def _limbo_testcase(id_, testcase):
             "extended_key_usage"
         ] == ["serverAuth"]
         peer_name = _get_limbo_peer(testcase["expected_peer_name"])
-        verifier = builder.build_server_verifier(peer_name)
+        # Some tests exercise invalid leaf SANs, which get caught before
+        # validation even begins.
+        try:
+            verifier = builder.build_server_verifier(peer_name)
+            assert should_pass
+        except ValueError:
+            assert not should_pass
     else:
         assert testcase["extended_key_usage"] == ["clientAuth"]
         verifier = builder.build_client_verifier()

--- a/tests/x509/verification/test_limbo.py
+++ b/tests/x509/verification/test_limbo.py
@@ -137,7 +137,6 @@ def _limbo_testcase(id_, testcase):
         # validation even begins.
         try:
             verifier = builder.build_server_verifier(peer_name)
-            assert should_pass
         except ValueError:
             assert not should_pass
     else:


### PR DESCRIPTION
Allows `build_server_verifier` to fail when failures are expected.

Replaces #11287.