### PR TITLE
Two minor fixes for code blocks in x509 docs

### DIFF
--- a/docs/x509/tutorial.rst
+++ b/docs/x509/tutorial.rst
@@ -116,6 +116,7 @@ Then we generate the certificate itself:
 
 .. code-block:: pycon
 
+    >>> import datetime
     >>> # Various details about who we are. For a self-signed certificate the
     >>> # subject and issuer are always the same.
     >>> subject = issuer = x509.Name([

--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -79,7 +79,7 @@ the root of trust:
     >>> # See the documentation on `time` below for more details. If
     >>> # significant time passes between creating a verifier and performing a
     >>> # verification, you may encounter issues with certificate expiration.
-    >>> verification_time = datetime.now(timezone.utc)
+    >>> verification_time = datetime.now(timezone.utc)  # doctest: +SKIP
     >>> builder = builder.time(verification_time)
     >>> verifier = builder.build_server_verifier(DNSName("cryptography.io"))
     >>> # NOTE: peer and untrusted_intermediates are Certificate and

--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -72,13 +72,14 @@ the root of trust:
     >>> from cryptography.x509 import Certificate, DNSName, load_pem_x509_certificates
     >>> from cryptography.x509.verification import PolicyBuilder, Store
     >>> import certifi
-    >>> from datetime import datetime
+    >>> from datetime import datetime, timezone
     >>> with open(certifi.where(), "rb") as pems:
     ...    store = Store(load_pem_x509_certificates(pems.read()))
     >>> builder = PolicyBuilder().store(store)
     >>> # See the documentation on `time` below for more details. If
     >>> # significant time passes between creating a verifier and performing a
     >>> # verification, you may encounter issues with certificate expiration.
+    >>> verification_time = datetime.now(timezone.utc)
     >>> builder = builder.time(verification_time)
     >>> verifier = builder.build_server_verifier(DNSName("cryptography.io"))
     >>> # NOTE: peer and untrusted_intermediates are Certificate and


### PR DESCRIPTION
This PR fixes two minor issues I noticed in the X.509 docs.

* A missing `import datetime` in the section [Creating a self-signed certificate](https://cryptography.io/en/latest/x509/tutorial/#creating-a-self-signed-certificate)
* A missing variable definition in the section [X.509 Verification](https://cryptography.io/en/latest/x509/verification/#module-cryptography.x509.verification)