### PR TITLE
serialization.rst: pkcs7_decrypt_der (binary mode)

### DIFF
--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -1450,6 +1450,7 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
         :class:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options`. For
         this operation only
         :attr:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options.Text` is supported.
+        The empty list handles binary data.
 
     :returns bytes: The decrypted message.
 
@@ -1505,6 +1506,7 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
         :class:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options`. For
         this operation only
         :attr:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options.Text` is supported.
+        The empty list handles binary data.
 
     :returns bytes: The decrypted message.
 
@@ -1563,6 +1565,7 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
         :class:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options`. For
         this operation only
         :attr:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options.Text` is supported.
+        The empty list handles binary data.
 
     :returns bytes: The decrypted message.
 


### PR DESCRIPTION
Hello. Please, mention that the ist of [PKCS7Options] is optional.

options = [pkcs7.PKCS7Options.Text]  # to decrypt text data
options = []  # to decrypt binary data (as is)

An example:

> :param options: An optional list of
>         :class:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options`. For
>         this operation only
>         :attr:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7Options.Text` is supported
>         or nothing for binary data.