### PR TITLE
Corrected the documented intent of the HKDFExpand.derive() function

### DIFF
--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -665,8 +665,8 @@ HKDF
                                                           called more than
                                                           once.
 
-        Derives a new key from the input key material by performing both the
-        extract and expand operations.
+        Derives a new key from the input key material by only performing the
+        expand operation.
 
     .. method:: verify(key_material, expected_key)
 


### PR DESCRIPTION
Corrected the documented intent of the HKDFExpand.derive() function so that it clearly states only expand is performed, and not extract and expand.

This solves issue https://github.com/pyca/cryptography/issues/12247