### PR TITLE
docs: Add instructions to build the docs

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -52,19 +52,6 @@ The docs can be built using ``nox``:
 
     $ nox -e docs
 
-Troubleshooting ``libenchant`` errors on macOS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If after installing ``libenchant`` using Homebrew there is still an error saying that
-the library was not found, it's because of `a bug`_ in version 3.2.2 of ``pyenchant``.
-The workaround is to manually specify the directory where Homebrew installed the
-library:
-
-.. code-block:: console
-
-    $ export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib
-    $ nox -e docs
-
 
 .. _`Homebrew`: https://brew.sh
 .. _`MacPorts`: https://www.macports.org

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -41,6 +41,30 @@ You can also specify a subset of tests to run as positional arguments:
     $ # run the whole x509 testsuite, plus the fernet tests
     $ nox -e local -- tests/x509/ tests/test_fernet.py
 
+Building the docs
+-----------------
+
+Building the docs on non-Windows platforms requires manually installing
+the C library `libenchant` (`installation instructions`_).
+The docs can be built using `nox`:
+
+.. code-block:: console
+
+    $ nox -e docs
+
+Troubleshooting `libenchant` errors on macOS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If after installing `libenchant` using Homebrew there is still an error saying that
+the library was not found, it's because of `a bug`_ in version 3.2.2 of `pyenchant`.
+The workaround is to manually specify the directory where Homebrew installed the
+library:
+
+.. code-block:: console
+
+    $ export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib
+    $ nox -e docs
+
 
 .. _`Homebrew`: https://brew.sh
 .. _`MacPorts`: https://www.macports.org
@@ -50,3 +74,5 @@ You can also specify a subset of tests to run as positional arguments:
 .. _`virtualenv`: https://pypi.org/project/virtualenv/
 .. _`pip`: https://pypi.org/project/pip/
 .. _`as documented here`: https://docs.rs/openssl/latest/openssl/#automatic
+.. _`installation instructions`: https://pyenchant.github.io/pyenchant/install.html#installing-the-enchant-c-library
+.. _`a bug`: https://github.com/pyenchant/pyenchant/pull/302

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -62,4 +62,3 @@ The docs can be built using ``nox``:
 .. _`pip`: https://pypi.org/project/pip/
 .. _`as documented here`: https://docs.rs/openssl/latest/openssl/#automatic
 .. _`installation instructions`: https://pyenchant.github.io/pyenchant/install.html#installing-the-enchant-c-library
-.. _`a bug`: https://github.com/pyenchant/pyenchant/pull/302

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -45,18 +45,18 @@ Building the docs
 -----------------
 
 Building the docs on non-Windows platforms requires manually installing
-the C library `libenchant` (`installation instructions`_).
-The docs can be built using `nox`:
+the C library ``libenchant`` (`installation instructions`_).
+The docs can be built using ``nox``:
 
 .. code-block:: console
 
     $ nox -e docs
 
-Troubleshooting `libenchant` errors on macOS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Troubleshooting ``libenchant`` errors on macOS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If after installing `libenchant` using Homebrew there is still an error saying that
-the library was not found, it's because of `a bug`_ in version 3.2.2 of `pyenchant`.
+If after installing ``libenchant`` using Homebrew there is still an error saying that
+the library was not found, it's because of `a bug`_ in version 3.2.2 of ``pyenchant``.
 The workaround is to manually specify the directory where Homebrew installed the
 library:
 


### PR DESCRIPTION
I noticed while trying to build the docs in a new environment that:

- `libenchant` needs to be manually installed (unless it's Windows, where the `pyenchant` wheel [already contains](https://pyenchant.github.io/pyenchant/install.html#using-the-binary-wheel) the precompiled library)
- This used to be mentioned in the docs, but was removed in [this PR](https://github.com/pyca/cryptography/pull/7962/files#diff-014b3ddf483ead235db0aab6127353d6b7b4d98890322655f7e3db5f0cd19b2eL26-L27)
- On arm64 MacOS, `pyenchant` cannot find the Homebrew-installed `libenchant`. This is a bug [fixed in 2023](https://github.com/pyenchant/pyenchant/pull/302), but `pyenchant` hasn't had a release since 2021, so the bug still affects the latest version.


This PR adds documentation for how to build the docs, including a sentence mentioning the need to install `libenchant`, and a troubleshooting section with a workaround for the bug mentioned above.

cc @woodruffw @alex @reaperhulk 