### PR TITLE
Add NIST standard SHA3 OIDs alongside existing deprecated ones

### DIFF
--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -166,6 +166,10 @@ class HashAlgorithmOID:
     SHA3_256 = ObjectIdentifier("1.3.6.1.4.1.37476.3.2.1.99.7.256")
     SHA3_384 = ObjectIdentifier("1.3.6.1.4.1.37476.3.2.1.99.7.384")
     SHA3_512 = ObjectIdentifier("1.3.6.1.4.1.37476.3.2.1.99.7.512")
+    SHA3_224_NIST = ObjectIdentifier("2.16.840.1.101.3.4.2.7")
+    SHA3_256_NIST = ObjectIdentifier("2.16.840.1.101.3.4.2.8")
+    SHA3_384_NIST = ObjectIdentifier("2.16.840.1.101.3.4.2.9")
+    SHA3_512_NIST = ObjectIdentifier("2.16.840.1.101.3.4.2.10")
 
 
 class PublicKeyAlgorithmOID:
@@ -290,6 +294,10 @@ _OID_NAMES = {
     HashAlgorithmOID.SHA3_256: "sha3_256",
     HashAlgorithmOID.SHA3_384: "sha3_384",
     HashAlgorithmOID.SHA3_512: "sha3_512",
+    HashAlgorithmOID.SHA3_224_NIST: "sha3_224",
+    HashAlgorithmOID.SHA3_256_NIST: "sha3_256",
+    HashAlgorithmOID.SHA3_384_NIST: "sha3_384",
+    HashAlgorithmOID.SHA3_512_NIST: "sha3_512",
     PublicKeyAlgorithmOID.DSA: "dsaEncryption",
     PublicKeyAlgorithmOID.EC_PUBLIC_KEY: "id-ecPublicKey",
     PublicKeyAlgorithmOID.RSAES_PKCS1_v1_5: "rsaEncryption",

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -136,6 +136,12 @@ pub const SHA3_384_OID: asn1::ObjectIdentifier =
 pub const SHA3_512_OID: asn1::ObjectIdentifier =
     asn1::oid!(1, 3, 6, 1, 4, 1, 37476, 3, 2, 1, 99, 7, 512);
 
+// NIST SHA3 OIDs (standard values)
+pub const SHA3_224_NIST_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 2, 7);
+pub const SHA3_256_NIST_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 2, 8);
+pub const SHA3_384_NIST_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 2, 9);
+pub const SHA3_512_NIST_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 2, 10);
+
 pub const MGF1_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 1, 8);
 pub const RSASSA_PSS_OID: asn1::ObjectIdentifier = asn1::oid!(1, 2, 840, 113549, 1, 1, 10);
 


### PR DESCRIPTION
Adds new SHA3_224_NIST, SHA3_256_NIST, SHA3_384_NIST, and SHA3_512_NIST OID constants using the official NIST OID values (2.16.840.1.101.3.4.2.x) in both Rust and Python APIs. The existing deprecated SHA3 OIDs are preserved for backward compatibility.

Related to #13331

🤖 Generated with [Claude Code](https://claude.ai/code)