### PR TITLE
Relax root CA AKI field checks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Changelog
   not be empty.
 * Added support for timestamp extraction to the
   :class:`~cryptography.fernet.MultiFernet` class.
+* Relax the Authority Key Identifier requirements on root CA certificates
+  during X.509 verification to allow fields permitted by :rfc:`5280` but
+  forbidden by the CA/Browser BRs.
 
 .. _v43-0-0:
 

--- a/src/rust/cryptography-x509-verification/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/extension.rs
@@ -412,18 +412,13 @@ pub(crate) mod ca {
                 ));
             }
 
-            // authorityCertIssuer and authorityCertSerialNumber MUST NOT be present.
-            if aki.authority_cert_issuer.is_some() {
-                return Err(ValidationError::Other(
-                    "authorityKeyIdentifier must not contain authorityCertIssuer".to_string(),
-                ));
-            }
-
-            if aki.authority_cert_serial_number.is_some() {
-                return Err(ValidationError::Other(
-                    "authorityKeyIdentifier must not contain authorityCertSerialNumber".to_string(),
-                ));
-            }
+            // NOTE: CABF 7.1.2.1.3 says that Root CAs MUST NOT
+            // have authorityCertIdentifier or authorityCertSerialNumber,
+            // but these are present in practice in trust program bundles
+            // due to older roots that have been grandfathered in.
+            // Other validators are permissive of these being present,
+            // so we don't check for them.
+            // See #11461 for more information.
         }
 
         Ok(())

--- a/tests/x509/verification/test_limbo.py
+++ b/tests/x509/verification/test_limbo.py
@@ -67,6 +67,12 @@ LIMBO_SKIP_TESTCASES = {
     # forbidden under CABF. This is consistent with what
     # Go's crypto/x509 and Rust's webpki crate do.
     "webpki::aki::root-with-aki-ski-mismatch",
+    # We allow root CAs where the AKI contains fields other than keyIdentifier,
+    # which is technically forbidden under CABF. No other implementations
+    # enforce this requirement.
+    "webpki::aki::root-with-aki-authoritycertissuer",
+    "webpki::aki::root-with-aki-authoritycertserialnumber",
+    "webpki::aki::root-with-aki-all-fields",
     # We allow RSA keys that aren't divisible by 8, which is technically
     # forbidden under CABF. No other implementation checks this either.
     "webpki::forbidden-rsa-not-divisable-by-8-in-root",


### PR DESCRIPTION
This addresses #11461 by dropping our forbidden AKI field checks on CAs. It also marks three x509-limbo tests as explicit skips, since these three tests enforced failure on those AKI fields.

CC @mxsasha

Closes #11461.