### PR TITLE
enable test contexts

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -88,6 +88,7 @@ def tests(session: nox.Session) -> None:
         cov_args = [
             "--cov=cryptography",
             "--cov=tests",
+            "--cov-context=test",
         ]
     else:
         cov_args = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,9 @@ exclude_lines = [
     "if typing.TYPE_CHECKING",
 ]
 
+[tool.coverage.html]
+show_contexts = true
+
 [tool.ruff]
 line-length = 79
 


### PR DESCRIPTION
this allows us to see what tests exercised what lines of code