### PR TITLE
refactor: replace returning pyobject with bound<'p, pyany> in x509::common::parse_general_names

### DIFF
--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -355,7 +355,7 @@ impl CertificateRevocationList {
                     let idp = ext.value::<crl::IssuingDistributionPoint<'_>>()?;
                     let (full_name, relative_name) = match idp.distribution_point {
                         Some(data) => certificate::parse_distribution_point_name(py, data)?,
-                        None => (py.None(), py.None()),
+                        None => (py.None().into_bound(py), py.None().into_bound(py)),
                     };
                     let py_reasons = if let Some(reasons) = idp.only_some_reasons {
                         certificate::parse_distribution_point_reasons(
@@ -611,7 +611,7 @@ pub(crate) fn parse_crl_reason_flags<'p>(
 
 pub fn parse_crl_entry_ext<'p>(
     py: pyo3::Python<'p>,
-    ext: &Extension<'_>,
+    ext: &Extension<'p>,
 ) -> CryptographyResult<Option<pyo3::Bound<'p, pyo3::PyAny>>> {
     match ext.extn_id {
         oid::CRL_REASON_OID => {

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -318,7 +318,7 @@ impl PyClientVerifier {
         let py_gns = parse_general_names(py, &leaf_gns)?;
 
         Ok(PyVerifiedClient {
-            subjects: Some(py_gns),
+            subjects: Some(py_gns.into()),
             chain: py_chain.unbind(),
         })
     }


### PR DESCRIPTION
This PR is the continuation of #11966, but for the `x509::common::parse_general_names` function, that does two things:

1. Replacement of `Result<..., CryptographyError>` usages with `CryptographyResult<...>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11892#discussion_r1828409224
2. Replacement of `CryptographyResult<pyo3::PyObject>` return types by `CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11903#discussion_r1833019409
