### PR TITLE
Make the Hmac paramter optional

### DIFF
--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -132,9 +132,9 @@ pub enum AlgorithmParameters<'a> {
     Pbkdf2(PBKDF2Params<'a>),
 
     #[defined_by(oid::HMAC_WITH_SHA1_OID)]
-    HmacWithSha1(asn1::Null),
+    HmacWithSha1(Option<asn1::Null>),
     #[defined_by(oid::HMAC_WITH_SHA256_OID)]
-    HmacWithSha256(asn1::Null),
+    HmacWithSha256(Option<asn1::Null>),
 
     // Used only in PKCS#7 AlgorithmIdentifiers
     // https://datatracker.ietf.org/doc/html/rfc3565#section-4.1
@@ -430,7 +430,7 @@ pub struct PBES2Params<'a> {
 
 const HMAC_SHA1_ALG: AlgorithmIdentifier<'static> = AlgorithmIdentifier {
     oid: asn1::DefinedByMarker::marker(),
-    params: AlgorithmParameters::HmacWithSha1(()),
+    params: AlgorithmParameters::HmacWithSha1(Some(())),
 };
 
 #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Eq, Hash, Clone, Debug)]

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -148,7 +148,7 @@ impl EncryptionAlgorithm {
                                 oid: asn1::DefinedByMarker::marker(),
                                 params:
                                     cryptography_x509::common::AlgorithmParameters::HmacWithSha256(
-                                        (),
+                                        Some(()),
                                     ),
                             }),
                         },


### PR DESCRIPTION
In PBKDF2 structs generally there is no Algorithm Parameter associated with the PRF, but without marking the parameter optional the parser expect a an actual parameter with a null value.

Verified this parses a struct like this

```
    Certificate SEQUENCE (2 elem)
        tbsCertificate TBSCertificate [?] OBJECT IDENTIFIER 1.2.840.113549.1.5.12 pkcs5PBKDF2 (PKCS #5 v2.0)
        signatureAlgorithm AlgorithmIdentifier SEQUENCE (4 elem)
            algorithm OBJECT IDENTIFIER [?] OCTET STRING (32 byte) A0F59750E136DA858B08A4B77F99E4EF19106CF1B888EA73611915A3EA16F611
            parameters ANY INTEGER 10000
            INTEGER 32
            SEQUENCE (1 elem)
                OBJECT IDENTIFIER 1.2.840.113549.2.9 hmacWithSHA256 (RSADSI digestAlgorithm)
```

(hexder: 304206092A864886F70D01050C30350420A0F59750E136DA858B08A4B77F99E4EF19106CF1B888EA73611915A3EA16F61102022710020120300A06082A864886F70D0209)
