### PR TITLE
Depend on CFFI 2.0.0 or newer on Python > 3.8

### DIFF
--- a/.github/requirements/build-requirements.in
+++ b/.github/requirements/build-requirements.in
@@ -1,7 +1,7 @@
 # Must be kept sync with build-system.requires at pyproject.toml
 setuptools!=74.0.0
-cffi>=1.12; platform_python_implementation != 'PyPy' and python_version < '3.14'
-cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.14'
+cffi>=1.12; platform_python_implementation != 'PyPy' and python_version == '3.8'
+cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.9'
 maturin>=1,<2
 
 # Must be kept sync with build-system.requires at vectors/pyproject.toml

--- a/.github/requirements/build-requirements.in
+++ b/.github/requirements/build-requirements.in
@@ -1,6 +1,6 @@
 # Must be kept sync with build-system.requires at pyproject.toml
 setuptools!=74.0.0
-cffi>=1.12; platform_python_implementation != 'PyPy' and python_version == '3.8'
+cffi>=1.14; platform_python_implementation != 'PyPy' and python_version == '3.8'
 cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.9'
 maturin>=1,<2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ requires = [
     "maturin>=1.9.4,<2",
 
     # Must be kept in sync with `project.dependencies`
-    "cffi>=1.14; platform_python_implementation != 'PyPy' and python_version < '3.14'",
-    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.14'",
+    "cffi>=1.14; platform_python_implementation != 'PyPy' and python_version == '3.8'",
+    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version > '3.9'",
     # Used by cffi (which import distutils, and in Python 3.12, distutils has
     # been removed from the stdlib, but installing setuptools puts it back) as
     # well as our build.rs for the rust/cffi bridge.
@@ -51,8 +51,8 @@ classifiers = [
 requires-python = ">=3.8,!=3.9.0,!=3.9.1"
 dependencies = [
     # Must be kept in sync with `build-system.requires`
-    "cffi>=1.14; platform_python_implementation != 'PyPy' and python_version < '3.14'",
-    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.14'",
+    "cffi>=1.14; platform_python_implementation != 'PyPy' and python_version == '3.8'",
+    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version > '3.9'",
     # Must be kept in sync with ./.github/requirements/build-requirements.{in,txt}
     "typing-extensions>=4.13.2; python_version < '3.11'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
     # Must be kept in sync with `project.dependencies`
     "cffi>=1.14; platform_python_implementation != 'PyPy' and python_version == '3.8'",
-    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version > '3.9'",
+    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.9'",
     # Used by cffi (which import distutils, and in Python 3.12, distutils has
     # been removed from the stdlib, but installing setuptools puts it back) as
     # well as our build.rs for the rust/cffi bridge.
@@ -52,7 +52,7 @@ requires-python = ">=3.8,!=3.9.0,!=3.9.1"
 dependencies = [
     # Must be kept in sync with `build-system.requires`
     "cffi>=1.14; platform_python_implementation != 'PyPy' and python_version == '3.8'",
-    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version > '3.9'",
+    "cffi>=2.0.0; platform_python_implementation != 'PyPy' and python_version >= '3.9'",
     # Must be kept in sync with ./.github/requirements/build-requirements.{in,txt}
     "typing-extensions>=4.13.2; python_version < '3.11'",
 ]


### PR DESCRIPTION
To hopefully fix the issue with CFFI 2.0.0 not installing on Python 3.14 under pip because it's a prerelease.