### PR TITLE
otp-generage-hardening

### DIFF
--- a/src/cryptography/hazmat/primitives/twofactor/totp.py
+++ b/src/cryptography/hazmat/primitives/twofactor/totp.py
@@ -31,6 +31,11 @@ class TOTP:
         )
 
     def generate(self, time: int | float) -> bytes:
+        if not isinstance(time, (int, float)):
+            raise TypeError(
+                "Time parameter must be an integer type or float type."
+            )
+
         counter = int(time / self._time_step)
         return self._hotp.generate(counter)
 

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -107,3 +107,13 @@ class TestHOTP:
         key = bytearray(b"a long key with lots of entropy goes here")
         hotp = HOTP(key, 6, SHA1(), backend)
         assert hotp.generate(10) == b"559978"
+
+    def test_invalid_counter(self, backend):
+        key = os.urandom(16)
+        hotp = HOTP(key, 6, SHA1(), backend)
+
+        with pytest.raises(TypeError):
+            hotp.generate(2.5)  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError):
+            hotp.generate(2**64)

--- a/tests/hazmat/primitives/twofactor/test_totp.py
+++ b/tests/hazmat/primitives/twofactor/test_totp.py
@@ -142,3 +142,10 @@ class TestTOTP:
         totp = TOTP(key, 8, hashes.SHA512(), 30, backend)
         time = 60
         assert totp.generate(time) == b"53049576"
+
+    def test_invalid_time(self, backend):
+        key = b"12345678901234567890"
+        totp = TOTP(key, 8, hashes.SHA1(), 30, backend)
+
+        with pytest.raises(TypeError):
+            totp.generate("test")  # type: ignore[arg-type]


### PR DESCRIPTION
Some minor checks for `HOTP.generate` and `TOTP.generate`.

I do not think anyone would ever hit that `2**64` counter.  Nonetheless, an exception handling for a potential `OverflowError` exception out of the `counter.to_bytes(length=8, byteorder="big")` feels appropriate.  Specially if someone tries a negative value.

I also thought about doing a value check (e.g., `if not 0 <= counter < 2**64`) under the `isinstance` check, but it feels like an unnecessary `2**64` calculation every time the generate method is called.  Ultimately, an unnecessary waste of cycles for 99.99% of  the times this will be called.

HTH!