### PR TITLE
Resolve new nightly clippy warning

### DIFF
--- a/src/rust/cryptography-x509/src/pkcs12.rs
+++ b/src/rust/cryptography-x509/src/pkcs12.rs
@@ -55,7 +55,7 @@ pub enum AttributeSet<'a> {
 #[derive(asn1::Asn1DefinedByWrite)]
 pub enum BagValue<'a> {
     #[defined_by(CERT_BAG_OID)]
-    CertBag(CertBag<'a>),
+    CertBag(Box<CertBag<'a>>),
 
     #[defined_by(KEY_BAG_OID)]
     KeyBag(asn1::Tlv<'a>),

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -285,14 +285,14 @@ fn cert_to_bag<'a>(
 ) -> CryptographyResult<cryptography_x509::pkcs12::SafeBag<'a>> {
     Ok(cryptography_x509::pkcs12::SafeBag {
         _bag_id: asn1::DefinedByMarker::marker(),
-        bag_value: asn1::Explicit::new(cryptography_x509::pkcs12::BagValue::CertBag(
+        bag_value: asn1::Explicit::new(cryptography_x509::pkcs12::BagValue::CertBag(Box::new(
             cryptography_x509::pkcs12::CertBag {
                 _cert_id: asn1::DefinedByMarker::marker(),
                 cert_value: asn1::Explicit::new(cryptography_x509::pkcs12::CertType::X509(
                     asn1::OctetStringEncoded::new(cert.raw.borrow_dependent().clone()),
                 )),
             },
-        )),
+        ))),
         attributes: pkcs12_attributes(friendly_name, local_key_id)?,
     })
 }


### PR DESCRIPTION
Move `CertBag` into a `Box` because it is significantly larger than the other enum variants