### PR TITLE
Silencing mmap mypy warning on windows

### DIFF
--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -38,12 +38,9 @@ def _aead_supported(cls):
 
 
 def large_mmap(length: int = 2**32):
-    # Silencing mypy warning on Windows, even though mmap doesn't exist there.
-    # See: https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
-    if sys.platform != "win32":
-        return mmap.mmap(-1, length, prot=mmap.PROT_READ)
-    else:
-        return mmap.mmap(-1, length)  # pragma: no cover
+    # Silencing mypy prot argument warning on Windows, even though this
+    # function is only used in non-Windows-based tests.
+    return mmap.mmap(-1, length, prot=mmap.PROT_READ)  # type: ignore[call-arg,attr-defined,unused-ignore]
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -42,6 +42,8 @@ def large_mmap(length: int = 2**32):
     # See: https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
     if sys.platform != "win32":
         return mmap.mmap(-1, length, prot=mmap.PROT_READ)
+    else:  # pragma: no cover
+        return mmap.mmap(-1, length)
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -38,7 +38,12 @@ def _aead_supported(cls):
 
 
 def large_mmap():
-    return mmap.mmap(-1, 2**32, prot=mmap.PROT_READ)
+    # Silencing mypy warning on Windows, even though mmap doesn't exist. See:
+    # https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
+    if sys.platform == "win32":
+        return mmap.mmap(-1, 2**32)
+    else:
+        return mmap.mmap(-1, 2**32, prot=mmap.PROT_READ)
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -37,13 +37,11 @@ def _aead_supported(cls):
         return False
 
 
-def large_mmap():
-    # Silencing mypy warning on Windows, even though mmap doesn't exist. See:
-    # https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
-    if sys.platform == "win32":
-        return mmap.mmap(-1, 2**32)
-    else:
-        return mmap.mmap(-1, 2**32, prot=mmap.PROT_READ)
+def large_mmap(length: int = 2**32):
+    # Silencing mypy warning on Windows, even though mmap doesn't exist there.
+    # See: https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
+    if sys.platform != "win32":
+        return mmap.mmap(-1, length, prot=mmap.PROT_READ)
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -39,7 +39,11 @@ def _aead_supported(cls):
 
 def large_mmap(length: int = 2**32):
     # Silencing mypy warning on Windows, even though mmap doesn't exist there.
-    return mmap.mmap(-1, length, prot=mmap.PROT_READ)  # type: ignore
+    # See: https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
+    if sys.platform != "win32":
+        return mmap.mmap(-1, length, prot=mmap.PROT_READ)
+    else:
+        return mmap.mmap(-1, length)  # pragma: no cover
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -39,11 +39,7 @@ def _aead_supported(cls):
 
 def large_mmap(length: int = 2**32):
     # Silencing mypy warning on Windows, even though mmap doesn't exist there.
-    # See: https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
-    if sys.platform != "win32":
-        return mmap.mmap(-1, length, prot=mmap.PROT_READ)
-    else:  # pragma: no cover
-        return mmap.mmap(-1, length)
+    return mmap.mmap(-1, length, prot=mmap.PROT_READ)  # type: ignore
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -255,7 +255,12 @@ class TestCipherUpdateInto:
     sys.platform not in {"linux", "darwin"}, reason="mmap required"
 )
 def test_update_auto_chunking():
-    large_data = mmap.mmap(-1, 2**29 + 2**20, prot=mmap.PROT_READ)
+    # Silencing mypy warning on Windows, even though mmap doesn't exist. See:
+    # https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
+    if sys.platform == "win32":
+        large_data = mmap.mmap(-1, 2**29 + 2**20)
+    else:
+        large_data = mmap.mmap(-1, 2**29 + 2**20, prot=mmap.PROT_READ)
 
     key = b"\x00" * 16
     c = ciphers.Cipher(AES(key), modes.ECB())

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -4,7 +4,6 @@
 
 
 import binascii
-import mmap
 import os
 import sys
 
@@ -20,6 +19,7 @@ from cryptography.hazmat.primitives.ciphers.algorithms import (
 )
 
 from ...utils import load_nist_vectors, load_vectors_from_file
+from .test_aead import large_mmap
 
 
 def test_deprecated_ciphers_import_with_warning():
@@ -255,12 +255,7 @@ class TestCipherUpdateInto:
     sys.platform not in {"linux", "darwin"}, reason="mmap required"
 )
 def test_update_auto_chunking():
-    # Silencing mypy warning on Windows, even though mmap doesn't exist. See:
-    # https://mypy.readthedocs.io/en/stable/common_issues.html#version-and-platform-checks
-    if sys.platform == "win32":
-        large_data = mmap.mmap(-1, 2**29 + 2**20)
-    else:
-        large_data = mmap.mmap(-1, 2**29 + 2**20, prot=mmap.PROT_READ)
+    large_data = large_mmap(length=2**29 + 2**20)
 
     key = b"\x00" * 16
     c = ciphers.Cipher(AES(key), modes.ECB())


### PR DESCRIPTION
As per #11560. Even though the lib doesn't exist on Windows

Just realized coverage does not pass as such; the simplest solution would probably be `# type: ignore` 😞 