### PR TITLE
asn1: Add support for `DEFAULT`

### DIFF
--- a/src/cryptography/hazmat/asn1/__init__.py
+++ b/src/cryptography/hazmat/asn1/__init__.py
@@ -3,6 +3,7 @@
 # for complete details.
 
 from cryptography.hazmat.asn1.asn1 import (
+    Default,
     GeneralizedTime,
     PrintableString,
     UtcTime,
@@ -12,6 +13,7 @@ from cryptography.hazmat.asn1.asn1 import (
 )
 
 __all__ = [
+    "Default",
     "GeneralizedTime",
     "PrintableString",
     "UtcTime",

--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -189,7 +189,7 @@ else:
 
 
 # TODO: replace with `Default[U]` once the min Python version is >= 3.12
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Default(typing.Generic[U]):
     value: U
 

--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -76,7 +76,7 @@ def _normalize_field_type(
     # from it if it exists.
     if get_type_origin(field_type) is Annotated:
         annotation = _extract_annotation(field_type.__metadata__)
-        field_type = get_type_args(field_type)[0]
+        field_type, _ = get_type_args(field_type)
     else:
         annotation = declarative_asn1.Annotation()
 

--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -61,8 +61,8 @@ def _is_union(field_type: type) -> bool:
 def _extract_annotation(metadata: tuple) -> declarative_asn1.Annotation:
     default = None
     for raw_annotation in metadata:
-        if isinstance(raw_annotation, declarative_asn1.Default):
-            default = raw_annotation
+        if isinstance(raw_annotation, Default):
+            default = raw_annotation.value
         else:
             raise TypeError(f"unsupported annotation: {raw_annotation}")
 
@@ -188,7 +188,12 @@ else:
         return dataclass_cls
 
 
-Default = declarative_asn1.Default
+# TODO: replace with `Default[U]` once the min Python version is >= 3.12
+@dataclasses.dataclass
+class Default(typing.Generic[U]):
+    value: U
+
+
 PrintableString = declarative_asn1.PrintableString
 UtcTime = declarative_asn1.UtcTime
 GeneralizedTime = declarative_asn1.GeneralizedTime

--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -62,7 +62,7 @@ def _extract_annotation(metadata: tuple) -> declarative_asn1.Annotation:
     default = None
     for raw_annotation in metadata:
         if isinstance(raw_annotation, declarative_asn1.Default):
-            default = declarative_asn1.Default(value=raw_annotation.value)
+            default = raw_annotation
         else:
             raise TypeError(f"unsupported annotation: {raw_annotation}")
 

--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -94,14 +94,19 @@ def _normalize_field_type(
             )
             annotated_type = _normalize_field_type(optional_type, field_name)
 
-            if (
-                annotation.default is not None
-                or annotated_type.annotation.default is not None
-            ):
+            if not annotated_type.annotation.is_empty():
+                raise TypeError(
+                    "optional (`X | None`) types cannot have `X` "
+                    "annotated: annotations must apply to the union "
+                    "(i.e: `Annotated[X | None, annotation]`)"
+                )
+
+            if annotation.default is not None:
                 raise TypeError(
                     "optional (`X | None`) types should not have a DEFAULT "
                     "annotation"
                 )
+
             rust_field_type = declarative_asn1.Type.Option(annotated_type)
         else:
             raise TypeError(

--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -18,14 +18,17 @@ if sys.version_info < (3, 11):
     if sys.version_info < (3, 9):
         get_type_hints = typing_extensions.get_type_hints
         get_type_args = typing_extensions.get_args
+        get_type_origin = typing_extensions.get_origin
         Annotated = typing_extensions.Annotated
     else:
         get_type_hints = typing.get_type_hints
         get_type_args = typing.get_args
+        get_type_origin = typing.get_origin
         Annotated = typing.Annotated
 else:
     get_type_hints = typing.get_type_hints
     get_type_args = typing.get_args
+    get_type_origin = typing.get_origin
     Annotated = typing.Annotated
 
 if sys.version_info < (3, 10):
@@ -52,7 +55,7 @@ def _is_union(field_type: type) -> bool:
         if hasattr(types, "UnionType")
         else (typing.Union,)
     )
-    return typing.get_origin(field_type) in union_types
+    return get_type_origin(field_type) in union_types
 
 
 def _extract_annotation(metadata: tuple) -> declarative_asn1.Annotation:
@@ -69,7 +72,7 @@ def _extract_annotation(metadata: tuple) -> declarative_asn1.Annotation:
 def _normalize_field_type(
     field_type: typing.Any, field_name: str
 ) -> declarative_asn1.AnnotatedType:
-    if typing.get_origin(field_type) is Annotated:
+    if get_type_origin(field_type) is Annotated:
         annotation = _extract_annotation(field_type.__metadata__)
         field_type = get_type_args(field_type)[0]
     else:

--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -72,6 +72,8 @@ def _extract_annotation(metadata: tuple) -> declarative_asn1.Annotation:
 def _normalize_field_type(
     field_type: typing.Any, field_name: str
 ) -> declarative_asn1.AnnotatedType:
+    # Strip the `Annotated[...]` off, and populate the annotation
+    # from it if it exists.
     if get_type_origin(field_type) is Annotated:
         annotation = _extract_annotation(field_type.__metadata__)
         field_type = get_type_args(field_type)[0]

--- a/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
@@ -25,6 +25,7 @@ class Annotation:
         cls,
         default: Default | None = None,
     ) -> Annotation: ...
+    def is_empty(self) -> bool: ...
 
 T = typing.TypeVar("T")
 

--- a/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
@@ -26,10 +26,13 @@ class Annotation:
         default: Default | None = None,
     ) -> Annotation: ...
 
-class Default:
-    value: typing.Any
+T = typing.TypeVar("T")
 
-    def __new__(cls, value: typing.Any) -> Default: ...
+# TODO: replace with `Default[T]` once the min Python version is >= 3.12
+class Default(typing.Generic[T]):
+    value: T
+
+    def __new__(cls, value: T) -> Default: ...
 
 class AnnotatedType:
     inner: Type

--- a/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
@@ -20,9 +20,16 @@ class Type:
     PyStr: typing.ClassVar[type]
 
 class Annotation:
+    default: Default | None
     def __new__(
         cls,
+        default: Default | None = None,
     ) -> Annotation: ...
+
+class Default:
+    value: typing.Any
+
+    def __new__(cls, value: typing.Any) -> Default: ...
 
 class AnnotatedType:
     inner: Type

--- a/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
@@ -20,20 +20,12 @@ class Type:
     PyStr: typing.ClassVar[type]
 
 class Annotation:
-    default: Default | None
+    default: typing.Any | None
     def __new__(
         cls,
-        default: Default | None = None,
+        default: typing.Any | None = None,
     ) -> Annotation: ...
     def is_empty(self) -> bool: ...
-
-T = typing.TypeVar("T")
-
-# TODO: replace with `Default[T]` once the min Python version is >= 3.12
-class Default(typing.Generic[T]):
-    value: T
-
-    def __new__(cls, value: T) -> Default: ...
 
 class AnnotatedType:
     inner: Type

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -105,11 +105,11 @@ pub(crate) fn decode_annotated_type<'a>(
 
     // Handle DEFAULT annotation if field is not present (by
     // returning the default value)
-    if let Some(default) = &ann_type.annotation.default {
+    if let Some(default) = &ann_type.annotation.get().default {
         let expected_tag = type_to_tag(inner);
         let next_tag = parser.peek_tag();
         if next_tag != Some(expected_tag) {
-            return Ok(default.value.clone_ref(py).into_bound(py));
+            return Ok(default.get().value.clone_ref(py).into_bound(py));
         }
     }
 
@@ -145,8 +145,8 @@ pub(crate) fn decode_annotated_type<'a>(
         Type::GeneralizedTime() => decode_generalized_time(py, parser)?.into_any(),
     };
 
-    match &ann_type.annotation.default {
-        Some(default) if decoded.eq(default.value.bind(py))? => Err(CryptographyError::Py(
+    match &ann_type.annotation.get().default {
+        Some(default) if decoded.eq(default.get().value.bind(py))? => Err(CryptographyError::Py(
             pyo3::exceptions::PyValueError::new_err(
                 "invalid DER: DEFAULT value was explicitly encoded".to_string(),
             ),

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -109,7 +109,7 @@ pub(crate) fn decode_annotated_type<'a>(
         let expected_tag = type_to_tag(inner);
         let next_tag = parser.peek_tag();
         if next_tag != Some(expected_tag) {
-            return Ok(default.get().value.clone_ref(py).into_bound(py));
+            return Ok(default.clone_ref(py).into_bound(py));
         }
     }
 
@@ -146,7 +146,7 @@ pub(crate) fn decode_annotated_type<'a>(
     };
 
     match &ann_type.annotation.get().default {
-        Some(default) if decoded.eq(default.get().value.bind(py))? => Err(CryptographyError::Py(
+        Some(default) if decoded.eq(default.bind(py))? => Err(CryptographyError::Py(
             pyo3::exceptions::PyValueError::new_err(
                 "invalid DER: DEFAULT value was explicitly encoded".to_string(),
             ),

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -148,7 +148,7 @@ pub(crate) fn decode_annotated_type<'a>(
     match &ann_type.annotation.default {
         Some(default) if decoded.eq(default.value.bind(py))? => Err(CryptographyError::Py(
             pyo3::exceptions::PyValueError::new_err(
-                "invalid DER: DEFAULT value was present in encoded data".to_string(),
+                "invalid DER: DEFAULT value was explicitly encoded".to_string(),
             ),
         )),
         _ => Ok(decoded),

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -26,6 +26,17 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
         let py = value.py();
         let annotated_type = self.annotated_type;
 
+        // Handle DEFAULT annotation if value is same as default (by
+        // not encoding the value)
+        if let Some(default) = &annotated_type.annotation.default {
+            if value
+                .eq(&default.value)
+                .map_err(|_| asn1::WriteError::AllocationError)?
+            {
+                return Ok(());
+            }
+        }
+
         let inner = annotated_type.inner.get();
         match &inner {
             Type::Sequence(_cls, fields) => write_value(

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -28,9 +28,9 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
 
         // Handle DEFAULT annotation if value is same as default (by
         // not encoding the value)
-        if let Some(default) = &annotated_type.annotation.default {
+        if let Some(default) = &annotated_type.annotation.get().default {
             if value
-                .eq(&default.value)
+                .eq(&default.get().value)
                 .map_err(|_| asn1::WriteError::AllocationError)?
             {
                 return Ok(());

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -30,7 +30,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
         // not encoding the value)
         if let Some(default) = &annotated_type.annotation.get().default {
             if value
-                .eq(&default.get().value)
+                .eq(default)
                 .map_err(|_| asn1::WriteError::AllocationError)?
             {
                 return Ok(());

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -317,7 +317,7 @@ mod tests {
                 py,
                 AnnotatedType {
                     inner: pyo3::Py::new(py, Type::PyInt()).unwrap(),
-                    annotation: Annotation {},
+                    annotation: Annotation { default: None },
                 },
             )
             .unwrap();
@@ -325,7 +325,7 @@ mod tests {
                 py,
                 AnnotatedType {
                     inner: pyo3::Py::new(py, Type::Option(ann_type)).unwrap(),
-                    annotation: Annotation {},
+                    annotation: Annotation { default: None },
                 },
             )
             .unwrap();

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -69,36 +69,20 @@ pub struct AnnotatedTypeObject<'a> {
 #[derive(Debug)]
 pub struct Annotation {
     #[pyo3(get)]
-    pub(crate) default: Option<pyo3::Py<Default>>,
+    pub(crate) default: Option<pyo3::Py<pyo3::types::PyAny>>,
 }
 
 #[pyo3::pymethods]
 impl Annotation {
     #[new]
     #[pyo3(signature = (default = None))]
-    fn new(default: Option<pyo3::Py<Default>>) -> Self {
+    fn new(default: Option<pyo3::Py<pyo3::types::PyAny>>) -> Self {
         Self { default }
     }
 
     #[pyo3(signature = ())]
     fn is_empty(&self) -> bool {
         self.default.is_none()
-    }
-}
-
-#[pyo3::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.asn1")]
-#[derive(Debug)]
-pub struct Default {
-    #[pyo3(get)]
-    pub value: pyo3::Py<pyo3::types::PyAny>,
-}
-
-#[pyo3::pymethods]
-impl Default {
-    #[new]
-    #[pyo3(signature = (value))]
-    fn new(value: pyo3::Py<pyo3::types::PyAny>) -> Self {
-        Self { value }
     }
 }
 

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -79,6 +79,11 @@ impl Annotation {
     fn new(default: Option<pyo3::Py<Default>>) -> Self {
         Self { default }
     }
+
+    #[pyo3(signature = ())]
+    fn is_empty(&self) -> bool {
+        self.default.is_none()
+    }
 }
 
 #[pyo3::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.asn1")]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -151,8 +151,8 @@ mod _rust {
 
         #[pymodule_export]
         use crate::declarative_asn1::types::{
-            non_root_python_to_rust, AnnotatedType, Annotation, GeneralizedTime, PrintableString,
-            Type, UtcTime,
+            non_root_python_to_rust, AnnotatedType, Annotation, Default, GeneralizedTime,
+            PrintableString, Type, UtcTime,
         };
     }
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -151,8 +151,8 @@ mod _rust {
 
         #[pymodule_export]
         use crate::declarative_asn1::types::{
-            non_root_python_to_rust, AnnotatedType, Annotation, Default, GeneralizedTime,
-            PrintableString, Type, UtcTime,
+            non_root_python_to_rust, AnnotatedType, Annotation, GeneralizedTime, PrintableString,
+            Type, UtcTime,
         };
     }
 

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -3,6 +3,7 @@
 # for complete details.
 
 import datetime
+import re
 import sys
 import typing
 
@@ -196,8 +197,10 @@ class TestSequenceAPI:
     def test_fail_optional_with_default_field(self) -> None:
         with pytest.raises(
             TypeError,
-            match="optional \\(`X \\| None`\\) types should not have a "
-            "DEFAULT annotation",
+            match=re.escape(
+                "optional (`X | None`) types should not have a "
+                "DEFAULT annotation"
+            ),
         ):
 
             @asn1.sequence
@@ -206,16 +209,21 @@ class TestSequenceAPI:
                     typing.Union[int, None], asn1.Default(value=9)
                 ]
 
+    def test_fail_optional_with_annotations_inside(self) -> None:
         with pytest.raises(
             TypeError,
-            match="optional \\(`X \\| None`\\) types should not have a "
-            "DEFAULT annotation",
+            match=re.escape(
+                "optional (`X | None`) types cannot have `X` "
+                "annotated: annotations must apply to the union (i.e: "
+                "`Annotated[X | None, annotation]`)"
+            ),
         ):
-            IntWithDefault = Annotated[int, asn1.Default(value=9)]  # noqa: N806
 
             @asn1.sequence
             class Example2:
-                invalid: typing.Union[IntWithDefault, None]
+                invalid: typing.Union[
+                    Annotated[int, asn1.Default(value=9)], None
+                ]
 
     def test_fields_of_variant_type(self) -> None:
         from cryptography.hazmat.bindings._rust import declarative_asn1

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -184,6 +184,15 @@ class TestSequenceAPI:
             class Example:
                 invalid: typing.Union[int, str]
 
+    def test_fail_unsupported_annotation(self) -> None:
+        with pytest.raises(
+            TypeError, match="unsupported annotation: some annotation"
+        ):
+
+            @asn1.sequence
+            class Example:
+                invalid: Annotated[int, "some annotation"]
+
     def test_fail_optional_with_default_field(self) -> None:
         with pytest.raises(
             TypeError,

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -8,8 +8,10 @@ import typing
 
 import pytest
 
-# TODO: Replace with `typing.Annotated` once min Python version is >= 3.9
-from typing_extensions import Annotated
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+else:
+    from typing import Annotated
 
 import cryptography.hazmat.asn1 as asn1
 

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -8,6 +8,9 @@ import typing
 
 import pytest
 
+# TODO: Replace with `typing.Annotated` once min Python version is >= 3.9
+from typing_extensions import Annotated
+
 import cryptography.hazmat.asn1 as asn1
 
 
@@ -178,6 +181,30 @@ class TestSequenceAPI:
             @asn1.sequence
             class Example:
                 invalid: typing.Union[int, str]
+
+    def test_fail_optional_with_default_field(self) -> None:
+        with pytest.raises(
+            TypeError,
+            match="optional \\(`X \\| None`\\) types should not have a "
+            "DEFAULT annotation",
+        ):
+
+            @asn1.sequence
+            class Example:
+                invalid: Annotated[
+                    typing.Union[int, None], asn1.Default(value=9)
+                ]
+
+        with pytest.raises(
+            TypeError,
+            match="optional \\(`X \\| None`\\) types should not have a "
+            "DEFAULT annotation",
+        ):
+            IntWithDefault = Annotated[int, asn1.Default(value=9)]  # noqa: N806
+
+            @asn1.sequence
+            class Example2:
+                invalid: typing.Union[IntWithDefault, None]
 
     def test_fields_of_variant_type(self) -> None:
         from cryptography.hazmat.bindings._rust import declarative_asn1

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -387,3 +387,15 @@ class TestSequence:
                 ),
             ]
         )
+
+    def test_fail_decode_default_value_present(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[bool, asn1.Default(True)]
+
+        with pytest.raises(
+            ValueError,
+            match="invalid DER: DEFAULT value was present in encoded data",
+        ):
+            asn1.decode_der(Example, b"\x30\x03\x01\x01\xff")

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -396,6 +396,6 @@ class TestSequence:
 
         with pytest.raises(
             ValueError,
-            match="invalid DER: DEFAULT value was present in encoded data",
+            match="invalid DER: DEFAULT value was explicitly encoded",
         ):
             asn1.decode_der(Example, b"\x30\x03\x01\x01\xff")

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -9,8 +9,10 @@ import typing
 
 import pytest
 
-# TODO: Replace with `typing.Annotated` once min Python version is >= 3.9
-from typing_extensions import Annotated
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+else:
+    from typing import Annotated
 
 import cryptography.hazmat.asn1 as asn1
 


### PR DESCRIPTION
This PR adds support for `DEFAULT` fields to the ASN.1 API. The field types must be annotated with `asn1.Default(value=X)`:

```python
@asn1.sequence
class Example
  field: typing.Annotated[int, asn1.Default(value=3)]
```

During decoding, if the field is not found then the object is initialized with the default value. During encoding, if the field has the same value as the default value, it is skipped (not encoded).

Trying to declare a field that is both OPTIONAL and DEFAULT will fail, warning the user to use only one:

```python
IntWithDefault = typing.Annotated[int, asn1.Default(value=3)]

@asn1.sequence
class Invalid:
  # this will raise a TypeError
  invalid_field1: IntWithDefault | None   

  # this will also raise
  invalid_field2: typing.Annotated[int | None, asn1.Default(value=3)]  
```

Part of https://github.com/pyca/cryptography/issues/12283