### PR TITLE
fix mitmproxy downstream tests

### DIFF
--- a/.github/downstream.d/mitmproxy.sh
+++ b/.github/downstream.d/mitmproxy.sh
@@ -2,10 +2,11 @@
 
 case "${1}" in
     install)
+        pip install uv
         git clone --depth=1 https://github.com/mitmproxy/mitmproxy
         cd mitmproxy
         git rev-parse HEAD
-        pip install -e ".[dev]"
+        uv pip install --system --group dev -e .
         ;;
     run)
         cd mitmproxy


### PR DESCRIPTION
`pip` apparently doesn't support `--group` yet, so `uv` it is.