### PR TITLE
Add ec.EllipticCurve group_order constants

### DIFF
--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -500,6 +500,14 @@ Key Interfaces
         Size (in :term:`bits`) of a secret scalar for the curve (as generated
         by :func:`generate_private_key`).
 
+    .. attribute:: group_order
+
+        .. versionadded:: 45
+
+        :type: int
+
+        The order of the curve's group.
+
 
 .. class:: EllipticCurveSignatureAlgorithm
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -56,7 +56,7 @@ class EllipticCurve(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def group_order(self) -> int:
         """
-        The order of the curve's group
+        The order of the curve's group.
         """
 
 

--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -52,6 +52,13 @@ class EllipticCurve(metaclass=abc.ABCMeta):
         Bit size of a secret scalar for the curve.
         """
 
+    @property
+    @abc.abstractmethod
+    def group_order(self) -> int:
+        """
+        The order of the curve's group
+        """
+
 
 class EllipticCurveSignatureAlgorithm(metaclass=abc.ABCMeta):
     @property
@@ -199,96 +206,121 @@ EllipticCurvePublicNumbers = rust_openssl.ec.EllipticCurvePublicNumbers
 class SECT571R1(EllipticCurve):
     name = "sect571r1"
     key_size = 570
+    group_order = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE661CE18FF55987308059B186823851EC7DD9CA1161DE93D5174D66E8382E9BB2FE84E47  # noqa: E501
 
 
 class SECT409R1(EllipticCurve):
     name = "sect409r1"
     key_size = 409
+    group_order = 0x10000000000000000000000000000000000000000000000000001E2AAD6A612F33307BE5FA47C3C9E052F838164CD37D9A21173  # noqa: E501
 
 
 class SECT283R1(EllipticCurve):
     name = "sect283r1"
     key_size = 283
+    group_order = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEF90399660FC938A90165B042A7CEFADB307  # noqa: E501
 
 
 class SECT233R1(EllipticCurve):
     name = "sect233r1"
     key_size = 233
+    group_order = 0x1000000000000000000000000000013E974E72F8A6922031D2603CFE0D7
 
 
 class SECT163R2(EllipticCurve):
     name = "sect163r2"
     key_size = 163
+    group_order = 0x40000000000000000000292FE77E70C12A4234C33
 
 
 class SECT571K1(EllipticCurve):
     name = "sect571k1"
     key_size = 571
+    group_order = 0x20000000000000000000000000000000000000000000000000000000000000000000000131850E1F19A63E4B391A8DB917F4138B630D84BE5D639381E91DEB45CFE778F637C1001  # noqa: E501
 
 
 class SECT409K1(EllipticCurve):
     name = "sect409k1"
     key_size = 409
+    group_order = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE5F83B2D4EA20400EC4557D5ED3E3E7CA5B4B5C83B8E01E5FCF  # noqa: E501
 
 
 class SECT283K1(EllipticCurve):
     name = "sect283k1"
     key_size = 283
+    group_order = 0x1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE9AE2ED07577265DFF7F94451E061E163C61  # noqa: E501
 
 
 class SECT233K1(EllipticCurve):
     name = "sect233k1"
     key_size = 233
+    group_order = 0x8000000000000000000000000000069D5BB915BCD46EFB1AD5F173ABDF
 
 
 class SECT163K1(EllipticCurve):
     name = "sect163k1"
     key_size = 163
+    group_order = 0x4000000000000000000020108A2E0CC0D99F8A5EF
 
 
 class SECP521R1(EllipticCurve):
     name = "secp521r1"
     key_size = 521
+    group_order = 0x1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA51868783BF2F966B7FCC0148F709A5D03BB5C9B8899C47AEBB6FB71E91386409  # noqa: E501
 
 
 class SECP384R1(EllipticCurve):
     name = "secp384r1"
     key_size = 384
+    group_order = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC7634D81F4372DDF581A0DB248B0A77AECEC196ACCC52973  # noqa: E501
 
 
 class SECP256R1(EllipticCurve):
     name = "secp256r1"
     key_size = 256
+    group_order = (
+        0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+    )
 
 
 class SECP256K1(EllipticCurve):
     name = "secp256k1"
     key_size = 256
+    group_order = (
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+    )
 
 
 class SECP224R1(EllipticCurve):
     name = "secp224r1"
     key_size = 224
+    group_order = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF16A2E0B8F03E13DD29455C5C2A3D
 
 
 class SECP192R1(EllipticCurve):
     name = "secp192r1"
     key_size = 192
+    group_order = 0xFFFFFFFFFFFFFFFFFFFFFFFF99DEF836146BC9B1B4D22831
 
 
 class BrainpoolP256R1(EllipticCurve):
     name = "brainpoolP256r1"
     key_size = 256
+    group_order = (
+        0xA9FB57DBA1EEA9BC3E660A909D838D718C397AA3B561A6F7901E0E82974856A7
+    )
 
 
 class BrainpoolP384R1(EllipticCurve):
     name = "brainpoolP384r1"
     key_size = 384
+    group_order = 0x8CB91E82A3386D280F5D6F7E50E641DF152F7109ED5456B31F166E6CAC0425A7CF3AB6AF6B7FC3103B883202E9046565  # noqa: E501
 
 
 class BrainpoolP512R1(EllipticCurve):
     name = "brainpoolP512r1"
     key_size = 512
+    group_order = 0xAADD9DB8DBE9C48B3FD4E6AE33C9FC07CB308DB3B3C9D20ED6639CCA70330870553E5C414CA92619418661197FAC10471DB1D381085DDADDB58796829CA90069  # noqa: E501
 
 
 _CURVE_TYPES: dict[str, EllipticCurve] = {

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -82,6 +82,7 @@ def test_get_curve_for_oid():
 class DummyCurve(ec.EllipticCurve):
     name = "dummy-curve"
     key_size = 1
+    group_order = 1
 
 
 class DummySignatureAlgorithm(ec.EllipticCurveSignatureAlgorithm):


### PR DESCRIPTION
Follow-up to https://github.com/pyca/cryptography/pull/10600

This PR hard-codes `group_order` constants for all the curves specified in `ec.py`

For what it's worth, I sourced them from https://neuromancer.sk/std/search/ for ease of copy-pasting - please do cross-check!

Some of the int literals are very long and had to be #noqa'd (I don't think there's any good way to avoid it)