### PR TITLE
install bindgen for boringssl

### DIFF
--- a/.github/workflows/build_openssl.sh
+++ b/.github/workflows/build_openssl.sh
@@ -77,4 +77,6 @@ elif [[ "${TYPE}" == "boringssl" ]]; then
   rm -rf "${OSSL_PATH}/bin"
   popd
   rm -rf boringssl/
+
+  sudo apt-get install -y bindgen
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           # When altering the openssl build process you may need to increment
           # the value on the end of this cache key so that you can prevent it
           # from fetching the cache and skipping the build step.
-          key: ${{ matrix.PYTHON.OPENSSL.TYPE }}-${{ matrix.PYTHON.OPENSSL.VERSION }}-${{ env.OPENSSL_HASH }}-12
+          key: ${{ matrix.PYTHON.OPENSSL.TYPE }}-${{ matrix.PYTHON.OPENSSL.VERSION }}-${{ env.OPENSSL_HASH }}-13
         if: matrix.PYTHON.OPENSSL
       - name: Build custom OpenSSL/LibreSSL
         run: .github/workflows/build_openssl.sh


### PR DESCRIPTION
it used to be in the 22.04 GHA image, but its no longer in the base 24.04 one