### PR TITLE
asn1: Add support for bytes, str and bool

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
@@ -11,7 +11,10 @@ def non_root_python_to_rust(cls: type) -> Type: ...
 # annotations like this:
 class Type:
     Sequence: typing.ClassVar[type]
+    PyBool: typing.ClassVar[type]
     PyInt: typing.ClassVar[type]
+    PyBytes: typing.ClassVar[type]
+    PyStr: typing.ClassVar[type]
 
 class Annotation:
     def __new__(

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -48,11 +48,30 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     Ok(())
                 }),
             ),
+            Type::PyBool() => {
+                let val: bool = value
+                    .extract()
+                    .map_err(|_| asn1::WriteError::AllocationError)?;
+                write_value(writer, &val)
+            }
             Type::PyInt() => {
                 let val: i64 = value
                     .extract()
                     .map_err(|_| asn1::WriteError::AllocationError)?;
                 write_value(writer, &val)
+            }
+            Type::PyBytes() => {
+                let val: &[u8] = value
+                    .extract()
+                    .map_err(|_| asn1::WriteError::AllocationError)?;
+                write_value(writer, &val)
+            }
+            Type::PyStr() => {
+                let val: &str = value
+                    .extract()
+                    .map_err(|_| asn1::WriteError::AllocationError)?;
+                let asn1_string: asn1::Utf8String<'_> = asn1::Utf8String::new(val);
+                write_value(writer, &asn1_string)
             }
         }
     }

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -20,9 +20,18 @@ pub enum Type {
 
     // Python types that we map to canonical ASN.1 types
     //
+    /// `bool` -> `Boolean`
+    #[pyo3(constructor = ())]
+    PyBool(),
     /// `int` -> `Integer`
     #[pyo3(constructor = ())]
     PyInt(),
+    /// `bytes` -> `Octet String`
+    #[pyo3(constructor = ())]
+    PyBytes(),
+    /// `str` -> `UTF8String`
+    #[pyo3(constructor = ())]
+    PyStr(),
 }
 
 /// A type that we know how to encode/decode, along with any
@@ -70,6 +79,12 @@ pub fn non_root_python_to_rust<'p>(
 ) -> pyo3::PyResult<pyo3::Bound<'p, Type>> {
     if class.is(pyo3::types::PyInt::type_object(py)) {
         Type::PyInt().into_pyobject(py)
+    } else if class.is(pyo3::types::PyBool::type_object(py)) {
+        Type::PyBool().into_pyobject(py)
+    } else if class.is(pyo3::types::PyString::type_object(py)) {
+        Type::PyStr().into_pyobject(py)
+    } else if class.is(pyo3::types::PyBytes::type_object(py)) {
+        Type::PyBytes().into_pyobject(py)
     } else {
         Err(pyo3::exceptions::PyTypeError::new_err(format!(
             "cannot handle type: {class:?}"


### PR DESCRIPTION
This PR adds support for encoding/decoding the ASN.1 types `BOOLEAN`, `OCTET STRING` and `UTF8String`. They are mapped to the Python types `bool`, `bytes` and `str` respectively.


Part of https://github.com/pyca/cryptography/issues/12283

cc @alex @reaperhulk 