### PR TITLE
A couple mypy/ruff fixes

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -202,8 +202,8 @@ def flake(session: nox.Session) -> None:
         *pyproject_data["project"]["optional-dependencies"]["nox"],
     )
 
-    session.run("ruff", "check", ".")
-    session.run("ruff", "format", "--check", ".")
+    session.run("ruff", "check")
+    session.run("ruff", "format", "--check")
     session.run(
         "mypy",
         "src/cryptography/",
@@ -286,8 +286,8 @@ def local(session: nox.Session):
         verbose=False,
     )
 
-    session.run("ruff", "format", ".")
-    session.run("ruff", "check", ".")
+    session.run("ruff", "format")
+    session.run("ruff", "check")
 
     session.run("cargo", "fmt", "--all", external=True)
     session.run("cargo", "check", "--all", "--tests", external=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ docstest = [
 sdist = ["build >=1.0.0"]
 # `click` included because its needed to type check `release.py`
 pep8test = [
-    "ruff >=0.3.6",
+    "ruff >=0.11.11",
     "mypy >=1.14",
     "check-sdist",
     "click >=8.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ sdist = ["build >=1.0.0"]
 # `click` included because its needed to type check `release.py`
 pep8test = [
     "ruff >=0.3.6",
-    "mypy >=1.4",
+    "mypy >=1.14",
     "check-sdist",
     "click >=8.0.1",
 ]
@@ -138,6 +138,7 @@ markers = [
 [tool.mypy]
 show_error_codes = true
 check_untyped_defs = true
+incremental = false
 no_implicit_reexport = true
 warn_redundant_casts = true
 warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,6 @@ markers = [
 [tool.mypy]
 show_error_codes = true
 check_untyped_defs = true
-incremental = false
 no_implicit_reexport = true
 warn_redundant_casts = true
 warn_unused_ignores = true


### PR DESCRIPTION
~~Fixes #13000.~~
~~Supersedes #12989.~~

**EDIT:**
* Bump ruff/mypy in `pyproject,toml` to match versions in `ci-constraints-requirements.txt`.
* Option `warn-unused-configs = true` requires `incremental = false` according to the [`--warn-unused-configs`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-warn-redundant-casts) documentation:
  > This requires turning off incremental mode using [`--no-incremental`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-incremental).