### PR TITLE
Revert "Silence new clippy warning"

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -3,12 +3,7 @@
 // for complete details.
 
 #![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
-#![allow(
-    unknown_lints,
-    non_local_definitions,
-    clippy::result_large_err,
-    clippy::useless_conversion
-)]
+#![allow(unknown_lints, non_local_definitions, clippy::result_large_err)]
 
 #[cfg(CRYPTOGRAPHY_OPENSSL_300_OR_GREATER)]
 use crate::error::CryptographyResult;


### PR DESCRIPTION
Reverts pyca/cryptography#12208

Latest pyo3 addresses this, I believe.