### PR TITLE
Add parameter ecdsa_deterministic to x509 sign methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,10 @@ Changelog
   involving small buffers.
 * Added :func:`~cryptography.hazmat.primitives.serialization.ssh_key_fingerprint`
   for computing fingerprints of SSH public keys.
+* Added support for deterministic ECDSA signing via the new keyword-only argument ``ecdsa_deterministic_signing`` in
+  :meth:`~cryptography.x509.CertificateBuilder.sign`,
+  :meth:`~cryptography.x509.CertificateRevocationListBuilder.sign`
+  and :meth:`~cryptography.x509.CertificateSigningRequestBuilder.sign`.
 
 .. _v44-0-3:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,7 +70,7 @@ Changelog
 * Added :func:`~cryptography.hazmat.primitives.serialization.ssh_key_fingerprint`
   for computing fingerprints of SSH public keys.
 * Added support for deterministic ECDSA signing via the new keyword-only argument
-  ``ecdsa_deterministic_signing`` in :meth:`~cryptography.x509.CertificateBuilder.sign`,
+  ``ecdsa_deterministic`` in :meth:`~cryptography.x509.CertificateBuilder.sign`,
   :meth:`~cryptography.x509.CertificateRevocationListBuilder.sign`
   and :meth:`~cryptography.x509.CertificateSigningRequestBuilder.sign`.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,8 +69,8 @@ Changelog
   involving small buffers.
 * Added :func:`~cryptography.hazmat.primitives.serialization.ssh_key_fingerprint`
   for computing fingerprints of SSH public keys.
-* Added support for deterministic ECDSA signing via the new keyword-only argument ``ecdsa_deterministic_signing`` in
-  :meth:`~cryptography.x509.CertificateBuilder.sign`,
+* Added support for deterministic ECDSA signing via the new keyword-only argument
+  ``ecdsa_deterministic_signing`` in :meth:`~cryptography.x509.CertificateBuilder.sign`,
   :meth:`~cryptography.x509.CertificateRevocationListBuilder.sign`
   and :meth:`~cryptography.x509.CertificateSigningRequestBuilder.sign`.
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -885,7 +885,7 @@ X.509 Certificate Builder
     :canonical: cryptography.x509.base.CertificateBuilder
 
     .. versionadded:: 1.0
-    
+
     .. note::
        All methods, except :meth:`sign`, return a **new** CertificateBuilder
        instance with the corresponding updated value. They do not modify the
@@ -936,7 +936,7 @@ X.509 Certificate Builder
 
         :param name: The :class:`~cryptography.x509.Name` that describes the
             issuer (CA).
-        
+
         :return: A new :class:`CertificateBuilder` with the updated issuer name.
 
     .. method:: subject_name(name)
@@ -945,7 +945,7 @@ X.509 Certificate Builder
 
         :param name: The :class:`~cryptography.x509.Name` that describes the
             subject.
-        
+
         :return: A new :class:`CertificateBuilder` with the updated subject name.
 
     .. method:: public_key(public_key)
@@ -954,7 +954,7 @@ X.509 Certificate Builder
 
         :param public_key: The subject's public key. This can be one of
             :data:`~cryptography.hazmat.primitives.asymmetric.types.CertificatePublicKeyTypes`.
-        
+
         :return: A new :class:`CertificateBuilder` with the updated public key.
 
     .. method:: serial_number(serial_number)
@@ -971,7 +971,7 @@ X.509 Certificate Builder
             identify this certificate (most notably during certificate
             revocation checking). Users should consider using
             :func:`~cryptography.x509.random_serial_number` when possible.
-        
+
         :return: A new :class:`CertificateBuilder` with the updated serial number.
 
     .. method:: not_valid_before(time)
@@ -983,7 +983,7 @@ X.509 Certificate Builder
         :param time: The :class:`datetime.datetime` object (in UTC) that marks the
             activation time for the certificate.  The certificate may not be
             trusted clients if it is used before this time.
-        
+
         :return: A new :class:`CertificateBuilder` with the updated activation time.
 
     .. method:: not_valid_after(time)
@@ -995,7 +995,7 @@ X.509 Certificate Builder
         :param time: The :class:`datetime.datetime` object (in UTC) that marks the
             expiration time for the certificate.  The certificate may not be
             trusted clients if it is used after this time.
-        
+
         :return: A new :class:`CertificateBuilder` with the updated expiration time.
 
     .. method:: add_extension(extval, critical)
@@ -1007,7 +1007,7 @@ X.509 Certificate Builder
 
         :param critical: Set to ``True`` if the extension must be understood and
              handled by whoever reads the certificate.
-        
+
         :return: A new :class:`CertificateBuilder` with the additional extension.
 
     .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
@@ -1049,7 +1049,7 @@ X.509 Certificate Builder
 
             .. versionadded:: 45.0.0
 
-            A Boolean flag defaulting to ``False`` that specifies whether the
+            A boolean flag defaulting to ``False`` that specifies whether the
             signing procedure should be deterministic or not, as defined in
             :rfc:`6979`. This only impacts the signing process, verification is
             not affected (the verification process is the same for both
@@ -1334,7 +1334,7 @@ X.509 Certificate Revocation List Builder
 
             .. versionadded:: 45.0.0
 
-            A Boolean flag defaulting to ``False`` that specifies whether the
+            A boolean flag defaulting to ``False`` that specifies whether the
             signing procedure should be deterministic or not, as defined in
             :rfc:`6979`. This only impacts the signing process, verification is
             not affected (the verification process is the same for both
@@ -1557,7 +1557,7 @@ X.509 CSR (Certificate Signing Request) Builder Object
 
             .. versionadded:: 45.0.0
 
-            A Boolean flag defaulting to ``False`` that specifies whether the
+            A boolean flag defaulting to ``False`` that specifies whether the
             signing procedure should be deterministic or not, as defined in
             :rfc:`6979`. This only impacts the signing process, verification is
             not affected (the verification process is the same for both
@@ -2571,7 +2571,7 @@ X.509 Extensions
       :return: A ``bytes`` object containing the encoded extension.
 
     .. attribute:: oid
-        
+
         :type: :class:`ObjectIdentifier`
 
         Returns

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1010,7 +1010,7 @@ X.509 Certificate Builder
 
         :return: A new :class:`CertificateBuilder` with the additional extension.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic=None)
 
         Sign the certificate using the CA's private key.
 
@@ -1045,15 +1045,19 @@ X.509 Certificate Builder
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
 
-        :param bool ecdsa_deterministic_signing:
+        :param ecdsa_deterministic:
 
             .. versionadded:: 45.0.0
 
-            A boolean flag defaulting to ``False`` that specifies whether the
-            signing procedure should be deterministic or not, as defined in
-            :rfc:`6979`. This only impacts the signing process, verification is
-            not affected (the verification process is the same for both
-            deterministic and non-deterministic signed messages).
+            This is a keyword-only argument. If ``private_key`` is an
+            ``EllipticCurvePrivateKey`` then this can be set to true to
+            use deterministic signing, as defined in :rfc:`6979`. This only
+            impacts the signing process, verification is not affected
+            (the verification process is the same for both
+            deterministic and non-deterministic signed messages). All other
+            key types **must** not pass a value other than ``None``.
+
+        :type ecdsa_deterministic: ``None``, ``bool``
 
         :returns: :class:`~cryptography.x509.Certificate`
 
@@ -1295,7 +1299,7 @@ X.509 Certificate Revocation List Builder
             obtained from an existing CRL or created with
             :class:`~cryptography.x509.RevokedCertificateBuilder`.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic=None)
 
         Sign this CRL using the CA's private key.
 
@@ -1330,15 +1334,19 @@ X.509 Certificate Revocation List Builder
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
 
-        :param bool ecdsa_deterministic_signing:
+        :param ecdsa_deterministic:
 
             .. versionadded:: 45.0.0
 
-            A boolean flag defaulting to ``False`` that specifies whether the
-            signing procedure should be deterministic or not, as defined in
-            :rfc:`6979`. This only impacts the signing process, verification is
-            not affected (the verification process is the same for both
-            deterministic and non-deterministic signed messages).
+            This is a keyword-only argument. If ``private_key`` is an
+            ``EllipticCurvePrivateKey`` then this can be set to true to
+            use deterministic signing, as defined in :rfc:`6979`. This only
+            impacts the signing process, verification is not affected
+            (the verification process is the same for both
+            deterministic and non-deterministic signed messages). All other
+            key types **must** not pass a value other than ``None``.
+
+        :type ecdsa_deterministic: ``None``, ``bool``
 
         :returns: :class:`~cryptography.x509.CertificateRevocationList`
 
@@ -1518,7 +1526,7 @@ X.509 CSR (Certificate Signing Request) Builder Object
         :returns: A new
             :class:`~cryptography.x509.CertificateSigningRequestBuilder`.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic=None)
 
         :param private_key: The private key
             that will be used to sign the request.  When the request is
@@ -1553,15 +1561,19 @@ X.509 CSR (Certificate Signing Request) Builder Object
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
 
-        :param bool ecdsa_deterministic_signing:
+        :param ecdsa_deterministic:
 
             .. versionadded:: 45.0.0
 
-            A boolean flag defaulting to ``False`` that specifies whether the
-            signing procedure should be deterministic or not, as defined in
-            :rfc:`6979`. This only impacts the signing process, verification is
-            not affected (the verification process is the same for both
-            deterministic and non-deterministic signed messages).
+            This is a keyword-only argument. If ``private_key`` is an
+            ``EllipticCurvePrivateKey`` then this can be set to true to
+            use deterministic signing, as defined in :rfc:`6979`. This only
+            impacts the signing process, verification is not affected
+            (the verification process is the same for both
+            deterministic and non-deterministic signed messages). All other
+            key types **must** not pass a value other than ``None``.
+
+        :type ecdsa_deterministic: ``None``, ``bool``
 
         :returns: A new
             :class:`~cryptography.x509.CertificateSigningRequest`.

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -1010,7 +1010,7 @@ X.509 Certificate Builder
         
         :return: A new :class:`CertificateBuilder` with the additional extension.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
 
         Sign the certificate using the CA's private key.
 
@@ -1044,6 +1044,16 @@ X.509 Certificate Builder
         :type rsa_padding: ``None``,
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+
+        :param bool ecdsa_deterministic_signing:
+
+            .. versionadded:: 45.0.0
+
+            A Boolean flag defaulting to ``False`` that specifies whether the
+            signing procedure should be deterministic or not, as defined in
+            :rfc:`6979`. This only impacts the signing process, verification is
+            not affected (the verification process is the same for both
+            deterministic and non-deterministic signed messages).
 
         :returns: :class:`~cryptography.x509.Certificate`
 
@@ -1285,7 +1295,7 @@ X.509 Certificate Revocation List Builder
             obtained from an existing CRL or created with
             :class:`~cryptography.x509.RevokedCertificateBuilder`.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
 
         Sign this CRL using the CA's private key.
 
@@ -1319,6 +1329,16 @@ X.509 Certificate Revocation List Builder
         :type rsa_padding: ``None``,
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+
+        :param bool ecdsa_deterministic_signing:
+
+            .. versionadded:: 45.0.0
+
+            A Boolean flag defaulting to ``False`` that specifies whether the
+            signing procedure should be deterministic or not, as defined in
+            :rfc:`6979`. This only impacts the signing process, verification is
+            not affected (the verification process is the same for both
+            deterministic and non-deterministic signed messages).
 
         :returns: :class:`~cryptography.x509.CertificateRevocationList`
 
@@ -1498,7 +1518,7 @@ X.509 CSR (Certificate Signing Request) Builder Object
         :returns: A new
             :class:`~cryptography.x509.CertificateSigningRequestBuilder`.
 
-    .. method:: sign(private_key, algorithm, *, rsa_padding=None)
+    .. method:: sign(private_key, algorithm, *, rsa_padding=None, ecdsa_deterministic_signing=False)
 
         :param private_key: The private key
             that will be used to sign the request.  When the request is
@@ -1532,6 +1552,16 @@ X.509 CSR (Certificate Signing Request) Builder Object
         :type rsa_padding: ``None``,
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PKCS1v15`,
             or :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+
+        :param bool ecdsa_deterministic_signing:
+
+            .. versionadded:: 45.0.0
+
+            A Boolean flag defaulting to ``False`` that specifies whether the
+            signing procedure should be deterministic or not, as defined in
+            :rfc:`6979`. This only impacts the signing process, verification is
+            not affected (the verification process is the same for both
+            deterministic and non-deterministic signed messages).
 
         :returns: A new
             :class:`~cryptography.x509.CertificateSigningRequest`.

--- a/src/cryptography/hazmat/bindings/_rust/x509.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/x509.pyi
@@ -45,18 +45,21 @@ def create_x509_certificate(
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
+    ecdsa_deterministic_signing: bool,
 ) -> x509.Certificate: ...
 def create_x509_csr(
     builder: x509.CertificateSigningRequestBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
+    ecdsa_deterministic_signing: bool,
 ) -> x509.CertificateSigningRequest: ...
 def create_x509_crl(
     builder: x509.CertificateRevocationListBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
+    ecdsa_deterministic_signing: bool,
 ) -> x509.CertificateRevocationList: ...
 
 class Sct:

--- a/src/cryptography/hazmat/bindings/_rust/x509.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/x509.pyi
@@ -45,21 +45,21 @@ def create_x509_certificate(
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
-    ecdsa_deterministic_signing: bool,
+    ecdsa_deterministic: bool | None,
 ) -> x509.Certificate: ...
 def create_x509_csr(
     builder: x509.CertificateSigningRequestBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
-    ecdsa_deterministic_signing: bool,
+    ecdsa_deterministic: bool | None,
 ) -> x509.CertificateSigningRequest: ...
 def create_x509_crl(
     builder: x509.CertificateRevocationListBuilder,
     private_key: PrivateKeyTypes,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
-    ecdsa_deterministic_signing: bool,
+    ecdsa_deterministic: bool | None,
 ) -> x509.CertificateRevocationList: ...
 
 class Sct:

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -331,7 +331,7 @@ class CertificateSigningRequestBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
-        ecdsa_deterministic_signing: bool = False,
+        ecdsa_deterministic: bool | None = None,
     ) -> CertificateSigningRequest:
         """
         Signs the request using the requestor's private key.
@@ -345,12 +345,18 @@ class CertificateSigningRequestBuilder:
             if not isinstance(private_key, rsa.RSAPrivateKey):
                 raise TypeError("Padding is only supported for RSA keys")
 
+        if ecdsa_deterministic is not None:
+            if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+                raise TypeError(
+                    "Deterministic ECDSA is only supported for EC keys"
+                )
+
         return rust_x509.create_x509_csr(
             self,
             private_key,
             algorithm,
             rsa_padding,
-            ecdsa_deterministic_signing,
+            ecdsa_deterministic,
         )
 
 
@@ -565,7 +571,7 @@ class CertificateBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
-        ecdsa_deterministic_signing: bool = False,
+        ecdsa_deterministic: bool | None = None,
     ) -> Certificate:
         """
         Signs the certificate using the CA's private key.
@@ -594,12 +600,18 @@ class CertificateBuilder:
             if not isinstance(private_key, rsa.RSAPrivateKey):
                 raise TypeError("Padding is only supported for RSA keys")
 
+        if ecdsa_deterministic is not None:
+            if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+                raise TypeError(
+                    "Deterministic ECDSA is only supported for EC keys"
+                )
+
         return rust_x509.create_x509_certificate(
             self,
             private_key,
             algorithm,
             rsa_padding,
-            ecdsa_deterministic_signing,
+            ecdsa_deterministic,
         )
 
 
@@ -727,7 +739,7 @@ class CertificateRevocationListBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
-        ecdsa_deterministic_signing: bool = False,
+        ecdsa_deterministic: bool | None = None,
     ) -> CertificateRevocationList:
         if self._issuer_name is None:
             raise ValueError("A CRL must have an issuer name")
@@ -744,12 +756,18 @@ class CertificateRevocationListBuilder:
             if not isinstance(private_key, rsa.RSAPrivateKey):
                 raise TypeError("Padding is only supported for RSA keys")
 
+        if ecdsa_deterministic is not None:
+            if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+                raise TypeError(
+                    "Deterministic ECDSA is only supported for EC keys"
+                )
+
         return rust_x509.create_x509_crl(
             self,
             private_key,
             algorithm,
             rsa_padding,
-            ecdsa_deterministic_signing,
+            ecdsa_deterministic,
         )
 
 

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -331,6 +331,7 @@ class CertificateSigningRequestBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
+        ecdsa_deterministic_signing: bool = False,
     ) -> CertificateSigningRequest:
         """
         Signs the request using the requestor's private key.
@@ -345,7 +346,11 @@ class CertificateSigningRequestBuilder:
                 raise TypeError("Padding is only supported for RSA keys")
 
         return rust_x509.create_x509_csr(
-            self, private_key, algorithm, rsa_padding
+            self,
+            private_key,
+            algorithm,
+            rsa_padding,
+            ecdsa_deterministic_signing,
         )
 
 
@@ -560,6 +565,7 @@ class CertificateBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
+        ecdsa_deterministic_signing: bool = False,
     ) -> Certificate:
         """
         Signs the certificate using the CA's private key.
@@ -589,7 +595,11 @@ class CertificateBuilder:
                 raise TypeError("Padding is only supported for RSA keys")
 
         return rust_x509.create_x509_certificate(
-            self, private_key, algorithm, rsa_padding
+            self,
+            private_key,
+            algorithm,
+            rsa_padding,
+            ecdsa_deterministic_signing,
         )
 
 
@@ -717,6 +727,7 @@ class CertificateRevocationListBuilder:
         backend: typing.Any = None,
         *,
         rsa_padding: padding.PSS | padding.PKCS1v15 | None = None,
+        ecdsa_deterministic_signing: bool = False,
     ) -> CertificateRevocationList:
         if self._issuer_name is None:
             raise ValueError("A CRL must have an issuer name")
@@ -734,7 +745,11 @@ class CertificateRevocationListBuilder:
                 raise TypeError("Padding is only supported for RSA keys")
 
         return rust_x509.create_x509_crl(
-            self, private_key, algorithm, rsa_padding
+            self,
+            private_key,
+            algorithm,
+            rsa_padding,
+            ecdsa_deterministic_signing,
         )
 
 

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -13,8 +13,7 @@ use cryptography_x509::{common, oid, pkcs7};
 use once_cell::sync::Lazy;
 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
 use openssl::pkcs7::Pkcs7;
-use pyo3::types::{PyAnyMethods, PyBool, PyBytesMethods, PyListMethods};
-use pyo3::BoundObject;
+use pyo3::types::{PyAnyMethods, PyBytesMethods, PyListMethods};
 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
 use pyo3::PyTypeInfo;
 
@@ -518,7 +517,7 @@ fn sign_and_serialize<'p>(
                         py_private_key.clone(),
                         py_hash_alg.clone(),
                         rsa_padding.clone(),
-                        PyBool::new(py, false).into_bound().into_any(),
+                        false,
                         &data_with_header,
                     )?,
                 )
@@ -568,7 +567,7 @@ fn sign_and_serialize<'p>(
                         py_private_key.clone(),
                         py_hash_alg.clone(),
                         rsa_padding.clone(),
-                        PyBool::new(py, false).into_bound().into_any(),
+                        false,
                         &signed_data,
                     )?,
                 )

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -13,7 +13,8 @@ use cryptography_x509::{common, oid, pkcs7};
 use once_cell::sync::Lazy;
 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
 use openssl::pkcs7::Pkcs7;
-use pyo3::types::{PyAnyMethods, PyBytesMethods, PyListMethods};
+use pyo3::types::{PyAnyMethods, PyBool, PyBytesMethods, PyListMethods};
+use pyo3::BoundObject;
 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
 use pyo3::PyTypeInfo;
 
@@ -517,6 +518,7 @@ fn sign_and_serialize<'p>(
                         py_private_key.clone(),
                         py_hash_alg.clone(),
                         rsa_padding.clone(),
+                        PyBool::new(py, false).into_bound().into_any(),
                         &data_with_header,
                     )?,
                 )
@@ -566,6 +568,7 @@ fn sign_and_serialize<'p>(
                         py_private_key.clone(),
                         py_hash_alg.clone(),
                         rsa_padding.clone(),
+                        PyBool::new(py, false).into_bound().into_any(),
                         &signed_data,
                     )?,
                 )

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -517,7 +517,7 @@ fn sign_and_serialize<'p>(
                         py_private_key.clone(),
                         py_hash_alg.clone(),
                         rsa_padding.clone(),
-                        false,
+                        None,
                         &data_with_header,
                     )?,
                 )
@@ -567,7 +567,7 @@ fn sign_and_serialize<'p>(
                         py_private_key.clone(),
                         py_hash_alg.clone(),
                         rsa_padding.clone(),
-                        false,
+                        None,
                         &signed_data,
                     )?,
                 )

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1003,6 +1003,7 @@ pub(crate) fn create_x509_certificate(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<Certificate> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -1065,6 +1066,7 @@ pub(crate) fn create_x509_certificate(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
+        ecdsa_deterministic_signing.clone(),
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&cryptography_x509::certificate::Certificate {

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1003,7 +1003,7 @@ pub(crate) fn create_x509_certificate(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
-    ecdsa_deterministic_signing: bool,
+    ecdsa_deterministic: Option<bool>,
 ) -> CryptographyResult<Certificate> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -1066,7 +1066,7 @@ pub(crate) fn create_x509_certificate(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
-        ecdsa_deterministic_signing,
+        ecdsa_deterministic,
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&cryptography_x509::certificate::Certificate {

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1003,7 +1003,7 @@ pub(crate) fn create_x509_certificate(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
-    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: bool,
 ) -> CryptographyResult<Certificate> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -1066,7 +1066,7 @@ pub(crate) fn create_x509_certificate(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
-        ecdsa_deterministic_signing.clone(),
+        ecdsa_deterministic_signing,
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&cryptography_x509::certificate::Certificate {

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -629,7 +629,7 @@ pub(crate) fn create_x509_crl(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
-    ecdsa_deterministic_signing: bool,
+    ecdsa_deterministic: Option<bool>,
 ) -> CryptographyResult<CertificateRevocationList> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -697,7 +697,7 @@ pub(crate) fn create_x509_crl(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
-        ecdsa_deterministic_signing,
+        ecdsa_deterministic,
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&crl::CertificateRevocationList {

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -629,6 +629,7 @@ pub(crate) fn create_x509_crl(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<CertificateRevocationList> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -696,6 +697,7 @@ pub(crate) fn create_x509_crl(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
+        ecdsa_deterministic_signing.clone(),
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&crl::CertificateRevocationList {

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -629,7 +629,7 @@ pub(crate) fn create_x509_crl(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
-    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: bool,
 ) -> CryptographyResult<CertificateRevocationList> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -697,7 +697,7 @@ pub(crate) fn create_x509_crl(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
-        ecdsa_deterministic_signing.clone(),
+        ecdsa_deterministic_signing,
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&crl::CertificateRevocationList {

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -292,6 +292,7 @@ pub(crate) fn create_x509_csr(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
 ) -> CryptographyResult<CertificateSigningRequest> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -381,6 +382,7 @@ pub(crate) fn create_x509_csr(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
+        ecdsa_deterministic_signing.clone(),
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&Csr {

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -292,7 +292,7 @@ pub(crate) fn create_x509_csr(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
-    ecdsa_deterministic_signing: bool,
+    ecdsa_deterministic: Option<bool>,
 ) -> CryptographyResult<CertificateSigningRequest> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -382,7 +382,7 @@ pub(crate) fn create_x509_csr(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
-        ecdsa_deterministic_signing,
+        ecdsa_deterministic,
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&Csr {

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -292,7 +292,7 @@ pub(crate) fn create_x509_csr(
     private_key: &pyo3::Bound<'_, pyo3::PyAny>,
     hash_algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
-    ecdsa_deterministic_signing: &pyo3::Bound<'_, pyo3::PyAny>,
+    ecdsa_deterministic_signing: bool,
 ) -> CryptographyResult<CertificateSigningRequest> {
     let sigalg = x509::sign::compute_signature_algorithm(
         py,
@@ -382,7 +382,7 @@ pub(crate) fn create_x509_csr(
         private_key.clone(),
         hash_algorithm.clone(),
         rsa_padding.clone(),
-        ecdsa_deterministic_signing.clone(),
+        ecdsa_deterministic_signing,
         &tbs_bytes,
     )?;
     let data = asn1::write_single(&Csr {

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -8,7 +8,8 @@ use cryptography_x509::ocsp_resp::{
     self, OCSPResponse as RawOCSPResponse, SingleResponse, SingleResponse as RawSingleResponse,
 };
 use cryptography_x509::{common, oid};
-use pyo3::types::{PyAnyMethods, PyBytesMethods, PyListMethods};
+use pyo3::types::{PyAnyMethods, PyBool, PyBytesMethods, PyListMethods};
+use pyo3::BoundObject;
 
 use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid, py_uint_to_big_endian_bytes};
 use crate::error::{CryptographyError, CryptographyResult};
@@ -834,6 +835,7 @@ pub(crate) fn create_ocsp_response(
         private_key.clone(),
         hash_algorithm.clone(),
         py.None().into_bound(py),
+        PyBool::new(py, false).into_bound().into_any(),
         &tbs_bytes,
     )?;
 

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -8,8 +8,7 @@ use cryptography_x509::ocsp_resp::{
     self, OCSPResponse as RawOCSPResponse, SingleResponse, SingleResponse as RawSingleResponse,
 };
 use cryptography_x509::{common, oid};
-use pyo3::types::{PyAnyMethods, PyBool, PyBytesMethods, PyListMethods};
-use pyo3::BoundObject;
+use pyo3::types::{PyAnyMethods, PyBytesMethods, PyListMethods};
 
 use crate::asn1::{big_byte_slice_to_py_int, oid_to_py_oid, py_uint_to_big_endian_bytes};
 use crate::error::{CryptographyError, CryptographyResult};
@@ -835,7 +834,7 @@ pub(crate) fn create_ocsp_response(
         private_key.clone(),
         hash_algorithm.clone(),
         py.None().into_bound(py),
-        PyBool::new(py, false).into_bound().into_any(),
+        false,
         &tbs_bytes,
     )?;
 

--- a/src/rust/src/x509/ocsp_resp.rs
+++ b/src/rust/src/x509/ocsp_resp.rs
@@ -834,7 +834,7 @@ pub(crate) fn create_ocsp_response(
         private_key.clone(),
         hash_algorithm.clone(),
         py.None().into_bound(py),
-        false,
+        None,
         &tbs_bytes,
     )?;
 

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -285,6 +285,7 @@ pub(crate) fn sign_data<'p>(
     private_key: pyo3::Bound<'p, pyo3::PyAny>,
     hash_algorithm: pyo3::Bound<'p, pyo3::PyAny>,
     rsa_padding: pyo3::Bound<'p, pyo3::PyAny>,
+    ecdsa_deterministic_signing: pyo3::Bound<'p, pyo3::PyAny>,
     data: &[u8],
 ) -> pyo3::PyResult<PyBackedBytes> {
     let key_type = identify_key_type(py, private_key.clone())?;
@@ -294,7 +295,9 @@ pub(crate) fn sign_data<'p>(
             private_key.call_method1(pyo3::intern!(py, "sign"), (data,))?
         }
         KeyType::Ec => {
-            let ecdsa = types::ECDSA.get(py)?.call1((hash_algorithm,))?;
+            let ecdsa = types::ECDSA
+                .get(py)?
+                .call1((hash_algorithm, ecdsa_deterministic_signing))?;
             private_key.call_method1(pyo3::intern!(py, "sign"), (data, ecdsa))?
         }
         KeyType::Rsa => {

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -285,7 +285,7 @@ pub(crate) fn sign_data<'p>(
     private_key: pyo3::Bound<'p, pyo3::PyAny>,
     hash_algorithm: pyo3::Bound<'p, pyo3::PyAny>,
     rsa_padding: pyo3::Bound<'p, pyo3::PyAny>,
-    ecdsa_deterministic_signing: bool,
+    ecdsa_deterministic: Option<bool>,
     data: &[u8],
 ) -> pyo3::PyResult<PyBackedBytes> {
     let key_type = identify_key_type(py, private_key.clone())?;
@@ -297,7 +297,7 @@ pub(crate) fn sign_data<'p>(
         KeyType::Ec => {
             let ecdsa = types::ECDSA
                 .get(py)?
-                .call1((hash_algorithm, ecdsa_deterministic_signing))?;
+                .call1((hash_algorithm, ecdsa_deterministic.unwrap_or(false)))?;
             private_key.call_method1(pyo3::intern!(py, "sign"), (data, ecdsa))?
         }
         KeyType::Rsa => {

--- a/src/rust/src/x509/sign.rs
+++ b/src/rust/src/x509/sign.rs
@@ -285,7 +285,7 @@ pub(crate) fn sign_data<'p>(
     private_key: pyo3::Bound<'p, pyo3::PyAny>,
     hash_algorithm: pyo3::Bound<'p, pyo3::PyAny>,
     rsa_padding: pyo3::Bound<'p, pyo3::PyAny>,
-    ecdsa_deterministic_signing: pyo3::Bound<'p, pyo3::PyAny>,
+    ecdsa_deterministic_signing: bool,
     data: &[u8],
 ) -> pyo3::PyResult<PyBackedBytes> {
     let key_type = identify_key_type(py, private_key.clone())?;

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -64,6 +64,14 @@ def _skip_curve_unsupported(backend, curve: ec.EllipticCurve):
         )
 
 
+def _skip_deterministic_ecdsa_unsupported(backend):
+    if not backend.ecdsa_deterministic_supported():
+        pytest.skip(
+            f"ECDSA deterministic signing is not supported by this"
+            f" backend {backend}"
+        )
+
+
 def _skip_exchange_algorithm_unsupported(backend, algorithm, curve):
     if not backend.elliptic_curve_exchange_algorithm_supported(
         algorithm, curve

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -3633,20 +3633,12 @@ class TestCertificateBuilder:
             x509.CertificateBuilder()
             .serial_number(777)
             .issuer_name(
-                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+                x509.Name([])
             )
             .subject_name(
-                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+                x509.Name([])
             )
             .public_key(private_key.public_key())
-            .add_extension(
-                x509.BasicConstraints(ca=False, path_length=None),
-                True,
-            )
-            .add_extension(
-                x509.SubjectAlternativeName([x509.DNSName("cryptography.io")]),
-                critical=False,
-            )
             .not_valid_before(not_valid_before)
             .not_valid_after(not_valid_after)
         )
@@ -3684,20 +3676,12 @@ class TestCertificateBuilder:
             x509.CertificateBuilder()
             .serial_number(777)
             .issuer_name(
-                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+                x509.Name([])
             )
             .subject_name(
-                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+                x509.Name([])
             )
             .public_key(rsa_key_2048.public_key())
-            .add_extension(
-                x509.BasicConstraints(ca=False, path_length=None),
-                True,
-            )
-            .add_extension(
-                x509.SubjectAlternativeName([x509.DNSName("cryptography.io")]),
-                critical=False,
-            )
             .not_valid_before(not_valid_before)
             .not_valid_after(not_valid_after)
         )
@@ -4888,16 +4872,7 @@ class TestCertificateSigningRequestBuilder:
         builder = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(
-                x509.Name(
-                    [
-                        x509.NameAttribute(
-                            NameOID.STATE_OR_PROVINCE_NAME, "Texas"
-                        ),
-                    ]
-                )
-            )
-            .add_extension(
-                x509.BasicConstraints(ca=True, path_length=2), critical=True
+                x509.Name([])
             )
         )
         csr1 = builder.sign(
@@ -4938,16 +4913,7 @@ class TestCertificateSigningRequestBuilder:
         builder = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(
-                x509.Name(
-                    [
-                        x509.NameAttribute(
-                            NameOID.STATE_OR_PROVINCE_NAME, "Texas"
-                        ),
-                    ]
-                )
-            )
-            .add_extension(
-                x509.BasicConstraints(ca=True, path_length=2), critical=True
+                x509.Name([])
             )
         )
         with pytest.raises(TypeError):

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -3632,12 +3632,8 @@ class TestCertificateBuilder:
         builder = (
             x509.CertificateBuilder()
             .serial_number(777)
-            .issuer_name(
-                x509.Name([])
-            )
-            .subject_name(
-                x509.Name([])
-            )
+            .issuer_name(x509.Name([]))
+            .subject_name(x509.Name([]))
             .public_key(private_key.public_key())
             .not_valid_before(not_valid_before)
             .not_valid_after(not_valid_after)
@@ -3675,12 +3671,8 @@ class TestCertificateBuilder:
         builder = (
             x509.CertificateBuilder()
             .serial_number(777)
-            .issuer_name(
-                x509.Name([])
-            )
-            .subject_name(
-                x509.Name([])
-            )
+            .issuer_name(x509.Name([]))
+            .subject_name(x509.Name([]))
             .public_key(rsa_key_2048.public_key())
             .not_valid_before(not_valid_before)
             .not_valid_after(not_valid_after)
@@ -4869,11 +4861,8 @@ class TestCertificateSigningRequestBuilder:
 
         private_key = ec.generate_private_key(ec.SECP256R1())
 
-        builder = (
-            x509.CertificateSigningRequestBuilder()
-            .subject_name(
-                x509.Name([])
-            )
+        builder = x509.CertificateSigningRequestBuilder().subject_name(
+            x509.Name([])
         )
         csr1 = builder.sign(
             private_key,
@@ -4910,11 +4899,8 @@ class TestCertificateSigningRequestBuilder:
         )
 
     def test_csr_deterministic_wrong_key_type(self, rsa_key_2048, backend):
-        builder = (
-            x509.CertificateSigningRequestBuilder()
-            .subject_name(
-                x509.Name([])
-            )
+        builder = x509.CertificateSigningRequestBuilder().subject_name(
+            x509.Name([])
         )
         with pytest.raises(TypeError):
             builder.sign(

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -25,7 +25,10 @@ from cryptography.x509.oid import (
 
 from ..hazmat.primitives.fixtures_dsa import DSA_KEY_2048
 from ..hazmat.primitives.fixtures_ec import EC_KEY_SECP256R1
-from ..hazmat.primitives.test_ec import _skip_curve_unsupported
+from ..hazmat.primitives.test_ec import (
+    _skip_curve_unsupported,
+    _skip_deterministic_ecdsa_unsupported,
+)
 from ..hazmat.primitives.test_rsa import rsa_key_512, rsa_key_2048
 from .test_x509 import DummyExtension
 
@@ -969,3 +972,99 @@ class TestCertificateRevocationListBuilder:
             .value
             == ci
         )
+
+    def test_build_crl_with_deterministic_ecdsa_signature(self, backend):
+        _skip_curve_unsupported(backend, ec.SECP256R1())
+        _skip_deterministic_ecdsa_unsupported(backend)
+
+        private_key = ec.generate_private_key(ec.SECP256R1())
+
+        last_update = datetime.datetime(2002, 1, 1, 12, 1)
+        next_update = datetime.datetime(2030, 1, 1, 12, 1)
+        builder = (
+            x509.CertificateRevocationListBuilder()
+            .issuer_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(
+                            NameOID.COMMON_NAME, "cryptography.io CA"
+                        )
+                    ]
+                )
+            )
+            .last_update(last_update)
+            .next_update(next_update)
+        )
+        revoked_cert = (
+            x509.RevokedCertificateBuilder()
+            .serial_number(2)
+            .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
+            .build(backend)
+        )
+        builder = builder.add_revoked_certificate(revoked_cert)
+        crl1 = builder.sign(
+            private_key,
+            hashes.SHA256(),
+            backend,
+            ecdsa_deterministic=True,
+        )
+        crl2 = builder.sign(
+            private_key,
+            hashes.SHA256(),
+            backend,
+            ecdsa_deterministic=True,
+        )
+
+        crl_nondet = builder.sign(
+            private_key,
+            hashes.SHA256(),
+            backend,
+        )
+
+        crl_nondet2 = builder.sign(
+            private_key,
+            hashes.SHA256(),
+            backend,
+            ecdsa_deterministic=False,
+        )
+
+        assert crl1.signature == crl2.signature
+        assert crl1.signature != crl_nondet.signature
+        assert crl_nondet.signature != crl_nondet2.signature
+        private_key.public_key().verify(
+            crl1.signature, crl1.tbs_certlist_bytes, ec.ECDSA(hashes.SHA256())
+        )
+
+    def test_deterministic_signature_wrong_key_type(
+        self, rsa_key_2048, backend
+    ):
+        last_update = datetime.datetime(2002, 1, 1, 12, 1)
+        next_update = datetime.datetime(2030, 1, 1, 12, 1)
+        builder = (
+            x509.CertificateRevocationListBuilder()
+            .issuer_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(
+                            NameOID.COMMON_NAME, "cryptography.io CA"
+                        )
+                    ]
+                )
+            )
+            .last_update(last_update)
+            .next_update(next_update)
+        )
+        revoked_cert = (
+            x509.RevokedCertificateBuilder()
+            .serial_number(2)
+            .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
+            .build(backend)
+        )
+        builder = builder.add_revoked_certificate(revoked_cert)
+        with pytest.raises(TypeError):
+            builder.sign(
+                rsa_key_2048,
+                hashes.SHA256(),
+                backend,
+                ecdsa_deterministic=True,
+            )

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -984,24 +984,11 @@ class TestCertificateRevocationListBuilder:
         builder = (
             x509.CertificateRevocationListBuilder()
             .issuer_name(
-                x509.Name(
-                    [
-                        x509.NameAttribute(
-                            NameOID.COMMON_NAME, "cryptography.io CA"
-                        )
-                    ]
-                )
+                x509.Name([])
             )
             .last_update(last_update)
             .next_update(next_update)
         )
-        revoked_cert = (
-            x509.RevokedCertificateBuilder()
-            .serial_number(2)
-            .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
-            .build(backend)
-        )
-        builder = builder.add_revoked_certificate(revoked_cert)
         crl1 = builder.sign(
             private_key,
             hashes.SHA256(),
@@ -1043,24 +1030,11 @@ class TestCertificateRevocationListBuilder:
         builder = (
             x509.CertificateRevocationListBuilder()
             .issuer_name(
-                x509.Name(
-                    [
-                        x509.NameAttribute(
-                            NameOID.COMMON_NAME, "cryptography.io CA"
-                        )
-                    ]
-                )
+                x509.Name([])
             )
             .last_update(last_update)
             .next_update(next_update)
         )
-        revoked_cert = (
-            x509.RevokedCertificateBuilder()
-            .serial_number(2)
-            .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
-            .build(backend)
-        )
-        builder = builder.add_revoked_certificate(revoked_cert)
         with pytest.raises(TypeError):
             builder.sign(
                 rsa_key_2048,

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -983,9 +983,7 @@ class TestCertificateRevocationListBuilder:
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
         builder = (
             x509.CertificateRevocationListBuilder()
-            .issuer_name(
-                x509.Name([])
-            )
+            .issuer_name(x509.Name([]))
             .last_update(last_update)
             .next_update(next_update)
         )
@@ -1029,9 +1027,7 @@ class TestCertificateRevocationListBuilder:
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
         builder = (
             x509.CertificateRevocationListBuilder()
-            .issuer_name(
-                x509.Name([])
-            )
+            .issuer_name(x509.Name([]))
             .last_update(last_update)
             .next_update(next_update)
         )


### PR DESCRIPTION
This work is largely from #12796 with some simplification and a rebase. See #12796 for more background.