### PR TITLE
friendlier error message converting a string to a buffer

### DIFF
--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -4,7 +4,9 @@
 
 use std::slice;
 
+use pyo3::exceptions::PyTypeError;
 use pyo3::types::{IntoPyDict, PyAnyMethods};
+use pyo3::PyErr;
 
 use crate::types;
 
@@ -19,6 +21,13 @@ fn _extract_buffer_length<'p>(
     mutable: bool,
 ) -> pyo3::PyResult<(pyo3::Bound<'p, pyo3::PyAny>, usize)> {
     let py = pyobj.py();
+    if pyobj.is_instance_of::<pyo3::types::PyString>() {
+        return Err(PyErr::new::<PyTypeError, _>(
+            "\n\
+             Cannot create a buffer from a string.\n\
+             Did you mean to pass a bytestring instead?",
+        ));
+    }
     let bufobj = if mutable {
         let kwargs = [(pyo3::intern!(py, "require_writable"), true)].into_py_dict(py)?;
         types::FFI_FROM_BUFFER

--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -30,11 +30,11 @@ fn _extract_buffer_length<'p>(
     .map_err(|_| {
         let errmsg = if pyobj.is_instance_of::<pyo3::types::PyString>() {
             format!(
-                "\nCannot convert \"{}\" instance to a buffer.\nDid you mean to pass a bytestring instead?",
+                "Cannot convert \"{}\" instance to a buffer.\nDid you mean to pass a bytestring instead?",
                 pyobj.get_type()
             )
         } else {
-            format!("\nCannot convert \"{}\" instance to a buffer.", pyobj.get_type())
+            format!("Cannot convert \"{}\" instance to a buffer.", pyobj.get_type())
         };
         pyo3::exceptions::PyTypeError::new_err(errmsg)
     })?;

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -250,6 +250,13 @@ class TestCipherUpdateInto:
         with pytest.raises(ValueError):
             encryptor.update_into(b"testing", buf)
 
+    def test_update_with_string(self, backend):
+        key = b"\x00" * 16
+        c = ciphers.Cipher(AES(key), modes.GCM(b"\x00" * 12), backend)
+        encryptor = c.encryptor()
+        with pytest.raises(TypeError, match="bytestring instead?"):
+            encryptor.update("hello")  # type: ignore[arg-type]
+
 
 @pytest.mark.skipif(
     sys.platform not in {"linux", "darwin"}, reason="mmap required"

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -250,7 +250,7 @@ class TestCipherUpdateInto:
         with pytest.raises(ValueError):
             encryptor.update_into(b"testing", buf)
 
-    def test_update_with_string(self, backend):
+    def test_update_with_invalid_type(self, backend):
         key = b"\x00" * 16
         c = ciphers.Cipher(AES(key), modes.GCM(b"\x00" * 12), backend)
         encryptor = c.encryptor()

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -256,6 +256,8 @@ class TestCipherUpdateInto:
         encryptor = c.encryptor()
         with pytest.raises(TypeError, match="bytestring instead?"):
             encryptor.update("hello")  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="instance to a buffer"):
+            encryptor.update(object)  # type: ignore[arg-type]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Consider this script:

```
import os

from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes

key = os.urandom(32)
iv = os.urandom(16)
cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
encryptor = cipher.encryptor()

encryptor.update('abcd1234')
```

Running it will generate this error right now:

```
Traceback (most recent call last):
  File "/Users/goldbaum/Documents/test/test2.py", line 10, in <module>
    encryptor.update('abcd1234')
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^
TypeError: argument 'data': from_buffer() cannot return the address of a unicode object
```

This error message has confused users in the past. See [here](https://stackoverflow.com/questions/59766666/typeerror-from-buffer-cannot-return-the-address-of-a-unicode-object), [here](https://github.com/pyca/cryptography/issues/10529), and [here](https://github.com/pyca/cryptography/issues/6687).

When I hit this I got to the correct solution quickly, but the fact that `from_buffer` isn't a function in user code threw me for a loop. 

We can also suggest the correct solution for what is IMO 99% of use-cases as well:

```
Traceback (most recent call last):
  File "/Users/goldbaum/Documents/test/test2.py", line 10, in <module>
    encryptor.update('abcd1234')
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^
TypeError: argument 'data':
Cannot convert "<class 'str'>" instance to a buffer.
Did you mean to pass a bytestring instead?
```