### PR TITLE
handle case where a "valid" pkey does not contain a valid EC key

### DIFF
--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -135,8 +135,11 @@ pub(crate) fn private_key_from_pkey(
     py: pyo3::Python<'_>,
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> CryptographyResult<ECPrivateKey> {
-    let curve = py_curve_from_curve(py, pkey.ec_key().unwrap().group())?;
-    check_key_infinity(&pkey.ec_key().unwrap())?;
+    let ec_key = pkey
+        .ec_key()
+        .map_err(|_| pyo3::exceptions::PyValueError::new_err("Invalid EC key"))?;
+    let curve = py_curve_from_curve(py, ec_key.group())?;
+    check_key_infinity(&ec_key)?;
     Ok(ECPrivateKey {
         pkey: pkey.to_owned(),
         curve: curve.into(),

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -466,6 +466,18 @@ class TestECDSAVectors:
                 backend=backend,
             )
 
+    def test_load_invalid_private_scalar_pem(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+
+        data = load_vectors_from_file(
+            os.path.join(
+                "asymmetric", "PKCS8", "ec-invalid-private-scalar.pem"
+            ),
+            lambda pemfile: pemfile.read().encode(),
+        )
+        with pytest.raises(ValueError):
+            serialization.load_pem_private_key(data, None)
+
     def test_signatures(self, backend, subtests):
         vectors = itertools.chain(
             load_vectors_from_file(

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -466,6 +466,13 @@ class TestECDSAVectors:
                 backend=backend,
             )
 
+    @pytest.mark.supported(
+        only_if=(
+            lambda backend: rust_openssl.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER
+            or rust_openssl.CRYPTOGRAPHY_IS_BORINGSSL
+        ),
+        skip_message="LibreSSL and OpenSSL 1.1.1 handle this differently",
+    )
     def test_load_invalid_private_scalar_pem(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
 


### PR DESCRIPTION
This probably needs the test case from #12100 