### PR TITLE
refactor(admissions): do not unpack tuples in hash calculation for admissions extension types

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -892,9 +892,7 @@ class PolicyInformation:
 
     def __hash__(self) -> int:
         if self.policy_qualifiers is not None:
-            pq: tuple[str | UserNotice, ...] | None = tuple(
-                self.policy_qualifiers
-            )
+            pq = tuple(self.policy_qualifiers)
         else:
             pq = None
 
@@ -2310,14 +2308,14 @@ class ProfessionInfo:
         )
 
     def __hash__(self) -> int:
-        if self.profession_oids is None:
-            profession_oids = None
-        else:
+        if self.profession_oids is not None:
             profession_oids = tuple(self.profession_oids)
+        else:
+            profession_oids = None
         return hash(
             (
                 self.naming_authority,
-                *tuple(self.profession_items),
+                tuple(self.profession_items),
                 profession_oids,
                 self.registration_number,
                 self.add_profession_info,
@@ -2389,7 +2387,7 @@ class Admission:
             (
                 self.admission_authority,
                 self.naming_authority,
-                *tuple(self.profession_infos),
+                tuple(self.profession_infos),
             )
         )
 
@@ -2439,7 +2437,7 @@ class Admissions(ExtensionType):
         )
 
     def __hash__(self) -> int:
-        return hash((self.authority, *tuple(self._admissions)))
+        return hash((self.authority, tuple(self._admissions)))
 
 
 class UnrecognizedExtension(ExtensionType):


### PR DESCRIPTION
This is a small improvement for the hash magic methods of the types added for the `Admissions` extension in #11875. I didn't pay enough attention when doing the initial implementation and overlooked an example of the `policy_qualifiers` field in `PolicyInformation` type:

https://github.com/pyca/cryptography/blob/916fd46c25424df4621efe4d0c263c3596ee5eff/src/cryptography/x509/extensions.py#L893-L901

I amended the methods `ProfessionInfo.__hash__()`, `Admission.__hash__()` and `Admissions.__hash__()` to avoid tuple unpacking and adjusted the none check for `profession_oids` to have the same logic as the one for the `policy_qualifiers`. I also removed the type hint from the `pq` local variable since `mypy` can infer the types starting with v1.11 (IIRC).