### PR TITLE
ci: update wycheproof convergence branch to main

### DIFF
--- a/.github/actions/fetch-vectors/action.yml
+++ b/.github/actions/fetch-vectors/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repository: "C2SP/wycheproof"
         path: "wycheproof"
-        # Latest commit on the wycheproof master branch, as of May 02, 2025.
+        # Latest commit on the wycheproof main branch, as of May 02, 2025.
         ref: "df4e933efef449fc88af0c06e028d425d84a9495" # wycheproof-ref
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/x509-limbo-version-bump.yml
+++ b/.github/workflows/x509-limbo-version-bump.yml
@@ -39,7 +39,7 @@ jobs:
           COMMIT_SHA: ${{ steps.check-sha-x509-limbo.outputs.COMMIT_SHA }}
       - id: check-sha-wycheproof
         run: |
-          SHA=$(git ls-remote https://github.com/C2SP/wycheproof refs/heads/master | cut -f1)
+          SHA=$(git ls-remote https://github.com/C2SP/wycheproof refs/heads/main | cut -f1)
           LAST_COMMIT=$(grep wycheproof-ref .github/actions/fetch-vectors/action.yml | grep -oE '[a-f0-9]{40}')
           if ! grep -q "$SHA" .github/actions/fetch-vectors/action.yml; then
             echo "COMMIT_SHA=${SHA}" >> $GITHUB_OUTPUT
@@ -51,7 +51,7 @@ jobs:
         run: |
           set -xe
           CURRENT_DATE=$(date "+%b %d, %Y")
-          sed -E -i "s/Latest commit on the wycheproof master branch.*/Latest commit on the wycheproof master branch, as of ${CURRENT_DATE}./" .github/actions/fetch-vectors/action.yml
+          sed -E -i "s/Latest commit on the wycheproof main branch.*/Latest commit on the wycheproof main branch, as of ${CURRENT_DATE}./" .github/actions/fetch-vectors/action.yml
           sed -E -i "s/ref: \"[0-9a-f]{40}\" # wycheproof-ref/ref: \"${COMMIT_SHA}\" # wycheproof-ref/" .github/actions/fetch-vectors/action.yml
           git status
         if: steps.check-sha-wycheproof.outputs.COMMIT_SHA


### PR DESCRIPTION
This updates the CI machinery that fetches Wycheproof to reflect that the upstream moved the convergence branch from 'master' to 'main' (https://github.com/C2SP/wycheproof/issues/136). 

I suspect the existing code would keep working through the redirects GitHub leaves in place, but thought I'd offer this patch just in case.