### PR TITLE
Update license metadata in `pyproject.toml` according to PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,11 @@ authors = [
 ]
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 readme = "README.rst"
-license = { text = "Apache-2.0 OR BSD-3-Clause" }
+license = "Apache-2.0 OR BSD-3-Clause"
+license-files = [ "LICENSE", "LICENSE.APACHE", "LICENSE.BSD" ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX",
@@ -105,9 +104,6 @@ features = ["pyo3/abi3-py37"]
 include = [
     "CHANGELOG.rst",
     "CONTRIBUTING.rst",
-    "LICENSE",
-    "LICENSE.APACHE",
-    "LICENSE.BSD",
 
     "docs/**/*",
 


### PR DESCRIPTION
`setuptools` [now warns](https://github.com/pyca/cryptography/actions/runs/14663972603/job/41154408745#step:10:973) when building a project that uses license classifiers:

```
DEBUG /github/home/.cache/uv/builds-v0/.tmpjaMf3z/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
DEBUG !!
DEBUG 
DEBUG         ********************************************************************************
DEBUG         Please consider removing the following classifiers in favor of a SPDX license expression:
DEBUG 
DEBUG         License :: OSI Approved :: MIT License
DEBUG 
DEBUG         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
DEBUG         ********************************************************************************
DEBUG 
DEBUG !!
```

This is due to [PEP 639](https://peps.python.org/pep-0639/), which changes the way the licenses (and their files) are specified in the project metadata (see also the packaging guide [here](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files)). ~This [is supported](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#id9) since version `77.0.3` of `setuptools`.~

This PR changes the metadata accordingly, ~and bumps the minimum version of `setuptools` to ensure it's supported.~

cc @woodruffw @alex 