### PR TITLE
Hopefully add Window / MacOS PyPy 3.10 / 3.11 support

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -204,6 +204,11 @@ jobs:
             DEPLOYMENT_TARGET: '10.13'
             _PYTHON_HOST_PLATFORM: 'macosx-10.9-x86_64'
             ARCHFLAGS: '-arch x86_64'
+          - VERSION: 'pypy-3.11'
+            BIN_PATH: 'pypy3'
+            DEPLOYMENT_TARGET: '10.13'
+            _PYTHON_HOST_PLATFORM: 'macosx-10.9-x86_64'
+            ARCHFLAGS: '-arch x86_64'
     name: "${{ matrix.PYTHON.VERSION }} ABI ${{ matrix.PYTHON.ABI_VERSION }} macOS ${{ matrix.PYTHON.ARCHFLAGS }}"
     steps:
       - name: Get build-requirements.txt from repository
@@ -291,10 +296,13 @@ jobs:
           - {VERSION: "3.11", "ABI_VERSION": "py37"}
           - {VERSION: "3.11", "ABI_VERSION": "py39"}
           - {VERSION: "pypy-3.10"}
+          - {VERSION: "pypy-3.11"}
         exclude:
           # We need to exclude the below configuration because there is no 32-bit pypy3
           - WINDOWS: {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc'}
             PYTHON: {VERSION: "pypy-3.10"}
+          - WINDOWS: {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc'}
+            PYTHON: {VERSION: "pypy-3.11"}
     name: "${{ matrix.PYTHON.VERSION }} ${{ matrix.WINDOWS.WINDOWS }} ${{ matrix.PYTHON.ABI_VERSION }}"
     steps:
       - name: Get build-requirements.txt from repository

--- a/src/rust/cryptography-x509/src/pkcs12.rs
+++ b/src/rust/cryptography-x509/src/pkcs12.rs
@@ -55,7 +55,7 @@ pub enum AttributeSet<'a> {
 #[derive(asn1::Asn1DefinedByWrite)]
 pub enum BagValue<'a> {
     #[defined_by(CERT_BAG_OID)]
-    CertBag(CertBag<'a>),
+    CertBag(Box<CertBag<'a>>),
 
     #[defined_by(KEY_BAG_OID)]
     KeyBag(asn1::Tlv<'a>),

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -386,14 +386,14 @@ fn cert_to_bag<'a>(
 ) -> CryptographyResult<cryptography_x509::pkcs12::SafeBag<'a>> {
     Ok(cryptography_x509::pkcs12::SafeBag {
         _bag_id: asn1::DefinedByMarker::marker(),
-        bag_value: asn1::Explicit::new(cryptography_x509::pkcs12::BagValue::CertBag(
+        bag_value: asn1::Explicit::new(cryptography_x509::pkcs12::BagValue::CertBag(Box::new(
             cryptography_x509::pkcs12::CertBag {
                 _cert_id: asn1::DefinedByMarker::marker(),
                 cert_value: asn1::Explicit::new(cryptography_x509::pkcs12::CertType::X509(
                     asn1::OctetStringEncoded::new(cert.raw.borrow_dependent().clone()),
                 )),
             },
-        )),
+        ))),
         attributes: pkcs12_attributes(friendly_name, local_key_id)?,
     })
 }


### PR DESCRIPTION
This PR adds wheels for Windows and MacOS for PyPy 3.11.
I also took the liberty to improve a little bit the `exclude` section in the CI in order to spare some useless runs. 🙏

There is 1 workflow that is failing, the linux+py3.12+rust-nightly, which I'm guessing is because of the rust-nightly (?).