### PR TITLE
feat(admissions): implement encoding of admissions extension

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -2439,6 +2439,9 @@ class Admissions(ExtensionType):
     def __hash__(self) -> int:
         return hash((self.authority, tuple(self._admissions)))
 
+    def public_bytes(self) -> bytes:
+        return rust_x509.encode_extension_value(self)
+
 
 class UnrecognizedExtension(ExtensionType):
     def __init__(self, oid: ObjectIdentifier, value: bytes) -> None:

--- a/src/rust/cryptography-x509/src/extensions.rs
+++ b/src/rust/cryptography-x509/src/extensions.rs
@@ -285,7 +285,7 @@ impl KeyUsage<'_> {
     }
 }
 
-// #[derive(asn1::Asn1Read, asn1::Asn1Write)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub struct NamingAuthority<'a> {
     pub id: Option<asn1::ObjectIdentifier>,
     pub url: Option<asn1::IA5String<'a>>,
@@ -302,9 +302,9 @@ type SequenceOfObjectIdentifiers<'a> = common::Asn1ReadableOrWritable<
     asn1::SequenceOfWriter<'a, asn1::ObjectIdentifier, Vec<asn1::ObjectIdentifier>>,
 >;
 
-// #[derive(asn1::Asn1Read, asn1::Asn1Write)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub struct ProfessionInfo<'a> {
-    // #[explicit(0)]
+    #[explicit(0)]
     pub naming_authority: Option<NamingAuthority<'a>>,
     pub profession_items: SequenceOfDisplayTexts<'a>,
     pub profession_oids: Option<SequenceOfObjectIdentifiers<'a>>,
@@ -312,29 +312,25 @@ pub struct ProfessionInfo<'a> {
     pub add_profession_info: Option<&'a [u8]>,
 }
 
-// #[derive(asn1::Asn1Read, asn1::Asn1Write)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub struct Admission<'a> {
-    // #[explicit(0)]
+    #[explicit(0)]
     pub admission_authority: Option<name::GeneralName<'a>>,
-    // #[explicit(1)]
+    #[explicit(1)]
     pub naming_authority: Option<NamingAuthority<'a>>,
-    /*
     pub profession_infos: common::Asn1ReadableOrWritable<
         asn1::SequenceOf<'a, ProfessionInfo<'a>>,
         asn1::SequenceOfWriter<'a, ProfessionInfo<'a>, Vec<ProfessionInfo<'a>>>,
     >,
-    */
 }
 
-// #[derive(asn1::Asn1Read, asn1::Asn1Write)]
+#[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub struct Admissions<'a> {
     pub admission_authority: Option<name::GeneralName<'a>>,
-    /*
     pub contents_of_admissions: common::Asn1ReadableOrWritable<
         asn1::SequenceOf<'a, Admission<'a>>,
         asn1::SequenceOfWriter<'a, Admission<'a>, Vec<Admission<'a>>>,
     >,
-    */
 }
 
 #[cfg(test)]

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -44,6 +44,7 @@ pub const FRESHEST_CRL_OID: asn1::ObjectIdentifier = asn1::oid!(2, 5, 29, 46);
 pub const INHIBIT_ANY_POLICY_OID: asn1::ObjectIdentifier = asn1::oid!(2, 5, 29, 54);
 pub const ACCEPTABLE_RESPONSES_OID: asn1::ObjectIdentifier =
     asn1::oid!(1, 3, 6, 1, 5, 5, 7, 48, 1, 4);
+pub const ADMISSIONS_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 8, 3, 3);
 
 // Public key identifiers
 pub const EC_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 10045, 2, 1);

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -476,7 +476,7 @@ fn encode_profession_info<'a>(
     let profession_items =
         common::Asn1ReadableOrWritable::new_write(asn1::SequenceOfWriter::new(profession_items));
     let py_oids = py_info.getattr(pyo3::intern!(py, "profession_oids"))?;
-    let profession_oids = if py_oids.is_truthy()? {
+    let profession_oids = if !py_oids.is_none() {
         let mut profession_oids = vec![];
         for py_oid in py_oids.iter()? {
             let py_oid = py_oid?;

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -420,22 +420,22 @@ fn encode_naming_authority<'a>(
     py: pyo3::Python<'_>,
     ka_str: &'a cryptography_keepalive::KeepAlive<pyo3::pybacked::PyBackedStr>,
     py_naming_authority: &pyo3::Bound<'a, pyo3::PyAny>,
-) -> Result<extensions::NamingAuthority<'a>, CryptographyError> {
+) -> CryptographyResult<extensions::NamingAuthority<'a>> {
     let py_oid = py_naming_authority.getattr(pyo3::intern!(py, "id"))?;
-    let id = if py_oid.is_truthy()? {
+    let id = if !py_oid.is_none() {
         Some(py_oid_to_oid(py_oid)?)
     } else {
         None
     };
     let py_url = py_naming_authority.getattr(pyo3::intern!(py, "url"))?;
-    let url = if py_url.is_truthy()? {
+    let url = if !py_url.is_none() {
         let py_url_str = ka_str.add(py_url.extract::<PyBackedStr>()?);
         asn1::IA5String::new(py_url_str)
     } else {
         None
     };
     let py_text = py_naming_authority.getattr(pyo3::intern!(py, "text"))?;
-    let text = if py_text.is_truthy()? {
+    let text = if !py_text.is_none() {
         let py_text_str = ka_str.add(py_text.extract::<PyBackedStr>()?);
         Some(extensions::DisplayText::Utf8String(asn1::Utf8String::new(
             py_text_str,
@@ -451,9 +451,9 @@ fn encode_profession_info<'a>(
     ka_bytes: &'a cryptography_keepalive::KeepAlive<pyo3::pybacked::PyBackedBytes>,
     ka_str: &'a cryptography_keepalive::KeepAlive<pyo3::pybacked::PyBackedStr>,
     py_info: &pyo3::Bound<'a, pyo3::PyAny>,
-) -> Result<extensions::ProfessionInfo<'a>, CryptographyError> {
+) -> CryptographyResult<extensions::ProfessionInfo<'a>> {
     let py_naming_authority = py_info.getattr(pyo3::intern!(py, "naming_authority"))?;
-    let naming_authority = if py_naming_authority.is_truthy()? {
+    let naming_authority = if !py_naming_authority.is_none() {
         Some(encode_naming_authority(py, ka_str, &py_naming_authority)?)
     } else {
         None
@@ -469,7 +469,7 @@ fn encode_profession_info<'a>(
     let profession_items =
         common::Asn1ReadableOrWritable::new_write(asn1::SequenceOfWriter::new(profession_items));
     let py_oids = py_info.getattr(pyo3::intern!(py, "profession_oids"))?;
-    let profession_oids = if py_oids.is_truthy()? {
+    let profession_oids = if !py_oids.is_none() {
         let mut profession_oids = vec![];
         for py_oid in py_oids.iter()? {
             let py_oid = py_oid?;
@@ -483,7 +483,7 @@ fn encode_profession_info<'a>(
         None
     };
     let py_registration_number = py_info.getattr(pyo3::intern!(py, "registration_number"))?;
-    let registration_number = if py_registration_number.is_truthy()? {
+    let registration_number = if !py_registration_number.is_none() {
         let py_registration_number_str =
             ka_str.add(py_registration_number.extract::<PyBackedStr>()?);
         asn1::PrintableString::new(py_registration_number_str)
@@ -491,7 +491,7 @@ fn encode_profession_info<'a>(
         None
     };
     let py_add_profession_info = py_info.getattr(pyo3::intern!(py, "add_profession_info"))?;
-    let add_profession_info = if py_add_profession_info.is_truthy()? {
+    let add_profession_info = if !py_add_profession_info.is_none() {
         Some(ka_bytes.add(py_add_profession_info.extract::<pyo3::pybacked::PyBackedBytes>()?))
     } else {
         None
@@ -510,9 +510,9 @@ fn encode_admission<'a>(
     ka_bytes: &'a cryptography_keepalive::KeepAlive<pyo3::pybacked::PyBackedBytes>,
     ka_str: &'a cryptography_keepalive::KeepAlive<pyo3::pybacked::PyBackedStr>,
     py_admission: &pyo3::Bound<'a, pyo3::PyAny>,
-) -> Result<extensions::Admission<'a>, CryptographyError> {
+) -> CryptographyResult<extensions::Admission<'a>> {
     let py_admission_authority = py_admission.getattr(pyo3::intern!(py, "admission_authority"))?;
-    let admission_authority = if py_admission_authority.is_truthy()? {
+    let admission_authority = if !py_admission_authority.is_none() {
         Some(x509::common::encode_general_name(
             py,
             ka_bytes,
@@ -523,7 +523,7 @@ fn encode_admission<'a>(
         None
     };
     let py_naming_authority = py_admission.getattr(pyo3::intern!(py, "naming_authority"))?;
-    let naming_authority = if py_naming_authority.is_truthy()? {
+    let naming_authority = if !py_naming_authority.is_none() {
         Some(encode_naming_authority(py, ka_str, &py_naming_authority)?)
     } else {
         None
@@ -694,7 +694,7 @@ pub(crate) fn encode_extension(
             let ka_bytes = cryptography_keepalive::KeepAlive::new();
             let ka_str = cryptography_keepalive::KeepAlive::new();
             let py_admission_authority = ext.getattr(pyo3::intern!(py, "authority"))?;
-            let admission_authority = if py_admission_authority.is_truthy()? {
+            let admission_authority = if !py_admission_authority.is_none() {
                 Some(x509::common::encode_general_name(
                     py,
                     &ka_bytes,

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -677,12 +677,7 @@ pub(crate) fn encode_extension(
                     let py_add_profession_info =
                         py_info.getattr(pyo3::intern!(py, "add_profession_info"))?;
                     let add_profession_info = if py_add_profession_info.is_truthy()? {
-                        asn1::parse_single(ka_bytes.add(py_add_profession_info.extract()?))
-                            .map_err(|e| {
-                                pyo3::exceptions::PyValueError::new_err(format!(
-                                    "OtherName value must be valid DER: {e:?}"
-                                ))
-                            })?
+                        Some(ka_bytes.add(py_add_profession_info.extract::<pyo3::pybacked::PyBackedBytes>()?))
                     } else {
                         None
                     };

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -476,7 +476,7 @@ fn encode_profession_info<'a>(
     let profession_items =
         common::Asn1ReadableOrWritable::new_write(asn1::SequenceOfWriter::new(profession_items));
     let py_oids = py_info.getattr(pyo3::intern!(py, "profession_oids"))?;
-    let profession_oids = if !py_oids.is_none() {
+    let profession_oids = if py_oids.is_truthy()? {
         let mut profession_oids = vec![];
         for py_oid in py_oids.iter()? {
             let py_oid = py_oid?;

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -493,7 +493,16 @@ fn encode_profession_info<'a>(
     let registration_number = if !py_registration_number.is_none() {
         let py_registration_number_str =
             ka_str.add(py_registration_number.extract::<PyBackedStr>()?);
-        asn1::PrintableString::new(py_registration_number_str)
+        match asn1::PrintableString::new(py_registration_number_str) {
+            Some(s) => Some(s),
+            None => {
+                return Err(CryptographyError::from(
+                    pyo3::exceptions::PyValueError::new_err(
+                        "registration_number value must be a valid PrintableString",
+                    ),
+                ))
+            }
+        }
     } else {
         None
     };

--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -430,7 +430,14 @@ fn encode_naming_authority<'a>(
     let py_url = py_naming_authority.getattr(pyo3::intern!(py, "url"))?;
     let url = if !py_url.is_none() {
         let py_url_str = ka_str.add(py_url.extract::<PyBackedStr>()?);
-        asn1::IA5String::new(py_url_str)
+        match asn1::IA5String::new(py_url_str) {
+            Some(s) => Some(s),
+            None => {
+                return Err(CryptographyError::from(
+                    pyo3::exceptions::PyValueError::new_err("url value must be a valid IA5String"),
+                ))
+            }
+        }
     } else {
         None
     };

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7128,6 +7128,17 @@ class TestAdmissions:
             ext.public_bytes() == b"0\x1c\x86\x18https://www.example.com/0\x00"
         )
 
+        # test for encoding none values
+        ext = x509.Admissions(
+            None,
+            [
+                x509.Admission(
+                    None, None, [x509.ProfessionInfo(None, [], [], None, None)]
+                )
+            ],
+        )
+        assert ext.public_bytes() == b"0\n0\x080\x060\x040\x020\x00"
+
         # example values taken from https://gemspec.gematik.de/downloads/gemSpec/gemSpec_OID/gemSpec_OID_V3.17.0.pdf
         ext = x509.Admissions(
             authority=x509.DirectoryName(

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7153,7 +7153,7 @@ class TestAdmissions:
             ],
         )
         assert ext.public_bytes() == (
-            b"0\x1a0\x180\n\xa1\x020\x000\x040\x020\x000\n0\x080\x06\xa0\x020\x000\x00"
+            b"0\x1e0\x1c0\x0c\xa1\x020\x000\x060\x040\x000\x000\x0c0\n0\x08\xa0\x020\x000\x000\x00"
         )
 
         # example values taken from https://gemspec.gematik.de/downloads/gemSpec/gemSpec_OID/gemSpec_OID_V3.17.0.pdf

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7116,6 +7116,92 @@ class TestAdmissions:
         assert hash(admissions1) != hash(admissions4)
         assert hash(admissions1) != hash(admissions5)
 
+    def test_public_bytes(self):
+        ext = x509.Admissions(None, [])
+        assert ext.public_bytes() == b"0\x020\x00"
+
+        ext = x509.Admissions(
+            x509.UniformResourceIdentifier(value="https://www.example.com/"),
+            [],
+        )
+        assert (
+            ext.public_bytes() == b"0\x1c\x86\x18https://www.example.com/0\x00"
+        )
+
+        # example values taken from https://gemspec.gematik.de/downloads/gemSpec/gemSpec_OID/gemSpec_OID_V3.17.0.pdf
+        ext = x509.Admissions(
+            authority=x509.DirectoryName(
+                value=x509.Name(
+                    [
+                        x509.NameAttribute(
+                            x509.oid.NameOID.COUNTRY_NAME, "DE"
+                        ),
+                        x509.NameAttribute(
+                            x509.NameOID.ORGANIZATIONAL_UNIT_NAME,
+                            "Elektronisches Gesundheitsberuferegister",
+                        ),
+                    ]
+                )
+            ),
+            admissions=[
+                x509.Admission(
+                    admission_authority=x509.DNSName("gematik.de"),
+                    naming_authority=x509.NamingAuthority(
+                        x509.ObjectIdentifier("1.2.276.0.76.3.1.91"),
+                        "https://gematik.de/",
+                        (
+                            "Gesellschaft für Telematikanwendungen "
+                            "der Gesundheitskarte mbH"
+                        ),
+                    ),
+                    profession_infos=[
+                        x509.ProfessionInfo(
+                            naming_authority=x509.NamingAuthority(
+                                x509.ObjectIdentifier("1.2.276.0.76.3.1.1"),
+                                "https://www.kbv.de/",
+                                "KBV Kassenärztliche Bundesvereinigung",
+                            ),
+                            registration_number="123456789",
+                            profession_items=[
+                                "Ärztin/Arzt",
+                                (
+                                    "Orthopädieschuhmacher/-in "
+                                    "und Orthopädietechniker/-in"
+                                ),
+                            ],
+                            profession_oids=[
+                                x509.ObjectIdentifier("1.2.276.0.76.4.30"),
+                                x509.ObjectIdentifier("1.2.276.0.76.4.305"),
+                            ],
+                            # DER-encoded:
+                            # `x509.OtherName(
+                            #   type_id=x509.ObjectIdentifier('1.2.276.0.76.4.60'),
+                            #   value=b'\x0c\x1dProbe-Client Broker-Betreiber'
+                            # )`
+                            add_profession_info=(
+                                b"\xa0*\x06\x07*\x82\x14\x00L\x04<\xa0\x1f"
+                                b"\x0c\x1dProbe-Client Broker-Betreiber"
+                            ),
+                        )
+                    ],
+                ),
+            ],
+        )
+        assert ext.public_bytes() == (
+            b"0\x82\x01\xa6\xa4B0@1\x0b0\t\x06\x03U\x04\x06\x13\x02DE110/\x06"
+            b"\x03U\x04\x0b\x0c(Elektronisches Gesundheitsberuferegister0\x82"
+            b"\x01^0\x82\x01Z\xa0\x0c\x82\ngematik.de\xa1b0`\x06\x08*\x82\x14"
+            b"\x00L\x03\x01[\x16\x13https://gematik.de/\x0c?Gesellschaft f\xc3"
+            b"\xbcr Telematikanwendungen der Gesundheitskarte mbH0\x81\xe50"
+            b"\x81\xe2\xa0I0G\x06\x08*\x82\x14\x00L\x03\x01\x01\x16\x13https://www."
+            b"kbv.de/\x0c&KBV Kassen\xc3\xa4rztliche Bundesvereinigung0G\x0c"
+            b"\x0c\xc3\x84rztin/Arzt\x0c7Orthop\xc3\xa4dieschuhmacher/-in und "
+            b"Orthop\xc3\xa4dietechniker/-in0\x13\x06\x07*\x82\x14\x00L\x04\x1e"
+            b"\x06\x08*\x82\x14\x00L\x04\x821\x13\t123456789\x04,\xa0*\x06"
+            b"\x07*\x82\x14\x00L\x04<\xa0\x1f\x0c\x1dProbe-Client Broker-"
+            b"Betreiber"
+        )
+
 
 def test_all_extension_oid_members_have_names_defined():
     for oid in dir(ExtensionOID):

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7156,6 +7156,20 @@ class TestAdmissions:
             b"0\x1e0\x1c0\x0c\xa1\x020\x000\x060\x040\x000\x000\x0c0\n0\x08\xa0\x020\x000\x000\x00"
         )
 
+        # test for non-ascii url value in naming authority
+        ext = x509.Admissions(
+            None,
+            [
+                x509.Admission(
+                    None,
+                    x509.NamingAuthority(None, "😄", None),
+                    [],
+                ),
+            ],
+        )
+        with pytest.raises(ValueError):
+            ext.public_bytes()
+
         # example values taken from https://gemspec.gematik.de/downloads/gemSpec/gemSpec_OID/gemSpec_OID_V3.17.0.pdf
         ext = x509.Admissions(
             authority=x509.DirectoryName(

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7153,7 +7153,7 @@ class TestAdmissions:
             ],
         )
         assert ext.public_bytes() == (
-            b"0\x1e0\x1c0\x0c\xa1\x020\x000\x060\x040\x000\x000\x0c0\n0\x08\xa0\x020\x000\x000\x00"
+            b"0\x1a0\x180\n\xa1\x020\x000\x040\x020\x000\n0\x080\x06\xa0\x020\x000\x00"
         )
 
         # test for non-ascii url value in naming authority

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7153,7 +7153,7 @@ class TestAdmissions:
             ],
         )
         assert ext.public_bytes() == (
-            b"0\x1a0\x180\n\xa1\x020\x000\x040\x020\x000\n0\x080\x06\xa0\x020\x000\x00"
+            b"0\x1e0\x1c0\x0c\xa1\x020\x000\x060\x040\x000\x000\x0c0\n0\x08\xa0\x020\x000\x000\x00"
         )
 
         # example values taken from https://gemspec.gematik.de/downloads/gemSpec/gemSpec_OID/gemSpec_OID_V3.17.0.pdf
@@ -7257,6 +7257,19 @@ class TestAdmissions:
         )
         with pytest.raises(ValueError):
             ext.public_bytes()
+
+        # test that none passed for `profession_oids` is encoded as none
+        ext = x509.Admissions(
+            None,
+            [
+                x509.Admission(
+                    None,
+                    None,
+                    [x509.ProfessionInfo(None, [], None, None, None)],
+                ),
+            ],
+        )
+        assert ext.public_bytes() == b"0\n0\x080\x060\x040\x020\x00"
 
 
 def test_all_extension_oid_members_have_names_defined():

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7174,8 +7174,8 @@ class TestAdmissions:
                                 x509.ObjectIdentifier("1.2.276.0.76.4.305"),
                             ],
                             # DER-encoded:
-                            # `x509.OtherName(
-                            #   type_id=x509.ObjectIdentifier('1.2.276.0.76.4.60'),
+                            # `OtherName(
+                            #   type_id=ObjectIdentifier('1.2.276.0.76.4.60'),
                             #   value=b'\x0c\x1dProbe-Client Broker-Betreiber'
                             # )`
                             add_profession_info=(

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7133,11 +7133,28 @@ class TestAdmissions:
             None,
             [
                 x509.Admission(
-                    None, None, [x509.ProfessionInfo(None, [], [], None, None)]
-                )
+                    None,
+                    x509.NamingAuthority(None, None, None),
+                    [x509.ProfessionInfo(None, [], [], None, None)],
+                ),
+                x509.Admission(
+                    None,
+                    None,
+                    [
+                        x509.ProfessionInfo(
+                            x509.NamingAuthority(None, None, None),
+                            [],
+                            [],
+                            None,
+                            None,
+                        )
+                    ],
+                ),
             ],
         )
-        assert ext.public_bytes() == b"0\n0\x080\x060\x040\x020\x00"
+        assert ext.public_bytes() == (
+            b"0\x1a0\x180\n\xa1\x020\x000\x040\x020\x000\n0\x080\x06\xa0\x020\x000\x00"
+        )
 
         # example values taken from https://gemspec.gematik.de/downloads/gemSpec/gemSpec_OID/gemSpec_OID_V3.17.0.pdf
         ext = x509.Admissions(

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -7156,20 +7156,6 @@ class TestAdmissions:
             b"0\x1a0\x180\n\xa1\x020\x000\x040\x020\x000\n0\x080\x06\xa0\x020\x000\x00"
         )
 
-        # test for non-ascii url value in naming authority
-        ext = x509.Admissions(
-            None,
-            [
-                x509.Admission(
-                    None,
-                    x509.NamingAuthority(None, "😄", None),
-                    [],
-                ),
-            ],
-        )
-        with pytest.raises(ValueError):
-            ext.public_bytes()
-
         # example values taken from https://gemspec.gematik.de/downloads/gemSpec/gemSpec_OID/gemSpec_OID_V3.17.0.pdf
         ext = x509.Admissions(
             authority=x509.DirectoryName(
@@ -7243,6 +7229,34 @@ class TestAdmissions:
             b"\x07*\x82\x14\x00L\x04<\xa0\x1f\x0c\x1dProbe-Client Broker-"
             b"Betreiber"
         )
+
+        # test for non-ascii url value in naming authority
+        ext = x509.Admissions(
+            None,
+            [
+                x509.Admission(
+                    None,
+                    x509.NamingAuthority(None, "😄", None),
+                    [],
+                ),
+            ],
+        )
+        with pytest.raises(ValueError):
+            ext.public_bytes()
+
+        # test for non-ascii registration number value in profession info
+        ext = x509.Admissions(
+            None,
+            [
+                x509.Admission(
+                    None,
+                    None,
+                    [x509.ProfessionInfo(None, [], [], "\x00", None)],
+                ),
+            ],
+        )
+        with pytest.raises(ValueError):
+            ext.public_bytes()
 
 
 def test_all_extension_oid_members_have_names_defined():


### PR DESCRIPTION
This is the fifth PR for https://github.com/pyca/cryptography/issues/11875 which adds encoding of the `Admissions` extension object. Please review with caution - this is the part I am least confident in, and will be grateful for all improvement suggestions. Please also bear with my Rust coding skills - for this PR, I mostly learned from the existing codebase and PyO3 docs.