### PR TITLE
Return ValueError instead of panicking in x509 encode_authority_key_identifier

### DIFF
--- a/src/rust/src/x509/extensions.rs
+++ b/src/rust/src/x509/extensions.rs
@@ -60,7 +60,11 @@ pub(crate) fn encode_authority_key_identifier<'a>(
     let authority_cert_serial_number =
         if let Some(authority_cert_serial_number) = aki.authority_cert_serial_number {
             serial_bytes = py_uint_to_big_endian_bytes(py, authority_cert_serial_number)?;
-            Some(SerialNumber::new(&serial_bytes).unwrap())
+            Some(SerialNumber::new(&serial_bytes).ok_or_else(|| {
+                CryptographyError::from(pyo3::exceptions::PyValueError::new_err(
+                    "Invalid serial number bytes",
+                ))
+            })?)
         } else {
             None
         };


### PR DESCRIPTION
In the vanishingly rare case that Python passes invalid bytes as serials, send back a ValueError exception instead of panicking.

Adding a test case is probably impractical. This is an extreme edge case that only applies when dealing with really messy bulk data.