### PR TITLE
Inconsistent IDP extension constraint check

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -1988,10 +1988,12 @@ class IssuingDistributionPoint(ExtensionType):
                 "must all be boolean."
             )
 
+        # Per RFC5280 Section 5.2.5, the Issuing Distribution Point extension in a CRL
+        # can have only one of onlyContainsUserCerts, onlyContainsCACerts,
+        # onlyContainsAttributeCerts set to TRUE.
         crl_constraints = [
             only_contains_user_certs,
             only_contains_ca_certs,
-            indirect_crl,
             only_contains_attribute_certs,
         ]
 
@@ -1999,7 +2001,7 @@ class IssuingDistributionPoint(ExtensionType):
             raise ValueError(
                 "Only one of the following can be set to True: "
                 "only_contains_user_certs, only_contains_ca_certs, "
-                "indirect_crl, only_contains_attribute_certs"
+                "only_contains_attribute_certs"
             )
 
         if not any(

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -1988,9 +1988,9 @@ class IssuingDistributionPoint(ExtensionType):
                 "must all be boolean."
             )
 
-        # Per RFC5280 Section 5.2.5, the Issuing Distribution Point extension in a CRL
-        # can have only one of onlyContainsUserCerts, onlyContainsCACerts,
-        # onlyContainsAttributeCerts set to TRUE.
+        # Per RFC5280 Section 5.2.5, the Issuing Distribution Point extension
+        # in a CRL can have only one of onlyContainsUserCerts,
+        # onlyContainsCACerts, onlyContainsAttributeCerts set to TRUE.
         crl_constraints = [
             only_contains_user_certs,
             only_contains_ca_certs,

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -5380,7 +5380,6 @@ class TestIssuingDistributionPointExtension:
             (TypeError, False, False, "notabool", False, None, None, None),
             (TypeError, False, False, False, "notabool", None, None, None),
             (ValueError, True, True, False, False, None, None, None),
-            (ValueError, False, False, True, True, None, None, None),
             (ValueError, False, False, False, False, None, None, None),
         ],
     )


### PR DESCRIPTION
Hello, I found an inconsistent IDP extension constraint check per RFC5280 Section 5.2.5. I do not think the indirectCRL needs to be subject to that. Excerpt from the RFC:

-- at most one of onlyContainsUserCerts, onlyContainsCACerts,
-- and onlyContainsAttributeCerts may be set to TRUE.

Thank you