### PR TITLE
Support for copying private keys

### DIFF
--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -235,6 +235,10 @@ impl DHPrivateKey {
             false,
         )
     }
+
+    fn __copy__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::pymethods]

--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -151,6 +151,10 @@ impl DsaPrivateKey {
             false,
         )
     }
+
+    fn __copy__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::pymethods]

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -378,6 +378,10 @@ impl ECPrivateKey {
             false,
         )
     }
+
+    fn __copy__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::pymethods]

--- a/src/rust/src/backend/ed25519.rs
+++ b/src/rust/src/backend/ed25519.rs
@@ -115,6 +115,10 @@ impl Ed25519PrivateKey {
             true,
         )
     }
+
+    fn __copy__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::pymethods]

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -113,6 +113,10 @@ impl Ed448PrivateKey {
             true,
         )
     }
+
+    fn __copy__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::pymethods]

--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -415,6 +415,10 @@ impl RsaPrivateKey {
             false,
         )
     }
+
+    fn __copy__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::pymethods]

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -115,6 +115,10 @@ impl X25519PrivateKey {
             true,
         )
     }
+
+    fn __copy__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::pymethods]

--- a/src/rust/src/backend/x448.rs
+++ b/src/rust/src/backend/x448.rs
@@ -114,6 +114,10 @@ impl X448PrivateKey {
             true,
         )
     }
+
+    fn __copy__(slf: pyo3::PyRef<'_, Self>) -> pyo3::PyRef<'_, Self> {
+        slf
+    }
 }
 
 #[pyo3::pymethods]

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -483,6 +483,17 @@ class TestDH:
 
         assert key1 == key2
 
+    def test_private_key_copy(self):
+        key_bytes = load_vectors_from_file(
+            os.path.join("asymmetric", "DH", "dhkey.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
+        key1 = serialization.load_pem_private_key(key_bytes)
+        key2 = copy.copy(key1)
+
+        assert key1 == key2
+
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.dh_supported(),

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -409,6 +409,16 @@ class TestDSA:
 
         assert key1 == key2
 
+    def test_private_key_copy(self):
+        key_bytes = load_vectors_from_file(
+            os.path.join("asymmetric", "PKCS8", "unenc-dsa-pkcs8.pem"),
+            lambda pemfile: pemfile.read().encode(),
+        )
+        key1 = serialization.load_pem_private_key(key_bytes, None)
+        key2 = copy.copy(key1)
+
+        assert key1 == key2
+
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.dsa_supported(),

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -763,6 +763,17 @@ class TestECEquality:
 
         assert key1 == key2
 
+    def test_private_key_copy(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+        key_bytes = load_vectors_from_file(
+            os.path.join("asymmetric", "PKCS8", "ec_private_key.pem"),
+            lambda pemfile: pemfile.read().encode(),
+        )
+        key1 = serialization.load_pem_private_key(key_bytes, None)
+        key2 = copy.copy(key1)
+
+        assert key1 == key2
+
 
 class TestECSerialization:
     @pytest.mark.parametrize(

--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -317,3 +317,19 @@ def test_public_key_copy(backend):
     key2 = copy.copy(key1)
 
     assert key1 == key2
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.ed25519_supported(),
+    skip_message="Requires OpenSSL with Ed25519 support",
+)
+def test_private_key_copy(backend):
+    key_bytes = load_vectors_from_file(
+        os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8.der"),
+        lambda derfile: derfile.read(),
+        mode="rb",
+    )
+    key1 = serialization.load_der_private_key(key_bytes, None)
+    key2 = copy.copy(key1)
+
+    assert key1 == key2

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -311,3 +311,19 @@ def test_public_key_copy(backend):
     key2 = copy.copy(key1)
 
     assert key1 == key2
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.ed448_supported(),
+    skip_message="Requires OpenSSL with Ed448 support",
+)
+def test_private_key_copy(backend):
+    key_bytes = load_vectors_from_file(
+        os.path.join("asymmetric", "Ed448", "ed448-pkcs8.der"),
+        lambda derfile: derfile.read(),
+        mode="rb",
+    )
+    key1 = serialization.load_der_private_key(key_bytes, None)
+    key2 = copy.copy(key1)
+
+    assert key1 == key2

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2781,3 +2781,9 @@ class TestRSAPEMPublicKeySerialization:
         key2 = copy.copy(key1)
 
         assert key1 == key2
+
+    def test_private_key_copy(self, rsa_key_2048: rsa.RSAPrivateKey):
+        key1 = rsa_key_2048
+        key2 = copy.copy(key1)
+
+        assert key1 == key2

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -369,3 +369,19 @@ def test_public_key_copy(backend):
     key2 = copy.copy(key1)
 
     assert key1 == key2
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.x25519_supported(),
+    skip_message="Requires OpenSSL with X25519 support",
+)
+def test_private_key_copy(backend):
+    key_bytes = load_vectors_from_file(
+        os.path.join("asymmetric", "X25519", "x25519-pkcs8.der"),
+        lambda derfile: derfile.read(),
+        mode="rb",
+    )
+    key1 = serialization.load_der_private_key(key_bytes, None)
+    key2 = copy.copy(key1)
+
+    assert key1 == key2

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -297,3 +297,19 @@ def test_public_key_copy(backend):
     key2 = copy.copy(key1)
 
     assert key1 == key2
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.x448_supported(),
+    skip_message="Requires OpenSSL with X448 support",
+)
+def test_private_key_copy(backend):
+    key_bytes = load_vectors_from_file(
+        os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
+        lambda derfile: derfile.read(),
+        mode="rb",
+    )
+    key1 = serialization.load_der_private_key(key_bytes, None)
+    key2 = copy.copy(key1)
+
+    assert key1 == key2


### PR DESCRIPTION
This should solve the issue https://github.com/pyca/cryptography/issues/11859, that private keys, like RSAPrivateKey can not be copied.