### PR TITLE
Update reference.rst:load_der_x509_certificate to note ValueError raised

### DIFF
--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -223,6 +223,9 @@ Loading Certificates
 
     :returns: An instance of :class:`~cryptography.x509.Certificate`.
 
+    :raises ValueError: If there isn't at least one certificate, or if any
+        certificate is malformed.
+
 Loading Certificate Revocation Lists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -223,8 +223,8 @@ Loading Certificates
 
     :returns: An instance of :class:`~cryptography.x509.Certificate`.
 
-    :raises ValueError: If there isn't at least one certificate, or if any
-        certificate is malformed.
+    :raises ValueError: If a certificate cannot be parsed from the provided
+        data.
 
 Loading Certificate Revocation Lists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
It raises the error and therefore should be noted in the documentation.

```
>>> x509.load_der_x509_certificate(b64.b64decode("foobar".encode()))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: error parsing asn1 value: ParseError { kind: InvalidLength }
```