### PR TITLE
fixes #12949 -- added support for decrypting des-cbc-md5 keys

### DIFF
--- a/src/cryptography/hazmat/decrepit/ciphers/algorithms.py
+++ b/src/cryptography/hazmat/decrepit/ciphers/algorithms.py
@@ -40,6 +40,11 @@ class TripleDES(BlockCipherAlgorithm):
         return len(self.key) * 8
 
 
+# Not actually supported, marker for tests
+class _DES:
+    key_size = 64
+
+
 class Blowfish(BlockCipherAlgorithm):
     name = "Blowfish"
     block_size = 64

--- a/src/rust/cryptography-key-parsing/src/pkcs8.rs
+++ b/src/rust/cryptography-key-parsing/src/pkcs8.rs
@@ -2,7 +2,9 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use cryptography_x509::common::{AlgorithmIdentifier, AlgorithmParameters, Pkcs12PbeParams};
+use cryptography_x509::common::{
+    AlgorithmIdentifier, AlgorithmParameters, PbeParams, Pkcs12PbeParams,
+};
 use cryptography_x509::csr::Attributes;
 use cryptography_x509::pkcs8::EncryptedPrivateKeyInfo;
 
@@ -153,6 +155,31 @@ fn pkcs12_pbe_decrypt(
         .map_err(|_| KeyParsingError::IncorrectPassword)
 }
 
+fn pkcs5_pbe_decrypt(
+    data: &[u8],
+    password: &[u8],
+    cipher: openssl::symm::Cipher,
+    hash: openssl::hash::MessageDigest,
+    params: &PbeParams,
+) -> KeyParsingResult<Vec<u8>> {
+    // PKCS#5 v1.5 uses PBKDF1 with iteration count
+    // For PKCS#5 PBE, we need key + IV length
+    let key_iv_len = cipher.key_len() + cipher.iv_len().unwrap();
+    let key_iv = cryptography_crypto::pbkdf1::pbkdf1(
+        hash,
+        password,
+        params.salt,
+        params.iterations,
+        key_iv_len,
+    )?;
+
+    let key = &key_iv[..cipher.key_len()];
+    let iv = &key_iv[cipher.key_len()..];
+
+    openssl::symm::decrypt(cipher, key, Some(iv), data)
+        .map_err(|_| KeyParsingError::IncorrectPassword)
+}
+
 pub fn parse_encrypted_private_key(
     data: &[u8],
     password: Option<&[u8]>,
@@ -164,6 +191,13 @@ pub fn parse_encrypted_private_key(
     };
 
     let plaintext = match epki.encryption_algorithm.params {
+        AlgorithmParameters::PbeWithMd5AndDesCbc(params) => pkcs5_pbe_decrypt(
+            epki.encrypted_data,
+            password,
+            openssl::symm::Cipher::des_cbc(),
+            openssl::hash::MessageDigest::md5(),
+            &params,
+        )?,
         AlgorithmParameters::PbeWithShaAnd3KeyTripleDesCbc(params) => pkcs12_pbe_decrypt(
             epki.encrypted_data,
             password,

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -165,6 +165,8 @@ pub enum AlgorithmParameters<'a> {
     #[defined_by(oid::RC2_CBC)]
     Rc2Cbc(Rc2CbcParams),
 
+    #[defined_by(oid::PBE_WITH_MD5_AND_DES_CBC)]
+    PbeWithMd5AndDesCbc(PbeParams),
     #[defined_by(oid::PBE_WITH_SHA_AND_3KEY_TRIPLEDES_CBC)]
     PbeWithShaAnd3KeyTripleDesCbc(Pkcs12PbeParams<'a>),
     #[defined_by(oid::PBE_WITH_SHA_AND_40_BIT_RC2_CBC)]
@@ -527,6 +529,13 @@ pub struct ScryptParams<'a> {
     pub block_size: u64,
     pub parallelization_parameter: u64,
     pub key_length: Option<u32>,
+}
+
+// RFC 8018 Appendix A.3
+#[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Eq, Hash, Clone, Debug)]
+pub struct PbeParams {
+    pub salt: [u8; 8],
+    pub iterations: u64,
 }
 
 // From RFC 7202 Appendix C

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -152,6 +152,7 @@ pub const EKU_CERTIFICATE_TRANSPARENCY_OID: asn1::ObjectIdentifier =
 
 pub const PBES2_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 5, 13);
 pub const PBKDF2_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 5, 12);
+pub const PBE_WITH_MD5_AND_DES_CBC: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 5, 3);
 pub const SCRYPT_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 6, 1, 4, 1, 11591, 4, 11);
 
 pub const PBE_WITH_SHA_AND_3KEY_TRIPLEDES_CBC: asn1::ObjectIdentifier =

--- a/src/rust/src/backend/cipher_registry.rs
+++ b/src/rust/src/backend/cipher_registry.rs
@@ -123,6 +123,7 @@ fn get_cipher_registry(
         let aes128 = types::AES128.get(py)?;
         let aes256 = types::AES256.get(py)?;
         let triple_des = types::TRIPLE_DES.get(py)?;
+        let des = types::DES.get(py)?;
         #[cfg(not(CRYPTOGRAPHY_OSSLCONF = "OPENSSL_NO_CAMELLIA"))]
         let camellia = types::CAMELLIA.get(py)?;
         #[cfg(not(CRYPTOGRAPHY_OSSLCONF = "OPENSSL_NO_BF"))]
@@ -305,6 +306,8 @@ fn get_cipher_registry(
 
             #[cfg(not(CRYPTOGRAPHY_OSSLCONF = "OPENSSL_NO_RC4"))]
             m.add(&arc4, none_type.as_any(), None, Cipher::rc4())?;
+
+            m.add(&des, &cbc, Some(64), Cipher::des_cbc())?;
 
             if let Some(rc2_cbc) = Cipher::from_nid(openssl::nid::Nid::RC2_CBC) {
                 m.add(&rc2, &cbc, Some(128), rc2_cbc)?;

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -513,6 +513,8 @@ pub static TRIPLE_DES: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.decrepit.ciphers.algorithms",
     &["TripleDES"],
 );
+pub static DES: LazyPyImport =
+    LazyPyImport::new("cryptography.hazmat.decrepit.ciphers.algorithms", &["_DES"]);
 pub static AES: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.ciphers.algorithms",
     &["AES"],


### PR DESCRIPTION
Implemented by Zed (claude sonnet 4) + a bit of cleanup by me with the following prompt:

> Add support to the existing private key parsing APIs for decrypting keys that have the OID 1.2.840.113549.1.5.3. There's an existing vector you can add to our tests for this (documented in test-vectors.rst). You can run tests + formatters + linters with `nox -e local`