### PR TITLE
Turn openssl-sys into a workspace dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rust-version = "1.65.0"
 asn1 = { version = "0.20.0", default-features = false }
 pyo3 = { version = "0.23.4", features = ["abi3"] }
 openssl = "0.10.69"
+openssl-sys = "0.9.104"
 
 [profile.release]
 overflow-checks = true

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -20,7 +20,7 @@ cryptography-x509-verification = { path = "cryptography-x509-verification" }
 cryptography-openssl = { path = "cryptography-openssl" }
 pem = { version = "3", default-features = false }
 openssl.workspace = true
-openssl-sys = "0.9.104"
+openssl-sys.workspace = true
 foreign-types-shared = "0.1"
 self_cell = "1"
 

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 pyo3.workspace = true
-openssl-sys = "0.9.104"
+openssl-sys.workspace = true
 
 [build-dependencies]
 cc = "1.2.10"

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 asn1.workspace = true
 cfg-if = "1"
 openssl.workspace = true
-openssl-sys = "0.9.104"
+openssl-sys.workspace = true
 cryptography-x509 = { path = "../cryptography-x509" }
 
 [lints.rust]

--- a/src/rust/cryptography-openssl/Cargo.toml
+++ b/src/rust/cryptography-openssl/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 cfg-if = "1"
 openssl.workspace = true
-ffi = { package = "openssl-sys", version = "0.9.101" }
+openssl-sys.workspace = true
 foreign-types = "0.3"
 foreign-types-shared = "0.1"
 

--- a/src/rust/cryptography-openssl/src/aead.rs
+++ b/src/rust/cryptography-openssl/src/aead.rs
@@ -2,6 +2,8 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use openssl_sys as ffi;
+
 use crate::{cvt, cvt_p, OpenSSLResult};
 use foreign_types_shared::{ForeignType, ForeignTypeRef};
 

--- a/src/rust/cryptography-openssl/src/cmac.rs
+++ b/src/rust/cryptography-openssl/src/cmac.rs
@@ -5,6 +5,7 @@
 use std::ptr;
 
 use foreign_types_shared::{ForeignType, ForeignTypeRef};
+use openssl_sys as ffi;
 
 use crate::hmac::DigestBytes;
 use crate::{cvt, cvt_p, OpenSSLResult};

--- a/src/rust/cryptography-openssl/src/fips.rs
+++ b/src/rust/cryptography-openssl/src/fips.rs
@@ -2,6 +2,9 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+#[cfg(not(any(CRYPTOGRAPHY_IS_LIBRESSL, CRYPTOGRAPHY_IS_BORINGSSL)))]
+use openssl_sys as ffi;
+
 #[cfg(CRYPTOGRAPHY_OPENSSL_300_OR_GREATER)]
 use crate::{cvt, OpenSSLResult};
 #[cfg(all(

--- a/src/rust/cryptography-openssl/src/hmac.rs
+++ b/src/rust/cryptography-openssl/src/hmac.rs
@@ -5,6 +5,7 @@
 use std::ptr;
 
 use foreign_types_shared::{ForeignType, ForeignTypeRef};
+use openssl_sys as ffi;
 
 use crate::{cvt, cvt_p, OpenSSLResult};
 
@@ -92,6 +93,7 @@ impl std::ops::Deref for DigestBytes {
 #[cfg(test)]
 mod tests {
     use super::DigestBytes;
+    use openssl_sys as ffi;
 
     #[test]
     fn test_digest_bytes() {

--- a/src/rust/cryptography-openssl/src/poly1305.rs
+++ b/src/rust/cryptography-openssl/src/poly1305.rs
@@ -4,6 +4,8 @@
 
 use std::mem::MaybeUninit;
 
+use openssl_sys as ffi;
+
 pub struct Poly1305State {
     // The state data must be allocated in the heap so that its address does not change. This is
     // because BoringSSL APIs that take a `poly1305_state*` ignore all the data before an aligned


### PR DESCRIPTION
Annoyingly matching is done on the crate name, not the package name, so renaming a workspace dep doesn't work.