### PR TITLE
added pep 723 metadata to release.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -2,6 +2,13 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+# /// script
+# dependencies = [
+#     "click",
+#     "packaging",
+# ]
+# ///
+
 import pathlib
 import re
 import subprocess


### PR DESCRIPTION
now I don't need to create a throwaway venv for every release