### PR TITLE
Fix coverage for pyo3::DowncastIntoError conversion

### DIFF
--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -297,6 +297,9 @@ mod tests {
             )
             .into();
             assert!(matches!(e, CryptographyError::OpenSSL(_)));
+
+            let e = pyo3::DowncastIntoError::new(py.None().into_bound(py), "abc").into();
+            assert!(matches!(e, CryptographyError::Py(_)));
         })
     }
 


### PR DESCRIPTION
Part of https://github.com/pyca/cryptography/pull/13566