### PR TITLE
remove CAST5, IDEA, Blowfish, and SEED from cipher module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Changelog
 * Removed the deprecated ``get_attribute_for_oid`` method on
   :class:`~cryptography.x509.CertificateSigningRequest`. Users should use
   :meth:`~cryptography.x509.Attributes.get_attribute_for_oid` instead.
+* Removed the deprecated ``CAST5``, ``SEED``, ``IDEA``, and ``Blowfish``
+  classes from the cipher module. These are still available in
+  :doc:`/hazmat/decrepit/index`.
 
 .. _v45-0-2:
 
@@ -188,10 +191,7 @@ Changelog
   now emits ASN.1 that more closely follows the recommendations in :rfc:`2315`.
 * Added new :doc:`/hazmat/decrepit/index` module which contains outdated and
   insecure cryptographic primitives.
-  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.CAST5`,
-  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.SEED`,
-  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.IDEA`, and
-  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.Blowfish`, which were
+  ``CAST5``, ``SEED``, ``IDEA``, and ``Blowfish``, which were
   deprecated in 37.0.0, have been added to this module. They will be removed
   from the ``cipher`` module in 45.0.0.
 * Moved :class:`~cryptography.hazmat.primitives.ciphers.algorithms.TripleDES`
@@ -792,11 +792,7 @@ Changelog
   ``pip`` will typically get a wheel and not need Rust installed, but check
   :doc:`/installation` for documentation on installing a newer ``rustc`` if
   required.
-* Deprecated
-  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.CAST5`,
-  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.SEED`,
-  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.IDEA`, and
-  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.Blowfish` because
+* Deprecated ``CAST5``, ``SEED``, ``IDEA``, and ``Blowfish`` because
   they are legacy algorithms with extremely low usage. These will be removed
   in a future version of ``cryptography``.
 * Added limited support for distinguished names containing a bit string.
@@ -2600,8 +2596,7 @@ Changelog
   to :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`. It will
   be removed from ``MGF1`` in two releases per our :doc:`/api-stability`
   policy.
-* Added :class:`~cryptography.hazmat.primitives.ciphers.algorithms.SEED`
-  support.
+* Added ``SEED`` support.
 * Added :class:`~cryptography.hazmat.primitives.cmac.CMAC`.
 * Added decryption support to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`
@@ -2620,8 +2615,7 @@ Changelog
 
 * Added :class:`~cryptography.hazmat.primitives.twofactor.hotp.HOTP`.
 * Added :class:`~cryptography.hazmat.primitives.twofactor.totp.TOTP`.
-* Added :class:`~cryptography.hazmat.primitives.ciphers.algorithms.IDEA`
-  support.
+* Added ``IDEA`` support.
 * Added signature support to
   :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey`
   and verification support to
@@ -2663,8 +2657,7 @@ Changelog
 * Added :class:`~cryptography.hazmat.primitives.kdf.hkdf.HKDF`.
 * Added ``multibackend``.
 * Set default random for ``openssl`` to the OS random engine.
-* Added :class:`~cryptography.hazmat.primitives.ciphers.algorithms.CAST5`
-  (CAST-128) support.
+* Added ``CAST5`` (CAST-128) support.
 
 
 .. _v0-1:

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -208,43 +208,6 @@ Algorithms
         to produce the full key.
     :type key: :term:`bytes-like`
 
-.. class:: CAST5(key)
-
-    .. versionadded:: 0.2
-
-    .. warning::
-
-        This algorithm has been deprecated and moved to the :doc:`/hazmat/decrepit/index`
-        module. If you need to continue using it then update your code to
-        use the new module path. It will be removed from this namespace in 45.0.0.
-
-    CAST5 (also known as CAST-128) is a block cipher approved for use in the
-    Canadian government by the `Communications Security Establishment`_. It is
-    a variable key length cipher and supports keys from 40-128 :term:`bits` in
-    length.
-
-    :param key: The secret key, This must be kept secret. 40 to 128
-        :term:`bits` in length in increments of 8 bits.
-    :type key: :term:`bytes-like`
-
-.. class:: SEED(key)
-
-    .. versionadded:: 0.4
-
-    .. warning::
-
-        This algorithm has been deprecated and moved to the :doc:`/hazmat/decrepit/index`
-        module. If you need to continue using it then update your code to
-        use the new module path. It will be removed from this namespace in 45.0.0.
-
-    SEED is a block cipher developed by the Korea Information Security Agency
-    (KISA). It is defined in :rfc:`4269` and is used broadly throughout South
-    Korean industry, but rarely found elsewhere.
-
-    :param key: The secret key. This must be kept secret. ``128``
-        :term:`bits` in length.
-    :type key: :term:`bytes-like`
-
 .. class:: SM4(key)
 
     .. versionadded:: 35.0.0
@@ -268,22 +231,6 @@ Weak ciphers
     These ciphers are considered weak for a variety of reasons. New
     applications should avoid their use and existing applications should
     strongly consider migrating away.
-
-.. class:: Blowfish(key)
-
-    .. warning::
-
-        This algorithm has been deprecated and moved to the :doc:`/hazmat/decrepit/index`
-        module. If you need to continue using it then update your code to
-        use the new module path. It will be removed from this namespace in 45.0.0.
-
-    Blowfish is a block cipher developed by Bruce Schneier. It is known to be
-    susceptible to attacks when using weak keys. The author has recommended
-    that users of Blowfish move to newer algorithms such as :class:`AES`.
-
-    :param key: The secret key. This must be kept secret. 32 to 448
-        :term:`bits` in length in increments of 8 bits.
-    :type key: :term:`bytes-like`
 
 .. class:: ARC4(key)
 
@@ -312,24 +259,6 @@ Weak ciphers
         >>> decryptor = cipher.decryptor()
         >>> decryptor.update(ct)
         b'a secret message'
-
-.. class:: IDEA(key)
-
-    .. warning::
-
-        This algorithm has been deprecated and moved to the :doc:`/hazmat/decrepit/index`
-        module. If you need to continue using it then update your code to
-        use the new module path. It will be removed from this namespace in 45.0.0.
-
-    IDEA (`International Data Encryption Algorithm`_) is a block cipher created
-    in 1991. It is an optional component of the `OpenPGP`_ standard. This cipher
-    is susceptible to attacks when using weak keys. It is recommended that you
-    do not use this cipher for new applications.
-
-    :param key: The secret key. This must be kept secret. ``128``
-        :term:`bits` in length.
-    :type key: :term:`bytes-like`
-
 
 .. _symmetric-encryption-modes:
 

--- a/src/cryptography/hazmat/primitives/ciphers/algorithms.py
+++ b/src/cryptography/hazmat/primitives/ciphers/algorithms.py
@@ -100,53 +100,6 @@ utils.deprecated(
     name="TripleDES",
 )
 
-utils.deprecated(
-    Blowfish,
-    __name__,
-    "Blowfish has been moved to "
-    "cryptography.hazmat.decrepit.ciphers.algorithms.Blowfish and "
-    "will be removed from "
-    "cryptography.hazmat.primitives.ciphers.algorithms in 45.0.0.",
-    utils.DeprecatedIn37,
-    name="Blowfish",
-)
-
-
-utils.deprecated(
-    CAST5,
-    __name__,
-    "CAST5 has been moved to "
-    "cryptography.hazmat.decrepit.ciphers.algorithms.CAST5 and "
-    "will be removed from "
-    "cryptography.hazmat.primitives.ciphers.algorithms in 45.0.0.",
-    utils.DeprecatedIn37,
-    name="CAST5",
-)
-
-
-utils.deprecated(
-    IDEA,
-    __name__,
-    "IDEA has been moved to "
-    "cryptography.hazmat.decrepit.ciphers.algorithms.IDEA and "
-    "will be removed from "
-    "cryptography.hazmat.primitives.ciphers.algorithms in 45.0.0.",
-    utils.DeprecatedIn37,
-    name="IDEA",
-)
-
-
-utils.deprecated(
-    SEED,
-    __name__,
-    "SEED has been moved to "
-    "cryptography.hazmat.decrepit.ciphers.algorithms.SEED and "
-    "will be removed from "
-    "cryptography.hazmat.primitives.ciphers.algorithms in 45.0.0.",
-    utils.DeprecatedIn37,
-    name="SEED",
-)
-
 
 class ChaCha20(CipherAlgorithm):
     name = "ChaCha20"

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -22,7 +22,6 @@ class CryptographyDeprecationWarning(UserWarning):
 # ubiquity of their use. They should not be removed until we agree on when that
 # cycle ends.
 DeprecatedIn36 = CryptographyDeprecationWarning
-DeprecatedIn37 = CryptographyDeprecationWarning
 DeprecatedIn40 = CryptographyDeprecationWarning
 DeprecatedIn41 = CryptographyDeprecationWarning
 DeprecatedIn42 = CryptographyDeprecationWarning

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -25,22 +25,6 @@ from .test_aead import large_mmap
 def test_deprecated_ciphers_import_with_warning():
     with pytest.warns(utils.CryptographyDeprecationWarning):
         from cryptography.hazmat.primitives.ciphers.algorithms import (
-            Blowfish,  # noqa: F401
-        )
-    with pytest.warns(utils.CryptographyDeprecationWarning):
-        from cryptography.hazmat.primitives.ciphers.algorithms import (
-            CAST5,  # noqa: F401
-        )
-    with pytest.warns(utils.CryptographyDeprecationWarning):
-        from cryptography.hazmat.primitives.ciphers.algorithms import (
-            IDEA,  # noqa: F401
-        )
-    with pytest.warns(utils.CryptographyDeprecationWarning):
-        from cryptography.hazmat.primitives.ciphers.algorithms import (
-            SEED,  # noqa: F401
-        )
-    with pytest.warns(utils.CryptographyDeprecationWarning):
-        from cryptography.hazmat.primitives.ciphers.algorithms import (
             ARC4,  # noqa: F401
         )
     with pytest.warns(utils.CryptographyDeprecationWarning):


### PR DESCRIPTION
These are still available in the decrepit module.