### PR TITLE
Remove unnecessary test dependencies on RSA-512

### DIFF
--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2136,12 +2136,11 @@ class TestRSAEncryption:
         only_if=lambda backend: backend._fips_enabled,
         skip_message="Requires FIPS",
     )
-    def test_rsa_fips_small_key(self, backend):
-        rsa_key_1024 = RSA_KEY_1024.private_key(
-            backend, unsafe_skip_rsa_key_validation=True
-        )
+    def test_rsa_fips_small_key(self, rsa_key_512: rsa.RSAPrivateKey, backend):
+        # Ideally this would use a larger disallowed key like RSA-1024, but
+        # RHEL-8 thinks that RSA-1024 is allowed by FIPS.
         with pytest.raises(ValueError):
-            rsa_key_1024.sign(b"somedata", padding.PKCS1v15(), hashes.SHA512())
+            rsa_key_512.sign(b"somedata", padding.PKCS1v15(), hashes.SHA512())
 
     def test_unsupported_padding(
         self, rsa_key_2048: rsa.RSAPrivateKey, backend

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -821,8 +821,8 @@ class TestRSASignature:
         ),
         skip_message="Does not support PSS.",
     )
-    def test_unsupported_hash(self, rsa_key_512: rsa.RSAPrivateKey, backend):
-        private_key = rsa_key_512
+    def test_unsupported_hash(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+        private_key = rsa_key_2048
         message = b"one little message"
         pss = padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=0)
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):
@@ -850,9 +850,9 @@ class TestRSASignature:
         skip_message="Does not support PSS.",
     )
     def test_prehashed_digest_mismatch(
-        self, rsa_key_512: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey, backend
     ):
-        private_key = rsa_key_512
+        private_key = rsa_key_2048
         message = b"one little message"
         h = hashes.Hash(hashes.SHA512(), backend)
         h.update(message)
@@ -2136,9 +2136,12 @@ class TestRSAEncryption:
         only_if=lambda backend: backend._fips_enabled,
         skip_message="Requires FIPS",
     )
-    def test_rsa_fips_small_key(self, rsa_key_512: rsa.RSAPrivateKey, backend):
+    def test_rsa_fips_small_key(self, backend):
+        rsa_key_1024 = RSA_KEY_1024.private_key(
+            backend, unsafe_skip_rsa_key_validation=True
+        )
         with pytest.raises(ValueError):
-            rsa_key_512.sign(b"somedata", padding.PKCS1v15(), hashes.SHA512())
+            rsa_key_1024.sign(b"somedata", padding.PKCS1v15(), hashes.SHA512())
 
     def test_unsupported_padding(
         self, rsa_key_2048: rsa.RSAPrivateKey, backend


### PR DESCRIPTION
`test_unsupported_hash` and `test_prehashed_digest_mismatch` work just fine with realistic RSA key sizes. (They also, as written, silently test nothing when the backend rejects RSA-512. As a reminder, RSA-512 was broken since 1999.)

`test_rsa_fips_small_key` wants a small key, but I assume RSA-1024 is fine.