### PR TITLE
hoist HKDF into rust for even more speed

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/openssl/kdf.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/openssl/kdf.pyi
@@ -47,3 +47,26 @@ class Argon2id:
     def verify_phc_encoded(
         cls, key_material: bytes, phc_encoded: str, secret: bytes | None = None
     ) -> None: ...
+
+class HKDF:
+    def __init__(
+        self,
+        algorithm: HashAlgorithm,
+        length: int,
+        salt: bytes | None,
+        info: bytes | None,
+        backend: typing.Any = None,
+    ): ...
+    def derive(self, key_material: Buffer) -> bytes: ...
+    def verify(self, key_material: bytes, expected_key: bytes) -> None: ...
+
+class HKDFExpand:
+    def __init__(
+        self,
+        algorithm: HashAlgorithm,
+        length: int,
+        info: bytes | None,
+        backend: typing.Any = None,
+    ): ...
+    def derive(self, key_material: Buffer) -> bytes: ...
+    def verify(self, key_material: bytes, expected_key: bytes) -> None: ...

--- a/src/cryptography/hazmat/primitives/kdf/hkdf.py
+++ b/src/cryptography/hazmat/primitives/kdf/hkdf.py
@@ -4,99 +4,13 @@
 
 from __future__ import annotations
 
-import typing
-
-from cryptography import utils
-from cryptography.exceptions import AlreadyFinalized, InvalidKey
-from cryptography.hazmat.primitives import constant_time, hashes, hmac
+from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
 
+HKDF = rust_openssl.kdf.HKDF
+HKDFExpand = rust_openssl.kdf.HKDFExpand
 
-class HKDF(KeyDerivationFunction):
-    def __init__(
-        self,
-        algorithm: hashes.HashAlgorithm,
-        length: int,
-        salt: bytes | None,
-        info: bytes | None,
-        backend: typing.Any = None,
-    ):
-        self._algorithm = algorithm
+KeyDerivationFunction.register(HKDF)
+KeyDerivationFunction.register(HKDFExpand)
 
-        if salt is None:
-            salt = b"\x00" * self._algorithm.digest_size
-        else:
-            utils._check_bytes("salt", salt)
-
-        self._salt = salt
-
-        self._hkdf_expand = HKDFExpand(self._algorithm, length, info)
-
-    def _extract(self, key_material: utils.Buffer) -> bytes:
-        h = hmac.HMAC(self._salt, self._algorithm)
-        h.update(key_material)
-        return h.finalize()
-
-    def derive(self, key_material: utils.Buffer) -> bytes:
-        utils._check_byteslike("key_material", key_material)
-        return self._hkdf_expand.derive(self._extract(key_material))
-
-    def verify(self, key_material: bytes, expected_key: bytes) -> None:
-        if not constant_time.bytes_eq(self.derive(key_material), expected_key):
-            raise InvalidKey
-
-
-class HKDFExpand(KeyDerivationFunction):
-    def __init__(
-        self,
-        algorithm: hashes.HashAlgorithm,
-        length: int,
-        info: bytes | None,
-        backend: typing.Any = None,
-    ):
-        self._algorithm = algorithm
-
-        max_length = 255 * algorithm.digest_size
-
-        if length > max_length:
-            raise ValueError(
-                f"Cannot derive keys larger than {max_length} octets."
-            )
-
-        self._length = length
-
-        if info is None:
-            info = b""
-        else:
-            utils._check_bytes("info", info)
-
-        self._info = info
-
-        self._used = False
-
-    def _expand(self, key_material: utils.Buffer) -> bytes:
-        output = [b""]
-        counter = 1
-
-        h_prime = hmac.HMAC(key_material, self._algorithm)
-        while self._algorithm.digest_size * (len(output) - 1) < self._length:
-            h = h_prime.copy()
-            h.update(output[-1])
-            h.update(self._info)
-            h.update(bytes([counter]))
-            output.append(h.finalize())
-            counter += 1
-
-        return b"".join(output)[: self._length]
-
-    def derive(self, key_material: utils.Buffer) -> bytes:
-        utils._check_byteslike("key_material", key_material)
-        if self._used:
-            raise AlreadyFinalized
-
-        self._used = True
-        return self._expand(key_material)
-
-    def verify(self, key_material: bytes, expected_key: bytes) -> None:
-        if not constant_time.bytes_eq(self.derive(key_material), expected_key):
-            raise InvalidKey
+__all__ = ["HKDF", "HKDFExpand"]

--- a/src/rust/src/backend/hmac.rs
+++ b/src/rust/src/backend/hmac.rs
@@ -100,7 +100,7 @@ impl Hmac {
         Ok(())
     }
 
-    fn copy(&self, py: pyo3::Python<'_>) -> CryptographyResult<Hmac> {
+    pub(crate) fn copy(&self, py: pyo3::Python<'_>) -> CryptographyResult<Hmac> {
         Ok(Hmac {
             ctx: Some(self.get_ctx()?.copy()?),
             algorithm: self.algorithm.clone_ref(py),

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -6,12 +6,14 @@
 use base64::engine::general_purpose::STANDARD_NO_PAD;
 #[cfg(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER)]
 use base64::engine::Engine;
+use pyo3::prelude::PyAnyMethods;
 #[cfg(not(CRYPTOGRAPHY_IS_LIBRESSL))]
 use cryptography_crypto::constant_time;
 #[cfg(not(CRYPTOGRAPHY_IS_LIBRESSL))]
 use pyo3::types::PyBytesMethods;
 
 use crate::backend::hashes;
+use crate::backend::hmac::Hmac;
 use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
 use crate::exceptions;
@@ -443,12 +445,239 @@ impl Argon2id {
     }
 }
 
+#[pyo3::pyclass(module = "cryptography.hazmat.primitives.kdf.hkdf", name = "HKDF")]
+struct Hkdf {
+    algorithm: pyo3::Py<pyo3::PyAny>,
+    salt: pyo3::Py<pyo3::types::PyBytes>,
+    info: Option<pyo3::Py<pyo3::types::PyBytes>>,
+    length: usize,
+    used: bool,
+}
+
+#[pyo3::pymethods]
+impl Hkdf {
+    #[new]
+    #[pyo3(signature = (algorithm, length, salt=None, info=None, backend=None))]
+    fn new(
+        py: pyo3::Python<'_>,
+        algorithm: pyo3::Py<pyo3::PyAny>,
+        length: usize,
+        salt: Option<pyo3::Py<pyo3::types::PyBytes>>,
+        info: Option<pyo3::Py<pyo3::types::PyBytes>>,
+        backend: Option<pyo3::Bound<'_, pyo3::PyAny>>,
+    ) -> CryptographyResult<Self> {
+        _ = backend;
+
+        let algorithm_bound = algorithm.bind(py);
+        let digest_size = algorithm_bound
+            .getattr(pyo3::intern!(py, "digest_size"))?
+            .extract::<usize>()?;
+
+        let max_length = 255 * digest_size;
+        if length > max_length {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot derive keys larger than {} octets.",
+                    max_length
+                )),
+            ));
+        }
+
+        let salt = if let Some(salt) = salt {
+            salt
+        } else {
+            let zero_salt = vec![0u8; digest_size];
+            pyo3::types::PyBytes::new(py, &zero_salt).into()
+        };
+
+        Ok(Hkdf {
+            algorithm,
+            salt,
+            info,
+            length,
+            used: false,
+        })
+    }
+
+    fn _extract<'p>(
+        &self,
+        py: pyo3::Python<'p>,
+        key_material: &[u8],
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
+        let algorithm_bound = self.algorithm.bind(py);
+        let mut hmac = Hmac::new_bytes(py, self.salt.as_bytes(py), algorithm_bound)?;
+        hmac.update_bytes(key_material)?;
+        hmac.finalize(py)
+    }
+
+    fn derive<'p>(
+        &mut self,
+        py: pyo3::Python<'p>,
+        key_material: CffiBuf<'_>,
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
+        if self.used {
+            return Err(exceptions::already_finalized_error());
+        }
+        self.used = true;
+
+        // HKDF Extract
+        let prk = self._extract(py, key_material.as_bytes())?;
+
+        // HKDF Expand
+        let mut hkdf_expand = HkdfExpand::new(
+            py,
+            self.algorithm.clone_ref(py),
+            self.length,
+            self.info.as_ref().map(|i| i.clone_ref(py)),
+            None,
+        )?;
+        let prk_bytes = prk.as_bytes();
+        let cffi_buf = CffiBuf::from_bytes(py, prk_bytes);
+        hkdf_expand.derive(py, cffi_buf)
+    }
+
+    fn verify(
+        &mut self,
+        py: pyo3::Python<'_>,
+        key_material: CffiBuf<'_>,
+        expected_key: CffiBuf<'_>,
+    ) -> CryptographyResult<()> {
+        let actual = self.derive(py, key_material)?;
+        let actual_bytes = actual.as_bytes();
+        let expected_bytes = expected_key.as_bytes();
+
+        if actual_bytes.len() != expected_bytes.len()
+            || !openssl::memcmp::eq(actual_bytes, expected_bytes)
+        {
+            return Err(CryptographyError::from(exceptions::InvalidKey::new_err(
+                "Keys do not match.",
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[pyo3::pyclass(
+    module = "cryptography.hazmat.primitives.kdf.hkdf",
+    name = "HKDFExpand"
+)]
+struct HkdfExpand {
+    algorithm: pyo3::Py<pyo3::PyAny>,
+    info: pyo3::Py<pyo3::types::PyBytes>,
+    length: usize,
+    used: bool,
+}
+
+#[pyo3::pymethods]
+impl HkdfExpand {
+    #[new]
+    #[pyo3(signature = (algorithm, length, info, backend=None))]
+    fn new(
+        py: pyo3::Python<'_>,
+        algorithm: pyo3::Py<pyo3::PyAny>,
+        length: usize,
+        info: Option<pyo3::Py<pyo3::types::PyBytes>>,
+        backend: Option<pyo3::Bound<'_, pyo3::PyAny>>,
+    ) -> CryptographyResult<Self> {
+        _ = backend;
+
+        let algorithm_bound = algorithm.bind(py);
+        let digest_size = algorithm_bound
+            .getattr(pyo3::intern!(py, "digest_size"))?
+            .extract::<usize>()?;
+
+        let max_length = 255 * digest_size;
+        if length > max_length {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot derive keys larger than {} octets.",
+                    max_length
+                )),
+            ));
+        }
+
+        let info = if let Some(info) = info {
+            info
+        } else {
+            pyo3::types::PyBytes::new(py, b"").into()
+        };
+
+        Ok(HkdfExpand {
+            algorithm,
+            info,
+            length,
+            used: false,
+        })
+    }
+
+    fn derive<'p>(
+        &mut self,
+        py: pyo3::Python<'p>,
+        key_material: CffiBuf<'_>,
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
+        if self.used {
+            return Err(exceptions::already_finalized_error());
+        }
+        self.used = true;
+
+        let algorithm_bound = self.algorithm.bind(py);
+
+        let mut output = Vec::new();
+        let mut counter = 1u16;
+        let mut previous_output = Vec::new();
+
+        let h_prime = Hmac::new_bytes(py, key_material.as_bytes(), algorithm_bound)?;
+        while output.len() < self.length {
+            let mut h = h_prime.copy(py)?;
+            h.update_bytes(&previous_output)?;
+            h.update_bytes(self.info.as_bytes(py))?;
+            h.update_bytes(&[counter])?;
+
+            let block = h.finalize(py)?;
+            let block_bytes = block.as_bytes();
+            previous_output = block_bytes.to_vec();
+            output.extend_from_slice(block_bytes);
+
+            counter += 1;
+        }
+
+        output.truncate(self.length);
+        Ok(pyo3::types::PyBytes::new(py, &output))
+    }
+
+    fn verify(
+        &mut self,
+        py: pyo3::Python<'_>,
+        key_material: CffiBuf<'_>,
+        expected_key: CffiBuf<'_>,
+    ) -> CryptographyResult<()> {
+        let actual = self.derive(py, key_material)?;
+        let actual_bytes = actual.as_bytes();
+        let expected_bytes = expected_key.as_bytes();
+
+        if actual_bytes.len() != expected_bytes.len()
+            || !openssl::memcmp::eq(actual_bytes, expected_bytes)
+        {
+            return Err(CryptographyError::from(exceptions::InvalidKey::new_err(
+                "Keys do not match.",
+            )));
+        }
+
+        Ok(())
+    }
+}
+
 #[pyo3::pymodule]
 pub(crate) mod kdf {
     #[pymodule_export]
     use super::derive_pbkdf2_hmac;
     #[pymodule_export]
     use super::Argon2id;
+    #[pymodule_export]
+    use super::Hkdf;
+    #[pymodule_export]
+    use super::HkdfExpand;
     #[pymodule_export]
     use super::Scrypt;
 }

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -468,8 +468,7 @@ impl Hkdf {
     ) -> CryptographyResult<Self> {
         _ = backend;
 
-        let algorithm_bound = algorithm.bind(py);
-        let digest_size = algorithm_bound
+        let digest_size = algorithm.bind(py)
             .getattr(pyo3::intern!(py, "digest_size"))?
             .extract::<usize>()?;
 
@@ -486,8 +485,7 @@ impl Hkdf {
         let salt = if let Some(salt) = salt {
             salt
         } else {
-            let zero_salt = vec![0u8; digest_size];
-            pyo3::types::PyBytes::new(py, &zero_salt).into()
+            pyo3::types::PyBytes::new_with(py, digest_size, |_| {}).into()
         };
 
         Ok(Hkdf {
@@ -582,8 +580,7 @@ impl HkdfExpand {
     ) -> CryptographyResult<Self> {
         _ = backend;
 
-        let algorithm_bound = algorithm.bind(py);
-        let digest_size = algorithm_bound
+        let digest_size = algorithm.bind(py)
             .getattr(pyo3::intern!(py, "digest_size"))?
             .extract::<usize>()?;
 

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -6,9 +6,9 @@
 use base64::engine::general_purpose::STANDARD_NO_PAD;
 #[cfg(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER)]
 use base64::engine::Engine;
-use pyo3::prelude::PyAnyMethods;
 #[cfg(not(CRYPTOGRAPHY_IS_LIBRESSL))]
 use cryptography_crypto::constant_time;
+use pyo3::prelude::PyAnyMethods;
 #[cfg(not(CRYPTOGRAPHY_IS_LIBRESSL))]
 use pyo3::types::PyBytesMethods;
 

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -480,8 +480,7 @@ impl Hkdf {
         if length > max_length {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err(format!(
-                    "Cannot derive keys larger than {} octets.",
-                    max_length
+                    "Cannot derive keys larger than {max_length} octets."
                 )),
             ));
         }
@@ -594,8 +593,7 @@ impl HkdfExpand {
         if length > max_length {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err(format!(
-                    "Cannot derive keys larger than {} octets.",
-                    max_length
+                    "Cannot derive keys larger than {max_length} octets."
                 )),
             ));
         }

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -8,8 +8,7 @@ use base64::engine::general_purpose::STANDARD_NO_PAD;
 use base64::engine::Engine;
 #[cfg(not(CRYPTOGRAPHY_IS_LIBRESSL))]
 use cryptography_crypto::constant_time;
-use pyo3::prelude::PyAnyMethods;
-use pyo3::types::PyBytesMethods;
+use pyo3::types::{PyAnyMethods, PyBytesMethods};
 
 use crate::backend::hashes;
 use crate::backend::hmac::Hmac;
@@ -544,9 +543,7 @@ impl Hkdf {
         let actual_bytes = actual.as_bytes();
         let expected_bytes = expected_key.as_bytes();
 
-        if actual_bytes.len() != expected_bytes.len()
-            || !openssl::memcmp::eq(actual_bytes, expected_bytes)
-        {
+        if !constant_time::bytes_eq(actual_bytes, expected_bytes) {
             return Err(CryptographyError::from(exceptions::InvalidKey::new_err(
                 "Keys do not match.",
             )));
@@ -664,9 +661,7 @@ impl HkdfExpand {
         let actual_bytes = actual.as_bytes();
         let expected_bytes = expected_key.as_bytes();
 
-        if actual_bytes.len() != expected_bytes.len()
-            || !openssl::memcmp::eq(actual_bytes, expected_bytes)
-        {
+        if !constant_time::bytes_eq(actual_bytes, expected_bytes) {
             return Err(CryptographyError::from(exceptions::InvalidKey::new_err(
                 "Keys do not match.",
             )));

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -632,9 +632,10 @@ impl HkdfExpand {
 
         Ok(pyo3::types::PyBytes::new_with(py, self.length, |output| {
             let mut pos = 0usize;
-            let mut counter = 1u8;
+            let mut counter = 0u8;
 
             while pos < self.length {
+                counter += 1;
                 let mut h = h_prime.copy(py)?;
 
                 let start = pos.saturating_sub(digest_size);
@@ -649,8 +650,6 @@ impl HkdfExpand {
                 let copy_len = (self.length - pos).min(digest_size);
                 output[pos..pos + copy_len].copy_from_slice(&block_bytes[..copy_len]);
                 pos += copy_len;
-
-                counter += 1;
             }
 
             Ok(())

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -523,10 +523,7 @@ impl Hkdf {
         }
         self.used = true;
 
-        // HKDF Extract
         let prk = self._extract(py, key_material.as_bytes())?;
-
-        // HKDF Expand
         let mut hkdf_expand = HkdfExpand::new(
             py,
             self.algorithm.clone_ref(py),

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -9,7 +9,6 @@ use base64::engine::Engine;
 #[cfg(not(CRYPTOGRAPHY_IS_LIBRESSL))]
 use cryptography_crypto::constant_time;
 use pyo3::prelude::PyAnyMethods;
-#[cfg(not(CRYPTOGRAPHY_IS_LIBRESSL))]
 use pyo3::types::PyBytesMethods;
 
 use crate::backend::hashes;

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -6,7 +6,6 @@
 use base64::engine::general_purpose::STANDARD_NO_PAD;
 #[cfg(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER)]
 use base64::engine::Engine;
-#[cfg(not(CRYPTOGRAPHY_IS_LIBRESSL))]
 use cryptography_crypto::constant_time;
 use pyo3::types::{PyAnyMethods, PyBytesMethods};
 

--- a/tests/doubles.py
+++ b/tests/doubles.py
@@ -36,7 +36,13 @@ class DummyMode(Mode):
 class DummyHashAlgorithm(hashes.HashAlgorithm):
     name = "dummy-hash"
     block_size = None
-    digest_size = 32
+
+    def __init__(self, digest_size: int = 32) -> None:
+        self._digest_size = digest_size
+
+    @property
+    def digest_size(self) -> int:
+        return self._digest_size
 
 
 class DummyKeySerializationEncryption(

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -12,10 +12,22 @@ from cryptography.exceptions import AlreadyFinalized, InvalidKey
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF, HKDFExpand
 
+from ...doubles import DummyHashAlgorithm
 from ...utils import load_nist_vectors, load_vectors_from_file
 
 
 class TestHKDF:
+    def test_overflow_protection_enormous_digest_size(self, backend):
+        # Test with digest size that would cause overflow when * by 255
+        enormous_digest_size = 2**60
+
+        dummy_hash = DummyHashAlgorithm(enormous_digest_size)
+
+        with pytest.raises(
+            ValueError, match="Digest size too large, would cause overflow"
+        ):
+            HKDF(dummy_hash, 32, salt=None, info=None)
+
     def test_length_limit(self, backend):
         big_length = 255 * hashes.SHA256().digest_size + 1
 
@@ -207,3 +219,14 @@ class TestHKDFExpand:
 
         with pytest.raises(TypeError):
             hkdf.derive("first")  # type: ignore[arg-type]
+
+    def test_overflow_protection_enormous_digest_size(self, backend):
+        # Test with digest size that would cause overflow when * by 255
+        enormous_digest_size = 2**60
+
+        dummy_hash = DummyHashAlgorithm(enormous_digest_size)
+
+        with pytest.raises(
+            ValueError, match="Digest size too large, would cause overflow"
+        ):
+            HKDFExpand(dummy_hash, 32, info=None)

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -19,9 +19,7 @@ from ...utils import load_nist_vectors, load_vectors_from_file
 
 class TestHKDF:
     def test_overflow_protection_enormous_digest_size(self, backend):
-        # Test with digest size that would cause overflow when * by 255
-        enormous_digest_size = 2**60
-
+        enormous_digest_size =  sys.maxsize >> 3
         dummy_hash = DummyHashAlgorithm(enormous_digest_size)
 
         with pytest.raises(
@@ -222,12 +220,7 @@ class TestHKDFExpand:
             hkdf.derive("first")  # type: ignore[arg-type]
 
     def test_overflow_protection_enormous_digest_size(self, backend):
-        # Handle 32-bit and 64-bit systems for this particular test
-        if sys.maxsize < 2**31:
-            enormous_digest_size = 2**30
-        else:
-            enormous_digest_size = 2**60
-
+        enormous_digest_size =  sys.maxsize >> 3
         dummy_hash = DummyHashAlgorithm(enormous_digest_size)
 
         with pytest.raises(

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -19,7 +19,7 @@ from ...utils import load_nist_vectors, load_vectors_from_file
 
 class TestHKDF:
     def test_overflow_protection_enormous_digest_size(self, backend):
-        enormous_digest_size =  sys.maxsize >> 3
+        enormous_digest_size = sys.maxsize >> 3
         dummy_hash = DummyHashAlgorithm(enormous_digest_size)
 
         with pytest.raises(
@@ -220,7 +220,7 @@ class TestHKDFExpand:
             hkdf.derive("first")  # type: ignore[arg-type]
 
     def test_overflow_protection_enormous_digest_size(self, backend):
-        enormous_digest_size =  sys.maxsize >> 3
+        enormous_digest_size = sys.maxsize >> 3
         dummy_hash = DummyHashAlgorithm(enormous_digest_size)
 
         with pytest.raises(

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -5,6 +5,7 @@
 
 import binascii
 import os
+import sys
 
 import pytest
 
@@ -221,8 +222,11 @@ class TestHKDFExpand:
             hkdf.derive("first")  # type: ignore[arg-type]
 
     def test_overflow_protection_enormous_digest_size(self, backend):
-        # Test with digest size that would cause overflow when * by 255
-        enormous_digest_size = 2**60
+        # Handle 32-bit and 64-bit systems for this particular test
+        if sys.maxsize < 2**31:
+            enormous_digest_size = 2**30
+        else:
+            enormous_digest_size = 2**60
 
         dummy_hash = DummyHashAlgorithm(enormous_digest_size)
 

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -219,7 +219,7 @@ class TestHKDFExpand:
         with pytest.raises(TypeError):
             hkdf.derive("first")  # type: ignore[arg-type]
 
-    def test_overflow_protection_enormous_digest_size(self, backend):
+    def test_overflow_protection_enormous_digest_size(self):
         enormous_digest_size = sys.maxsize >> 3
         dummy_hash = DummyHashAlgorithm(enormous_digest_size)
 
@@ -227,3 +227,13 @@ class TestHKDFExpand:
             ValueError, match="Digest size too large, would cause overflow"
         ):
             HKDFExpand(dummy_hash, 32, info=None)
+
+    def test_length_limit(self):
+        big_length = 255 * hashes.SHA256().digest_size + 1
+
+        with pytest.raises(ValueError):
+            HKDFExpand(
+                hashes.SHA256(),
+                big_length,
+                info=None,
+            )


### PR DESCRIPTION
This PR was done via zed+claude sonnet 4 (with some cleanup and additions) using the following prompt:

Please implement HKDF in rust. You can follow the example in hmac.rs to see similar structure, but implement the general HKDF algorithm as seen in hkdf.py