### PR TITLE
Rebuild ci-constraints-requirements.txt

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -41,7 +41,9 @@ colorlog==6.8.2
     # via nox
 coverage==7.2.7 ; python_full_version < '3.8'
     # via pytest-cov
-coverage==7.6.1 ; python_full_version >= '3.8'
+coverage==7.6.1 ; python_full_version >= '3.8' and python_full_version < '3.10'
+    # via pytest-cov
+coverage==7.6.3 ; python_full_version >= '3.10'
     # via pytest-cov
 distlib==0.3.9
     # via virtualenv
@@ -108,7 +110,9 @@ mypy-extensions==1.0.0
     # via mypy
 nh3==0.2.18 ; python_full_version >= '3.8'
     # via readme-renderer
-nox==2024.4.15
+nox==2024.4.15 ; python_full_version < '3.8'
+    # via cryptography (pyproject.toml)
+nox==2024.10.9 ; python_full_version >= '3.8'
     # via cryptography (pyproject.toml)
 packaging==24.0 ; python_full_version < '3.8'
     # via


### PR DESCRIPTION
Needed to generate python-version-specific pins for coverage and nox