### PR TITLE
Update recommended PBKDF2HMAC iteration counts

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -238,7 +238,7 @@ password through a key derivation function such as
     ...     algorithm=hashes.SHA256(),
     ...     length=32,
     ...     salt=salt,
-    ...     iterations=1_000_000,
+    ...     iterations=1_200_000,
     ... )
     >>> key = base64.urlsafe_b64encode(kdf.derive(password))
     >>> f = Fernet(key)
@@ -252,7 +252,7 @@ In this scheme, the salt has to be stored in a retrievable location in order
 to derive the same key from the password in the future.
 
 The iteration count used should be adjusted to be as high as your server can
-tolerate. A good default is at least 1,000,000 iterations, which is what `Django
+tolerate. A good default is at least 1,200,000 iterations, which is what `Django
 recommends as of January 2025`_.
 
 Implementation

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -162,7 +162,7 @@ PBKDF2
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     salt=salt,
-        ...     iterations=1_000_000,
+        ...     iterations=1_200_000,
         ... )
         >>> key = kdf.derive(b"my great password")
         >>> # verify
@@ -170,7 +170,7 @@ PBKDF2
         ...     algorithm=hashes.SHA256(),
         ...     length=32,
         ...     salt=salt,
-        ...     iterations=1_000_000,
+        ...     iterations=1_200_000,
         ... )
         >>> kdf.verify(b"my great password", key)
 


### PR DESCRIPTION
This updates the docs to reflect the current default of 1,200,000 iterations as used by Django in the [referenced code location](https://github.com/django/django/blob/955b7c6ba105b328f387a9d63540dbabd4a05828/django/contrib/auth/hashers.py#L321) (changed on 2025-01-15).