### PR TITLE
extensions: forbid empty EKU set

### DIFF
--- a/.github/actions/fetch-vectors/action.yml
+++ b/.github/actions/fetch-vectors/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         repository: "C2SP/x509-limbo"
         path: "x509-limbo"
-        # Latest commit on the x509-limbo main branch, as of Jul 24, 2024.
-        ref: "74eb21a7e67e0275bdcaa703c6a2be21d5bec06f" # x509-limbo-ref
+        # Latest commit on the x509-limbo main branch, as of Jul 29, 2024.
+        ref: "90654348f454dab05323a4c2f0d7b3dcbd94778c" # x509-limbo-ref


### PR DESCRIPTION
This was previously caught indirectly in path validation, via an `any(...)` check over the listed EKUs which would then fail when none were present. Moving it into the type's construction will hopefully make it clearer that the EKU is outright malformed.

xref https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12

See: https://github.com/pyca/cryptography/issues/11352