### PR TITLE
asn1: Add support for `OPTIONAL`

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
@@ -13,6 +13,7 @@ def non_root_python_to_rust(cls: type) -> Type: ...
 # annotations like this:
 class Type:
     Sequence: typing.ClassVar[type]
+    Option: typing.ClassVar[type]
     PyBool: typing.ClassVar[type]
     PyInt: typing.ClassVar[type]
     PyBytes: typing.ClassVar[type]

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -7,7 +7,7 @@ use pyo3::types::PyAnyMethods;
 
 use crate::asn1::big_byte_slice_to_py_int;
 use crate::declarative_asn1::types::{
-    AnnotatedType, GeneralizedTime, PrintableString, Type, UtcTime,
+    type_to_tag, AnnotatedType, GeneralizedTime, PrintableString, Type, UtcTime,
 };
 use crate::error::CryptographyError;
 
@@ -124,6 +124,16 @@ pub(crate) fn decode_annotated_type<'a>(
                 let val = cls.call(py, (), Some(&kwargs))?.into_bound(py);
                 Ok(val)
             })
+        }
+        Type::Option(cls) => {
+            let inner_tag = type_to_tag(cls.get().inner.get());
+            match parser.peek_tag() {
+                Some(t) if t == inner_tag => {
+                    let decoded_value = decode_annotated_type(py, parser, cls.get())?;
+                    Ok(decoded_value.into_any())
+                }
+                _ => Ok(pyo3::types::PyNone::get(py).to_owned().into_any()),
+            }
         }
         Type::PyBool() => Ok(decode_pybool(py, parser)?.into_any()),
         Type::PyInt() => Ok(decode_pyint(py, parser)?.into_any()),

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -50,6 +50,18 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     Ok(())
                 }),
             ),
+            Type::Option(cls) => {
+                if !value.is_none() {
+                    let object = AnnotatedTypeObject {
+                        annotated_type: cls.get(),
+                        value,
+                    };
+                    object.write(writer)
+                } else {
+                    // Missing OPTIONAL values are omitted from DER encoding
+                    Ok(())
+                }
+            }
             Type::PyBool() => {
                 let val: bool = value
                     .extract()

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -270,3 +270,32 @@ class TestSequence:
                 )
             ]
         )
+
+    def test_ok_sequence_with_optionals(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: typing.Union[bool, None]
+            b: int
+            c: bytes
+            d: typing.Union[None, str]
+
+        assert_roundtrips(
+            [
+                # All fields are present
+                (
+                    Example(a=True, b=9, c=b"c", d="d"),
+                    b"\x30\x0c\x01\x01\xff\x02\x01\x09\x04\x01c\x0c\x01d",
+                ),
+                # All optional fields are missing
+                (
+                    Example(a=None, b=9, c=b"c", d=None),
+                    b"\x30\x06\x02\x01\x09\x04\x01c",
+                ),
+                # Some optional fields are missing
+                (
+                    Example(a=True, b=9, c=b"c", d=None),
+                    b"\x30\x09\x01\x01\xff\x02\x01\x09\x04\x01c",
+                ),
+            ]
+        )


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/issues/12283

Example:
```python
@asn1.sequence
class Example:
    a: typing.Union[bool, None] # or bool | None
    b: int

asn1.decode_der(Example, encoded_bytes)
```

Decoding is done by peeking the next tag, and returning `None` if it doesn't match the tag of the `T` inside `Option<T>`