### PR TITLE
mark gil_used = false in all pymodules

### DIFF
--- a/src/rust/src/asn1.rs
+++ b/src/rust/src/asn1.rs
@@ -130,7 +130,7 @@ fn encode_dss_signature<'p>(
     Ok(pyo3::types::PyBytes::new(py, &result))
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 #[pyo3(name = "asn1")]
 pub(crate) mod asn1_mod {
     #[pymodule_export]

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -1174,7 +1174,7 @@ impl AesGcmSiv {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod aead {
     #[pymodule_export]
     use super::{AesCcm, AesGcm, AesGcmSiv, AesOcb3, AesSiv, ChaCha20Poly1305};

--- a/src/rust/src/backend/ciphers.rs
+++ b/src/rust/src/backend/ciphers.rs
@@ -608,7 +608,7 @@ fn _advance_aad(ctx: pyo3::Bound<'_, pyo3::PyAny>, n: u64) {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod ciphers {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/cmac.rs
+++ b/src/rust/src/backend/cmac.rs
@@ -101,7 +101,7 @@ impl Cmac {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod cmac {
     #[pymodule_export]
     use super::Cmac;

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -541,7 +541,7 @@ impl DHParameterNumbers {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod dh {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -508,7 +508,7 @@ impl DsaParameterNumbers {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod dsa {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -661,7 +661,7 @@ impl EllipticCurvePublicNumbers {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod ec {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/ed25519.rs
+++ b/src/rust/src/backend/ed25519.rs
@@ -163,7 +163,7 @@ impl Ed25519PublicKey {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod ed25519 {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -160,7 +160,7 @@ impl Ed448PublicKey {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod ed448 {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/hashes.rs
+++ b/src/rust/src/backend/hashes.rs
@@ -244,7 +244,7 @@ impl XOFHash {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod hashes {
     #[pymodule_export]
     use super::{hash_supported, Hash, XOFHash};

--- a/src/rust/src/backend/hmac.rs
+++ b/src/rust/src/backend/hmac.rs
@@ -108,7 +108,7 @@ impl Hmac {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod hmac {
     #[pymodule_export]
     use super::Hmac;

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -670,7 +670,7 @@ impl HkdfExpand {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod kdf {
     #[pymodule_export]
     use super::derive_pbkdf2_hmac;

--- a/src/rust/src/backend/keys.rs
+++ b/src/rust/src/backend/keys.rs
@@ -361,7 +361,7 @@ fn public_key_from_pkey<'p>(
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod keys {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/poly1305.rs
+++ b/src/rust/src/backend/poly1305.rs
@@ -202,7 +202,7 @@ impl Poly1305 {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod poly1305 {
     #[pymodule_export]
     use super::Poly1305;

--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -824,7 +824,7 @@ impl RsaPublicNumbers {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod rsa {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -149,7 +149,7 @@ impl X25519PublicKey {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod x25519 {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/backend/x448.rs
+++ b/src/rust/src/backend/x448.rs
@@ -148,7 +148,7 @@ impl X448PublicKey {
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod x448 {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/exceptions.rs
+++ b/src/rust/src/exceptions.rs
@@ -44,7 +44,7 @@ pub(crate) fn already_finalized_error() -> CryptographyError {
     CryptographyError::from(AlreadyFinalized::new_err("Context was already finalized."))
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod exceptions {
     #[pymodule_export]
     use super::Reasons;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -94,7 +94,7 @@ fn enable_fips(providers: &mut LoadedProviders) -> CryptographyResult<()> {
     Ok(())
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 mod _rust {
     use pyo3::types::PyModuleMethods;
 
@@ -116,7 +116,7 @@ mod _rust {
     #[pymodule_export]
     use crate::test_support::test_support;
 
-    #[pyo3::pymodule]
+    #[pyo3::pymodule(gil_used = false)]
     mod x509 {
         #[pymodule_export]
         use crate::x509::certificate::{
@@ -143,7 +143,7 @@ mod _rust {
         };
     }
 
-    #[pyo3::pymodule]
+    #[pyo3::pymodule(gil_used = false)]
     mod ocsp {
         #[pymodule_export]
         use crate::x509::ocsp_req::{create_ocsp_request, load_der_ocsp_request, OCSPRequest};
@@ -153,7 +153,7 @@ mod _rust {
         };
     }
 
-    #[pyo3::pymodule]
+    #[pyo3::pymodule(gil_used = false)]
     mod openssl {
         use pyo3::prelude::PyModuleMethods;
 

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -819,7 +819,7 @@ fn load_pkcs12<'p>(
         .call1((private_key, cert, additional_certs))?)
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod pkcs12 {
     #[pymodule_export]
     use super::{

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -804,7 +804,7 @@ fn load_der_pkcs7_certificates<'p>(
     }
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 #[pyo3(name = "pkcs7")]
 pub(crate) mod pkcs7_mod {
     #[pymodule_export]

--- a/src/rust/src/test_support.rs
+++ b/src/rust/src/test_support.rs
@@ -104,7 +104,7 @@ fn pkcs7_verify(
     Ok(())
 }
 
-#[pyo3::pymodule]
+#[pyo3::pymodule(gil_used = false)]
 pub(crate) mod test_support {
     #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
     #[pymodule_export]


### PR DESCRIPTION
Marks all pymodules with `gil_used = false`, since the GIL isn't used for synchronization anywhere.

see https://github.com/pyca/cryptography/pull/12555#issuecomment-3134595469