### PR TITLE
feat(admissions): add admission type for the admissions extension

### DIFF
--- a/src/cryptography/x509/__init__.py
+++ b/src/cryptography/x509/__init__.py
@@ -30,6 +30,7 @@ from cryptography.x509.base import (
 )
 from cryptography.x509.extensions import (
     AccessDescription,
+    Admission,
     AuthorityInformationAccess,
     AuthorityKeyIdentifier,
     BasicConstraints,
@@ -176,6 +177,7 @@ __all__ = [
     "OID_CA_ISSUERS",
     "OID_OCSP",
     "AccessDescription",
+    "Admission",
     "Attribute",
     "AttributeNotFound",
     "Attributes",

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -2384,7 +2384,7 @@ class Admission:
             (
                 self.admission_authority,
                 self.naming_authority,
-                *self.profession_infos,
+                *tuple(self.profession_infos),
             )
         )
 

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -2320,6 +2320,75 @@ class ProfessionInfo:
         )
 
 
+class Admission:
+    def __init__(
+        self,
+        admission_authority: GeneralName | None,
+        naming_authority: NamingAuthority | None,
+        profession_infos: typing.Iterable[ProfessionInfo],
+    ) -> None:
+        if admission_authority is not None and not isinstance(
+            admission_authority, GeneralName
+        ):
+            raise TypeError("admission_authority must be a GeneralName")
+
+        if naming_authority is not None and not isinstance(
+            naming_authority, NamingAuthority
+        ):
+            raise TypeError("naming_authority must be a NamingAuthority")
+
+        profession_infos = list(profession_infos)
+        if not all(
+            isinstance(info, ProfessionInfo) for info in profession_infos
+        ):
+            raise TypeError(
+                "Every item in the profession_infos list must be a "
+                "ProfessionInfo"
+            )
+
+        self._admission_authority = admission_authority
+        self._naming_authority = naming_authority
+        self._profession_infos = profession_infos
+
+    @property
+    def admission_authority(self) -> GeneralName | None:
+        return self._admission_authority
+
+    @property
+    def naming_authority(self) -> NamingAuthority | None:
+        return self._naming_authority
+
+    @property
+    def profession_infos(self) -> list[ProfessionInfo]:
+        return self._profession_infos
+
+    def __repr__(self) -> str:
+        return (
+            f"<Admission(admission_authority={self.admission_authority}, "
+            f"naming_authority={self.naming_authority}, "
+            f"profession_infos={self.profession_infos})>"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Admission):
+            return NotImplemented
+
+        return (
+            self.admission_authority == other.admission_authority
+            and self.naming_authority == other.naming_authority
+            and self.profession_infos == other.profession_infos
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.admission_authority,
+                self.naming_authority,
+                *self.profession_infos,
+            )
+        )
+
+
 class UnrecognizedExtension(ExtensionType):
     def __init__(self, oid: ObjectIdentifier, value: bytes) -> None:
         if not isinstance(oid, ObjectIdentifier):

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -312,6 +312,15 @@ pub struct ProfessionInfo<'a> {
     pub add_profession_info: Option<&'a [u8]>,
 }
 
+pub struct Admission<'a> {
+    pub admission_authority: Option<name::GeneralName<'a>>,
+    pub naming_authority: Option<NamingAuthority<'a>>,
+    pub profession_infos: common::Asn1ReadableOrWritable<
+        asn1::SequenceOf<'a, ProfessionInfo<'a>>,
+        asn1::SequenceOfWriter<'a, ProfessionInfo<'a>, Vec<ProfessionInfo<'a>>>,
+    >,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{BasicConstraints, Extension, Extensions, KeyUsage};

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -312,13 +312,18 @@ pub struct ProfessionInfo<'a> {
     pub add_profession_info: Option<&'a [u8]>,
 }
 
+// #[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub struct Admission<'a> {
+    // #[explicit(0)]
     pub admission_authority: Option<name::GeneralName<'a>>,
+    // #[explicit(1)]
     pub naming_authority: Option<NamingAuthority<'a>>,
+    /*
     pub profession_infos: common::Asn1ReadableOrWritable<
         asn1::SequenceOf<'a, ProfessionInfo<'a>>,
         asn1::SequenceOfWriter<'a, ProfessionInfo<'a>, Vec<ProfessionInfo<'a>>>,
     >,
+    */
 }
 
 #[cfg(test)]

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -6668,6 +6668,333 @@ class TestProfessionInfo:
         assert hash(info1) != hash(info7)
 
 
+class TestAdmission:
+    def test_invalid_init(self):
+        with pytest.raises(TypeError):
+            x509.Admission(
+                42,  # type:ignore[arg-type]
+                None,
+                [],
+            )
+        with pytest.raises(TypeError):
+            x509.Admission(
+                None,
+                42,  # type:ignore[arg-type]
+                [],
+            )
+        with pytest.raises(TypeError):
+            x509.Admission(
+                None,
+                None,
+                42,  # type:ignore[arg-type]
+            )
+        with pytest.raises(TypeError):
+            x509.Admission(
+                None,
+                None,
+                [42],  # type:ignore[list-item]
+            )
+
+    def test_eq(self):
+        admission1 = x509.Admission(None, None, [])
+        admission2 = x509.Admission(None, None, [])
+        assert admission1 == admission2
+
+        admission1 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        admission2 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        assert admission1 == admission2
+
+    def test_ne(self):
+        admission1 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        admission2 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [],
+        )
+        admission3 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            None,
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        admission4 = x509.Admission(
+            None,
+            None,
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        admission5 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            None,
+            [],
+        )
+        admission6 = x509.Admission(
+            None,
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [],
+        )
+        admission7 = x509.Admission(None, None, [])
+
+        assert admission1 != admission2
+        assert admission1 != admission3
+        assert admission1 != admission4
+        assert admission1 != admission5
+        assert admission1 != admission6
+        assert admission1 != admission7
+        assert admission1 != object()
+
+    def test_repr(self):
+        admission = x509.Admission(None, None, [])
+        assert repr(admission) == (
+            "<Admission("
+            "admission_authority=None, "
+            "naming_authority=None, "
+            "profession_infos=[])>"
+        )
+
+        admission = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        assert repr(admission) == (
+            "<Admission("
+            "admission_authority=<OtherName("
+            "type_id=<ObjectIdentifier("
+            "oid=2.5.4.6, name=countryName)>, "
+            "value=b'\\x04\\x04\\x13\\x02DE')>, "
+            "naming_authority=<NamingAuthority("
+            "id=<ObjectIdentifier(oid=1.2.3, name=Unknown OID)>, "
+            "url=https://example.com, text=spam)>, "
+            "profession_infos=[<ProfessionInfo("
+            "naming_authority=<NamingAuthority("
+            "id=<ObjectIdentifier(oid=1.2.3.4, name=Unknown OID)>, "
+            "url=https://example.org, text=eggs)>, "
+            "profession_items=['bacon'], "
+            "profession_oids=[<ObjectIdentifier("
+            "oid=1.2.3.4.5, name=Unknown OID)>], "
+            "registration_number=sausage, "
+            "add_profession_info=b'\\x01\\x02\\x03')>])>"
+        )
+
+    def test_hash(self):
+        admission1 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        admission2 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        admission3 = x509.Admission(
+            x509.UniformResourceIdentifier(value="https://www.example.de"),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        admission4 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(None, None, None),
+            [
+                x509.ProfessionInfo(
+                    x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.3.4"),
+                        "https://example.org",
+                        "eggs",
+                    ),
+                    ["bacon"],
+                    [x509.ObjectIdentifier("1.2.3.4.5")],
+                    "sausage",
+                    b"\x01\x02\x03",
+                )
+            ],
+        )
+        admission5 = x509.Admission(
+            x509.OtherName(
+                type_id=x509.oid.NameOID.COUNTRY_NAME,
+                value=b"\x04\x04\x13\x02DE",
+            ),
+            x509.NamingAuthority(
+                x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
+            ),
+            [],
+        )
+        admission6 = x509.Admission(None, None, [])
+
+        assert hash(admission1) == hash(admission2)
+        assert hash(admission1) != hash(admission3)
+        assert hash(admission1) != hash(admission4)
+        assert hash(admission1) != hash(admission5)
+        assert hash(admission1) != hash(admission6)
+
+
 def test_all_extension_oid_members_have_names_defined():
     for oid in dir(ExtensionOID):
         if oid.startswith("__"):


### PR DESCRIPTION
This is the third PR for https://github.com/pyca/cryptography/issues/11875. The relevant part of the ASN.1 syntax, as specified in [Common PKI v2.0](https://www.elektronische-vertrauensdienste.de/EVD/SharedDocuments/Downloads/QES/Common_PKI_v2.0_02.pdf), Table 29b:

```
Admissions ::= SEQUENCE {
  admissionAuthority [0] EXPLICIT GeneralName OPTIONAL,
  namingAuthority [1] EXPLICIT NamingAuthority OPTIONAL,
  professionInfos SEQUENCE OF ProfessionInfo
}
```