### PR TITLE
Don't include engine.h when OPENSSL_NO_ENGINE is defined

### DIFF
--- a/src/_cffi_src/openssl/engine.py
+++ b/src/_cffi_src/openssl/engine.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 INCLUDES = """
+#if !defined(OPENSSL_NO_ENGINE) || CRYPTOGRAPHY_IS_LIBRESSL
 #include <openssl/engine.h>
+#endif
 """
 
 TYPES = """


### PR DESCRIPTION
Resolves #11690 (see discussion for details)
Resubmit of: #11328 

Before fix:
```
[root@c10s-a cryptography]# pip --verbose install .
Using pip 23.3.2 from /usr/lib/python3.12/site-packages/pip (python 3.12)
Processing /root/git/cryptography
  Running command pip subprocess to install build dependencies
  Collecting maturin<2,>=1
    Using cached maturin-1.7.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl.metadata (18 kB)
  Collecting cffi>=1.12
    Using cached cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
  Collecting setuptools!=74.0.0,!=74.1.0,!=74.1.1,!=74.1.2
    Using cached setuptools-75.1.0-py3-none-any.whl.metadata (6.9 kB)
  Collecting pycparser (from cffi>=1.12)
    Using cached pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
  Using cached maturin-1.7.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl (8.9 MB)
  Using cached cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (479 kB)
  Using cached setuptools-75.1.0-py3-none-any.whl (1.2 MB)
  Using cached pycparser-2.22-py3-none-any.whl (117 kB)
  Installing collected packages: setuptools, pycparser, maturin, cffi
  Successfully installed cffi-1.17.1 maturin-1.7.4 pycparser-2.22 setuptools-75.1.0
  WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
  Installing build dependencies ... done
  Running command Getting requirements to build wheel
  Getting requirements to build wheel ... done
  Running command Preparing metadata (pyproject.toml)
  📦 Including license file "/root/git/cryptography/LICENSE"
  📦 Including license file "/root/git/cryptography/LICENSE.APACHE"
  📦 Including license file "/root/git/cryptography/LICENSE.BSD"
  🍹 Building a mixed python/rust project
  🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
  🐍 Not using a specific python interpreter
  📡 Using build options features, locked from pyproject.toml
  cryptography-44.0.0.dev1.dist-info
  Checking for Rust toolchain....
  Running `maturin pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-7956kl03 --interpreter /usr/bin/python3`
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: cffi>=1.12 in /usr/local/lib64/python3.12/site-packages (from cryptography==44.0.0.dev1) (1.17.1)
Requirement already satisfied: pycparser in /usr/local/lib/python3.12/site-packages (from cffi>=1.12->cryptography==44.0.0.dev1) (2.22)
Building wheels for collected packages: cryptography
  Running command Building wheel for cryptography (pyproject.toml)
  Running `maturin pep517 build-wheel -i /usr/bin/python3 --compatibility off`
  📦 Including license file "/root/git/cryptography/LICENSE"
  📦 Including license file "/root/git/cryptography/LICENSE.APACHE"
  📦 Including license file "/root/git/cryptography/LICENSE.BSD"
  🍹 Building a mixed python/rust project
  🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
  🐍 Not using a specific python interpreter
  📡 Using build options features, locked from pyproject.toml
     Compiling cryptography-cffi v0.1.0 (/root/git/cryptography/src/rust/cryptography-cffi)
  The following warnings were emitted during compilation:

  warning: cryptography-cffi@0.1.0: /root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out/_openssl.c:638:10: fatal error: openssl/engine.h: No such file or directory
  warning: cryptography-cffi@0.1.0:   638 | #include <openssl/engine.h>
  warning: cryptography-cffi@0.1.0:       |          ^~~~~~~~~~~~~~~~~~
  warning: cryptography-cffi@0.1.0: compilation terminated.

  error: failed to run custom build command for `cryptography-cffi v0.1.0 (/root/git/cryptography/src/rust/cryptography-cffi)`

  Caused by:
    process didn't exit successfully: `/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-d5dcadf634761a15/build-script-build` (exit status: 1)
    --- stdout
    cargo:rerun-if-env-changed=PYO3_PYTHON
    cargo:rerun-if-changed=../../_cffi_src/
    cargo:rerun-if-changed=../../cryptography/__about__.py
    cargo:rustc-cfg=python_implementation="CPython"
    OUT_DIR = Some(/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out)
    TARGET = Some(x86_64-unknown-linux-gnu)
    OPT_LEVEL = Some(3)
    HOST = Some(x86_64-unknown-linux-gnu)
    cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
    CC_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
    CC_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CC
    HOST_CC = None
    cargo:rerun-if-env-changed=CC
    CC = None
    cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
    RUSTC_WRAPPER = None
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    DEBUG = Some(false)
    CARGO_CFG_TARGET_FEATURE = Some(avx,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,sse,sse2,sse3,sse4.1,sse4.2,ssse3,xsave)
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    OUT_DIR = Some(/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out)
    cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    CARGO_CFG_TARGET_FEATURE = Some(avx,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,sse,sse2,sse3,sse4.1,sse4.2,ssse3,xsave)
    HOST = Some(x86_64-unknown-linux-gnu)
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    OUT_DIR = Some(/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out)
    cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    CARGO_CFG_TARGET_FEATURE = Some(avx,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,sse,sse2,sse3,sse4.1,sse4.2,ssse3,xsave)
    HOST = Some(x86_64-unknown-linux-gnu)
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    OUT_DIR = Some(/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out)
    cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    CARGO_CFG_TARGET_FEATURE = Some(avx,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,sse,sse2,sse3,sse4.1,sse4.2,ssse3,xsave)
    HOST = Some(x86_64-unknown-linux-gnu)
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    OUT_DIR = Some(/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out)
    cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
    cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    CRATE_CC_NO_DEFAULTS = None
    CARGO_CFG_TARGET_FEATURE = Some(avx,avx2,bmi1,bmi2,cmpxchg16b,f16c,fma,fxsr,lzcnt,movbe,popcnt,sse,sse2,sse3,sse4.1,sse4.2,ssse3,xsave)
    HOST = Some(x86_64-unknown-linux-gnu)
    cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
    CFLAGS_x86_64-unknown-linux-gnu = None
    cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
    CFLAGS_x86_64_unknown_linux_gnu = None
    cargo:rerun-if-env-changed=HOST_CFLAGS
    HOST_CFLAGS = None
    cargo:rerun-if-env-changed=CFLAGS
    CFLAGS = None
    cargo:warning=/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out/_openssl.c:638:10: fatal error: openssl/engine.h: No such file or directory
    cargo:warning=  638 | #include <openssl/engine.h>
    cargo:warning=      |          ^~~~~~~~~~~~~~~~~~
    cargo:warning=compilation terminated.

    --- stderr


    error occurred: Command "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-I" "/usr/include" "-I" "/usr/include/python3.12" "-Wall" "-Wextra" "-Wconversion" "-Wno-error=sign-conversion" "-Wno-unused-parameter" "-fmacro-prefix-map=/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out=." "-DPy_LIMITED_API=0x030700f0" "-o" "/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out/706326e402f2c5c3-_openssl.o" "-c" "/root/git/cryptography/src/rust/target/release/build/cryptography-cffi-81f286d50e58b4bc/out/_openssl.c" with args cc did not execute successfully (status code exit status: 1).


  💥 maturin failed
    Caused by: Failed to build a native library through cargo
    Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_ENVIRONMENT_SIGNATURE="cpython-3.12-64bit" PYO3_PYTHON="/usr/bin/python3" PYTHON_SYS_EXECUTABLE="/usr/bin/python3" "cargo" "rustc" "--features" "pyo3/abi3-py37" "--message-format" "json-render-diagnostics" "--locked" "--manifest-path" "/root/git/cryptography/src/rust/Cargo.toml" "--release" "--lib"`
  Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/usr/bin/python3', '--compatibility', 'off'] returned non-zero exit status 1
  error: subprocess-exited-with-error
  
  × Building wheel for cryptography (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /usr/bin/python3 /usr/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py build_wheel /tmp/tmpr3siswyd
  cwd: /root/git/cryptography
  Building wheel for cryptography (pyproject.toml) ... error
  ERROR: Failed building wheel for cryptography
Failed to build cryptography
ERROR: Could not build wheels for cryptography, which is required to install pyproject.toml-based projects
```

After fix:
```
[root@c10s-a cryptography]# pip --verbose install .
Using pip 23.3.2 from /usr/lib/python3.12/site-packages/pip (python 3.12)
Processing /root/git/cryptography
  Running command pip subprocess to install build dependencies
  Collecting maturin<2,>=1
    Using cached maturin-1.7.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl.metadata (18 kB)
  Collecting cffi>=1.12
    Using cached cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
  Collecting setuptools!=74.0.0,!=74.1.0,!=74.1.1,!=74.1.2
    Using cached setuptools-75.1.0-py3-none-any.whl.metadata (6.9 kB)
  Collecting pycparser (from cffi>=1.12)
    Using cached pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
  Using cached maturin-1.7.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl (8.9 MB)
  Using cached cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (479 kB)
  Using cached setuptools-75.1.0-py3-none-any.whl (1.2 MB)
  Using cached pycparser-2.22-py3-none-any.whl (117 kB)
  Installing collected packages: setuptools, pycparser, maturin, cffi
  Successfully installed cffi-1.17.1 maturin-1.7.4 pycparser-2.22 setuptools-75.1.0
  WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
  Installing build dependencies ... done
  Running command Getting requirements to build wheel
  Getting requirements to build wheel ... done
  Running command Preparing metadata (pyproject.toml)
  📦 Including license file "/root/git/cryptography/LICENSE"
  📦 Including license file "/root/git/cryptography/LICENSE.APACHE"
  📦 Including license file "/root/git/cryptography/LICENSE.BSD"
  🍹 Building a mixed python/rust project
  🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
  🐍 Not using a specific python interpreter
  📡 Using build options features, locked from pyproject.toml
  cryptography-44.0.0.dev1.dist-info
  Checking for Rust toolchain....
  Running `maturin pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-ipjd_yfq --interpreter /usr/bin/python3`
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: cffi>=1.12 in /usr/local/lib64/python3.12/site-packages (from cryptography==44.0.0.dev1) (1.17.1)
Requirement already satisfied: pycparser in /usr/local/lib/python3.12/site-packages (from cffi>=1.12->cryptography==44.0.0.dev1) (2.22)
Building wheels for collected packages: cryptography
  Running command Building wheel for cryptography (pyproject.toml)
  Running `maturin pep517 build-wheel -i /usr/bin/python3 --compatibility off`
  📦 Including license file "/root/git/cryptography/LICENSE"
  📦 Including license file "/root/git/cryptography/LICENSE.APACHE"
  📦 Including license file "/root/git/cryptography/LICENSE.BSD"
  🍹 Building a mixed python/rust project
  🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
  🐍 Not using a specific python interpreter
  📡 Using build options features, locked from pyproject.toml
     Compiling cryptography-cffi v0.1.0 (/root/git/cryptography/src/rust/cryptography-cffi)
     Compiling cryptography-rust v0.1.0 (/root/git/cryptography/src/rust)
      Finished `release` profile [optimized] target(s) in 35.09s
  📦 Including files matching "CHANGELOG.rst"
  📦 Including files matching "CONTRIBUTING.rst"
  📦 Including files matching "LICENSE"
  📦 Including files matching "LICENSE.APACHE"
  📦 Including files matching "LICENSE.BSD"
  📦 Including files matching "docs/**/*"
  📦 Including files matching "src/_cffi_src/**/*.py"
  📦 Including files matching "src/_cffi_src/**/*.c"
  📦 Including files matching "src/_cffi_src/**/*.h"
  📦 Including files matching "src/rust/**/Cargo.toml"
  📦 Including files matching "src/rust/**/Cargo.lock"
  📦 Including files matching "src/rust/**/*.rs"
  📦 Including files matching "tests/**/*.py"
  📦 Built wheel for abi3 Python ≥ 3.7 to /root/git/cryptography/src/rust/target/wheels/cryptography-44.0.0.dev1-cp37-abi3-linux_x86_64.whl
  /root/git/cryptography/src/rust/target/wheels/cryptography-44.0.0.dev1-cp37-abi3-linux_x86_64.whl
  Building wheel for cryptography (pyproject.toml) ... done
  Created wheel for cryptography: filename=cryptography-44.0.0.dev1-cp37-abi3-linux_x86_64.whl size=1536590 sha256=52af80ffd55cf7477e99470b7e1766b503aa521509bd539d3829c06931dfa4f9
  Stored in directory: /tmp/pip-ephem-wheel-cache-9uvwjeeg/wheels/2a/3d/6e/0c421f1c3661f2d0e220f66588c1af168312b29e5582cf31a7
Successfully built cryptography
Installing collected packages: cryptography
Successfully installed cryptography-44.0.0.dev1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
```