### PR TITLE
fix(x509): use backward compatible syntax for types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         PYTHON:
+          - {VERSION: "3.8", NOXSESSION: "flake"}
           - {VERSION: "3.13", NOXSESSION: "flake"}
           - {VERSION: "3.13", NOXSESSION: "rust"}
           - {VERSION: "3.12", NOXSESSION: "docs", OPENSSL: {TYPE: "openssl", VERSION: "3.5.0"}}

--- a/src/cryptography/hazmat/bindings/_rust/x509.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/x509.pyi
@@ -229,7 +229,9 @@ class Criticality:
     AGNOSTIC: Criticality
     NON_CRITICAL: Criticality
 
-type MaybeExtensionValidatorCallback[T: x509.ExtensionType] = typing.Callable[
+T = typing.TypeVar("T", contravariant=True, bound=x509.ExtensionType)
+
+MaybeExtensionValidatorCallback = typing.Callable[
     [
         Policy,
         x509.Certificate,
@@ -238,12 +240,10 @@ type MaybeExtensionValidatorCallback[T: x509.ExtensionType] = typing.Callable[
     None,
 ]
 
-type PresentExtensionValidatorCallback[T: x509.ExtensionType] = (
-    typing.Callable[
-        [Policy, x509.Certificate, T],
-        None,
-    ]
-)
+PresentExtensionValidatorCallback = typing.Callable[
+    [Policy, x509.Certificate, T],
+    None,
+]
 
 class ExtensionPolicy:
     @staticmethod
@@ -255,13 +255,13 @@ class ExtensionPolicy:
     def require_not_present(
         self, extension_type: type[x509.ExtensionType]
     ) -> ExtensionPolicy: ...
-    def may_be_present[T: x509.ExtensionType](
+    def may_be_present(
         self,
         extension_type: type[T],
         criticality: Criticality,
         validator: MaybeExtensionValidatorCallback[T] | None,
     ) -> ExtensionPolicy: ...
-    def require_present[T: x509.ExtensionType](
+    def require_present(
         self,
         extension_type: type[T],
         criticality: Criticality,


### PR DESCRIPTION
An attempt to fix the issue we are hitting on `mypy` Python 3.9 (but also I think it won't work with Python 3.9 itself as well):

```
.nox/lint/lib/python3.9/site-packages/cryptography/x509/certificate_transparency.py:8: note: In module imported here,
.nox/lint/lib/python3.9/site-packages/cryptography/x509/__init__.py:7: note: ... from here,
.nox/lint/lib/python3.9/site-packages/werkzeug/serving.py:93: note: ... from here,
.nox/lint/lib/python3.9/site-packages/werkzeug/__init__.py:1: note: ... from here:
.nox/lint/lib/python3.9/site-packages/cryptography/hazmat/bindings/_rust/x509.pyi:232:7: error:
invalid syntax  [syntax]
    type MaybeExtensionValidatorCallback[T: x509.ExtensionType] = typing.C...
          ^
Found 1 error in 1 file (errors prevented further checking)

nox > Command pre-commit run --show-diff-on-failure --all-files failed with exit code 1
nox > Session lint failed.
```

It was introduced originally here: https://github.com/pyca/cryptography/commit/4cfd7b1208e3b806cfa20f8e0f8d21d01bfd768f

I would appreciate a review since I'm definitely not a Python types expert.