### PR TITLE
document PKCS12Certificate's constructor, rename a variable

### DIFF
--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -946,7 +946,7 @@ file suffix.
         ...     b"friendlyname", key, cert, None, encryption
         ... )
 
-.. function:: serialize_java_truststore(certs, encryption_algorithm)
+.. function:: serialize_java_truststore(pkcs12_certs, encryption_algorithm)
 
     .. versionadded:: 45.0.0
 
@@ -982,11 +982,17 @@ file suffix.
         ...     [pkcs12.PKCS12Certificate(cert, b"friendlyname")], BestAvailableEncryption(b"password")
         ... )
 
-.. class:: PKCS12Certificate
+.. class:: PKCS12Certificate(cert, friendly_name=None)
 
     .. versionadded:: 36.0.0
 
     Represents additional data provided for a certificate in a PKCS12 file.
+
+    :param cert: The certificate to associate with the additional data.
+    :type cert: :class:`~cryptography.x509.Certificate`
+
+    :param friendly_name: An optional friendly name for the certificate.
+    :type friendly_name: bytes or None
 
     .. attribute:: certificate
 

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -536,16 +536,16 @@ fn serialize_safebags<'p>(
 }
 
 #[pyo3::pyfunction]
-#[pyo3(signature = (certs, encryption_algorithm))]
+#[pyo3(signature = (pkcs12_certs, encryption_algorithm))]
 fn serialize_java_truststore<'p>(
     py: pyo3::Python<'p>,
-    certs: Vec<pyo3::Py<PKCS12Certificate>>,
+    pkcs12_certs: Vec<pyo3::Py<PKCS12Certificate>>,
     encryption_algorithm: pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
     let encryption_details = decode_encryption_algorithm(py, encryption_algorithm)?;
     let mut safebags = vec![];
 
-    for cert in &certs {
+    for cert in &pkcs12_certs {
         safebags.push(cert_to_bag(
             cert.get().certificate.get(),
             cert.get().friendly_name.as_ref().map(|v| v.as_bytes(py)),


### PR DESCRIPTION
Some tiny followups from #12393 

Documenting the constructor and the attributes feels duplicative, but probably is less confusing to users...