### PR TITLE
Speedup rsa_recover_prime_factors() by using random value

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -238,7 +238,7 @@ def rsa_recover_prime_factors(n: int, e: int, d: int) -> tuple[int, int]:
     spotted = False
     tries = 0
     while not spotted and tries < _MAX_RECOVERY_ATTEMPTS:
-        a = random.randint(2, n-1)
+        a = random.randint(2, n - 1)
         tries += 1
         k = t
         # Cycle through all values a^{t*2^i}=a^k

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -241,7 +241,6 @@ def rsa_recover_prime_factors(n: int, e: int, d: int) -> tuple[int, int]:
     spotted = False
     tries = 0
     while not spotted and tries < _MAX_RECOVERY_ATTEMPTS:
-        print(tries)
         a = random.randint(2, n - 1)
         tries += 1
         k = t

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -213,9 +213,8 @@ def rsa_recover_private_exponent(e: int, p: int, q: int) -> int:
 
 
 # Controls the number of iterations rsa_recover_prime_factors will perform
-# to obtain the prime factors. Each iteration increments by 2 so the actual
-# maximum attempts is half this number.
-_MAX_RECOVERY_ATTEMPTS = 1000
+# to obtain the prime factors.
+_MAX_RECOVERY_ATTEMPTS = 500
 
 
 def rsa_recover_prime_factors(n: int, e: int, d: int) -> tuple[int, int]:

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import abc
+import random
 import typing
 from math import gcd
 
@@ -235,8 +236,10 @@ def rsa_recover_prime_factors(n: int, e: int, d: int) -> tuple[int, int]:
     # See "Digitalized Signatures and Public Key Functions as Intractable
     # as Factorization", M. Rabin, 1979
     spotted = False
-    a = 2
-    while not spotted and a < _MAX_RECOVERY_ATTEMPTS:
+    tries = 0
+    while not spotted and tries < _MAX_RECOVERY_ATTEMPTS:
+        a = random.randint(2, n-1)
+        tries += 1
         k = t
         # Cycle through all values a^{t*2^i}=a^k
         while k < ktot:
@@ -249,8 +252,6 @@ def rsa_recover_prime_factors(n: int, e: int, d: int) -> tuple[int, int]:
                 spotted = True
                 break
             k *= 2
-        # This value was not any good... let's try another!
-        a += 2
     if not spotted:
         raise ValueError("Unable to compute factors p and q from exponent d.")
     # Found !

--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -223,6 +223,9 @@ def rsa_recover_prime_factors(n: int, e: int, d: int) -> tuple[int, int]:
     Compute factors p and q from the private exponent d. We assume that n has
     no more than two factors. This function is adapted from code in PyCrypto.
     """
+    # reject invalid values early
+    if 17 != pow(17, e * d, n):
+        raise ValueError("n, d, e don't match")
     # See 8.2.2(i) in Handbook of Applied Cryptography.
     ktot = d * e - 1
     # The quantity d*e-1 is a multiple of phi(n), even,
@@ -238,6 +241,7 @@ def rsa_recover_prime_factors(n: int, e: int, d: int) -> tuple[int, int]:
     spotted = False
     tries = 0
     while not spotted and tries < _MAX_RECOVERY_ATTEMPTS:
+        print(tries)
         a = random.randint(2, n - 1)
         tries += 1
         k = t

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2398,6 +2398,8 @@ class TestRSAPrimeFactorRecovery:
     def test_invalid_recover_prime_factors(self):
         with pytest.raises(ValueError):
             rsa.rsa_recover_prime_factors(34, 3, 7)
+        with pytest.raises(ValueError):
+            rsa.rsa_recover_prime_factors(629, 17, 20)
 
 
 class TestRSAPrivateKeySerialization:


### PR DESCRIPTION
I noticed that the rsa_recover_prime_factors() function can be very slow for some inputs, much slower than other implementations of the same functionality, e.g., in rsatool.

Digging into the algorithm, its seems that while the comments indicate this was implemented according to the Handbook of Applied Cryptography, the algorithm actually differs in a crucial detail.

The original algorithm assumes uses a random value a for each factorization attempt. However, the code in python cryptography uses a=2 and a 2 increment in each loop.

It appears the 50% probability of finding a fitting a does not hold for low values, so it takes plenty of rounds until the existing code finds a fitting a. (I lack the number theoretic background to explain why that is, it's based on my observations.)

Using a random value for a speeds up the code considerably. On my system, the example below takes around 4 seconds with the original code, 0.1 seconds with the modification to use a random value.

```
#!/usr/bin/python3

from cryptography.hazmat.primitives.asymmetric import rsa

n = 0xb7a43c3d64a2d5d9098fd8533fc84d60596f69d33b0df956f6659ea4e26127aeb0ee7ca82b580f36a14c4904723b5db91a9f93124a1d856af48ae8e31d5c7b05c5749654b8c390021a03eb70077a65c491d3e22aa26f9015c34ff128e0d3ce8cc28a9053f2d8cb0940199db5592752fcf111c861623678f741094ef189ece630ad2c24702c72f43dbd5f12fe3902e448b947d570fc920566270f21b1be36060d233e02a592f73210d998a5813f86a949a2a60d17382d02736d2b80b7b6ca62c78e91dc88229501b639f8bdf6fa549e64ef8eb3a535e7f697ae4f46c3c70f51a5f5fc8f2c2c6b9289576ddc2fc59f63d9dd9f22ef8e053c5186706d6ab365b3f9
d = 0x191b5b2109a1399b72b337e029d838bbf37e47f999194ffd93b250fe39f50e77d3b8c752369ad379a493c967d2364b9a0309ce11b210572d4841b595576e4d637c9b73f221509b5fae2edb01760445e59a0a5de17653ca5f2f54bea3d8191d242174d046a9ecf9d549ee36a1948ecbc9c92ba539ab33c756068e3f3cc69e9cd9cf89080ed319ee4e8c6eb516497c9bc6e0ec7891adc639141df42b02676bec5039ac5ce7d410d3b232a0030baa75337877dedb2ead8d7993da8c4a91bd397fc82405e6c73021fed5a264ec24d8ae32c47f6d4b72ead725fc0b511699e44390ad9a85e706f39fa82ca42de551295872a68ce8bf80949d4a0a9c37de97e767ac01
e = 0x10001

p, q = rsa.rsa_recover_prime_factors(n, e, d)
