### PR TITLE
bump mypy

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -87,7 +87,7 @@ markupsafe==2.1.5 ; python_full_version < '3.9'
     # via jinja2
 markupsafe==3.0.2 ; python_full_version >= '3.9'
     # via jinja2
-mypy==1.14.1 ; python_full_version < '3.9'
+mypy==1.15.0 ; python_full_version < '3.9'
     # via cryptography (pyproject.toml)
 mypy==1.15.0 ; python_full_version >= '3.9'
     # via cryptography (pyproject.toml)


### PR DESCRIPTION
Required to fix this CI warning:
```
pyproject.toml: [mypy]: Unrecognized option: strict_bytes = True
```

Indeed option `--strict-bytes` was added in mypy 1.15:
* https://mypy.readthedocs.io/en/stable/changelog.html#strict-bytes
* https://github.com/python/mypy/blob/master/CHANGELOG.md#--strict-bytes