### PR TITLE
refactor: replace returning pyobject with bound<'p, pyany> in x509::certificate::parse_distribution_point_reasons

### DIFF
--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -642,10 +642,10 @@ pub(crate) fn parse_distribution_points(
     Ok(py_dps.into_any().unbind())
 }
 
-pub(crate) fn parse_distribution_point_reasons(
-    py: pyo3::Python<'_>,
+pub(crate) fn parse_distribution_point_reasons<'p>(
+    py: pyo3::Python<'p>,
     reasons: Option<&asn1::BitString<'_>>,
-) -> Result<pyo3::PyObject, CryptographyError> {
+) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
     let reason_bit_mapping = types::REASON_BIT_MAPPING.get(py)?;
 
     Ok(match reasons {
@@ -656,9 +656,9 @@ pub(crate) fn parse_distribution_point_reasons(
                     vec.push(reason_bit_mapping.get_item(i)?);
                 }
             }
-            pyo3::types::PyFrozenSet::new(py, &vec)?.into_any().unbind()
+            pyo3::types::PyFrozenSet::new(py, &vec)?.into_any()
         }
-        None => py.None(),
+        None => py.None().into_bound(py),
     })
 }
 

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -363,7 +363,7 @@ impl CertificateRevocationList {
                             Some(reasons.unwrap_read()),
                         )?
                     } else {
-                        py.None()
+                        py.None().into_bound(py)
                     };
                     Ok(Some(types::ISSUING_DISTRIBUTION_POINT.get(py)?.call1((
                         full_name,


### PR DESCRIPTION
This PR is the continuation of #11966, but for the `x509::certificate::parse_distribution_point_reasons` function, that does two things:

1. Replacement of `Result<..., CryptographyError>` usages with `CryptographyResult<...>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11892#discussion_r1828409224
2. Replacement of `CryptographyResult<pyo3::PyObject>` return types by `CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11903#discussion_r1833019409