### PR TITLE
Convert PKCS#7 types to GATs

### DIFF
--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -270,6 +270,9 @@ pub trait Asn1Operation {
     type SequenceOfVec<'a, T>
     where
         T: 'a;
+    type SetOf<'a, T>
+    where
+        T: 'a;
     type SetOfVec<'a, T>
     where
         T: 'a;
@@ -284,6 +287,10 @@ impl Asn1Operation for Asn1Read {
         = asn1::SequenceOf<'a, T>
     where
         T: 'a;
+    type SetOf<'a, T>
+        = asn1::SetOf<'a, T>
+    where
+        T: 'a;
     type SetOfVec<'a, T>
         = asn1::SetOf<'a, T>
     where
@@ -293,6 +300,10 @@ impl Asn1Operation for Asn1Read {
 impl Asn1Operation for Asn1Write {
     type SequenceOfVec<'a, T>
         = asn1::SequenceOfWriter<'a, T, Vec<T>>
+    where
+        T: 'a;
+    type SetOf<'a, T>
+        = asn1::SetOfWriter<'a, T>
     where
         T: 'a;
     type SetOfVec<'a, T>

--- a/src/rust/cryptography-x509/src/pkcs12.rs
+++ b/src/rust/cryptography-x509/src/pkcs12.rs
@@ -2,7 +2,7 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use crate::common::Utf8StoredBMPString;
+use crate::common::{Asn1Operation, Utf8StoredBMPString};
 use crate::{pkcs7, pkcs8};
 
 pub const CERT_BAG_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 12, 10, 1, 3);
@@ -14,9 +14,9 @@ pub const FRIENDLY_NAME_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 1135
 pub const LOCAL_KEY_ID_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 9, 21);
 
 #[derive(asn1::Asn1Write, asn1::Asn1Read)]
-pub struct Pfx<'a> {
+pub struct Pfx<'a, Op: Asn1Operation> {
     pub version: u8,
-    pub auth_safe: pkcs7::ContentInfo<'a>,
+    pub auth_safe: pkcs7::ContentInfo<'a, Op>,
     pub mac_data: Option<MacData<'a>>,
 }
 

--- a/src/rust/cryptography-x509/src/pkcs7.rs
+++ b/src/rust/cryptography-x509/src/pkcs7.rs
@@ -2,6 +2,7 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use crate::common::Asn1Operation;
 use crate::{certificate, common, csr, name};
 
 pub const PKCS7_DATA_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 7, 1);
@@ -10,19 +11,19 @@ pub const PKCS7_ENVELOPED_DATA_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 84
 pub const PKCS7_ENCRYPTED_DATA_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 7, 6);
 
 #[derive(asn1::Asn1Write, asn1::Asn1Read)]
-pub struct ContentInfo<'a> {
+pub struct ContentInfo<'a, Op: Asn1Operation> {
     pub _content_type: asn1::DefinedByMarker<asn1::ObjectIdentifier>,
 
     #[defined_by(_content_type)]
-    pub content: Content<'a>,
+    pub content: Content<'a, Op>,
 }
 
 #[derive(asn1::Asn1DefinedByWrite, asn1::Asn1DefinedByRead)]
-pub enum Content<'a> {
+pub enum Content<'a, Op: Asn1Operation> {
     #[defined_by(PKCS7_ENVELOPED_DATA_OID)]
-    EnvelopedData(asn1::Explicit<Box<EnvelopedData<'a>>, 0>),
+    EnvelopedData(asn1::Explicit<Box<EnvelopedData<'a, Op>>, 0>),
     #[defined_by(PKCS7_SIGNED_DATA_OID)]
-    SignedData(asn1::Explicit<Box<SignedData<'a>>, 0>),
+    SignedData(asn1::Explicit<Box<SignedData<'a, Op>>, 0>),
     #[defined_by(PKCS7_DATA_OID)]
     Data(Option<asn1::Explicit<&'a [u8], 0>>),
     #[defined_by(PKCS7_ENCRYPTED_DATA_OID)]
@@ -30,34 +31,18 @@ pub enum Content<'a> {
 }
 
 #[derive(asn1::Asn1Write, asn1::Asn1Read)]
-pub struct SignedData<'a> {
+pub struct SignedData<'a, Op: Asn1Operation> {
     pub version: u8,
-    pub digest_algorithms: common::Asn1ReadableOrWritable<
-        asn1::SetOf<'a, common::AlgorithmIdentifier<'a>>,
-        asn1::SetOfWriter<'a, common::AlgorithmIdentifier<'a>>,
-    >,
-    pub content_info: ContentInfo<'a>,
+    pub digest_algorithms: Op::SetOf<'a, common::AlgorithmIdentifier<'a>>,
+    pub content_info: ContentInfo<'a, Op>,
     #[implicit(0)]
-    pub certificates: Option<
-        common::Asn1ReadableOrWritable<
-            asn1::SetOf<'a, certificate::Certificate<'a>>,
-            asn1::SetOfWriter<'a, certificate::Certificate<'a>>,
-        >,
-    >,
+    pub certificates: Option<Op::SetOf<'a, certificate::Certificate<'a>>>,
 
     // We don't ever supply any of these, so for now, don't fill out the fields.
     #[implicit(1)]
-    pub crls: Option<
-        common::Asn1ReadableOrWritable<
-            asn1::SetOf<'a, asn1::Sequence<'a>>,
-            asn1::SetOfWriter<'a, asn1::Sequence<'a>>,
-        >,
-    >,
+    pub crls: Option<Op::SetOf<'a, asn1::Sequence<'a>>>,
 
-    pub signer_infos: common::Asn1ReadableOrWritable<
-        asn1::SetOf<'a, SignerInfo<'a>>,
-        asn1::SetOfWriter<'a, SignerInfo<'a>>,
-    >,
+    pub signer_infos: Op::SetOf<'a, SignerInfo<'a>>,
 }
 
 #[derive(asn1::Asn1Write, asn1::Asn1Read)]
@@ -76,12 +61,9 @@ pub struct SignerInfo<'a> {
 }
 
 #[derive(asn1::Asn1Write, asn1::Asn1Read)]
-pub struct EnvelopedData<'a> {
+pub struct EnvelopedData<'a, Op: Asn1Operation> {
     pub version: u8,
-    pub recipient_infos: common::Asn1ReadableOrWritable<
-        asn1::SetOf<'a, RecipientInfo<'a>>,
-        asn1::SetOfWriter<'a, RecipientInfo<'a>>,
-    >,
+    pub recipient_infos: Op::SetOf<'a, RecipientInfo<'a>>,
     pub encrypted_content_info: EncryptedContentInfo<'a>,
 }
 

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -3,11 +3,11 @@
 // for complete details.
 
 use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use std::hash::{Hash, Hash, Hasher, Hasher};
 
-use cryptography_x509::common::Utf8StoredBMPString;
+use cryptography_x509::common::{Asn1Write, Utf8StoredBMPString, Utf8StoredBMPString};
 use pyo3::types::{PyAnyMethods, PyBytesMethods, PyListMethods};
-use pyo3::{IntoPyObject, PyTypeInfo};
+use pyo3::{IntoPyObject, IntoPyObject, PyTypeInfo, PyTypeInfo};
 
 use crate::backend::{ciphers, hashes, hmac, kdf, keys};
 use crate::buf::CffiBuf;
@@ -479,7 +479,7 @@ fn serialize_key_and_certificates<'p>(
                 &cert_bag_contents,
             )?;
 
-            auth_safe_contents.push(cryptography_x509::pkcs7::ContentInfo {
+            auth_safe_contents.push(cryptography_x509::pkcs7::ContentInfo::<Asn1Write> {
                 _content_type: asn1::DefinedByMarker::marker(),
                 content: cryptography_x509::pkcs7::Content::EncryptedData(asn1::Explicit::new(
                     cryptography_x509::pkcs7::EncryptedData {
@@ -497,7 +497,7 @@ fn serialize_key_and_certificates<'p>(
                 )),
             })
         } else {
-            auth_safe_contents.push(cryptography_x509::pkcs7::ContentInfo {
+            auth_safe_contents.push(cryptography_x509::pkcs7::ContentInfo::<Asn1Write> {
                 _content_type: asn1::DefinedByMarker::marker(),
                 content: cryptography_x509::pkcs7::Content::Data(Some(asn1::Explicit::new(
                     &cert_bag_contents,


### PR DESCRIPTION
This does not currently work because rust-asn1 doesn't handle Asn1Definedby{Readable,Writable} correctly