### PR TITLE
Docs: Modernize password key derivation advice

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -221,7 +221,8 @@ Using passwords with Fernet
 
 It is possible to use passwords with Fernet. To do this, you need to run the
 password through a key derivation function such as
-:class:`~cryptography.hazmat.primitives.kdf.pbkdf2.PBKDF2HMAC`, bcrypt or
+:class:`~cryptography.hazmat.primitives.kdf.pbkdf2.PBKDF2HMAC`,
+:class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id` or
 :class:`~cryptography.hazmat.primitives.kdf.scrypt.Scrypt`.
 
 .. doctest::


### PR DESCRIPTION
I was just reading https://n0rdy.foo/posts/20250121/okta-bcrypt-lessons-for-better-apis/ which talks about dangerous APIs for bcrypt (i.e. silent truncation of inputs).

pyca/cryptography does not support bcrypt and therefore has no such issues, but the Fernet docs do mention bcrypt off-hand as a password key derivation mechanism. If someone followed this implicit advice, they might end up using a library with a dangerous API (per the article), which would of course be counter to the goals of Fernet.

So, I just made a quick edit to name Argon2id instead.