### PR TITLE
Refactor PEM encryption into cryptography-key-parsing crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "cryptography-x509",
  "openssl",
  "openssl-sys",
+ "pem",
 ]
 
 [[package]]

--- a/src/rust/cryptography-key-parsing/Cargo.toml
+++ b/src/rust/cryptography-key-parsing/Cargo.toml
@@ -15,6 +15,7 @@ cryptography-openssl = { path = "../cryptography-openssl" }
 cryptography-x509 = { path = "../cryptography-x509" }
 openssl.workspace = true
 openssl-sys.workspace = true
+pem.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(CRYPTOGRAPHY_IS_LIBRESSL)', 'cfg(CRYPTOGRAPHY_IS_BORINGSSL)', 'cfg(CRYPTOGRAPHY_OSSLCONF, values("OPENSSL_NO_RC2", "OPENSSL_NO_RC4"))', 'cfg(CRYPTOGRAPHY_IS_AWSLC)'] }

--- a/src/rust/cryptography-key-parsing/src/lib.rs
+++ b/src/rust/cryptography-key-parsing/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod dsa;
 pub mod ec;
+pub mod pem;
 pub mod pkcs8;
 pub mod rsa;
 pub mod spki;
@@ -24,6 +25,13 @@ pub enum KeyParsingError {
     UnsupportedEncryptionAlgorithm(asn1::ObjectIdentifier),
     EncryptedKeyWithoutPassword,
     IncorrectPassword,
+    // PEM encryption errors
+    PemMissingDekInfo,
+    PemInvalidDekInfo,
+    PemInvalidIv,
+    PemUnableToDeriveKey,
+    PemUnsupportedCipher,
+    PemInvalidProcType,
 }
 
 impl From<asn1::ParseError> for KeyParsingError {

--- a/src/rust/cryptography-key-parsing/src/pem.rs
+++ b/src/rust/cryptography-key-parsing/src/pem.rs
@@ -1,0 +1,67 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use std::borrow::Cow;
+
+use crate::{KeyParsingError, KeyParsingResult};
+
+/// Decrypts PEM encryption (legacy format with Proc-Type and DEK-Info headers).
+/// Returns a tuple of (decrypted contents, was_encrypted flag).
+///
+/// If no `Proc-Type` header is preseent, the PEM contents is returned
+/// undecrypted.
+///
+/// Supported ciphers: AES-128-CBC, AES-256-CBC, DES-EDE3-CBC
+pub fn decrypt_pem<'a>(
+    pem: &'a pem::Pem,
+    password: Option<&[u8]>,
+) -> KeyParsingResult<(Cow<'a, [u8]>, bool)> {
+    match pem.headers().get("Proc-Type") {
+        Some("4,ENCRYPTED") => {
+            let dek_info = pem
+                .headers()
+                .get("DEK-Info")
+                .ok_or(KeyParsingError::PemMissingDekInfo)?;
+
+            let (cipher_algorithm, iv) = dek_info
+                .split_once(',')
+                .ok_or(KeyParsingError::PemInvalidDekInfo)?;
+
+            let password = match password {
+                None | Some(b"") => return Err(KeyParsingError::EncryptedKeyWithoutPassword),
+                Some(p) => p,
+            };
+
+            // There's no RFC that defines these, but these are the ones in
+            // very wide use that we support.
+            let cipher = match cipher_algorithm {
+                "AES-128-CBC" => openssl::symm::Cipher::aes_128_cbc(),
+                "AES-256-CBC" => openssl::symm::Cipher::aes_256_cbc(),
+                "DES-EDE3-CBC" => openssl::symm::Cipher::des_ede3_cbc(),
+                _ => return Err(KeyParsingError::PemUnsupportedCipher),
+            };
+
+            let iv = cryptography_crypto::encoding::hex_decode(iv)
+                .ok_or(KeyParsingError::PemInvalidIv)?;
+
+            let key = cryptography_crypto::pbkdf1::openssl_kdf(
+                openssl::hash::MessageDigest::md5(),
+                password,
+                iv.get(..8)
+                    .ok_or(KeyParsingError::PemInvalidIv)?
+                    .try_into()
+                    .unwrap(),
+                cipher.key_len(),
+            )
+            .map_err(|_| KeyParsingError::PemUnableToDeriveKey)?;
+
+            let decrypted = openssl::symm::decrypt(cipher, &key, Some(&iv), pem.contents())
+                .map_err(|_| KeyParsingError::IncorrectPassword)?;
+
+            Ok((Cow::Owned(decrypted), true))
+        }
+        Some(_) => Err(KeyParsingError::PemInvalidProcType),
+        None => Ok((Cow::Borrowed(pem.contents()), false)),
+    }
+}

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -101,6 +101,34 @@ impl From<cryptography_key_parsing::KeyParsingError> for CryptographyError {
                     "Incorrect password, could not decrypt key",
                 ))
             }
+            cryptography_key_parsing::KeyParsingError::PemMissingDekInfo => {
+                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
+                    "Encrypted PEM doesn't have a DEK-Info header.",
+                ))
+            }
+            cryptography_key_parsing::KeyParsingError::PemInvalidDekInfo => {
+                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
+                    "Encrypted PEM's DEK-Info header is not valid.",
+                ))
+            }
+            cryptography_key_parsing::KeyParsingError::PemInvalidIv => CryptographyError::Py(
+                pyo3::exceptions::PyValueError::new_err("DEK-Info IV is not valid hex"),
+            ),
+            cryptography_key_parsing::KeyParsingError::PemUnableToDeriveKey => {
+                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
+                    "Unable to derive key from password (are you in FIPS mode?)",
+                ))
+            }
+            cryptography_key_parsing::KeyParsingError::PemUnsupportedCipher => {
+                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
+                    "Key encrypted with unknown cipher.",
+                ))
+            }
+            cryptography_key_parsing::KeyParsingError::PemInvalidProcType => {
+                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
+                    "Proc-Type PEM header is not valid, key could not be decrypted.",
+                ))
+            }
         }
     }
 }


### PR DESCRIPTION
Move encrypted PEM decryption logic from backend/keys.rs into a new pem module in cryptography-key-parsing crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)