### PR TITLE
Support OpenSSL Providers

### DIFF
--- a/src/_cffi_src/build_openssl.py
+++ b/src/_cffi_src/build_openssl.py
@@ -37,11 +37,14 @@ ffi = build_ffi_for_binding(
         "pem",
         "rand",
         "rsa",
+        "context",
         "ssl",
         "x509",
         "x509name",
         "x509v3",
         "x509_vfy",
+        "provider",
+        "store",
     ],
 )
 

--- a/src/_cffi_src/openssl/context.py
+++ b/src/_cffi_src/openssl/context.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-includes = """
+INCLUDES = """
 #include <openssl/crypto.h>
 """
 

--- a/src/_cffi_src/openssl/context.py
+++ b/src/_cffi_src/openssl/context.py
@@ -1,0 +1,21 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+includes = """
+#include <openssl/crypto.h>
+"""
+
+TYPES = """
+typedef ... OSSL_LIB_CTX;
+"""
+
+FUNCTIONS = """
+OSSL_LIB_CTX *OSSL_LIB_CTX_new(void);
+void OSSL_LIB_CTX_free(OSSL_LIB_CTX *);
+"""
+
+CUSTOMIZATIONS = """
+"""

--- a/src/_cffi_src/openssl/provider.py
+++ b/src/_cffi_src/openssl/provider.py
@@ -1,0 +1,23 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+includes = """
+#include <openssl/provider.h>
+"""
+
+TYPES = """
+typedef ... OSSL_PROVIDER;
+"""
+
+FUNCTIONS = """
+OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *, const char *);
+OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *, const char *, int);
+int OSSL_PROVIDER_unload(OSSL_PROVIDER *);
+int OSSL_PROVIDER_available(OSSL_LIB_CTX *, const char *);
+"""
+
+CUSTOMIZATIONS = """
+"""

--- a/src/_cffi_src/openssl/provider.py
+++ b/src/_cffi_src/openssl/provider.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-includes = """
+INCLUDES = """
 #include <openssl/provider.h>
 """
 

--- a/src/_cffi_src/openssl/provider.py
+++ b/src/_cffi_src/openssl/provider.py
@@ -13,10 +13,12 @@ typedef ... OSSL_PROVIDER;
 """
 
 FUNCTIONS = """
+int OSSL_PROVIDER_set_default_search_path(OSSL_LIB_CTX *, const char *);
+
 OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *, const char *);
 OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *, const char *, int);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *);
-int OSSL_PROVIDER_available(OSSL_LIB_CTX *, const char *);
+range-select)
 """
 
 CUSTOMIZATIONS = """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -127,8 +127,6 @@ typedef ... SSL_SESSION;
 
 typedef ... SSL;
 
-typedef ... OSSL_LIB_CTX;
-
 static const long TLSEXT_NAMETYPE_host_name;
 static const long TLSEXT_STATUSTYPE_ocsp;
 

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -127,6 +127,8 @@ typedef ... SSL_SESSION;
 
 typedef ... SSL;
 
+typedef ... OSSL_LIB_CTX;
+
 static const long TLSEXT_NAMETYPE_host_name;
 static const long TLSEXT_STATUSTYPE_ocsp;
 
@@ -336,6 +338,7 @@ const SSL_METHOD *TLS_client_method(void);
 
 /*- These aren't macros these arguments are all const X on openssl > 1.0.x -*/
 SSL_CTX *SSL_CTX_new(SSL_METHOD *);
+SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *, const char *, const SSL_METHOD *);
 long SSL_CTX_get_timeout(const SSL_CTX *);
 
 const SSL_CIPHER *SSL_get_current_cipher(const SSL *);

--- a/src/_cffi_src/openssl/store.py
+++ b/src/_cffi_src/openssl/store.py
@@ -4,15 +4,15 @@
 
 from __future__ import annotations
 
-includes = """
+INCLUDES = """
 #include <openssl/store.h>
 """
 
 TYPES = """
 typedef ... OSSL_STORE_CTX;
-typedef ... UI_METHOD;
 typedef ... OSSL_STORE_post_process_info_fn;
 typedef ... OSSL_STORE_INFO;
+typedef ... OSSL_PARAM;
 """
 
 FUNCTIONS = """

--- a/src/_cffi_src/openssl/store.py
+++ b/src/_cffi_src/openssl/store.py
@@ -1,0 +1,45 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+includes = """
+#include <openssl/store.h>
+"""
+
+TYPES = """
+typedef ... OSSL_STORE_CTX;
+typedef ... UI_METHOD;
+typedef ... OSSL_STORE_post_process_info_fn;
+typedef ... OSSL_STORE_INFO;
+"""
+
+FUNCTIONS = """
+OSSL_STORE_CTX * OSSL_STORE_open(const char *, const UI_METHOD *,
+                   void *, OSSL_STORE_post_process_info_fn, void *);
+OSSL_STORE_CTX * OSSL_STORE_open_ex(const char *, OSSL_LIB_CTX *, const char *,
+                   const UI_METHOD *, void *,
+                   const OSSL_PARAM [],
+                   OSSL_STORE_post_process_info_fn,
+                   void *);
+int OSSL_STORE_close(OSSL_STORE_CTX *);
+const char *OSSL_STORE_INFO_type_string(int);
+
+OSSL_STORE_INFO *OSSL_STORE_load(OSSL_STORE_CTX *);
+void OSSL_STORE_INFO_free(OSSL_STORE_INFO *);
+int OSSL_STORE_INFO_get_type(const OSSL_STORE_INFO *);
+EVP_PKEY *OSSL_STORE_INFO_get0_PARAMS(const OSSL_STORE_INFO *);
+EVP_PKEY *OSSL_STORE_INFO_get1_PARAMS(const OSSL_STORE_INFO *);
+EVP_PKEY *OSSL_STORE_INFO_get0_PUBKEY(const OSSL_STORE_INFO *);
+EVP_PKEY *OSSL_STORE_INFO_get1_PUBKEY(const OSSL_STORE_INFO *);
+EVP_PKEY *OSSL_STORE_INFO_get0_PKEY(const OSSL_STORE_INFO *);
+EVP_PKEY *OSSL_STORE_INFO_get1_PKEY(const OSSL_STORE_INFO *);
+X509 *OSSL_STORE_INFO_get0_CERT(const OSSL_STORE_INFO *);
+X509 *OSSL_STORE_INFO_get1_CERT(const OSSL_STORE_INFO *);
+X509_CRL *OSSL_STORE_INFO_get0_CRL(const OSSL_STORE_INFO *);
+X509_CRL *OSSL_STORE_INFO_get1_CRL(const OSSL_STORE_INFO *);
+"""
+
+CUSTOMIZATIONS = """
+"""

--- a/src/_cffi_src/openssl/store.py
+++ b/src/_cffi_src/openssl/store.py
@@ -10,9 +10,10 @@ INCLUDES = """
 
 TYPES = """
 typedef ... OSSL_STORE_CTX;
-typedef ... OSSL_STORE_post_process_info_fn;
 typedef ... OSSL_STORE_INFO;
 typedef ... OSSL_PARAM;
+typedef OSSL_STORE_INFO *(*OSSL_STORE_post_process_info_fn)(OSSL_STORE_INFO *,
+                                                            void *);
 """
 
 FUNCTIONS = """


### PR DESCRIPTION
We've been trying to use pyOpenSSL to leverage private keys stored in a TPM or PKCS#11 store, however this project doesn't currently support the ability to load a provider. To load a provider you must create an `OSSL_LIB_CTX` which can then be used with `OSSL_PROVIDER_load`. Once you have the `OSSL_LIB_CTX` with the provider loaded in, you can then pass that context into `SSL_CTX_new_ex` to create an SSL Context with that provider, and you can also load objects with the provider using the OSSL_STORE API using the `OSSL_STORE_open_ex` function.

I've only added in functions that are available in OpenSSL 3.0 to keep support simple, as that seems to be the minimally supported version for this project. My hope is that by adding this support that I can implement some basic provider support in pyOpenSSL, which can then be used to establish TLS connections utilizing HMS/TPM secured keys and certificates.

I've tested manually, but if you'd like I can add some basic unit tests it just doesn't seem like many of these CFFI bindings currently are being tested.