### PR TITLE
support for PKCS7_NO_VERIFY in test_support.pkcs7_verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ target/
 .rust-cov/
 *.lcov
 *.profdata
+venv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -43,6 +43,7 @@ class PKCS7Options(utils.Enum):
     NoCapabilities = "Don't embed SMIME capabilities"
     NoAttributes = "Don't embed authenticatedAttributes"
     NoCerts = "Don't embed signer certificate"
+    NoVerify = "Don't verify the signers certificate of a signed message"
 
 
 class PKCS7SignatureBuilder:

--- a/src/rust/src/test_support.rs
+++ b/src/rust/src/test_support.rs
@@ -81,6 +81,9 @@ fn pkcs7_verify(
     if options.contains(types::PKCS7_TEXT.get(py)?)? {
         flags |= openssl::pkcs7::Pkcs7Flags::TEXT;
     }
+    if options.contains(types::PKCS7_NO_VERIFY.get(py)?)? {
+        flags |= openssl::pkcs7::Pkcs7Flags::NOVERIFY;
+    }
 
     let store = {
         let mut b = openssl::x509::store::X509StoreBuilder::new()?;

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -349,6 +349,10 @@ pub static PKCS7_DETACHED_SIGNATURE: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.serialization.pkcs7",
     &["PKCS7Options", "DetachedSignature"],
 );
+pub static PKCS7_NO_VERIFY: LazyPyImport = LazyPyImport::new(
+    "cryptography.hazmat.primitives.serialization.pkcs7",
+    &["PKCS7Options", "NoVerify"],
+);
 
 pub static SMIME_ENVELOPED_ENCODE: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.serialization.pkcs7",

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -349,6 +349,8 @@ pub static PKCS7_DETACHED_SIGNATURE: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.serialization.pkcs7",
     &["PKCS7Options", "DetachedSignature"],
 );
+
+#[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
 pub static PKCS7_NO_VERIFY: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.serialization.pkcs7",
     &["PKCS7Options", "NoVerify"],


### PR DESCRIPTION
This PR adds support for Pkcs7Flags::NOVERIFY so that we can verify pkcs7 signatures without verifying the certificates. 

M2Crypto also exposes this option but I would prefer to use cryptography ;)

It is needed when the verifying a signed apple wallet pass. Now I can verify it with the call

```python
    test_support.pkcs7_verify(
        serialization.Encoding.DER,
        signature,
        manifest_json.encode("utf-8"),
        [],
        [pkcs7.PKCS7Options.NoVerify],
    )
```

without the NoVerify option I get the error:

```
cryptography.exceptions.InternalError: Unknown OpenSSL error. This error is commonly encountered
...
... (error:10800075:PKCS7 routines:PKCS7_verify:certificate verify error:../crypto/pkcs7/pk7_smime.c:295:Verify error: unable to get local issuer certificate)
```

The unittests as in https://github.com/pyca/cryptography/blob/7a20576a420983e5ca04aa70a9bfb47fd285f097/tests/hazmat/primitives/test_pkcs7.py#L412

use ECPrivateKey but when using RSAPrivateKey I get the above error.