### PR TITLE
Add parameter ecdsa_deterministic_signing to x509 sign methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,10 @@ Changelog
   This extension defines the period during which the private key corresponding
   to the certificate's public key may be used.
 * Added support for compiling against `aws-lc`_.
+* Added support for deterministic ECDSA signing via the new keyword-only argument ``ecdsa_deterministic_signing`` in
+  :meth:`~cryptography.x509.CertificateBuilder.sign`,
+  :meth:`~cryptography.x509.CertificateRevocationListBuilder.sign`
+  and :meth:`~cryptography.x509.CertificateSigningRequestBuilder.sign`.
 
 .. _v44-0-2:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1010,7 +1010,7 @@ X.509 Certificate Builder
         
         :return: A new :class:`CertificateBuilder` with the additional extension.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
 
         Sign the certificate using the CA's private key.
 
@@ -1044,6 +1044,16 @@ X.509 Certificate Builder
         :type rsa_padding: ``None``,
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+
+        :param bool ecdsa_deterministic_signing:
+
+            .. versionadded:: 45.0.0
+
+            A Boolean flag defaulting to ``False`` that specifies whether the
+            signing procedure should be deterministic or not, as defined in
+            :rfc:`6979`. This only impacts the signing process, verification is
+            not affected (the verification process is the same for both
+            deterministic and non-deterministic signed messages).
 
         :returns: :class:`~cryptography.x509.Certificate`
 
@@ -1285,7 +1295,7 @@ X.509 Certificate Revocation List Builder
             obtained from an existing CRL or created with
             :class:`~cryptography.x509.RevokedCertificateBuilder`.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
 
         Sign this CRL using the CA's private key.
 
@@ -1319,6 +1329,16 @@ X.509 Certificate Revocation List Builder
         :type rsa_padding: ``None``,
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+
+        :param bool ecdsa_deterministic_signing:
+
+            .. versionadded:: 45.0.0
+
+            A Boolean flag defaulting to ``False`` that specifies whether the
+            signing procedure should be deterministic or not, as defined in
+            :rfc:`6979`. This only impacts the signing process, verification is
+            not affected (the verification process is the same for both
+            deterministic and non-deterministic signed messages).
 
         :returns: :class:`~cryptography.x509.CertificateRevocationList`
 
@@ -1498,7 +1518,7 @@ X.509 CSR (Certificate Signing Request) Builder Object
         :returns: A new
             :class:`~cryptography.x509.CertificateSigningRequestBuilder`.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
 
         :param private_key: The private key
             that will be used to sign the request.  When the request is
@@ -1532,6 +1552,16 @@ X.509 CSR (Certificate Signing Request) Builder Object
         :type rsa_padding: ``None``,
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+
+        :param bool ecdsa_deterministic_signing:
+
+            .. versionadded:: 45.0.0
+
+            A Boolean flag defaulting to ``False`` that specifies whether the
+            signing procedure should be deterministic or not, as defined in
+            :rfc:`6979`. This only impacts the signing process, verification is
+            not affected (the verification process is the same for both
+            deterministic and non-deterministic signed messages).
 
         :returns: A new
             :class:`~cryptography.x509.CertificateSigningRequest`.

--- a/src/cryptography/hazmat/bindings/_rust/x509.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/x509.pyi
@@ -45,18 +45,21 @@ def create_x509_certificate(
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
+    ecdsa_deterministic_signing: bool,
 ) -> x509.Certificate: ...
 def create_x509_csr(
     builder: x509.CertificateSigningRequestBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
+    ecdsa_deterministic_signing: bool,
 ) -> x509.CertificateSigningRequest: ...
 def create_x509_crl(
     builder: x509.CertificateRevocationListBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
+    ecdsa_deterministic_signing: bool,
 ) -> x509.CertificateRevocationList: ...
 
 class Sct:

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -331,6 +331,7 @@ class CertificateSigningRequestBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
+        ecdsa_deterministic_signing: bool = False,
     ) -> CertificateSigningRequest:
         """
         Signs the request using the requestor's private key.
@@ -345,7 +346,11 @@ class CertificateSigningRequestBuilder:
                 raise TypeError("Padding is only supported for RSA keys")
 
         return rust_x509.create_x509_csr(
-            self, private_key, algorithm, rsa_padding
+            self,
+            private_key,
+            algorithm,
+            rsa_padding,
+            ecdsa_deterministic_signing,
         )
 
 
@@ -560,6 +565,7 @@ class CertificateBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
+        ecdsa_deterministic_signing: bool = False,
     ) -> Certificate:
         """
         Signs the certificate using the CA's private key.
@@ -589,7 +595,11 @@ class CertificateBuilder:
                 raise TypeError("Padding is only supported for RSA keys")
 
         return rust_x509.create_x509_certificate(
-            self, private_key, algorithm, rsa_padding
+            self,
+            private_key,
+            algorithm,
+            rsa_padding,
+            ecdsa_deterministic_signing,
         )
 
 
@@ -717,6 +727,7 @@ class CertificateRevocationListBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
+        ecdsa_deterministic_signing: bool = False,
     ) -> CertificateRevocationList:
         if self._issuer_name is None:
             raise ValueError("A CRL must have an issuer name")
@@ -734,7 +745,11 @@ class CertificateRevocationListBuilder:
                 raise TypeError("Padding is only supported for RSA keys")
 
         return rust_x509.create_x509_crl(
-            self, private_key, algorithm, rsa_padding
+            self,
+            private_key,
+            algorithm,
+            rsa_padding,
+            ecdsa_deterministic_signing,
         )
 
 

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -13,7 +13,8 @@ use cryptography_x509::{common, oid, pkcs7};
 use once_cell::sync::Lazy;
 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
 use openssl::pkcs7::Pkcs7;
-use pyo3::types::{PyAnyMethods, PyBytesMethods, PyListMethods};
+use pyo3::types::{PyAnyMethods, PyBool, PyBytesMethods, PyListMethods};
+use pyo3::BoundObject;
 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
 use pyo3::PyTypeInfo;
 
@@ -517,6 +518,7 @@ fn sign_and_serialize<'p>(
                         py_private_key.clone(),
                         py_hash_alg.clone(),
                         rsa_padding.clone(),
+                        PyBool::new(py, false).into_bound().into_any(),
                         &data_with_header,
                     )?,
                 )
@@ -566,6 +568,7 @@ fn sign_and_serialize<'p>(
                         py_private_key.clone(),
                         py_hash_alg.clone(),
                         rsa_padding.clone(),
+                        PyBool::new(py, false).into_bound().into_any(),
                         &signed_data,
                     )?,
                 )

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1000,6 +1000,7 @@ pub(crate) fn create_x509_certificate(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<Certificate> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -1062,6 +1063,7 @@ pub(crate) fn create_x509_certificate(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
+        ecdsa_deterministic_signing.clone(),
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&cryptography_x509::certificate::Certificate {

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -628,6 +628,7 @@ pub(crate) fn create_x509_crl(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<CertificateRevocationList> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -695,6 +696,7 @@ pub(crate) fn create_x509_crl(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
+        ecdsa_deterministic_signing.clone(),
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&crl::CertificateRevocationList {

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -292,6 +292,7 @@ pub(crate) fn create_x509_csr(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<CertificateSigningRequest> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -381,6 +382,7 @@ pub(crate) fn create_x509_csr(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
+        ecdsa_deterministic_signing.clone(),
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&Csr {

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -8,7 +8,8 @@ use cryptography_x509::ocsp_resp::{
     self, OCSPResponse as RawOCSPResponse, SingleResponse, SingleResponse as RawSingleResponse,
 };
 use cryptography_x509::{common, oid};
-use pyo3::types::{PyAnyMethods, PyBytesMethods, PyListMethods};
+use pyo3::types::{PyAnyMethods, PyBool, PyBytesMethods, PyListMethods};
+use pyo3::BoundObject;
 
 use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid, py_uint_to_big_endian_bytes};
 use crate::error::{CryptographyError, CryptographyResult};
@@ -834,6 +835,7 @@ pub(crate) fn create_ocsp_response(
         private_key.clone(),
         hash_algorithm.clone(),
         py.None().into_bound(py),
+        PyBool::new(py, false).into_bound().into_any(),
         &tbs_bytes,
     )?;
 

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -285,6 +285,7 @@ pub(crate) fn sign_data<'p>(
     private_key: pyo3::Bound<'p, pyo3::PyAny>,
     hash_algorithm: pyo3::Bound<'p, pyo3::PyAny>,
     rsa_padding: pyo3::Bound<'p, pyo3::PyAny>,
+    ecdsa_deterministic_signing: pyo3::Bound<'p, pyo3::PyAny>,
     data: &[u8],
 ) -> pyo3::PyResult<PyBackedBytes> {
     let key_type = identify_key_type(py, private_key.clone())?;
@@ -294,7 +295,9 @@ pub(crate) fn sign_data<'p>(
             private_key.call_method1(pyo3::intern!(py, "sign"), (data,))?
         }
         KeyType::Ec => {
-            let ecdsa = types::ECDSA.get(py)?.call1((hash_algorithm,))?;
+            let ecdsa = types::ECDSA
+                .get(py)?
+                .call1((hash_algorithm, ecdsa_deterministic_signing))?;
             private_key.call_method1(pyo3::intern!(py, "sign"), (data, ecdsa))?
         }
         KeyType::Rsa => {

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -64,6 +64,14 @@ def _skip_curve_unsupported(backend, curve: ec.EllipticCurve):
         )
 
 
+def _skip_deterministic_ecdsa_unsupported(backend):
+    if not backend.ecdsa_deterministic_supported():
+        pytest.skip(
+            f"ECDSA deterministic signing is not supported by this"
+            f" backend {backend}"
+        )
+
+
 def _skip_exchange_algorithm_unsupported(backend, algorithm, curve):
     if not backend.elliptic_curve_exchange_algorithm_supported(
         algorithm, curve

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -31,6 +31,7 @@ from cryptography.hazmat.primitives.asymmetric import (
 from cryptography.hazmat.primitives.asymmetric.utils import (
     decode_dss_signature,
 )
+from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509.extensions import ExtendedKeyUsage
 from cryptography.x509.name import _ASN1Type
 from cryptography.x509.oid import (
@@ -48,7 +49,10 @@ from ..hazmat.primitives.fixtures_ec import EC_KEY_SECP256R1
 from ..hazmat.primitives.fixtures_rsa import (
     RSA_KEY_2048_ALT,
 )
-from ..hazmat.primitives.test_ec import _skip_curve_unsupported
+from ..hazmat.primitives.test_ec import (
+    _skip_curve_unsupported,
+    _skip_deterministic_ecdsa_unsupported,
+)
 from ..hazmat.primitives.test_rsa import rsa_key_512, rsa_key_2048
 from ..utils import (
     load_nist_vectors,
@@ -3605,6 +3609,82 @@ class TestCertificateBuilder:
             x509.DNSName("cryptography.io"),
         ]
 
+    @pytest.mark.parametrize(
+        ("hashalg", "curve"),
+        [
+            (hashes.SHA224, ec.SECP224R1),
+            (hashes.SHA256, ec.SECP256R1),
+            (hashes.SHA384, ec.SECP384R1),
+            (hashes.SHA512, ec.SECP521R1),
+            (hashes.SHA3_224, ec.SECP224R1),
+            (hashes.SHA3_256, ec.SECP256R1),
+            (hashes.SHA3_384, ec.SECP384R1),
+            (hashes.SHA3_512, ec.SECP521R1),
+        ],
+    )
+    def test_build_cert_with_deterministic_ecdsa_signature(
+        self, hashalg, curve, backend
+    ):
+        _skip_curve_unsupported(backend, curve())
+        _skip_deterministic_ecdsa_unsupported(backend)
+        if not backend.signature_hash_supported(hashalg()):
+            pytest.skip(f"{hashalg} signature not supported")
+
+        h = hashes.Hash(hashalg())
+        h.update(b"test_build_cert_with_deterministic_ecdsa_signature.issuer")
+        private_value = int.from_bytes(h.finalize(), "big")
+        issuer_private_key = ec.derive_private_key(private_value, curve())
+        h = hashes.Hash(hashalg())
+        h.update(b"test_build_cert_with_deterministic_ecdsa_signature.subject")
+        private_value = int.from_bytes(h.finalize(), "big")
+        subject_private_key = ec.derive_private_key(private_value, curve())
+
+        not_valid_before = datetime.datetime(2002, 1, 1, 12, 1)
+        not_valid_after = datetime.datetime(2030, 12, 31, 8, 30)
+
+        builder = (
+            x509.CertificateBuilder()
+            .serial_number(777)
+            .issuer_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+            )
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+            )
+            .public_key(subject_private_key.public_key())
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                True,
+            )
+            .add_extension(
+                x509.SubjectAlternativeName([x509.DNSName("cryptography.io")]),
+                critical=False,
+            )
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+        )
+        cert1 = builder.sign(
+            issuer_private_key,
+            hashalg(),
+            backend,
+            ecdsa_deterministic_signing=True,
+        )
+        cert2 = builder.sign(
+            issuer_private_key,
+            hashalg(),
+            backend,
+            ecdsa_deterministic_signing=True,
+        )
+        cert_nondet = builder.sign(issuer_private_key, hashalg(), backend)
+
+        cert1_bytes = cert1.public_bytes(Encoding.DER)
+        assert cert1_bytes == cert2.public_bytes(Encoding.DER)
+        assert cert1_bytes != cert_nondet.public_bytes(Encoding.DER)
+
+        issuer_private_key.public_key().verify(
+            cert1.signature, cert1.tbs_certificate_bytes, ec.ECDSA(hashalg())
+        )
+
     def test_build_cert_with_bmpstring_universalstring_name(
         self, rsa_key_2048: rsa.RSAPrivateKey, backend
     ):
@@ -4503,6 +4583,83 @@ class TestCertificateBuilder:
         assert ext.value == unrecognized
 
 
+class TestCertificateRevocationListBuilder:
+    @pytest.mark.parametrize(
+        ("hashalg", "curve"),
+        [
+            (hashes.SHA224, ec.SECP224R1),
+            (hashes.SHA256, ec.SECP256R1),
+            (hashes.SHA384, ec.SECP384R1),
+            (hashes.SHA512, ec.SECP521R1),
+            (hashes.SHA3_224, ec.SECP224R1),
+            (hashes.SHA3_256, ec.SECP256R1),
+            (hashes.SHA3_384, ec.SECP384R1),
+            (hashes.SHA3_512, ec.SECP521R1),
+        ],
+    )
+    def test_build_crl_with_deterministic_ecdsa_signature(
+        self, hashalg, curve, backend
+    ):
+        _skip_curve_unsupported(backend, curve())
+        _skip_deterministic_ecdsa_unsupported(backend)
+        if not backend.signature_hash_supported(hashalg()):
+            pytest.skip(f"{hashalg} signature not supported")
+
+        h = hashes.Hash(hashalg())
+        h.update(b"test_build_crl_with_deterministic_ecdsa_signature.issuer")
+        private_value = int.from_bytes(h.finalize(), "big")
+        private_key = ec.derive_private_key(private_value, curve())
+
+        last_update = datetime.datetime(2002, 1, 1, 12, 1)
+        next_update = datetime.datetime(2030, 1, 1, 12, 1)
+        builder = (
+            x509.CertificateRevocationListBuilder()
+            .issuer_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(
+                            NameOID.COMMON_NAME, "cryptography.io CA"
+                        )
+                    ]
+                )
+            )
+            .last_update(last_update)
+            .next_update(next_update)
+        )
+        revoked_cert = (
+            x509.RevokedCertificateBuilder()
+            .serial_number(2)
+            .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
+            .build(backend)
+        )
+        builder = builder.add_revoked_certificate(revoked_cert)
+        crl1 = builder.sign(
+            private_key,
+            hashalg(),
+            backend,
+            ecdsa_deterministic_signing=True,
+        )
+        crl2 = builder.sign(
+            private_key,
+            hashalg(),
+            backend,
+            ecdsa_deterministic_signing=True,
+        )
+
+        crl_nondet = builder.sign(
+            private_key,
+            hashalg(),
+            backend,
+        )
+
+        crl1_bytes = crl1.public_bytes(Encoding.DER)
+        assert crl1_bytes == crl2.public_bytes(Encoding.DER)
+        assert crl1_bytes != crl_nondet.public_bytes(Encoding.DER)
+        private_key.public_key().verify(
+            crl1.signature, crl1.tbs_certlist_bytes, ec.ECDSA(hashalg())
+        )
+
+
 class TestCertificateSigningRequestBuilder:
     def test_sign_invalid_hash_algorithm(
         self, rsa_key_2048: rsa.RSAPrivateKey, backend
@@ -4774,6 +4931,73 @@ class TestCertificateSigningRequestBuilder:
         assert isinstance(basic_constraints.value, x509.BasicConstraints)
         assert basic_constraints.value.ca is True
         assert basic_constraints.value.path_length == 2
+
+    @pytest.mark.parametrize(
+        ("hashalg", "curve"),
+        [
+            (hashes.SHA224, ec.SECP224R1),
+            (hashes.SHA256, ec.SECP256R1),
+            (hashes.SHA384, ec.SECP384R1),
+            (hashes.SHA512, ec.SECP521R1),
+            (hashes.SHA3_224, ec.SECP224R1),
+            (hashes.SHA3_256, ec.SECP256R1),
+            (hashes.SHA3_384, ec.SECP384R1),
+            (hashes.SHA3_512, ec.SECP521R1),
+        ],
+    )
+    def test_build_ca_request_with_deterministic_ec(
+        self, hashalg, curve, backend
+    ):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+        _skip_deterministic_ecdsa_unsupported(backend)
+
+        h = hashes.Hash(hashalg())
+        h.update(b"test_build_ca_request_with_deterministic_ec.subject")
+        private_value = int.from_bytes(h.finalize(), "big")
+        private_key = ec.derive_private_key(private_value, curve())
+
+        builder = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(
+                            NameOID.STATE_OR_PROVINCE_NAME, "Texas"
+                        ),
+                    ]
+                )
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=2), critical=True
+            )
+        )
+        csr1 = builder.sign(
+            private_key,
+            hashalg(),
+            backend,
+            ecdsa_deterministic_signing=True,
+        )
+        csr2 = builder.sign(
+            private_key,
+            hashalg(),
+            backend,
+            ecdsa_deterministic_signing=True,
+        )
+
+        csr_nondet = builder.sign(
+            private_key,
+            hashalg(),
+            backend,
+        )
+
+        csr1_bytes = csr1.public_bytes(Encoding.DER)
+        assert csr1_bytes == csr2.public_bytes(Encoding.DER)
+        assert csr1_bytes != csr_nondet.public_bytes(Encoding.DER)
+        private_key.public_key().verify(
+            csr1.signature,
+            csr1.tbs_certrequest_bytes,
+            ec.ECDSA(hashalg()),
+        )
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.ed25519_supported(),


### PR DESCRIPTION
Hi! This is a feature I implemented for myself in order to generate [reproducible test vectors for W3C Web Authentication](https://www.w3.org/TR/2025/WD-webauthn-3-20250127/#sctn-test-vectors) (see also the [pull request](https://github.com/w3c/webauthn/pull/2209)). The feature already exists in the ECDSA layer, so this patch just plumbs it through to the X.509 layer. I named the parameter `ecdsa_deterministic_signing` to mirror the corresponding `deterministic_signing` parameter in the `ec` module, and the `ecdsa_` prefix mirroring its sibling parameter `rsa_padding`.

I tried to get this to work in `PKCS7SignatureBuilder.add_signer` too, since its `sign_and_serialize` Rust implementation also has calls that need a new `false` argument, but didn't manage to get `PKCS7SignatureBuilder.sign()` to produce reproducible outputs. I think one reason for that is that `sign_and_serialize` in Rust internally sets the signing time to `now()`, but making that injectable as a parameter didn't seem to suffice to make the result deterministic. My experiments are available on [my `wip/pkcs7-sign-ecdsa-deterministic` branch](https://github.com/emlun/python-cryptography/tree/wip/pkcs7-sign-ecdsa-deterministic) in case there's interest in it.