### PR TITLE
Add SSL_set_info_callback function declaration

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -264,6 +264,7 @@ int SSL_CTX_add_client_CA(SSL_CTX *, X509 *);
 void SSL_CTX_set_client_CA_list(SSL_CTX *, Cryptography_STACK_OF_X509_NAME *);
 
 void SSL_CTX_set_info_callback(SSL_CTX *, void (*)(const SSL *, int, int));
+void SSL_set_info_callback(SSL *, void (*) (const SSL *, int, int));
 
 void SSL_CTX_set_msg_callback(SSL_CTX *,
                               void (*)(


### PR DESCRIPTION
we need this to have a `set_info_callback` on an SSL.Connection which twisted needs for reasons I don't understand