### PR TITLE
ExtensionPolicy changes required for Python callback support.

### DIFF
--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -463,7 +463,7 @@ impl<'a, 'chain, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
         let leaf_extensions = leaf.certificate().extensions()?;
 
         self.policy
-            .permits_ee(leaf.certificate(), &leaf_extensions)
+            .permits_ee(leaf, &leaf_extensions)
             .map_err(|e| e.set_cert(leaf.clone()))?;
 
         let mut chain = self.build_chain_inner(

--- a/src/rust/cryptography-x509-verification/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/extension.rs
@@ -18,7 +18,6 @@ use crate::{
     ops::CryptoOps, policy::Policy, ValidationError, ValidationErrorKind, ValidationResult,
 };
 
-#[derive(Clone)]
 pub struct ExtensionPolicy<'cb, B: CryptoOps> {
     pub authority_information_access: ExtensionValidator<'cb, B>,
     pub authority_key_identifier: ExtensionValidator<'cb, B>,
@@ -31,27 +30,6 @@ pub struct ExtensionPolicy<'cb, B: CryptoOps> {
 }
 
 impl<'cb, B: CryptoOps + 'cb> ExtensionPolicy<'cb, B> {
-    pub fn new_permit_all() -> Self {
-        const fn make_permissive_validator<'cb, B: CryptoOps + 'cb>() -> ExtensionValidator<'cb, B>
-        {
-            ExtensionValidator::MaybePresent {
-                criticality: Criticality::Agnostic,
-                validator: None,
-            }
-        }
-
-        ExtensionPolicy {
-            authority_information_access: make_permissive_validator(),
-            authority_key_identifier: make_permissive_validator(),
-            subject_key_identifier: make_permissive_validator(),
-            key_usage: make_permissive_validator(),
-            subject_alternative_name: make_permissive_validator(),
-            basic_constraints: make_permissive_validator(),
-            name_constraints: make_permissive_validator(),
-            extended_key_usage: make_permissive_validator(),
-        }
-    }
-
     pub fn new_default_webpki_ca() -> Self {
         ExtensionPolicy {
             // 5280 4.2.2.1: Authority Information Access
@@ -238,7 +216,6 @@ impl<'cb, B: CryptoOps + 'cb> ExtensionPolicy<'cb, B> {
 }
 
 /// Represents different criticality states for an extension.
-#[derive(Clone)]
 pub enum Criticality {
     /// The extension MUST be marked as critical.
     Critical,
@@ -283,7 +260,6 @@ pub type MaybeExtensionValidatorCallback<'cb, B> = Arc<
 >;
 
 /// Represents different validation states for an extension.
-#[derive(Clone)]
 pub enum ExtensionValidator<'cb, B: CryptoOps> {
     /// The extension MUST NOT be present.
     NotPresent,

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -25,7 +25,10 @@ use cryptography_x509::oid::{
 use once_cell::sync::Lazy;
 
 use crate::ops::CryptoOps;
-use crate::policy::extension::ExtensionPolicy;
+pub use crate::policy::extension::{
+    Criticality, ExtensionPolicy, ExtensionValidator, MaybeExtensionValidatorCallback,
+    PresentExtensionValidatorCallback,
+};
 use crate::types::{DNSName, DNSPattern, IPAddress};
 use crate::{ValidationError, ValidationErrorKind, ValidationResult, VerificationCertificate};
 
@@ -230,11 +233,11 @@ pub struct PolicyDefinition<'a, B: CryptoOps> {
     /// algorithm identifiers.
     pub permitted_signature_algorithms: Arc<HashSet<AlgorithmIdentifier<'a>>>,
 
-    ca_extension_policy: ExtensionPolicy<B>,
-    ee_extension_policy: ExtensionPolicy<B>,
+    ca_extension_policy: ExtensionPolicy<'a, B>,
+    ee_extension_policy: ExtensionPolicy<'a, B>,
 }
 
-impl<'a, B: CryptoOps> PolicyDefinition<'a, B> {
+impl<'a, B: CryptoOps + 'a> PolicyDefinition<'a, B> {
     fn new(
         ops: B,
         subject: Option<Subject<'a>>,

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -376,11 +376,11 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
     /// Checks whether the given CA certificate is compatible with this policy.
     pub(crate) fn permits_ca<'chain>(
         &self,
-        cert: &Certificate<'chain>,
+        cert: &VerificationCertificate<'chain, B>,
         current_depth: u8,
         extensions: &Extensions<'_>,
     ) -> ValidationResult<'chain, (), B> {
-        self.permits_basic(cert)?;
+        self.permits_basic(cert.certificate())?;
 
         // 5280 4.1.2.6: Subject
         // CA certificates MUST have a subject populated with a non-empty distinguished name.
@@ -416,10 +416,10 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
     /// Checks whether the given EE certificate is compatible with this policy.
     pub(crate) fn permits_ee<'chain>(
         &self,
-        cert: &Certificate<'chain>,
+        cert: &VerificationCertificate<'chain, B>,
         extensions: &Extensions<'_>,
     ) -> ValidationResult<'chain, (), B> {
-        self.permits_basic(cert)?;
+        self.permits_basic(cert.certificate())?;
 
         self.ee_extension_policy.permits(self, cert, extensions)?;
 
@@ -447,7 +447,7 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
         issuer_extensions: &Extensions<'_>,
     ) -> ValidationResult<'chain, (), B> {
         // The issuer needs to be a valid CA at the current depth.
-        self.permits_ca(issuer.certificate(), current_depth, issuer_extensions)
+        self.permits_ca(issuer, current_depth, issuer_extensions)
             .map_err(|e| e.set_cert(issuer.clone()))?;
 
         // CA/B 7.1.3.1 SubjectPublicKeyInfo


### PR DESCRIPTION
Should be merged after #12416, will rebase if there are any changes there. Creating as draft for now.

This PR changes the validator callback types to allow storing python callbacks in them. 
The callback types have to be `Send` and `Sync` to allow the `ExtensionPolicy` to be stored inside a `PyExtensionPolicy` pyclass. They are  `Arc` to be able to clone the `ExtensionPolicy`, which is required for the builder-style API of `PyExtensionPolicy`.

Hopefully this makes sense on it's own. I was originally going to include this as part of a larger PR adding all the functionality required to expose extension policies to python, but that was getting too big. 