### PR TITLE
Free threaded support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
         run: |
           .nox/local/bin/python -m ensurepip
           .nox/local/bin/python -m pip install git+https://github.com/colesbury/cffi@ft
+          echo "PYTHON_GIL=0" >> $GITHUB_ENV
       - name: Tests
         run: |
             nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo ${{ matrix.PYTHON.NOXARGS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           - {VERSION: "3.12", NOXSESSION: "rust,tests", RUST: "beta"}
           - {VERSION: "3.12", NOXSESSION: "rust,tests", RUST: "nightly"}
           - {VERSION: "3.12", NOXSESSION: "tests-rust-debug"}
+          - {VERSION: "3.13t", NOXSESSION: "local"}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -63,7 +64,16 @@ jobs:
           persist-credentials: false
       - name: Setup python
         id: setup-python
+        if: matrix.PYTHON.VERSION != '3.13t'
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: ${{ matrix.PYTHON.VERSION }}
+          cache: pip
+          cache-dependency-path: ci-constraints-requirements.txt
+        timeout-minutes: 3
+      - name: Setup python (free-threaded)
+        if: matrix.PYTHON.VERSION == '3.13t'
+        uses: quansight-labs/setup-python@869aeafb7eeb9dc48ba68acc0479e6fc3fd7ce5e # 5.4.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           cache: pip
@@ -134,6 +144,12 @@ jobs:
             nox -v --install-only
         env:
           NOXSESSION: ${{ matrix.PYTHON.NOXSESSION }}
+      - name: override cffi version in free-threaded environment
+        if: matrix.PYTHON.VERSION == '3.13t'
+        # FIXME FIXME total hack
+        run: |
+          .nox/local/bin/python -m ensurepip
+          .nox/local/bin/python -m pip install git+https://github.com/colesbury/cffi@ft
       - name: Tests
         run: |
             nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo ${{ matrix.PYTHON.NOXARGS }}

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -78,8 +78,15 @@ fn main() {
         build.include(python_include);
     }
 
-    // Enable abi3 mode if we're not using PyPy.
-    if python_impl != "PyPy" {
+    let is_free_threaded = run_python_script(
+        &python,
+        "import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')), end='')",
+    )
+    .unwrap()
+        == "True";
+
+    // Enable abi3 mode if we're not using PyPy or the free-threaded build
+    if !(python_impl == "PyPy" || is_free_threaded) {
         // cp37 (Python 3.7 to help our grep when we some day drop 3.7 support)
         build.define("Py_LIMITED_API", "0x030700f0");
     }

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -248,7 +248,7 @@ class TestANSIX923:
 @pytest.mark.parametrize("algorithm", [padding.PKCS7, padding.ANSIX923])
 def test_multithreaded_padding(algorithm):
     switch_default = sys.getswitchinterval()
-    sys.setswitchinterval(.0000001)
+    sys.setswitchinterval(0.0000001)
     num_threads = 4
     padder = algorithm(num_threads * 256).padder()
     validate_padder = algorithm(num_threads * 256).padder()

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -245,7 +245,18 @@ class TestANSIX923:
         assert final == unpadded + unpadded
 
 
-@pytest.mark.parametrize("algorithm", [padding.PKCS7, padding.ANSIX923])
+@pytest.mark.parametrize(
+    "algorithm",
+    [
+        padding.PKCS7,
+        pytest.param(
+            padding.ANSIX923,
+            marks=pytest.mark.xfail(
+                reason="Python implementation of ANSIX923 is not thread-safe"
+            ),
+        ),
+    ],
+)
 def test_multithreaded_padding(algorithm):
     switch_default = sys.getswitchinterval()
     sys.setswitchinterval(0.0000001)


### PR DESCRIPTION
Towards fixing #12489.

Adds free-threaded CI using a hacky workaround to avoid building against the version of cffi on PyPI.

Also adds multithreaded tests for hashing and padding. The padding test is marked as xfail for `ANSIX923` because of #12553.