### PR TITLE
Fix coverage for `type_to_tag`

### DIFF
--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -303,6 +303,8 @@ mod tests {
     // Needed for coverage of `type_to_tag(Type::Option(..))`, since
     // `type_to_tag` is never called with an optional value.
     fn test_option_type_to_tag() {
+        pyo3::Python::initialize();
+
         pyo3::Python::attach(|py| {
             let ann_type = pyo3::Py::new(
                 py,

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -293,3 +293,35 @@ pub(crate) mod types {
     #[pymodule_export]
     use super::{AnnotatedType, Annotation, GeneralizedTime, PrintableString, Type, UtcTime};
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::{type_to_tag, AnnotatedType, Annotation, Type};
+
+    #[test]
+    // Needed for coverage of `type_to_tag(Type::Option(..))`, since
+    // `type_to_tag` is never called with an optional value.
+    fn test_option_type_to_tag() {
+        pyo3::Python::attach(|py| {
+            let ann_type = pyo3::Py::new(
+                py,
+                AnnotatedType {
+                    inner: pyo3::Py::new(py, Type::PyInt()).unwrap(),
+                    annotation: Annotation {},
+                },
+            )
+            .unwrap();
+            let optional_type = pyo3::Py::new(
+                py,
+                AnnotatedType {
+                    inner: pyo3::Py::new(py, Type::Option(ann_type)).unwrap(),
+                    annotation: Annotation {},
+                },
+            )
+            .unwrap();
+            let expected_tag = type_to_tag(&Type::Option(optional_type));
+            assert_eq!(expected_tag, type_to_tag(&Type::PyInt()))
+        })
+    }
+}

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -328,3 +328,28 @@ class TestSequence:
                 ),
             ]
         )
+
+    def test_ok_sequence_all_types_optional(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class MyField:
+            a: int
+
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: typing.Union[MyField, None]
+            b: typing.Union[int, None]
+            c: typing.Union[bytes, None]
+            d: typing.Union[asn1.PrintableString, None]
+            e: typing.Union[asn1.UtcTime, None]
+            f: typing.Union[asn1.GeneralizedTime, None]
+
+        assert_roundtrips(
+            [
+                (
+                    Example(a=None, b=None, c=None, d=None, e=None, f=None),
+                    b"\x30\x00",
+                )
+            ]
+        )


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/pull/13566