### PR TITLE
Fix parsing of multi-byte characters for RFC4514

### DIFF
--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -105,14 +105,26 @@ def _unescape_dn_value(val: str) -> str:
     # special = escaped / SPACE / SHARP / EQUALS
     # escaped = DQUOTE / PLUS / COMMA / SEMI / LANGLE / RANGLE
     def sub(m):
-        val = m.group(1)
-        # Regular escape
-        if len(val) == 1:
-            return val
-        # Hex-value scape
-        return chr(int(val, 16))
+        val = m.group(0)
+        # Special character escape
+        if len(val) == 2:
+            return val[1:]
 
-    return _RFC4514NameParser._PAIR_RE.sub(sub, val)
+        ret = ""
+        buf = bytearray()
+        while val:
+            buf.append(int(val[1:3], 16))
+            val = val[3:]
+            try:
+                ret += buf.decode()
+                buf.clear()
+            except UnicodeDecodeError:
+                continue  # Multi-byte, expect more data
+        if buf:
+            raise ValueError
+        return ret
+
+    return _RFC4514NameParser._PAIR_MULTI_RE.sub(sub, val)
 
 
 NameAttributeValueType = typing.TypeVar(
@@ -373,8 +385,10 @@ class _RFC4514NameParser:
     _OID_RE = re.compile(r"(0|([1-9]\d*))(\.(0|([1-9]\d*)))+")
     _DESCR_RE = re.compile(r"[a-zA-Z][a-zA-Z\d-]*")
 
-    _PAIR = r"\\([\\ #=\"\+,;<>]|[\da-zA-Z]{2})"
-    _PAIR_RE = re.compile(_PAIR)
+    _ESCAPE_SPECIAL = r"[\\ #=\"\+,;<>]"
+    _ESCAPE_HEX = r"[\da-zA-Z]{2}"
+    _PAIR = rf"\\({_ESCAPE_SPECIAL}|{_ESCAPE_HEX})"
+    _PAIR_MULTI_RE = re.compile(rf"(\\{_ESCAPE_SPECIAL})|((\\{_ESCAPE_HEX})+)")
     _LUTF1 = r"[\x01-\x1f\x21\x24-\x2A\x2D-\x3A\x3D\x3F-\x5B\x5D-\x7F]"
     _SUTF1 = r"[\x01-\x21\x23-\x2A\x2D-\x3A\x3D\x3F-\x5B\x5D-\x7F]"
     _TUTF1 = r"[\x01-\x1F\x21\x23-\x2A\x2D-\x3A\x3D\x3F-\x5B\x5D-\x7F]"

--- a/src/cryptography/x509/name.py
+++ b/src/cryptography/x509/name.py
@@ -110,19 +110,8 @@ def _unescape_dn_value(val: str) -> str:
         if len(val) == 2:
             return val[1:]
 
-        ret = ""
-        buf = bytearray()
-        while val:
-            buf.append(int(val[1:3], 16))
-            val = val[3:]
-            try:
-                ret += buf.decode()
-                buf.clear()
-            except UnicodeDecodeError:
-                continue  # Multi-byte, expect more data
-        if buf:
-            raise ValueError
-        return ret
+        # Unicode string of hex
+        return binascii.unhexlify(val.replace("\\", "")).decode()
 
     return _RFC4514NameParser._PAIR_MULTI_RE.sub(sub, val)
 

--- a/tests/x509/test_name.py
+++ b/tests/x509/test_name.py
@@ -21,6 +21,7 @@ class TestRFC4514:
             "C=US,UNKNOWN=Joe , Smith,DC=example",
             "C=US,CN,DC=example",
             "C=US,FOOBAR=example",
+            "CN=Lu\\C4\\8Di\\C4partial character",
         ]:
             with subtests.test():
                 with pytest.raises(ValueError):

--- a/tests/x509/test_name.py
+++ b/tests/x509/test_name.py
@@ -160,6 +160,10 @@ class TestRFC4514:
                 Name([NameAttribute(NameOID.ORGANIZATION_NAME, "abc")]),
             ),
             ("", Name([])),
+            (
+                r"CN=Lu\C4\8Di\C4\87",
+                Name([NameAttribute(NameOID.COMMON_NAME, "Lučić")]),
+            ),
         ]:
             with subtests.test():
                 result = Name.from_rfc4514_string(value)

--- a/tests/x509/test_name.py
+++ b/tests/x509/test_name.py
@@ -165,6 +165,15 @@ class TestRFC4514:
                 r"CN=Lu\C4\8Di\C4\87",
                 Name([NameAttribute(NameOID.COMMON_NAME, "Lučić")]),
             ),
+            (
+                r"CN=Lu\C4\8D\=i\C4\87\#,C=\55\53",
+                Name(
+                    [
+                        NameAttribute(NameOID.COUNTRY_NAME, "US"),
+                        NameAttribute(NameOID.COMMON_NAME, "Luč=ić#"),
+                    ]
+                ),
+            ),
         ]:
             with subtests.test():
                 result = Name.from_rfc4514_string(value)


### PR DESCRIPTION
The last example of https://datatracker.ietf.org/doc/html/rfc4514#section-4 shows a string containing multi-octet UTF-8 characters:

```
   Finally, this example shows an RDN whose commonName value consists of
   5 letters:

      Unicode Character                Code       UTF-8   Escaped
      -------------------------------  ------     ------  --------
      LATIN CAPITAL LETTER L           U+004C     0x4C    L
      LATIN SMALL LETTER U             U+0075     0x75    u
      LATIN SMALL LETTER C WITH CARON  U+010D     0xC48D  \C4\8D
      LATIN SMALL LETTER I             U+0069     0x69    i
      LATIN SMALL LETTER C WITH ACUTE  U+0107     0xC487  \C4\87

   This could be encoded in printable [ASCII](https://datatracker.ietf.org/doc/html/rfc4514#ref-ASCII) [ASCII] (useful for
   debugging purposes) as:

      CN=Lu\C4\8Di\C4\87
```

The current implementation of `x509.Name.from_rfc4514_string` does not correctly handle this case.

This PR addresses this by combining repeated `\hh` sequences into single characters when needed. It also adds a test for the above example from the RFC which would previously fail.