### PR TITLE
chore: fix clippy warning emitted in rust-nightly job

### DIFF
--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -183,7 +183,7 @@ impl Subject<'_> {
                 DNSPattern::new(pattern.0).map_or(false, |p| p.matches(name))
             }
             (GeneralName::IPAddress(addr), Self::IP(name)) => {
-                IPAddress::from_bytes(addr).map_or(false, |addr| addr == *name)
+                IPAddress::from_bytes(addr) == Some(*name)
             }
             _ => false,
         }


### PR DESCRIPTION
This is a small PR that resolves the `unnecessary_map_or` warning emitted by `clippy` [here](https://github.com/pyca/cryptography/actions/runs/11873212727/job/33087807313?pr=11964).