### PR TITLE
Make wycheproof x25519 and x448 tests more flexible

### DIFF
--- a/tests/wycheproof/test_x25519.py
+++ b/tests/wycheproof/test_x25519.py
@@ -20,10 +20,8 @@ from .utils import wycheproof_tests
 )
 @wycheproof_tests("x25519_test.json")
 def test_x25519(backend, wycheproof):
-    assert set(wycheproof.testgroup.items()) == {
-        ("curve", "curve25519"),
-        ("type", "XdhComp"),
-    }
+    assert wycheproof.testgroup["curve"] == "curve25519"
+    assert wycheproof.testgroup["type"] = "XdhComp"
 
     private_key = X25519PrivateKey.from_private_bytes(
         binascii.unhexlify(wycheproof.testcase["private"])

--- a/tests/wycheproof/test_x448.py
+++ b/tests/wycheproof/test_x448.py
@@ -20,10 +20,8 @@ from .utils import wycheproof_tests
 )
 @wycheproof_tests("x448_test.json")
 def test_x448(backend, wycheproof):
-    assert set(wycheproof.testgroup.items()) == {
-        ("curve", "curve448"),
-        ("type", "XdhComp"),
-    }
+    assert wycheproof.testgroup["curve"] == "curve448"
+    assert wycheproof.testgroup["type"] = "XdhComp"
 
     private_key = X448PrivateKey.from_private_bytes(
         binascii.unhexlify(wycheproof.testcase["private"])


### PR DESCRIPTION
Needed due to additional `"source"` field seen in https://github.com/pyca/cryptography/pull/12675