### PR TITLE
Fix: pkcs7.pkcs7_decrypt_der supports PKCS7Options::Binary

### DIFF
--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -381,10 +381,11 @@ fn check_decrypt_parameters<'p>(
         }
     }
 
-    // Check if any option is not PKCS7Options::Text
+    // Check if any option is not PKCS7Options::Text or PKCS7Options::Binary
     let text_option = types::PKCS7_TEXT.get(py)?;
+    let binary_option = types::PKCS7_BINARY.get(py)?;
     for opt in options.iter() {
-        if !opt.eq(text_option.clone())? {
+        if !opt.eq(text_option.clone())? && !opt.eq(binary_option.clone())? {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err(
                     "Only the following options are supported for decryption: Text",


### PR DESCRIPTION
Hello. As I see, pkcs7.decrypt_der() supports binary data, but check_decrypt_parameters() does not allow this mode.

> 
> // Check if any option is not PKCS7Options::Text
>     **let text_option = types::PKCS7_TEXT.get(py)?;**
>     for opt in options.iter() {
>         if !opt.eq(text_option.clone())? {
>             return Err(CryptographyError::from(
>                 pyo3::exceptions::PyValueError::new_err(
>                     "Only the following options are supported for decryption: Text",
>                 ),
>             ));
>         }
>     }

But

> fn decrypt_der<'p>(
> ...
> // If text_mode, remove the headers after checking the content type
>     **let plain_data = if options.contains(types::PKCS7_TEXT.get(py)?)? {**
>         let stripped_data = types::SMIME_REMOVE_TEXT_HEADERS
>             .get(py)?
>             .call1((plain_content.as_bytes(),))?;
>         pyo3::types::PyBytes::new(py, stripped_data.extract()?)
>     } else {
>         **pyo3::types::PyBytes::new(py, plain_content.as_bytes())**
>     };

I guess that the second condition is for binary data.

PS I can add/fix tests.