### PR TITLE
chore: replace plain hyperlinks to rfc sections with rfc roles with section argument

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -2228,7 +2228,7 @@ X.509 Extensions
     public key corresponding to the private key used to sign a certificate.
     This extension is typically used to assist in determining the appropriate
     certificate chain. For more information about generation and use of this
-    extension see `RFC 5280 section 4.2.1.1`_.
+    extension see :rfc:`5280#section-4.2.1.1`.
 
     .. attribute:: oid
 
@@ -4133,10 +4133,8 @@ Exceptions
         :type: int
 
         The integer value of the unsupported type. The complete list of
-        types can be found in `RFC 5280 section 4.2.1.6`_.
+        types can be found in :rfc:`5280#section-4.2.1.6`.
 
 
-.. _`RFC 5280 section 4.2.1.1`: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1
-.. _`RFC 5280 section 4.2.1.6`: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
 .. _`CABForum Guidelines`: https://cabforum.org/baseline-requirements-documents/
 .. _`Common PKI v2`: https://www.elektronische-vertrauensdienste.de/EVD/SharedDocuments/Downloads/QES/Common_PKI_v2.0_02.pdf


### PR DESCRIPTION
I noticed there are several hardcoded RFC refs, I think two of them can be safely replaced by using the Sphinx `:rfc:` role with section anchor. It renders the same URL as before, but the link text formatting aligns to the rest of RFC refs throughout the document.