### PR TITLE
fix type annotation for load_ssh_public_identity

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -1124,7 +1124,7 @@ def _load_ssh_public_identity(
 
 
 def load_ssh_public_identity(
-    data: bytes,
+    data: utils.Buffer,
 ) -> SSHCertificate | SSHPublicKeyTypes:
     return _load_ssh_public_identity(data)
 


### PR DESCRIPTION
looks like new mypy (https://github.com/pyca/cryptography/pull/13013) notices its wrong