### PR TITLE
Allow DEP_OPENSSL_INCLUDE to not be set

### DIFF
--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -59,14 +59,12 @@ fn main() {
          print(os.pathsep.join(b.include_dirs), end='')",
     )
     .unwrap();
-    let openssl_include =
-        std::env::var_os("DEP_OPENSSL_INCLUDE").expect("unable to find openssl include path");
     let openssl_c = Path::new(&out_dir).join("_openssl.c");
 
     let mut build = cc::Build::new();
     build
         .file(openssl_c)
-        .include(openssl_include)
+        .includes(std::env::var_os("DEP_OPENSSL_INCLUDE"))
         .flag_if_supported("-Wconversion")
         .flag_if_supported("-Wno-error=sign-conversion")
         .flag_if_supported("-Wno-unused-parameter");


### PR DESCRIPTION
This can happen on pkg-config builds if the headers are in the default include path, as it seems they happen on openbsd

fixes #11417