### PR TITLE
Fix weird wording in ExtensionPolicy documentation.

### DIFF
--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -331,27 +331,26 @@ the root of trust:
 
     .. staticmethod:: permit_all()
 
-        Creates an ExtensionPolicy initialized with a policy that does 
-        not put any constraints on a certificate's extensions. 
+        Creates an ExtensionPolicy that does not put any constraints on a certificate's extensions. 
         This can serve as a base for a fully custom extension policy.
 
         :returns: An instance of :class:`ExtensionPolicy`
 
     .. staticmethod:: webpki_defaults_ca()
 
-        Creates an ExtensionPolicy initialized with a 
-        CA extension policy based on CA/B Forum guidelines.
+        Creates an ExtensionPolicy for CA certificates,
+        based on CA/B Forum guidelines.
 
-        This is the CA extension policy used by :class:`PolicyBuilder`.
+        This is the default CA extension policy used by :class:`PolicyBuilder`.
 
         :returns: An instance of :class:`ExtensionPolicy`
 
     .. staticmethod:: webpki_defaults_ee()
 
-        Creates an ExtensionPolicy initialized with an
-        EE extension policy based on CA/B Forum guidelines.
+        Creates an ExtensionPolicy for EE certificates,
+        based on CA/B Forum guidelines.
 
-        This is the EE extension policy used by :class:`PolicyBuilder`.
+        This is the default EE extension policy used by :class:`PolicyBuilder`.
 
         :returns: An instance of :class:`ExtensionPolicy`
 


### PR DESCRIPTION
I was just looking through the docs and noticed that some `ExtensionPolicy` method descriptions were still formulated as if it was called `ExtensionPolicyBuilder`.