### PR TITLE
Allow passing around user data inside a Policy object.

### DIFF
--- a/src/rust/cryptography-x509-verification/src/certificate.rs
+++ b/src/rust/cryptography-x509-verification/src/certificate.rs
@@ -55,6 +55,7 @@ Xw4nMqk=
         type Key = ();
         type Err = ();
         type CertificateExtra = ();
+        type PolicyExtra = ();
 
         fn public_key(&self, _cert: &Certificate<'_>) -> Result<Self::Key, Self::Err> {
             // Simulate failing to retrieve a public key.

--- a/src/rust/cryptography-x509-verification/src/ops.rs
+++ b/src/rust/cryptography-x509-verification/src/ops.rs
@@ -72,6 +72,9 @@ pub trait CryptoOps {
     /// Extra data that's passed around with the certificate.
     type CertificateExtra;
 
+    /// Extra data that's accessible alongside the PolicyDefinition.
+    type PolicyExtra;
+
     /// Extracts the public key from the given `Certificate` in
     /// a `Key` format known by the cryptographic backend, or `None`
     /// if the key is malformed.

--- a/src/rust/cryptography-x509-verification/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/extension.rs
@@ -552,7 +552,7 @@ mod tests {
     use crate::certificate::tests::PublicKeyErrorOps;
     use crate::ops::tests::{cert, v1_cert_pem};
     use crate::ops::CryptoOps;
-    use crate::policy::{Policy, Subject, ValidationResult};
+    use crate::policy::{Policy, PolicyDefinition, Subject, ValidationResult};
     use crate::types::DNSName;
 
     #[test]
@@ -602,12 +602,13 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::server(
+        let policy_def = PolicyDefinition::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
             None,
         );
+        let policy = Policy::new(&policy_def, ());
 
         // Test a policy that stipulates that a given extension MUST be present.
         let extension_validator =
@@ -642,12 +643,13 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::server(
+        let policy_def = PolicyDefinition::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
             None,
         );
+        let policy = Policy::new(&policy_def, ());
 
         // Test a validator that stipulates that a given extension CAN be present.
         let extension_validator = ExtensionValidator::maybe_present(
@@ -676,12 +678,13 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::server(
+        let policy_def = PolicyDefinition::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
             None,
         );
+        let policy = Policy::new(&policy_def, ());
 
         // Test a validator that stipulates that a given extension MUST NOT be present.
         let extension_validator = ExtensionValidator::not_present();
@@ -707,12 +710,13 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::server(
+        let policy_def = PolicyDefinition::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
             None,
         );
+        let policy = Policy::new(&policy_def, ());
 
         // Test a present policy that stipulates that a given extension MUST be critical.
         let extension_validator =
@@ -736,12 +740,13 @@ mod tests {
         let cert_pem = v1_cert_pem();
         let cert = cert(&cert_pem);
         let ops = PublicKeyErrorOps {};
-        let policy = Policy::server(
+        let policy_def = PolicyDefinition::server(
             ops,
             Subject::DNS(DNSName::new("example.com").unwrap()),
             epoch(),
             None,
         );
+        let policy = Policy::new(&policy_def, ());
 
         // Test a maybe present validator that stipulates that a given extension MUST be critical.
         let extension_validator = ExtensionValidator::maybe_present(


### PR DESCRIPTION
As discussed here https://github.com/pyca/cryptography/pull/12360#discussion_r1938330310
This PR is mostly changes to the `cryptography-x509-verification` module. I will do the `PyPolicy` implementation and attribute moving next.