### PR TITLE
Support 128-bit OID arcs

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "asn1"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a10032de7d9e6f21c3f1cb1c9c0f94cf30ef67f38310588fe6cfa53e0d3f0"
+checksum = "3522623dbb7db59b34439c022ab0445a0257a62ad20d499da3a3507394708559"
 dependencies = [
  "asn1_derive",
 ]
 
 [[package]]
 name = "asn1_derive"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df30ecdcaf8338675a1413460a1b11df89789e1fcc6a10dc52f6e38b6982aa2"
+checksum = "da79157fc864ed738b596d622929466c68ed48371f17a5f05e329880420a160d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,7 +18,7 @@ rust-version.workspace = true
 once_cell = "1"
 cfg-if = "1"
 pyo3 = { version = "0.22.5", features = ["abi3"] }
-asn1 = { version = "0.17.0", default-features = false }
+asn1 = { version = "0.18.0", default-features = false }
 cryptography-cffi = { path = "cryptography-cffi" }
 cryptography-keepalive = { path = "cryptography-keepalive" }
 cryptography-key-parsing = { path = "cryptography-key-parsing" }

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -7,7 +7,7 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-asn1 = { version = "0.17.0", default-features = false }
+asn1 = { version = "0.18.0", default-features = false }
 cfg-if = "1"
 openssl = "0.10.68"
 openssl-sys = "0.9.104"

--- a/src/rust/cryptography-x509-verification/Cargo.toml
+++ b/src/rust/cryptography-x509-verification/Cargo.toml
@@ -7,7 +7,7 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-asn1 = { version = "0.17.0", default-features = false }
+asn1 = { version = "0.18.0", default-features = false }
 cryptography-x509 = { path = "../cryptography-x509" }
 cryptography-key-parsing = { path = "../cryptography-key-parsing" }
 once_cell = "1"

--- a/src/rust/cryptography-x509/Cargo.toml
+++ b/src/rust/cryptography-x509/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 rust-version = "1.65.0"
 
 [dependencies]
-asn1 = { version = "0.17.0", default-features = false }
+asn1 = { version = "0.18.0", default-features = false }

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -6056,10 +6056,11 @@ class TestObjectIdentifier:
         x509.ObjectIdentifier("1.39.999")
         x509.ObjectIdentifier("2.5.29.3")
         x509.ObjectIdentifier("2.999.37.5.22.8")
+        x509.ObjectIdentifier(f"2.25.{2**128 - 1}")
 
     def test_oid_arc_too_large(self):
         with pytest.raises(ValueError):
-            x509.ObjectIdentifier(f"2.25.{2**128 - 1}")
+            x509.ObjectIdentifier(f"2.25.{2**128}")
 
 
 class TestName:


### PR DESCRIPTION
Addresses #11338, but can only be merged after the release of version `0.18.0` of [alex/rust-asn1](https://github.com/alex/rust-asn1) which will include the (already merged) alex/rust-asn1#484 PR.

In essence, this PR is just a unit test fix to allow OID arcs up to 128 bits. I updated the `Cargo.toml` files to point to the (as of yet unreleased) `asn1 = { version = "0.18.0", default-features = false }`, but the `Cargo.lock` file will still need to be updated after the release.