### PR TITLE
refactor: replace returning pyobject with bound<'p, pyany> in backend::keys module, public_key functions

### DIFF
--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -520,7 +520,6 @@ fn serialize_key_and_certificates<'p>(
             if let Some(ref key) = key {
                 if !cert
                     .public_key(py)?
-                    .into_bound(py)
                     .eq(key.call_method0(pyo3::intern!(py, "public_key"))?)?
                 {
                     return Err(CryptographyError::from(

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -66,7 +66,10 @@ impl Certificate {
         slf
     }
 
-    pub(crate) fn public_key(&self, py: pyo3::Python<'_>) -> CryptographyResult<pyo3::PyObject> {
+    pub(crate) fn public_key<'p>(
+        &self,
+        py: pyo3::Python<'p>,
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
         keys::load_der_public_key_bytes(
             py,
             self.raw.borrow_dependent().tbs_cert.spki.tlv().full_data(),

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -47,7 +47,10 @@ impl CertificateSigningRequest {
         self.raw.borrow_owner().as_bytes(py) == other.raw.borrow_owner().as_bytes(py)
     }
 
-    fn public_key(&self, py: pyo3::Python<'_>) -> CryptographyResult<pyo3::PyObject> {
+    fn public_key<'p>(
+        &self,
+        py: pyo3::Python<'p>,
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
         keys::load_der_public_key_bytes(
             py,
             self.raw.borrow_dependent().csr_info.spki.tlv().full_data(),
@@ -225,7 +228,7 @@ impl CertificateSigningRequest {
         let public_key = slf.public_key(py)?;
         Ok(sign::verify_signature_with_signature_algorithm(
             py,
-            public_key.bind(py).clone(),
+            public_key.clone(),
             &slf.raw.borrow_dependent().signature_alg,
             slf.raw.borrow_dependent().signature.as_bytes(),
             &asn1::write_single(&slf.raw.borrow_dependent().csr_info)?,

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -228,7 +228,7 @@ impl CertificateSigningRequest {
         let public_key = slf.public_key(py)?;
         Ok(sign::verify_signature_with_signature_algorithm(
             py,
-            public_key.clone(),
+            public_key,
             &slf.raw.borrow_dependent().signature_alg,
             slf.raw.borrow_dependent().signature.as_bytes(),
             &asn1::write_single(&slf.raw.borrow_dependent().csr_info)?,

--- a/src/rust/src/x509/verify.rs
+++ b/src/rust/src/x509/verify.rs
@@ -31,7 +31,7 @@ impl CryptoOps for PyCryptoOps {
 
     fn public_key(&self, cert: &Certificate<'_>) -> Result<Self::Key, Self::Err> {
         pyo3::Python::with_gil(|py| -> Result<Self::Key, Self::Err> {
-            keys::load_der_public_key_bytes(py, cert.tbs_cert.spki.tlv().full_data())
+            Ok(keys::load_der_public_key_bytes(py, cert.tbs_cert.spki.tlv().full_data())?.unbind())
         })
     }
 


### PR DESCRIPTION
This PR is the continuation of #11966, but for the `load_der_public_key`, `load_der_public_key_bytes`, `load_pem_public_key` and `public_key_from_pkey` functions in `backend::keys` module, that does the replacement of `CryptographyResult<pyo3::PyObject>` return types by `CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>>`, originally suggested by @alex in https://github.com/pyca/cryptography/pull/11903#discussion_r1833019409.
