### PR TITLE
chore(admissions): add changelog entry for the admissions extension addition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changelog
   forbidden by the CA/Browser BRs.
 * Added support for :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id`
   when using OpenSSL 3.2.0+.
+* Added support for the :class:`~cryptography.x509.Admissions` certificate extension.
 
 .. _v43-0-3:
 


### PR DESCRIPTION
This is the last PR for adding the `Admissions` X509 extension, closing #11875. This only adds an entry to the changelog.