### PR TITLE
disable openssl main branch updating

### DIFF
--- a/.github/workflows/boring-open-awslc-bump.yml
+++ b/.github/workflows/boring-open-awslc-bump.yml
@@ -1,4 +1,4 @@
-name: Bump BoringSSL, OpenSSL, AWS-LC
+name: Bump BoringSSL, AWS-LC
 permissions:
   contents: read
 
@@ -28,16 +28,6 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
 
           fi
-      - id: check-sha-openssl
-        run: |
-          SHA=$(git ls-remote https://github.com/openssl/openssl refs/heads/master | cut -f1)
-          LAST_COMMIT=$(grep openssl .github/workflows/ci.yml | grep TYPE | grep -oE '[a-f0-9]{40}')
-          if ! grep -q "$SHA" .github/workflows/ci.yml; then
-            echo "COMMIT_SHA=${SHA}" >> $GITHUB_OUTPUT
-            echo "COMMIT_MSG<<EOF" >> $GITHUB_OUTPUT
-            echo -e "## OpenSSL\n[Commit: ${SHA}](https://github.com/openssl/openssl/commit/${SHA})\n\n[Diff](https://github.com/openssl/openssl/compare/${LAST_COMMIT}...${SHA}) between the last commit hash merged to this repository and the new commit." >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
       - id: check-tag-aws-lc
         run: |
           # Get the latest tag from AWS-LC repository
@@ -60,16 +50,6 @@ jobs:
         if: steps.check-sha-boring.outputs.COMMIT_SHA
         env:
           COMMIT_SHA: ${{ steps.check-sha-boring.outputs.COMMIT_SHA }}
-      - name: Update OpenSSL
-        run: |
-          set -xe
-          CURRENT_DATE=$(date "+%b %d, %Y")
-          sed -E -i "s/Latest commit on the OpenSSL master branch.*/Latest commit on the OpenSSL master branch, as of ${CURRENT_DATE}./" .github/workflows/ci.yml
-          sed -E -i "s/TYPE: \"openssl\", VERSION: \"[0-9a-f]{40}\"/TYPE: \"openssl\", VERSION: \"${COMMIT_SHA}\"/" .github/workflows/ci.yml
-          git status
-        if: steps.check-sha-openssl.outputs.COMMIT_SHA
-        env:
-          COMMIT_SHA: ${{ steps.check-sha-openssl.outputs.COMMIT_SHA }}
       - name: Update AWS-LC
         run: |
           set -xe
@@ -85,17 +65,16 @@ jobs:
         with:
           app_id: ${{ secrets.BORINGBOT_APP_ID }}
           private_key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
-        if: steps.check-sha-boring.outputs.COMMIT_SHA || steps.check-sha-openssl.outputs.COMMIT_SHA || steps.check-tag-aws-lc.outputs.NEW_TAG
+        if: steps.check-sha-boring.outputs.COMMIT_SHA || steps.check-tag-aws-lc.outputs.NEW_TAG
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           branch: "bump-openssl-boringssl"
-          commit-message: "Bump BoringSSL, OpenSSL, AWS-LC in CI"
-          title: "Bump BoringSSL, OpenSSL, AWS-LC in CI"
+          commit-message: "Bump BoringSSL, AWS-LC in CI"
+          title: "Bump BoringSSL, AWS-LC in CI"
           author: "pyca-boringbot[bot] <pyca-boringbot[bot]+106132319@users.noreply.github.com>"
           body: |
             ${{ steps.check-sha-boring.outputs.COMMIT_MSG }}
-            ${{ steps.check-sha-openssl.outputs.COMMIT_MSG }}
             ${{ steps.check-tag-aws-lc.outputs.COMMIT_MSG }}
           token: ${{ steps.generate-token.outputs.token }}
-        if: steps.check-sha-boring.outputs.COMMIT_SHA || steps.check-sha-openssl.outputs.COMMIT_SHA || steps.check-tag-aws-lc.outputs.NEW_TAG
+        if: steps.check-sha-boring.outputs.COMMIT_SHA || steps.check-tag-aws-lc.outputs.NEW_TAG


### PR DESCRIPTION
they're transitioning to openssl 4 so we need to wait until we have a path in rust-openssl for testing against this. this can be reverted once we can compile with rust-openssl again