### PR TITLE
Refactor TraditionalOpenSSL to use bespoke PEM encryption

### DIFF
--- a/src/rust/cryptography-crypto/src/encoding.rs
+++ b/src/rust/cryptography-crypto/src/encoding.rs
@@ -30,9 +30,19 @@ pub fn hex_decode(v: &str) -> Option<Vec<u8>> {
     Some(b)
 }
 
+pub fn hex_encode(data: &[u8]) -> String {
+    const HEX_CHARS: &[u8; 16] = b"0123456789ABCDEF";
+    let mut result = String::with_capacity(data.len() * 2);
+    for &byte in data {
+        result.push(HEX_CHARS[(byte >> 4) as usize] as char);
+        result.push(HEX_CHARS[(byte & 0x0F) as usize] as char);
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
-    use super::hex_decode;
+    use super::{hex_decode, hex_encode};
 
     #[test]
     fn test_hex_decode() {
@@ -47,6 +57,19 @@ mod tests {
             ("ABCD", Some(vec![0xAB, 0xCD])),
         ] {
             assert_eq!(hex_decode(text), expected);
+        }
+    }
+
+    #[test]
+    fn test_hex_encode() {
+        for (input, expected) in [
+            (&[][..], ""),
+            (&[0][..], "00"),
+            (&[0xAB][..], "AB"),
+            (&[0xAB, 0xCD][..], "ABCD"),
+            (&[0x12, 0x34, 0x56][..], "123456"),
+        ] {
+            assert_eq!(hex_encode(input), expected);
         }
     }
 }

--- a/src/rust/cryptography-key-parsing/src/pem.rs
+++ b/src/rust/cryptography-key-parsing/src/pem.rs
@@ -65,3 +65,51 @@ pub fn decrypt_pem<'a>(
         None => Ok((Cow::Borrowed(pem.contents()), false)),
     }
 }
+
+/// PEM encoding configuration using LF line endings (Unix-style)
+pub const ENCODE_CONFIG: pem::EncodeConfig =
+    pem::EncodeConfig::new().set_line_ending(pem::LineEnding::LF);
+
+/// Encrypts DER data with legacy PEM encryption (Proc-Type and DEK-Info
+/// headers). Returns PEM-formatted bytes with encryption headers.
+///
+/// If password is empty, returns unencrypted PEM. Otherwise, encrypts using
+/// AES-256-CBC.
+pub fn encrypt_pem(
+    tag: &str,
+    der_data: &[u8],
+    password: &[u8],
+) -> crate::KeySerializationResult<Vec<u8>> {
+    if password.is_empty() {
+        // No encryption - just encode as PEM
+        let pem = pem::Pem::new(tag, der_data);
+        return Ok(pem::encode_config(&pem, ENCODE_CONFIG).into_bytes());
+    }
+
+    let cipher = openssl::symm::Cipher::aes_256_cbc();
+    let iv_len = cipher.iv_len().unwrap();
+    let mut iv = vec![0u8; iv_len];
+    cryptography_openssl::rand::rand_bytes(&mut iv)?;
+
+    // Derive key using MD5-based KDF (for compatibility with traditional
+    // OpenSSL format)
+    let key = cryptography_crypto::pbkdf1::openssl_kdf(
+        openssl::hash::MessageDigest::md5(),
+        password,
+        iv.get(..8).unwrap().try_into().unwrap(),
+        cipher.key_len(),
+    )?;
+
+    // Encrypt the DER data
+    let encrypted = openssl::symm::encrypt(cipher, &key, Some(&iv), der_data)?;
+
+    let iv_hex = cryptography_crypto::encoding::hex_encode(&iv);
+
+    let mut pem = pem::Pem::new(tag, encrypted);
+    pem.headers_mut().add("Proc-Type", "4,ENCRYPTED").unwrap();
+    pem.headers_mut()
+        .add("DEK-Info", &format!("AES-256-CBC,{}", iv_hex))
+        .unwrap();
+
+    Ok(pem::encode_config(&pem, ENCODE_CONFIG).into_bytes())
+}

--- a/src/rust/cryptography-openssl/src/lib.rs
+++ b/src/rust/cryptography-openssl/src/lib.rs
@@ -15,6 +15,7 @@ pub mod hmac;
     CRYPTOGRAPHY_IS_AWSLC
 ))]
 pub mod poly1305;
+pub mod rand;
 pub mod utils;
 
 pub type OpenSSLResult<T> = Result<T, openssl::error::ErrorStack>;

--- a/src/rust/cryptography-openssl/src/rand.rs
+++ b/src/rust/cryptography-openssl/src/rand.rs
@@ -1,0 +1,24 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use crate::OpenSSLResult;
+
+/// Fill a buffer with random bytes.
+pub fn rand_bytes(buf: &mut [u8]) -> OpenSSLResult<()> {
+    #[cfg(any(
+        CRYPTOGRAPHY_IS_LIBRESSL,
+        CRYPTOGRAPHY_IS_BORINGSSL,
+        CRYPTOGRAPHY_IS_AWSLC
+    ))]
+    openssl::rand::rand_bytes(buf)?;
+
+    #[cfg(not(any(
+        CRYPTOGRAPHY_IS_LIBRESSL,
+        CRYPTOGRAPHY_IS_BORINGSSL,
+        CRYPTOGRAPHY_IS_AWSLC
+    )))]
+    openssl::rand::rand_priv_bytes(buf)?;
+
+    Ok(())
+}

--- a/src/rust/src/asn1.rs
+++ b/src/rust/src/asn1.rs
@@ -102,7 +102,7 @@ pub(crate) fn encode_der_data<'p>(
             py,
             &pem::encode_config(
                 &pem::Pem::new(pem_tag, data),
-                pem::EncodeConfig::new().set_line_ending(pem::LineEnding::LF),
+                cryptography_key_parsing::pem::ENCODE_CONFIG,
             )
             .into_bytes(),
         ))

--- a/src/rust/src/backend/rand.rs
+++ b/src/rust/src/backend/rand.rs
@@ -9,18 +9,7 @@ pub(crate) fn get_rand_bytes(
     size: usize,
 ) -> CryptographyResult<pyo3::Bound<'_, pyo3::types::PyBytes>> {
     Ok(pyo3::types::PyBytes::new_with(py, size, |b| {
-        #[cfg(any(
-            CRYPTOGRAPHY_IS_LIBRESSL,
-            CRYPTOGRAPHY_IS_BORINGSSL,
-            CRYPTOGRAPHY_IS_AWSLC
-        ))]
-        openssl::rand::rand_bytes(b).map_err(CryptographyError::from)?;
-        #[cfg(not(any(
-            CRYPTOGRAPHY_IS_LIBRESSL,
-            CRYPTOGRAPHY_IS_BORINGSSL,
-            CRYPTOGRAPHY_IS_AWSLC
-        )))]
-        openssl::rand::rand_priv_bytes(b).map_err(CryptographyError::from)?;
+        cryptography_openssl::rand::rand_bytes(b).map_err(CryptographyError::from)?;
         Ok(())
     })?)
 }

--- a/src/rust/src/backend/utils.rs
+++ b/src/rust/src/backend/utils.rs
@@ -150,14 +150,12 @@ pub(crate) fn pkey_private_bytes<'p>(
         }
         if let Ok(rsa) = pkey.rsa() {
             if encoding.is(&types::ENCODING_PEM.get(py)?) {
-                let pem_bytes = if password.is_empty() {
-                    rsa.private_key_to_pem()?
-                } else {
-                    rsa.private_key_to_pem_passphrase(
-                        openssl::symm::Cipher::aes_256_cbc(),
-                        password,
-                    )?
-                };
+                let der_bytes = rsa.private_key_to_der()?;
+                let pem_bytes = cryptography_key_parsing::pem::encrypt_pem(
+                    "RSA PRIVATE KEY",
+                    &der_bytes,
+                    password,
+                )?;
                 return Ok(pyo3::types::PyBytes::new(py, &pem_bytes));
             } else if encoding.is(&types::ENCODING_DER.get(py)?) {
                 if !password.is_empty() {
@@ -173,14 +171,12 @@ pub(crate) fn pkey_private_bytes<'p>(
             }
         } else if let Ok(dsa) = pkey.dsa() {
             if encoding.is(&types::ENCODING_PEM.get(py)?) {
-                let pem_bytes = if password.is_empty() {
-                    dsa.private_key_to_pem()?
-                } else {
-                    dsa.private_key_to_pem_passphrase(
-                        openssl::symm::Cipher::aes_256_cbc(),
-                        password,
-                    )?
-                };
+                let der_bytes = dsa.private_key_to_der()?;
+                let pem_bytes = cryptography_key_parsing::pem::encrypt_pem(
+                    "DSA PRIVATE KEY",
+                    &der_bytes,
+                    password,
+                )?;
                 return Ok(pyo3::types::PyBytes::new(py, &pem_bytes));
             } else if encoding.is(&types::ENCODING_DER.get(py)?) {
                 if !password.is_empty() {
@@ -196,14 +192,12 @@ pub(crate) fn pkey_private_bytes<'p>(
             }
         } else if let Ok(ec) = pkey.ec_key() {
             if encoding.is(&types::ENCODING_PEM.get(py)?) {
-                let pem_bytes = if password.is_empty() {
-                    ec.private_key_to_pem()?
-                } else {
-                    ec.private_key_to_pem_passphrase(
-                        openssl::symm::Cipher::aes_256_cbc(),
-                        password,
-                    )?
-                };
+                let der_bytes = ec.private_key_to_der()?;
+                let pem_bytes = cryptography_key_parsing::pem::encrypt_pem(
+                    "EC PRIVATE KEY",
+                    &der_bytes,
+                    password,
+                )?;
                 return Ok(pyo3::types::PyBytes::new(py, &pem_bytes));
             } else if encoding.is(&types::ENCODING_DER.get(py)?) {
                 if !password.is_empty() {


### PR DESCRIPTION
OpenSSL now only serializes keys to DER format, while our bespoke implementation in cryptography-key-parsing handles PEM wrapping and encryption with legacy Proc-Type/DEK-Info headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)