### PR TITLE
Update recommended PBKDF2HMAC iteration counts

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -237,7 +237,7 @@ password through a key derivation function such as
     ...     algorithm=hashes.SHA256(),
     ...     length=32,
     ...     salt=salt,
-    ...     iterations=480000,
+    ...     iterations=1_000_000,
     ... )
     >>> key = base64.urlsafe_b64encode(kdf.derive(password))
     >>> f = Fernet(key)
@@ -251,8 +251,8 @@ In this scheme, the salt has to be stored in a retrievable location in order
 to derive the same key from the password in the future.
 
 The iteration count used should be adjusted to be as high as your server can
-tolerate. A good default is at least 480,000 iterations, which is what `Django
-recommends as of December 2022`_.
+tolerate. A good default is at least 1,000,000 iterations, which is what `Django
+recommends as of January 2025`_.
 
 Implementation
 --------------
@@ -280,5 +280,5 @@ unsuitable for very large files at this time.
 
 
 .. _`Fernet`: https://github.com/fernet/spec/
-.. _`Django recommends as of December 2022`: https://github.com/django/django/blob/main/django/contrib/auth/hashers.py
+.. _`Django recommends as of January 2025`: https://github.com/django/django/blob/main/django/contrib/auth/hashers.py
 .. _`specification`: https://github.com/fernet/spec/blob/master/Spec.md

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -162,7 +162,7 @@ PBKDF2
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     salt=salt,
-        ...     iterations=480000,
+        ...     iterations=1_000_000,
         ... )
         >>> key = kdf.derive(b"my great password")
         >>> # verify
@@ -170,7 +170,7 @@ PBKDF2
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     salt=salt,
-        ...     iterations=480000,
+        ...     iterations=1_000_000,
         ... )
         >>> kdf.verify(b"my great password", key)
 


### PR DESCRIPTION
This uses the current (as of 2025-01-07) default of 1,000,000 iterations used by Django in the [referenced code location](https://github.com/django/django/blob/40d5516385448a73426aad396778f369a363eda9/django/contrib/auth/hashers.py#L321).