### PR TITLE
PKCS#7 signing & verification - Certificate extension policies

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
@@ -21,6 +21,13 @@ from cryptography.hazmat.primitives.ciphers import (
     algorithms,
 )
 from cryptography.utils import _check_byteslike
+from cryptography.x509 import Certificate
+from cryptography.x509.oid import ExtendedKeyUsageOID
+from cryptography.x509.verification import (
+    Criticality,
+    ExtensionPolicy,
+    Policy,
+)
 
 load_pem_pkcs7_certificates = rust_pkcs7.load_pem_pkcs7_certificates
 
@@ -51,6 +58,111 @@ class PKCS7Options(utils.Enum):
     NoCapabilities = "Don't embed SMIME capabilities"
     NoAttributes = "Don't embed authenticatedAttributes"
     NoCerts = "Don't embed signer certificate"
+
+
+def pkcs7_x509_extension_policies() -> tuple[ExtensionPolicy, ExtensionPolicy]:
+    """
+    Gets the default X.509 extension policy for S/MIME. Some specifications
+    that differ from the standard ones:
+    - Certificates used as end entities (i.e., the cert used to sign
+      a PKCS#7/SMIME message) should not have ca=true in their basic
+      constraints extension.
+    - EKU_CLIENT_AUTH_OID is not required
+    - EKU_EMAIL_PROTECTION_OID is required
+    """
+
+    # CA policy - TODO: is default CA policy sufficient? Too much?
+    ca_policy = ExtensionPolicy.webpki_defaults_ca()
+
+    # EE policy
+    def _validate_basic_constraints(
+        policy: Policy, cert: Certificate, bc: x509.BasicConstraints | None
+    ) -> None:
+        if bc is not None and bc.ca:
+            raise ValueError("Basic Constraints CA must be False.")
+
+    def _validate_key_usage(
+        policy: Policy, cert: Certificate, ku: x509.KeyUsage | None
+    ) -> None:
+        if (
+            ku is not None
+            and not ku.digital_signature
+            and not ku.content_commitment
+        ):
+            raise ValueError(
+                "Key Usage, if specified, must have at least one of the "
+                "digital signature or content commitment (formerly non "
+                "repudiation) bits set."
+            )
+
+    def _validate_subject_alternative_name(
+        policy: Policy,
+        cert: Certificate,
+        san: x509.SubjectAlternativeName,
+    ) -> None:
+        """
+        For each general name in the SAN, for those which are email addresses:
+        - If it is an RFC822Name, general part must be ascii.
+        - If it is an OtherName, general part must be non-ascii.
+        """
+        for general_name in san:
+            if (
+                isinstance(general_name, x509.RFC822Name)
+                and "@" in general_name.value
+                and not general_name.value.split("@")[0].isascii()
+            ):
+                raise ValueError(
+                    f"RFC822Name {general_name.value} contains non-ASCII "
+                    "characters."
+                )
+            if (
+                isinstance(general_name, x509.OtherName)
+                and "@" in general_name.value.decode()
+                and general_name.value.decode().split("@")[0].isascii()
+            ):
+                raise ValueError(
+                    f"OtherName {general_name.value.decode()} is ASCII, "
+                    "so must be stored in RFC822Name."
+                )
+
+    def _validate_extended_key_usage(
+        policy: Policy, cert: Certificate, eku: x509.ExtendedKeyUsage | None
+    ) -> None:
+        if (
+            eku is not None
+            and ExtendedKeyUsageOID.EMAIL_PROTECTION not in eku
+            and ExtendedKeyUsageOID.ANY_EXTENDED_KEY_USAGE not in eku
+        ):
+            raise ValueError(
+                "Extended Key Usage, if specified, must include "
+                "emailProtection or anyExtendedKeyUsage."
+            )
+
+    ee_policy = (
+        ExtensionPolicy.webpki_defaults_ee()
+        .may_be_present(
+            x509.BasicConstraints,
+            Criticality.AGNOSTIC,
+            _validate_basic_constraints,
+        )
+        .may_be_present(
+            x509.KeyUsage,
+            Criticality.CRITICAL,
+            _validate_key_usage,
+        )
+        .require_present(
+            x509.SubjectAlternativeName,
+            Criticality.AGNOSTIC,
+            _validate_subject_alternative_name,
+        )
+        .may_be_present(
+            x509.ExtendedKeyUsage,
+            Criticality.AGNOSTIC,
+            _validate_extended_key_usage,
+        )
+    )
+
+    return ca_policy, ee_policy
 
 
 class PKCS7SignatureBuilder:


### PR DESCRIPTION
This is a fork PR of #12465, which was created by @nitneuqr and adds verification of PKCS#7 (S/MIME) certificates. This fork rebases the PR to main and applies the patch given in the PR to avoid a custom `ca.pem` in tests.

forking as I lack permissions to apply the patch and rebase in @nitneuqr's repo. If we prefer to merge #12465 I will close this PR.

closes #12104 