### PR TITLE
Rename PBES1 types to better match their origins in the spec

### DIFF
--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -165,10 +165,10 @@ pub enum AlgorithmParameters<'a> {
     #[defined_by(oid::RC2_CBC)]
     Rc2Cbc(Rc2CbcParams),
 
-    #[defined_by(oid::PBES1_WITH_SHA_AND_3KEY_TRIPLEDES_CBC)]
-    Pbes1WithShaAnd3KeyTripleDesCbc(PBES1Params),
-    #[defined_by(oid::PBES1_WITH_SHA_AND_40_BIT_RC2_CBC)]
-    Pbe1WithShaAnd40BitRc2Cbc(PBES1Params),
+    #[defined_by(oid::PBE_WITH_SHA_AND_3KEY_TRIPLEDES_CBC)]
+    PbeWithShaAnd3KeyTripleDesCbc(Pkcs12PbeParams<'a>),
+    #[defined_by(oid::PBE_WITH_SHA_AND_40_BIT_RC2_CBC)]
+    PbeWithShaAnd40BitRc2Cbc(Pkcs12PbeParams<'a>),
 
     #[default]
     Other(asn1::ObjectIdentifier, Option<asn1::Tlv<'a>>),
@@ -529,9 +529,10 @@ pub struct ScryptParams<'a> {
     pub key_length: Option<u32>,
 }
 
+// From RFC 7202 Appendix C
 #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Eq, Hash, Clone, Debug)]
-pub struct PBES1Params {
-    pub salt: [u8; 8],
+pub struct Pkcs12PbeParams<'a> {
+    pub salt: &'a [u8],
     pub iterations: u64,
 }
 

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -154,9 +154,9 @@ pub const PBES2_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 5
 pub const PBKDF2_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 5, 12);
 pub const SCRYPT_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 6, 1, 4, 1, 11591, 4, 11);
 
-pub const PBES1_WITH_SHA_AND_3KEY_TRIPLEDES_CBC: asn1::ObjectIdentifier =
+pub const PBE_WITH_SHA_AND_3KEY_TRIPLEDES_CBC: asn1::ObjectIdentifier =
     asn1::oid!(1, 2, 840, 113549, 1, 12, 1, 3);
-pub const PBES1_WITH_SHA_AND_40_BIT_RC2_CBC: asn1::ObjectIdentifier =
+pub const PBE_WITH_SHA_AND_40_BIT_RC2_CBC: asn1::ObjectIdentifier =
     asn1::oid!(1, 2, 840, 113549, 1, 12, 1, 6);
 
 pub const AES_128_CBC_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 1, 2);

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -112,14 +112,14 @@ pub(crate) fn symmetric_encrypt(
 }
 
 enum EncryptionAlgorithm {
-    PBESv1SHA1And3KeyTripleDESCBC,
+    PBESHA1And3KeyTripleDESCBC,
     PBESv2SHA256AndAES256CBC,
 }
 
 impl EncryptionAlgorithm {
     fn salt_length(&self) -> usize {
         match self {
-            EncryptionAlgorithm::PBESv1SHA1And3KeyTripleDESCBC => 8,
+            EncryptionAlgorithm::PBESHA1And3KeyTripleDESCBC => 8,
             EncryptionAlgorithm::PBESv2SHA256AndAES256CBC => 16,
         }
     }
@@ -131,11 +131,11 @@ impl EncryptionAlgorithm {
         iv: &'a [u8],
     ) -> cryptography_x509::common::AlgorithmIdentifier<'a> {
         match self {
-            EncryptionAlgorithm::PBESv1SHA1And3KeyTripleDESCBC => {
+            EncryptionAlgorithm::PBESHA1And3KeyTripleDESCBC => {
                 cryptography_x509::common::AlgorithmIdentifier {
                     oid: asn1::DefinedByMarker::marker(),
-                    params: cryptography_x509::common::AlgorithmParameters::Pbes1WithShaAnd3KeyTripleDesCbc(cryptography_x509::common::PBES1Params{
-                        salt: salt[..8].try_into().unwrap(),
+                    params: cryptography_x509::common::AlgorithmParameters::PbeWithShaAnd3KeyTripleDesCbc(cryptography_x509::common::Pkcs12PbeParams{
+                        salt,
                         iterations: cipher_kdf_iter,
                     }),
                 }
@@ -189,7 +189,7 @@ impl EncryptionAlgorithm {
         data: &[u8],
     ) -> CryptographyResult<Vec<u8>> {
         match self {
-            EncryptionAlgorithm::PBESv1SHA1And3KeyTripleDESCBC => {
+            EncryptionAlgorithm::PBESHA1And3KeyTripleDESCBC => {
                 let key = cryptography_crypto::pkcs12::kdf(
                     password,
                     salt,
@@ -341,7 +341,7 @@ fn decode_encryption_algorithm<'a>(
         let key_cert_alg =
             encryption_algorithm.getattr(pyo3::intern!(py, "_key_cert_algorithm"))?;
         let cipher = if key_cert_alg.is(&types::PBES_PBESV1SHA1AND3KEYTRIPLEDESCBC.get(py)?) {
-            EncryptionAlgorithm::PBESv1SHA1And3KeyTripleDESCBC
+            EncryptionAlgorithm::PBESHA1And3KeyTripleDESCBC
         } else if key_cert_alg.is(&types::PBES_PBESV2SHA256ANDAES256CBC.get(py)?) {
             EncryptionAlgorithm::PBESv2SHA256AndAES256CBC
         } else {


### PR DESCRIPTION
PBEParams is defined in RFC 8018 as going with PBES1, but then its also used by PKCS#12 ciphers in RFC 7292.