### PR TITLE
Fix incorrect DSA attribute description

### DIFF
--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -277,7 +277,7 @@ Key interfaces
 
         :type: int
 
-        The bit length of :attr:`~DSAParameterNumbers.q`.
+        The bit length of :attr:`~DSAParameterNumbers.p`.
 
     .. method:: sign(data, algorithm)
 
@@ -347,7 +347,7 @@ Key interfaces
 
         :type: int
 
-        The bit length of :attr:`~DSAParameterNumbers.q`.
+        The bit length of :attr:`~DSAParameterNumbers.p`.
 
     .. method:: parameters()
 


### PR DESCRIPTION
## Info

Fix incorrect `key_size` attribute description (the bit length of the prime modulus). Fixes issue #13052.

## Overview

The documentation for the `DSAPublicKey` and `DSAPrivateKey` (`hazmat/primitives/asymmetric/dsa`) currently (`45.0.3`) has an incorrect description of the `key_size` attribute.

- [dsa.DSAPublicKey](https://cryptography.io/en/45.0.3/hazmat/primitives/asymmetric/dsa/#cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey)
- [dsa.DSAPrivateKey](https://cryptography.io/en/45.0.3/hazmat/primitives/asymmetric/dsa/#cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey)

Instead of the incorrect `q` (subgroup order), must be `p` (prime modulus).

## Conclusion

The incorrect description of the `key_size` attribute currently exists only in the documentation.

Correct attribute description must be:

```rst
	.. attribute:: key_size

		:type: int

		The bit length of :attr:`~DSAParameterNumbers.p`.
```
