### PR TITLE
Reject d, e values <= 1

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/rsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/rsa.py
@@ -235,6 +235,8 @@ def rsa_recover_prime_factors(n: int, e: int, d: int) -> tuple[int, int]:
     no more than two factors. This function is adapted from code in PyCrypto.
     """
     # reject invalid values early
+    if d <= 1 or e <= 1:
+        raise ValueError("d, e can't be <= 1")
     if 17 != pow(17, e * d, n):
         raise ValueError("n, d, e don't match")
     # See 8.2.2(i) in Handbook of Applied Cryptography.

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2400,6 +2400,10 @@ class TestRSAPrimeFactorRecovery:
             rsa.rsa_recover_prime_factors(34, 3, 7)
         with pytest.raises(ValueError):
             rsa.rsa_recover_prime_factors(629, 17, 20)
+        with pytest.raises(ValueError):
+            rsa.rsa_recover_prime_factors(21, 1, 1)
+        with pytest.raises(ValueError):
+            rsa.rsa_recover_prime_factors(21, -1, -1)
 
 
 class TestRSAPrivateKeySerialization:


### PR DESCRIPTION
This avoids a potential infinite loop (e.g. with d=e=1 or d=e=-1).

The function rsa_recover_prime_factors contains this code:
```
    ktot = d * e - 1
    # The quantity d*e-1 is a multiple of phi(n), even,
    # and can be represented as t*2^s.
    t = ktot
    while t % 2 == 0:
        t = t // 2
```
This can lead to an infinite loop if t is already 0. This is the case if d/e are both 1 or -1. With certain n values, this also survives the existing input plausibility check. This patch adds an additional check making sure that d/e are both not 1 or smaller, which would be invalid anyway.

Example DoS / infinite loop:
```
from cryptography.hazmat.primitives.asymmetric import rsa
x = rsa.rsa_recover_prime_factors(21, 1, 1) # -1, -1 also works
```

One might consider this as a low impact security vulnerability / DoS in situations where input values are potentially attacker controlled.