### PR TITLE
Mark that check-sdist is a Python 3.8+ only dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ docs = ["sphinx >=5.3.0", "sphinx-rtd-theme >=1.1.1"]
 docstest = ["pyenchant >=1.6.11", "readme-renderer", "sphinxcontrib-spelling >=4.0.1"]
 sdist = ["build"]
 # `click` included because its needed to type check `release.py`
-pep8test = ["ruff", "mypy", "check-sdist", "click"]
+pep8test = ["ruff", "mypy", "check-sdist; python_version >= '3.8'", "click"]
 
 [tool.maturin]
 python-source = "src"


### PR DESCRIPTION
It has no versions that support Python 3.7. This is necessary to support using `uv` to manage our ci-constraints file