### PR TITLE
feat(repo): Be more strict in the cffi compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "maturin>=1,<2",
 
     # Must be kept in sync with `project.dependencies`
-    "cffi>=1.12; platform_python_implementation != 'PyPy'",
+    "cffi>=1.14; platform_python_implementation != 'PyPy'",
     # Used by cffi (which import distutils, and in Python 3.12, distutils has
     # been removed from the stdlib, but installing setuptools puts it back) as
     # well as our build.rs for the rust/cffi bridge.
@@ -50,7 +50,7 @@ classifiers = [
 requires-python = ">=3.7,!=3.9.0,!=3.9.1"
 dependencies = [
     # Must be kept in sync with `build-system.requires`
-    "cffi>=1.12; platform_python_implementation != 'PyPy'",
+    "cffi>=1.14; platform_python_implementation != 'PyPy'",
 ]
 
 [project.urls]


### PR DESCRIPTION
Testing uv in aother project with the option
`--resolution lowest`
showed that current python versions would not work at all with the minimum required version of cffi, 1.12.

This has very likely no impact on production systems, but it empowers other projects to validate that the minimum requirements of themselves and their dependencies are correct.

I have tested these version specifiers by fiddling with pyproject.toml and uv sync.
As soon as the Python version compiled with the minor version, I updated the dependency specification.
I have not run the nox tests. It didn´t work, and I started to do something on my blog end ended up writing PRs to the cryptography project. I am trying to force myself to limit my yak shaving at least a bit.

I have tried to figure out, why I get compilation errors with, for example, python 3.10 and cffi 1.13, but looking for the error I got in the cffi repo, I did not find any results. I presume that this means that the problem I am solving does not really exist in production installations.