### PR TITLE
add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ target/
 .rust-cov/
 *.lcov
 *.profdata
+**/*.DS_Store


### PR DESCRIPTION
adding **/*.DS_Store to prevent Mac users from accidently committing .DS_Store files.

Just making life easier for developers using Macs.