### PR TITLE
Revert OpenSSL API compatibility level

### DIFF
--- a/src/_cffi_src/openssl/cryptography.py
+++ b/src/_cffi_src/openssl/cryptography.py
@@ -5,8 +5,6 @@
 from __future__ import annotations
 
 INCLUDES = r"""
-/* define our OpenSSL API compatibility level to 3.0.0. Any symbols older than
-   that will raise an error during compilation. */
 #define OPENSSL_API_COMPAT 0x10100000L
 
 #if defined(_WIN32)


### PR DESCRIPTION
We still don't support OpenSSL <3.0 except via the forks though