### PR TITLE
refactor: Split SafeBag serialization into its own function for PKCS#12 structures.

### DIFF
--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -413,10 +413,11 @@ fn serialize_bags<'p>(
         let mut plain_safebags = vec![];
         for safebag in safebags {
             match safebag.bag_value.as_inner() {
-                cryptography_x509::pkcs12::BagValue::ShroudedKeyBag(_) => &mut shrouded_safebags,
-                _ => &mut plain_safebags,
+                cryptography_x509::pkcs12::BagValue::ShroudedKeyBag(_) => {
+                    shrouded_safebags.push(safebag)
+                }
+                _ => plain_safebags.push(safebag),
             }
-            .push(safebag);
         }
         if !plain_safebags.is_empty() {
             plain_safebag_contents =


### PR DESCRIPTION
This PR covers the refactoring required for #12393, which mostly involves splitting the safebag serialization out of `serialize_key_and_certificates`.

## Summary

The PKCS#12 format contains an `AuthenticatedSafe` which holds a collection of `ContentInfo` objects. Each of these `ContentInfo` objects may or maynot be encrypted, and will (typically) hold one or more `SafeBags`. These `SafeBags` are where the actual content of the PKCS#12 file is held, and in the context of this library will either be a certificate (`CertBag`) or private key (`KeyBag` or `ShroudedKeyBag`).

As it stands, `serialize_key_and_certificates` (in `pkcs12.rs`) performs the majority of roles in the serialization process.
If encryption is enabled, the process looks like this:
1. `serialize_key_and_certificates` takes in collections of keys and certificates.
2. Each certificate is placed in a CertBag, and the bags are placed in an encrypted ContentInfo.
3. Each key is placed in a ShroudedKeyBag (encrypted), and the bags are placed in an unencrypted ContentInfo (to avoid re-encryption)
4. All ContentInfo are added to the primary PKU structure and serialized.

If encryption is not enabled, the process is similar:
1. `serialize_key_and_certificates` takes in collections of keys and certificates.
2. Each certificate is placed in a CertBag, and the bags are placed in an unencrypted ContentInfo.
3. Each key is placed in a KeyBag (unencrypted), and the bags are placed in an unencrypted ContentInfo
4. All ContentInfo are added to the primary PKU structure and serialized.

The goal of this PR is to let `serialize_key_and_certificates` focus on just the SafeBag aspect of the process. Once it gathers all of its SafeBags, it will hand them off to a new function (`serialize_bags`) which will determine the appropriate structuring and serialization process. By making this change, new functions may be added which create more specialized collections of SafeBags, without duplicating the logic of `serialize_key_and_certificates` more than necessary.

## Implementation

As noted above, the main change here is a new `serialize_bags` method. While the overall logic is very similar to what it was before the refactoring, I did want to touch on how this method actually functions, given that it accepts a single slice of bags.

Previously, SafeBags were separated by keys and certificates. This was useful as, with encryption enabled, the keys would be placed into ShroudedKeyBags which were not to be re-encrypted. However, this separation was occurring regardless of whether encryption was enabled. With the new, more generic `serialize_bags`, I found it made more sense to instead accept a single list of bags and only split apart ShroudedKeyBags if encryption was enabled. This way the function arguments stay simple and caller wouldn't need to worry about how the bags were being handled- simply that they needed to be provided.

Under the refactoring, the process looks like this:
1. `serialize_key_and_certificates` takes in collections of keys and certificates.
2. Each certificate is placed in a CertBag.
3. Each key is placed in a KeyBag (unencrypted) or ShroudedKeyBag (encrypted)
4. All SafeBags are handed to `serialize_bags` for final serialization.
5a. If encryption is disabled, `serialize_bags` groups all SafeBags together and serializes them under a single ContentInfo.
5b. If encryption is enabled, `serialize_bags` groups ShroudedKeyBags into their own unencrypted ContentInfo, and the remaining bags into an encrypted ContentInfo.
6. All ContentInfo are added to the primary PKU structure and serialized.