### PR TITLE
fix(admissions): allow profession_oids field being none

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -2227,7 +2227,7 @@ class ProfessionInfo:
         self,
         naming_authority: NamingAuthority | None,
         profession_items: typing.Iterable[str],
-        profession_oids: typing.Iterable[ObjectIdentifier],
+        profession_oids: typing.Iterable[ObjectIdentifier] | None,
         registration_number: str | None,
         add_profession_info: bytes | None,
     ) -> None:
@@ -2242,14 +2242,15 @@ class ProfessionInfo:
                 "Every item in the profession_items list must be a str"
             )
 
-        profession_oids = list(profession_oids)
-        if not all(
-            isinstance(oid, ObjectIdentifier) for oid in profession_oids
-        ):
-            raise TypeError(
-                "Every item in the profession_oids list must be an "
-                "ObjectIdentifier"
-            )
+        if profession_oids is not None:
+            profession_oids = list(profession_oids)
+            if not all(
+                isinstance(oid, ObjectIdentifier) for oid in profession_oids
+            ):
+                raise TypeError(
+                    "Every item in the profession_oids list must be an "
+                    "ObjectIdentifier"
+                )
 
         if registration_number is not None and not isinstance(
             registration_number, str
@@ -2276,7 +2277,7 @@ class ProfessionInfo:
         return self._profession_items
 
     @property
-    def profession_oids(self) -> list[ObjectIdentifier]:
+    def profession_oids(self) -> list[ObjectIdentifier] | None:
         return self._profession_oids
 
     @property
@@ -2309,11 +2310,15 @@ class ProfessionInfo:
         )
 
     def __hash__(self) -> int:
+        if self.profession_oids is None:
+            profession_oids = (None,)
+        else:
+            profession_oids = tuple(self.profession_oids)
         return hash(
             (
                 self.naming_authority,
                 *tuple(self.profession_items),
-                *tuple(self.profession_oids),
+                *tuple(profession_oids),
                 self.registration_number,
                 self.add_profession_info,
             )

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -2311,7 +2311,7 @@ class ProfessionInfo:
 
     def __hash__(self) -> int:
         if self.profession_oids is None:
-            profession_oids = (None,)
+            profession_oids: tuple[ObjectIdentifier | None, ...] = (None,)
         else:
             profession_oids = tuple(self.profession_oids)
         return hash(

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -2311,14 +2311,14 @@ class ProfessionInfo:
 
     def __hash__(self) -> int:
         if self.profession_oids is None:
-            profession_oids: tuple[ObjectIdentifier | None, ...] = (None,)
+            profession_oids = None
         else:
             profession_oids = tuple(self.profession_oids)
         return hash(
             (
                 self.naming_authority,
                 *tuple(self.profession_items),
-                *tuple(profession_oids),
+                profession_oids,
                 self.registration_number,
                 self.add_profession_info,
             )

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -6493,6 +6493,10 @@ class TestProfessionInfo:
         info2 = x509.ProfessionInfo(None, [], [], None, None)
         assert info1 == info2
 
+        info1 = x509.ProfessionInfo(None, [], None, None, None)
+        info2 = x509.ProfessionInfo(None, [], None, None, None)
+        assert info1 == info2
+
         info1 = x509.ProfessionInfo(
             x509.NamingAuthority(
                 x509.ObjectIdentifier("1.2.3"), "https://example.com", "spam"
@@ -6566,6 +6570,7 @@ class TestProfessionInfo:
         info8 = x509.ProfessionInfo(None, [], [], "spam", None)
         info9 = x509.ProfessionInfo(None, [], [], None, b"\x01\x02\x03")
         info10 = x509.ProfessionInfo(None, [], [], None, None)
+        info11 = x509.ProfessionInfo(None, [], None, None, None)
 
         assert info1 != info2
         assert info1 != info2
@@ -6577,6 +6582,7 @@ class TestProfessionInfo:
         assert info1 != info8
         assert info1 != info9
         assert info1 != info10
+        assert info1 != info11
         assert info1 != object()
 
     def test_repr(self):
@@ -6586,6 +6592,16 @@ class TestProfessionInfo:
             "naming_authority=None, "
             "profession_items=[], "
             "profession_oids=[], "
+            "registration_number=None, "
+            "add_profession_info=None)>"
+        )
+
+        info = x509.ProfessionInfo(None, [], None, None, None)
+        assert repr(info) == (
+            "<ProfessionInfo("
+            "naming_authority=None, "
+            "profession_items=[], "
+            "profession_oids=None, "
             "registration_number=None, "
             "add_profession_info=None)>"
         )
@@ -6659,6 +6675,10 @@ class TestProfessionInfo:
         info7 = x509.ProfessionInfo(
             x509.NamingAuthority(None, None, None), [], [], None, None
         )
+        info8 = x509.ProfessionInfo(
+            x509.NamingAuthority(None, None, None), [], None, None, None
+        )
+        info9 = x509.ProfessionInfo(None, [], None, None, None)
 
         assert hash(info1) == hash(info2)
         assert hash(info1) != hash(info3)
@@ -6666,6 +6686,8 @@ class TestProfessionInfo:
         assert hash(info1) != hash(info5)
         assert hash(info1) != hash(info6)
         assert hash(info1) != hash(info7)
+        assert hash(info1) != hash(info8)
+        assert hash(info1) != hash(info9)
 
 
 class TestAdmission:

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -6443,7 +6443,7 @@ class TestProfessionInfo:
             x509.ProfessionInfo(
                 None,
                 None,  # type:ignore[arg-type]
-                None,  # type:ignore[arg-type]
+                None,
                 None,
                 None,
             )


### PR DESCRIPTION
This is the fix that I mentioned [in the review of #11892](https://github.com/pyca/cryptography/pull/11892#discussion_r1828456536). The ASN.1 syntax for `ProfessionInfo` is
```
ProfessionInfo ::= SEQUENCE {
  namingAuthority [0] EXPLICIT NamingAuthority OPTIONAL,
  professionItems SEQUENCE OF DirectoryString (SIZE(1..128)),
  professionOIDs SEQUENCE OF OBJECT IDENTIFIER OPTIONAL,
  registrationNumber PrintableString(SIZE(1..128)) OPTIONAL,
  addProfessionInfo OCTET STRING OPTIONAL
}
```
but I missed the optional part for `professionOIDs` in #11881. This PR makes sure that `professionOIDs` can be initialized with/encoded and parsed as `None`.

Note that this PR contains changes of both #11892 and #11903, its actual diff is a lot smaller. Will make this PR to a draft for now, first the both PRs above should get a good shape for merging.