### PR TITLE
Switch paramiko.sh to be fully uv-based

### DIFF
--- a/.github/downstream.d/paramiko.sh
+++ b/.github/downstream.d/paramiko.sh
@@ -5,9 +5,7 @@ case "${1}" in
         git clone --depth=1 https://github.com/paramiko/paramiko
         cd paramiko
         git rev-parse HEAD
-        uv pip install pip
-        uv pip install -e . --group dev
-        pip install . --group dev
+        uv sync
         ;;
     run)
         cd paramiko

--- a/.github/downstream.d/paramiko.sh
+++ b/.github/downstream.d/paramiko.sh
@@ -5,7 +5,8 @@ case "${1}" in
         git clone --depth=1 https://github.com/paramiko/paramiko
         cd paramiko
         git rev-parse HEAD
-        uv sync
+        uv --version
+        uv sync --inexact --active
         ;;
     run)
         cd paramiko


### PR DESCRIPTION
This is ~= what I do in local dev after the 4.0 update. I have some local idiosyncracies re: where UV sticks its venv, and whether the venv has pip in it (I create the venvs via `uv venv --seed`), _but_ I don't believe either of those matter for this environment/use case.