### PR TITLE
downstream: run only sigstore-python unit tests

### DIFF
--- a/.github/downstream.d/sigstore.sh
+++ b/.github/downstream.d/sigstore.sh
@@ -11,7 +11,8 @@ case "${1}" in
         ;;
     run)
         cd /tmp/sigstore-python
-        pytest test
+        # Run only the unit tests, and skip any that require network access.
+        pytest test/unit --skip-online
         ;;
     *)
         exit 1


### PR DESCRIPTION
The integration tests are always online and require OIDC access, neither of which is desirable in terms of stability/permissions here.

Limiting things to just unit tests + offline reduces the test run time from ~6s to ~300ms on my local machine as well.