### PR TITLE
pyo3: bump version to v0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.65.0"
 
 [workspace.dependencies]
 asn1 = { version = "0.20.0", default-features = false }
-pyo3 = { version = "0.23.5", features = ["abi3"] }
+pyo3 = { version = "0.24.0", features = ["abi3"] }
 openssl = "0.10.71"
 openssl-sys = "0.9.104"
 


### PR DESCRIPTION
pyo3 version prior to 0.24.0 are not able to parse
properly exotic python version. This is fix since
https://github.com/PyO3/pyo3/pull/4949 available on the
v0.24.0 version
