### PR TITLE
refactor: replace returning pyobject with bound<'p, pyany> in x509::common::parse_general_name

### DIFF
--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -790,7 +790,7 @@ fn parse_admissions<'p, 'a>(
     for admission in admissions.clone() {
         let py_admission_authority = match admission.admission_authority {
             Some(authority) => x509::parse_general_name(py, authority)?,
-            None => py.None(),
+            None => py.None().into_bound(py),
         };
         let py_naming_authority = match admission.naming_authority {
             Some(data) => parse_naming_authority(py, data)?,
@@ -950,7 +950,7 @@ pub fn parse_cert_ext<'p>(
             let admissions = ext.value::<Admissions<'_>>()?;
             let admission_authority = match admissions.admission_authority {
                 Some(authority) => x509::parse_general_name(py, authority)?,
-                None => py.None(),
+                None => py.None().into_bound(py),
             };
             let py_admissions =
                 parse_admissions(py, admissions.contents_of_admissions.unwrap_read())?;


### PR DESCRIPTION
This PR is the continuation of #11966, but for the `x509::common::parse_general_name` function, that does two things:

1. Replacement of `Result<..., CryptographyError>` usages with `CryptographyResult<...>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11892#discussion_r1828409224
2. Replacement of `CryptographyResult<pyo3::PyObject>` return types by `CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11903#discussion_r1833019409