### PR TITLE
CRL hash algorithm getter breaks with PSS padding

### DIFF
--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -196,15 +196,11 @@ impl CertificateRevocationList {
     fn signature_hash_algorithm<'p>(
         &self,
         py: pyo3::Python<'p>,
-    ) -> pyo3::PyResult<pyo3::Bound<'p, pyo3::PyAny>> {
-        let oid = self.signature_algorithm_oid(py)?;
-        match types::SIG_OIDS_TO_HASH.get(py)?.get_item(oid) {
-            Ok(v) => Ok(v),
-            Err(_) => Err(exceptions::UnsupportedAlgorithm::new_err(format!(
-                "Signature algorithm OID: {} not recognized",
-                self.owned.borrow_dependent().signature_algorithm.oid()
-            ))),
-        }
+    ) -> Result<pyo3::Bound<'p, pyo3::PyAny>, CryptographyError> {
+        sign::identify_signature_hash_algorithm(
+            py,
+            &self.owned.borrow_dependent().signature_algorithm,
+        )
     }
 
     #[getter]

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -299,6 +299,7 @@ class TestCertificateRevocationListBuilder:
         crl = builder.sign(private_key, hashes.SHA256(), rsa_padding=pss)
         assert len(crl) == 0
         assert isinstance(crl.signature_algorithm_parameters, padding.PSS)
+        assert isinstance(crl.signature_hash_algorithm, hashes.SHA256)
         assert crl.signature_algorithm_parameters._salt_length == 32
         private_key.public_key().verify(
             crl.signature,


### PR DESCRIPTION
Calling `crl.signature_hash_algorithm` on a PSS-padded CRL object would result in following exception:
```
cryptography.exceptions.UnsupportedAlgorithm: Signature algorithm OID: 1.2.840.113549.1.1.10 not recognized
```
This PR fixes this issue.