### PR TITLE
Add support for extract_timestamp in MultiFernet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Changelog
 
 * Enforce the :rfc:`5280` requirement that extended key usage extensions must
   not be empty.
+* Added support for timestamp extraction to the
+  :class:`~cryptography.fernet.MultiFernet` class.
 
 .. _v43-0-0:
 

--- a/src/cryptography/fernet.py
+++ b/src/cryptography/fernet.py
@@ -213,3 +213,11 @@ class MultiFernet:
             except InvalidToken:
                 pass
         raise InvalidToken
+
+    def extract_timestamp(self, msg: bytes | str) -> int:
+        for f in self._fernets:
+            try:
+                return f.extract_timestamp(msg)
+            except InvalidToken:
+                pass
+        raise InvalidToken


### PR DESCRIPTION
Add support for extracting timestamp from Fernet-encrypted tokens in the `MultiFernet` class

closes https://github.com/pyca/cryptography/issues/11426