### PR TITLE
Migrate external Rust dependencies to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,17 @@ license = "Apache-2.0 OR BSD-3-Clause"
 
 [workspace.dependencies]
 asn1 = { version = "0.22.0", default-features = false }
-pyo3 = { version = "0.26", features = ["abi3"] }
-pyo3-build-config = { version = "0.26" }
+base64 = "0.22"
+cc = "1.2.40"
+cfg-if = "1"
+foreign-types = "0.3"
+foreign-types-shared = "0.1"
 openssl = "0.10.73"
 openssl-sys = "0.9.108"
+pem = { version = "3", default-features = false }
+pyo3 = { version = "0.26", features = ["abi3"] }
+pyo3-build-config = { version = "0.26" }
+self_cell = "1"
 
 [profile.release]
 overflow-checks = true

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -8,22 +8,22 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-base64 = "0.22"
-cfg-if = "1"
-pyo3.workspace = true
 asn1.workspace = true
+base64.workspace = true
+cfg-if.workspace = true
 cryptography-cffi = { path = "cryptography-cffi" }
 cryptography-crypto = { path = "cryptography-crypto" }
 cryptography-keepalive = { path = "cryptography-keepalive" }
 cryptography-key-parsing = { path = "cryptography-key-parsing" }
+cryptography-openssl = { path = "cryptography-openssl" }
 cryptography-x509 = { path = "cryptography-x509" }
 cryptography-x509-verification = { path = "cryptography-x509-verification" }
-cryptography-openssl = { path = "cryptography-openssl" }
-pem = { version = "3", default-features = false }
+foreign-types-shared.workspace = true
 openssl.workspace = true
 openssl-sys.workspace = true
-foreign-types-shared = "0.1"
-self_cell = "1"
+pem.workspace = true
+pyo3.workspace = true
+self_cell.workspace = true
 
 [build-dependencies]
 pyo3-build-config.workspace = true

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -12,7 +12,7 @@ pyo3.workspace = true
 openssl-sys.workspace = true
 
 [build-dependencies]
-cc = "1.2.40"
+cc.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(python_implementation, values("CPython", "PyPy"))'] }

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -9,12 +9,12 @@ license.workspace = true
 
 [dependencies]
 asn1.workspace = true
-cfg-if = "1"
-openssl.workspace = true
-openssl-sys.workspace = true
+cfg-if.workspace = true
 cryptography-crypto = { path = "../cryptography-crypto" }
 cryptography-openssl = { path = "../cryptography-openssl" }
 cryptography-x509 = { path = "../cryptography-x509" }
+openssl.workspace = true
+openssl-sys.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(CRYPTOGRAPHY_IS_LIBRESSL)', 'cfg(CRYPTOGRAPHY_IS_BORINGSSL)', 'cfg(CRYPTOGRAPHY_OSSLCONF, values("OPENSSL_NO_RC2", "OPENSSL_NO_RC4"))', 'cfg(CRYPTOGRAPHY_IS_AWSLC)'] }

--- a/src/rust/cryptography-openssl/Cargo.toml
+++ b/src/rust/cryptography-openssl/Cargo.toml
@@ -8,11 +8,11 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-cfg-if = "1"
+cfg-if.workspace = true
+foreign-types.workspace = true
+foreign-types-shared.workspace = true
 openssl.workspace = true
 openssl-sys.workspace = true
-foreign-types = "0.3"
-foreign-types-shared = "0.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER)', 'cfg(CRYPTOGRAPHY_IS_LIBRESSL)', 'cfg(CRYPTOGRAPHY_IS_BORINGSSL)', 'cfg(CRYPTOGRAPHY_IS_AWSLC)'] }

--- a/src/rust/cryptography-x509-verification/Cargo.toml
+++ b/src/rust/cryptography-x509-verification/Cargo.toml
@@ -13,4 +13,4 @@ cryptography-x509 = { path = "../cryptography-x509" }
 cryptography-key-parsing = { path = "../cryptography-key-parsing" }
 
 [dev-dependencies]
-pem = { version = "3", default-features = false }
+pem.workspace = true


### PR DESCRIPTION
Consolidates external crate versions (base64, cc, cfg-if, foreign-types, foreign-types-shared, pem, self_cell) to workspace.dependencies for centralized version management across all workspace members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)