### PR TITLE
refactor: replace returning pyobject with bound<'p, pyany> in x509::certificate::parse_distribution_points

### DIFF
--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -629,17 +629,17 @@ fn parse_distribution_point(
         .unbind())
 }
 
-pub(crate) fn parse_distribution_points(
-    py: pyo3::Python<'_>,
+pub(crate) fn parse_distribution_points<'p>(
+    py: pyo3::Python<'p>,
     ext: &Extension<'_>,
-) -> Result<pyo3::PyObject, CryptographyError> {
+) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
     let dps = ext.value::<asn1::SequenceOf<'_, DistributionPoint<'_>>>()?;
     let py_dps = pyo3::types::PyList::empty(py);
     for dp in dps {
         let py_dp = parse_distribution_point(py, dp)?;
         py_dps.append(py_dp)?;
     }
-    Ok(py_dps.into_any().unbind())
+    Ok(py_dps.into_any())
 }
 
 pub(crate) fn parse_distribution_point_reasons(


### PR DESCRIPTION
This PR is the continuation of #11966, but for the `x509::certificate::parse_distribution_points` function, that does two things:

1. Replacement of `Result<..., CryptographyError>` usages with `CryptographyResult<...>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11892#discussion_r1828409224
2. Replacement of `CryptographyResult<pyo3::PyObject>` return types by `CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11903#discussion_r1833019409