### PR TITLE
Move CFB, OFB, and CFB8 modes to decrepit module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,11 @@ Changelog
   Python installation.
 * ``public_bytes`` methods on public keys now raise ``TypeError`` (instead of
   ``ValueError`` if an invalid encoding is provided for the given ``format``).
+* Moved :class:`~cryptography.hazmat.decrepit.ciphers.modes.CFB`,
+  :class:`~cryptography.hazmat.decrepit.ciphers.modes.OFB`, and
+  :class:`~cryptography.hazmat.decrepit.ciphers.modes.CFB8` into
+  :doc:`/hazmat/decrepit/index` and deprecated them in the ``modes`` module.
+  They will be removed from the ``modes`` module in 49.0.0.
 
 .. _v46-0-2:
 

--- a/docs/hazmat/decrepit/index.rst
+++ b/docs/hazmat/decrepit/index.rst
@@ -12,3 +12,4 @@ their use is **strongly discouraged**.
     :maxdepth: 2
 
     ciphers
+    modes

--- a/docs/hazmat/decrepit/modes.rst
+++ b/docs/hazmat/decrepit/modes.rst
@@ -1,0 +1,98 @@
+.. hazmat::
+
+
+Decrepit Cipher Modes
+=====================
+
+.. module:: cryptography.hazmat.decrepit.ciphers.modes
+
+This module contains decrepit cipher modes. These modes should not be used
+unless necessary for backwards compatibility or interoperability with legacy
+systems. Their use is **strongly discouraged**.
+
+These modes work with :class:`~cryptography.hazmat.primitives.ciphers.Cipher`
+objects in the same way as modes from
+:mod:`~cryptography.hazmat.primitives.ciphers.modes`.
+
+.. class:: CFB(initialization_vector)
+
+    .. versionadded:: 47.0.0
+
+    CFB (Cipher Feedback) is a mode of operation for block ciphers. It
+    transforms a block cipher into a stream cipher.
+
+    **This mode does not require padding.**
+
+    :param initialization_vector: Must be random and unpredictable. It must
+        be the same length as the cipher's block size.
+    :type initialization_vector: :term:`bytes-like`
+
+    .. doctest::
+
+        >>> import os
+        >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
+        >>> from cryptography.hazmat.decrepit.ciphers.modes import CFB
+        >>> key = os.urandom(16)
+        >>> iv = os.urandom(16)
+        >>> cipher = Cipher(algorithms.AES(key), CFB(iv))
+        >>> encryptor = cipher.encryptor()
+        >>> ct = encryptor.update(b"a secret message")
+        >>> decryptor = cipher.decryptor()
+        >>> decryptor.update(ct)
+        b'a secret message'
+
+
+.. class:: CFB8(initialization_vector)
+
+    .. versionadded:: 47.0.0
+
+    CFB8 (Cipher Feedback with 8-bit segment size) is a mode of operation
+    similar to CFB. It operates on 8-bit segments rather than full blocks.
+
+    **This mode does not require padding.**
+
+    :param initialization_vector: Must be random and unpredictable. It must
+        be the same length as the cipher's block size.
+    :type initialization_vector: :term:`bytes-like`
+
+    .. doctest::
+
+        >>> import os
+        >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
+        >>> from cryptography.hazmat.decrepit.ciphers.modes import CFB8
+        >>> key = os.urandom(16)
+        >>> iv = os.urandom(16)
+        >>> cipher = Cipher(algorithms.AES(key), CFB8(iv))
+        >>> encryptor = cipher.encryptor()
+        >>> ct = encryptor.update(b"a secret message")
+        >>> decryptor = cipher.decryptor()
+        >>> decryptor.update(ct)
+        b'a secret message'
+
+
+.. class:: OFB(initialization_vector)
+
+    .. versionadded:: 47.0.0
+
+    OFB (Output Feedback) is a mode of operation for block ciphers. It
+    transforms a block cipher into a stream cipher.
+
+    **This mode does not require padding.**
+
+    :param initialization_vector: Must be random and unpredictable. It must
+        be the same length as the cipher's block size.
+    :type initialization_vector: :term:`bytes-like`
+
+    .. doctest::
+
+        >>> import os
+        >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
+        >>> from cryptography.hazmat.decrepit.ciphers.modes import OFB
+        >>> key = os.urandom(16)
+        >>> iv = os.urandom(16)
+        >>> cipher = Cipher(algorithms.AES(key), OFB(iv))
+        >>> encryptor = cipher.encryptor()
+        >>> ct = encryptor.update(b"a secret message")
+        >>> decryptor = cipher.decryptor()
+        >>> decryptor.update(ct)
+        b'a secret message'

--- a/docs/hazmat/decrepit/modes.rst
+++ b/docs/hazmat/decrepit/modes.rst
@@ -27,21 +27,6 @@ objects in the same way as modes from
         be the same length as the cipher's block size.
     :type initialization_vector: :term:`bytes-like`
 
-    .. doctest::
-
-        >>> import os
-        >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
-        >>> from cryptography.hazmat.decrepit.ciphers.modes import CFB
-        >>> key = os.urandom(16)
-        >>> iv = os.urandom(16)
-        >>> cipher = Cipher(algorithms.AES(key), CFB(iv))
-        >>> encryptor = cipher.encryptor()
-        >>> ct = encryptor.update(b"a secret message")
-        >>> decryptor = cipher.decryptor()
-        >>> decryptor.update(ct)
-        b'a secret message'
-
-
 .. class:: CFB8(initialization_vector)
 
     .. versionadded:: 47.0.0
@@ -55,21 +40,6 @@ objects in the same way as modes from
         be the same length as the cipher's block size.
     :type initialization_vector: :term:`bytes-like`
 
-    .. doctest::
-
-        >>> import os
-        >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
-        >>> from cryptography.hazmat.decrepit.ciphers.modes import CFB8
-        >>> key = os.urandom(16)
-        >>> iv = os.urandom(16)
-        >>> cipher = Cipher(algorithms.AES(key), CFB8(iv))
-        >>> encryptor = cipher.encryptor()
-        >>> ct = encryptor.update(b"a secret message")
-        >>> decryptor = cipher.decryptor()
-        >>> decryptor.update(ct)
-        b'a secret message'
-
-
 .. class:: OFB(initialization_vector)
 
     .. versionadded:: 47.0.0
@@ -82,17 +52,3 @@ objects in the same way as modes from
     :param initialization_vector: Must be random and unpredictable. It must
         be the same length as the cipher's block size.
     :type initialization_vector: :term:`bytes-like`
-
-    .. doctest::
-
-        >>> import os
-        >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
-        >>> from cryptography.hazmat.decrepit.ciphers.modes import OFB
-        >>> key = os.urandom(16)
-        >>> iv = os.urandom(16)
-        >>> cipher = Cipher(algorithms.AES(key), OFB(iv))
-        >>> encryptor = cipher.encryptor()
-        >>> ct = encryptor.update(b"a secret message")
-        >>> decryptor = cipher.decryptor()
-        >>> decryptor.update(ct)
-        b'a secret message'

--- a/docs/hazmat/primitives/symmetric-encryption.rst
+++ b/docs/hazmat/primitives/symmetric-encryption.rst
@@ -324,6 +324,12 @@ Modes
 
 .. class:: OFB(initialization_vector)
 
+    .. warning::
+
+        This algorithm has been deprecated and moved to the :doc:`/hazmat/decrepit/index`
+        module. If you need to continue using it then update your code to
+        use the new module path. It will be removed from this namespace in 49.0.0.
+
     OFB (Output Feedback) is a mode of operation for block ciphers. It
     transforms a block cipher into a stream cipher.
 
@@ -338,6 +344,12 @@ Modes
 
 .. class:: CFB(initialization_vector)
 
+    .. warning::
+
+        This algorithm has been deprecated and moved to the :doc:`/hazmat/decrepit/index`
+        module. If you need to continue using it then update your code to
+        use the new module path. It will be removed from this namespace in 49.0.0.
+
     CFB (Cipher Feedback) is a mode of operation for block ciphers. It
     transforms a block cipher into a stream cipher.
 
@@ -351,6 +363,12 @@ Modes
     :type initialization_vector: :term:`bytes-like`
 
 .. class:: CFB8(initialization_vector)
+
+    .. warning::
+
+        This algorithm has been deprecated and moved to the :doc:`/hazmat/decrepit/index`
+        module. If you need to continue using it then update your code to
+        use the new module path. It will be removed from this namespace in 49.0.0.
 
     CFB (Cipher Feedback) is a mode of operation for block ciphers. It
     transforms a block cipher into a stream cipher. The CFB8 variant uses an

--- a/src/cryptography/hazmat/decrepit/ciphers/modes.py
+++ b/src/cryptography/hazmat/decrepit/ciphers/modes.py
@@ -1,0 +1,53 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+from cryptography import utils
+from cryptography.hazmat.primitives._modes import (
+    ModeWithInitializationVector,
+    _check_iv_and_key_length,
+)
+
+
+class OFB(ModeWithInitializationVector):
+    name = "OFB"
+
+    def __init__(self, initialization_vector: utils.Buffer):
+        utils._check_byteslike("initialization_vector", initialization_vector)
+        self._initialization_vector = initialization_vector
+
+    @property
+    def initialization_vector(self) -> utils.Buffer:
+        return self._initialization_vector
+
+    validate_for_algorithm = _check_iv_and_key_length
+
+
+class CFB(ModeWithInitializationVector):
+    name = "CFB"
+
+    def __init__(self, initialization_vector: utils.Buffer):
+        utils._check_byteslike("initialization_vector", initialization_vector)
+        self._initialization_vector = initialization_vector
+
+    @property
+    def initialization_vector(self) -> utils.Buffer:
+        return self._initialization_vector
+
+    validate_for_algorithm = _check_iv_and_key_length
+
+
+class CFB8(ModeWithInitializationVector):
+    name = "CFB8"
+
+    def __init__(self, initialization_vector: utils.Buffer):
+        utils._check_byteslike("initialization_vector", initialization_vector)
+        self._initialization_vector = initialization_vector
+
+    @property
+    def initialization_vector(self) -> utils.Buffer:
+        return self._initialization_vector
+
+    validate_for_algorithm = _check_iv_and_key_length

--- a/src/cryptography/hazmat/primitives/_modes.py
+++ b/src/cryptography/hazmat/primitives/_modes.py
@@ -1,0 +1,105 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+import abc
+
+from cryptography import utils
+from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
+from cryptography.hazmat.primitives._cipheralgorithm import (
+    BlockCipherAlgorithm,
+    CipherAlgorithm,
+)
+
+
+class Mode(metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """
+        A string naming this mode (e.g. "ECB", "CBC").
+        """
+
+    @abc.abstractmethod
+    def validate_for_algorithm(self, algorithm: CipherAlgorithm) -> None:
+        """
+        Checks that all the necessary invariants of this (mode, algorithm)
+        combination are met.
+        """
+
+
+class ModeWithInitializationVector(Mode, metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def initialization_vector(self) -> utils.Buffer:
+        """
+        The value of the initialization vector for this mode as bytes.
+        """
+
+
+class ModeWithTweak(Mode, metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def tweak(self) -> utils.Buffer:
+        """
+        The value of the tweak for this mode as bytes.
+        """
+
+
+class ModeWithNonce(Mode, metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def nonce(self) -> utils.Buffer:
+        """
+        The value of the nonce for this mode as bytes.
+        """
+
+
+class ModeWithAuthenticationTag(Mode, metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def tag(self) -> bytes | None:
+        """
+        The value of the tag supplied to the constructor of this mode.
+        """
+
+
+def _check_aes_key_length(self: Mode, algorithm: CipherAlgorithm) -> None:
+    if algorithm.key_size > 256 and algorithm.name == "AES":
+        raise ValueError(
+            "Only 128, 192, and 256 bit keys are allowed for this AES mode"
+        )
+
+
+def _check_iv_length(
+    self: ModeWithInitializationVector, algorithm: BlockCipherAlgorithm
+) -> None:
+    iv_len = len(self.initialization_vector)
+    if iv_len * 8 != algorithm.block_size:
+        raise ValueError(f"Invalid IV size ({iv_len}) for {self.name}.")
+
+
+def _check_nonce_length(
+    nonce: utils.Buffer, name: str, algorithm: CipherAlgorithm
+) -> None:
+    if not isinstance(algorithm, BlockCipherAlgorithm):
+        raise UnsupportedAlgorithm(
+            f"{name} requires a block cipher algorithm",
+            _Reasons.UNSUPPORTED_CIPHER,
+        )
+    if len(nonce) * 8 != algorithm.block_size:
+        raise ValueError(f"Invalid nonce size ({len(nonce)}) for {name}.")
+
+
+def _check_iv_and_key_length(
+    self: ModeWithInitializationVector, algorithm: CipherAlgorithm
+) -> None:
+    if not isinstance(algorithm, BlockCipherAlgorithm):
+        raise UnsupportedAlgorithm(
+            f"{self} requires a block cipher algorithm",
+            _Reasons.UNSUPPORTED_CIPHER,
+        )
+    _check_aes_key_length(self, algorithm)
+    _check_iv_length(self, algorithm)

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 from cryptography import utils
 from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
+from cryptography.hazmat.decrepit.ciphers.modes import CFB as CFB
+from cryptography.hazmat.decrepit.ciphers.modes import CFB8 as CFB8
+from cryptography.hazmat.decrepit.ciphers.modes import OFB as OFB
 from cryptography.hazmat.primitives._cipheralgorithm import (
     BlockCipherAlgorithm,
     CipherAlgorithm,
@@ -152,18 +155,6 @@ class GCM(ModeWithInitializationVector, ModeWithAuthenticationTag):
                 "bytes."
             )
 
-
-# Import decrepit modes after base classes are defined to avoid circular
-# imports
-from cryptography.hazmat.decrepit.ciphers.modes import (  # noqa: E402
-    CFB as CFB,
-)
-from cryptography.hazmat.decrepit.ciphers.modes import (  # noqa: E402
-    CFB8 as CFB8,
-)
-from cryptography.hazmat.decrepit.ciphers.modes import (  # noqa: E402
-    OFB as OFB,
-)
 
 utils.deprecated(
     OFB,

--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -4,106 +4,33 @@
 
 from __future__ import annotations
 
-import abc
-
 from cryptography import utils
 from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 from cryptography.hazmat.primitives._cipheralgorithm import (
     BlockCipherAlgorithm,
     CipherAlgorithm,
 )
+from cryptography.hazmat.primitives._modes import (
+    Mode as Mode,
+)
+from cryptography.hazmat.primitives._modes import (
+    ModeWithAuthenticationTag as ModeWithAuthenticationTag,
+)
+from cryptography.hazmat.primitives._modes import (
+    ModeWithInitializationVector as ModeWithInitializationVector,
+)
+from cryptography.hazmat.primitives._modes import (
+    ModeWithNonce as ModeWithNonce,
+)
+from cryptography.hazmat.primitives._modes import (
+    ModeWithTweak as ModeWithTweak,
+)
+from cryptography.hazmat.primitives._modes import (
+    _check_aes_key_length,
+    _check_iv_and_key_length,
+    _check_nonce_length,
+)
 from cryptography.hazmat.primitives.ciphers import algorithms
-
-
-class Mode(metaclass=abc.ABCMeta):
-    @property
-    @abc.abstractmethod
-    def name(self) -> str:
-        """
-        A string naming this mode (e.g. "ECB", "CBC").
-        """
-
-    @abc.abstractmethod
-    def validate_for_algorithm(self, algorithm: CipherAlgorithm) -> None:
-        """
-        Checks that all the necessary invariants of this (mode, algorithm)
-        combination are met.
-        """
-
-
-class ModeWithInitializationVector(Mode, metaclass=abc.ABCMeta):
-    @property
-    @abc.abstractmethod
-    def initialization_vector(self) -> utils.Buffer:
-        """
-        The value of the initialization vector for this mode as bytes.
-        """
-
-
-class ModeWithTweak(Mode, metaclass=abc.ABCMeta):
-    @property
-    @abc.abstractmethod
-    def tweak(self) -> utils.Buffer:
-        """
-        The value of the tweak for this mode as bytes.
-        """
-
-
-class ModeWithNonce(Mode, metaclass=abc.ABCMeta):
-    @property
-    @abc.abstractmethod
-    def nonce(self) -> utils.Buffer:
-        """
-        The value of the nonce for this mode as bytes.
-        """
-
-
-class ModeWithAuthenticationTag(Mode, metaclass=abc.ABCMeta):
-    @property
-    @abc.abstractmethod
-    def tag(self) -> bytes | None:
-        """
-        The value of the tag supplied to the constructor of this mode.
-        """
-
-
-def _check_aes_key_length(self: Mode, algorithm: CipherAlgorithm) -> None:
-    if algorithm.key_size > 256 and algorithm.name == "AES":
-        raise ValueError(
-            "Only 128, 192, and 256 bit keys are allowed for this AES mode"
-        )
-
-
-def _check_iv_length(
-    self: ModeWithInitializationVector, algorithm: BlockCipherAlgorithm
-) -> None:
-    iv_len = len(self.initialization_vector)
-    if iv_len * 8 != algorithm.block_size:
-        raise ValueError(f"Invalid IV size ({iv_len}) for {self.name}.")
-
-
-def _check_nonce_length(
-    nonce: utils.Buffer, name: str, algorithm: CipherAlgorithm
-) -> None:
-    if not isinstance(algorithm, BlockCipherAlgorithm):
-        raise UnsupportedAlgorithm(
-            f"{name} requires a block cipher algorithm",
-            _Reasons.UNSUPPORTED_CIPHER,
-        )
-    if len(nonce) * 8 != algorithm.block_size:
-        raise ValueError(f"Invalid nonce size ({len(nonce)}) for {name}.")
-
-
-def _check_iv_and_key_length(
-    self: ModeWithInitializationVector, algorithm: CipherAlgorithm
-) -> None:
-    if not isinstance(algorithm, BlockCipherAlgorithm):
-        raise UnsupportedAlgorithm(
-            f"{self} requires a block cipher algorithm",
-            _Reasons.UNSUPPORTED_CIPHER,
-        )
-    _check_aes_key_length(self, algorithm)
-    _check_iv_length(self, algorithm)
 
 
 class CBC(ModeWithInitializationVector):
@@ -153,48 +80,6 @@ class ECB(Mode):
     name = "ECB"
 
     validate_for_algorithm = _check_aes_key_length
-
-
-class OFB(ModeWithInitializationVector):
-    name = "OFB"
-
-    def __init__(self, initialization_vector: utils.Buffer):
-        utils._check_byteslike("initialization_vector", initialization_vector)
-        self._initialization_vector = initialization_vector
-
-    @property
-    def initialization_vector(self) -> utils.Buffer:
-        return self._initialization_vector
-
-    validate_for_algorithm = _check_iv_and_key_length
-
-
-class CFB(ModeWithInitializationVector):
-    name = "CFB"
-
-    def __init__(self, initialization_vector: utils.Buffer):
-        utils._check_byteslike("initialization_vector", initialization_vector)
-        self._initialization_vector = initialization_vector
-
-    @property
-    def initialization_vector(self) -> utils.Buffer:
-        return self._initialization_vector
-
-    validate_for_algorithm = _check_iv_and_key_length
-
-
-class CFB8(ModeWithInitializationVector):
-    name = "CFB8"
-
-    def __init__(self, initialization_vector: utils.Buffer):
-        utils._check_byteslike("initialization_vector", initialization_vector)
-        self._initialization_vector = initialization_vector
-
-    @property
-    def initialization_vector(self) -> utils.Buffer:
-        return self._initialization_vector
-
-    validate_for_algorithm = _check_iv_and_key_length
 
 
 class CTR(ModeWithNonce):
@@ -266,3 +151,51 @@ class GCM(ModeWithInitializationVector, ModeWithAuthenticationTag):
                 f"Authentication tag cannot be more than {block_size_bytes} "
                 "bytes."
             )
+
+
+# Import decrepit modes after base classes are defined to avoid circular
+# imports
+from cryptography.hazmat.decrepit.ciphers.modes import (  # noqa: E402
+    CFB as CFB,
+)
+from cryptography.hazmat.decrepit.ciphers.modes import (  # noqa: E402
+    CFB8 as CFB8,
+)
+from cryptography.hazmat.decrepit.ciphers.modes import (  # noqa: E402
+    OFB as OFB,
+)
+
+utils.deprecated(
+    OFB,
+    __name__,
+    "OFB has been moved to "
+    "cryptography.hazmat.decrepit.ciphers.modes.OFB and "
+    "will be removed from "
+    "cryptography.hazmat.primitives.ciphers.modes in 49.0.0.",
+    utils.DeprecatedIn47,
+    name="OFB",
+)
+
+
+utils.deprecated(
+    CFB,
+    __name__,
+    "CFB has been moved to "
+    "cryptography.hazmat.decrepit.ciphers.modes.CFB and "
+    "will be removed from "
+    "cryptography.hazmat.primitives.ciphers.modes in 49.0.0.",
+    utils.DeprecatedIn47,
+    name="CFB",
+)
+
+
+utils.deprecated(
+    CFB8,
+    __name__,
+    "CFB8 has been moved to "
+    "cryptography.hazmat.decrepit.ciphers.modes.CFB8 and "
+    "will be removed from "
+    "cryptography.hazmat.primitives.ciphers.modes in 49.0.0.",
+    utils.DeprecatedIn47,
+    name="CFB8",
+)

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -26,6 +26,7 @@ DeprecatedIn40 = CryptographyDeprecationWarning
 DeprecatedIn41 = CryptographyDeprecationWarning
 DeprecatedIn42 = CryptographyDeprecationWarning
 DeprecatedIn43 = CryptographyDeprecationWarning
+DeprecatedIn47 = CryptographyDeprecationWarning
 
 
 # If you're wondering why we don't use `Buffer`, it's because `Buffer` would

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -582,12 +582,12 @@ pub static CBC: LazyPyImport =
     LazyPyImport::new("cryptography.hazmat.primitives.ciphers.modes", &["CBC"]);
 #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
 pub static CFB: LazyPyImport =
-    LazyPyImport::new("cryptography.hazmat.primitives.ciphers.modes", &["CFB"]);
+    LazyPyImport::new("cryptography.hazmat.decrepit.ciphers.modes", &["CFB"]);
 #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
 pub static CFB8: LazyPyImport =
-    LazyPyImport::new("cryptography.hazmat.primitives.ciphers.modes", &["CFB8"]);
+    LazyPyImport::new("cryptography.hazmat.decrepit.ciphers.modes", &["CFB8"]);
 pub static OFB: LazyPyImport =
-    LazyPyImport::new("cryptography.hazmat.primitives.ciphers.modes", &["OFB"]);
+    LazyPyImport::new("cryptography.hazmat.decrepit.ciphers.modes", &["OFB"]);
 pub static ECB: LazyPyImport =
     LazyPyImport::new("cryptography.hazmat.primitives.ciphers.modes", &["ECB"]);
 pub static CTR: LazyPyImport =

--- a/tests/hazmat/primitives/decrepit/test_3des.py
+++ b/tests/hazmat/primitives/decrepit/test_3des.py
@@ -12,6 +12,7 @@ import os
 import pytest
 
 from cryptography.hazmat.decrepit.ciphers import algorithms
+from cryptography.hazmat.decrepit.ciphers.modes import CFB, CFB8, OFB
 from cryptography.hazmat.primitives.ciphers import modes
 
 from ....utils import load_nist_vectors
@@ -52,7 +53,7 @@ class TestTripleDESModeCBC:
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.TripleDES(b"\x00" * 8), modes.OFB(b"\x00" * 8)
+        algorithms.TripleDES(b"\x00" * 8), OFB(b"\x00" * 8)
     ),
     skip_message="Does not support TripleDES OFB",
 )
@@ -68,7 +69,7 @@ class TestTripleDESModeOFB:
             "TOFBinvperm.rsp",
         ],
         lambda keys, **kwargs: algorithms.TripleDES(binascii.unhexlify(keys)),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
     test_mmt = generate_encrypt_test(
@@ -78,13 +79,13 @@ class TestTripleDESModeOFB:
         lambda key1, key2, key3, **kwargs: algorithms.TripleDES(
             binascii.unhexlify(key1 + key2 + key3)
         ),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.TripleDES(b"\x00" * 8), modes.CFB(b"\x00" * 8)
+        algorithms.TripleDES(b"\x00" * 8), CFB(b"\x00" * 8)
     ),
     skip_message="Does not support TripleDES CFB",
 )
@@ -100,7 +101,7 @@ class TestTripleDESModeCFB:
             "TCFB64vartext.rsp",
         ],
         lambda keys, **kwargs: algorithms.TripleDES(binascii.unhexlify(keys)),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )
 
     test_mmt = generate_encrypt_test(
@@ -110,13 +111,13 @@ class TestTripleDESModeCFB:
         lambda key1, key2, key3, **kwargs: algorithms.TripleDES(
             binascii.unhexlify(key1 + key2 + key3)
         ),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.TripleDES(b"\x00" * 8), modes.CFB8(b"\x00" * 8)
+        algorithms.TripleDES(b"\x00" * 8), CFB8(b"\x00" * 8)
     ),
     skip_message="Does not support TripleDES CFB8",
 )
@@ -132,7 +133,7 @@ class TestTripleDESModeCFB8:
             "TCFB8vartext.rsp",
         ],
         lambda keys, **kwargs: algorithms.TripleDES(binascii.unhexlify(keys)),
-        lambda iv, **kwargs: modes.CFB8(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB8(binascii.unhexlify(iv)),
     )
 
     test_mmt = generate_encrypt_test(
@@ -142,7 +143,7 @@ class TestTripleDESModeCFB8:
         lambda key1, key2, key3, **kwargs: algorithms.TripleDES(
             binascii.unhexlify(key1 + key2 + key3)
         ),
-        lambda iv, **kwargs: modes.CFB8(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB8(binascii.unhexlify(iv)),
     )
 
 

--- a/tests/hazmat/primitives/decrepit/test_algorithms.py
+++ b/tests/hazmat/primitives/decrepit/test_algorithms.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.decrepit.ciphers.algorithms import (
     Blowfish,
     TripleDES,
 )
+from cryptography.hazmat.decrepit.ciphers.modes import CFB, OFB
 from cryptography.hazmat.primitives import ciphers
 from cryptography.hazmat.primitives.ciphers import modes
 
@@ -137,7 +138,7 @@ class TestBlowfishModeCBC:
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        Blowfish(b"\x00" * 56), modes.OFB(b"\x00" * 8)
+        Blowfish(b"\x00" * 56), OFB(b"\x00" * 8)
     ),
     skip_message="Does not support Blowfish OFB",
 )
@@ -147,13 +148,13 @@ class TestBlowfishModeOFB:
         os.path.join("ciphers", "Blowfish"),
         ["bf-ofb.txt"],
         lambda key, **kwargs: Blowfish(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        Blowfish(b"\x00" * 56), modes.CFB(b"\x00" * 8)
+        Blowfish(b"\x00" * 56), CFB(b"\x00" * 8)
     ),
     skip_message="Does not support Blowfish CFB",
 )
@@ -163,7 +164,7 @@ class TestBlowfishModeCFB:
         os.path.join("ciphers", "Blowfish"),
         ["bf-cfb.txt"],
         lambda key, **kwargs: Blowfish(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )
 
 
@@ -219,7 +220,7 @@ class TestCAST5ModeCBC:
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        CAST5(b"\x00" * 16), modes.OFB(b"\x00" * 8)
+        CAST5(b"\x00" * 16), OFB(b"\x00" * 8)
     ),
     skip_message="Does not support CAST5 OFB",
 )
@@ -229,13 +230,13 @@ class TestCAST5ModeOFB:
         os.path.join("ciphers", "CAST5"),
         ["cast5-ofb.txt"],
         lambda key, **kwargs: CAST5(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        CAST5(b"\x00" * 16), modes.CFB(b"\x00" * 8)
+        CAST5(b"\x00" * 16), CFB(b"\x00" * 8)
     ),
     skip_message="Does not support CAST5 CFB",
 )
@@ -245,7 +246,7 @@ class TestCAST5ModeCFB:
         os.path.join("ciphers", "CAST5"),
         ["cast5-cfb.txt"],
         lambda key, **kwargs: CAST5(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )
 
 
@@ -297,7 +298,7 @@ class TestIDEAModeCBC:
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        IDEA(b"\x00" * 16), modes.OFB(b"\x00" * 8)
+        IDEA(b"\x00" * 16), OFB(b"\x00" * 8)
     ),
     skip_message="Does not support IDEA OFB",
 )
@@ -307,13 +308,13 @@ class TestIDEAModeOFB:
         os.path.join("ciphers", "IDEA"),
         ["idea-ofb.txt"],
         lambda key, **kwargs: IDEA(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        IDEA(b"\x00" * 16), modes.CFB(b"\x00" * 8)
+        IDEA(b"\x00" * 16), CFB(b"\x00" * 8)
     ),
     skip_message="Does not support IDEA CFB",
 )
@@ -323,7 +324,7 @@ class TestIDEAModeCFB:
         os.path.join("ciphers", "IDEA"),
         ["idea-cfb.txt"],
         lambda key, **kwargs: IDEA(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )
 
 
@@ -375,7 +376,7 @@ class TestSEEDModeCBC:
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        SEED(b"\x00" * 16), modes.OFB(b"\x00" * 16)
+        SEED(b"\x00" * 16), OFB(b"\x00" * 16)
     ),
     skip_message="Does not support SEED OFB",
 )
@@ -385,13 +386,13 @@ class TestSEEDModeOFB:
         os.path.join("ciphers", "SEED"),
         ["seed-ofb.txt"],
         lambda key, **kwargs: SEED(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        SEED(b"\x00" * 16), modes.CFB(b"\x00" * 16)
+        SEED(b"\x00" * 16), CFB(b"\x00" * 16)
     ),
     skip_message="Does not support SEED CFB",
 )
@@ -401,5 +402,5 @@ class TestSEEDModeCFB:
         os.path.join("ciphers", "SEED"),
         ["seed-cfb.txt"],
         lambda key, **kwargs: SEED(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )

--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -10,6 +10,7 @@ import pytest
 
 from cryptography.exceptions import AlreadyFinalized, _Reasons
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
+from cryptography.hazmat.decrepit.ciphers.modes import CFB, CFB8, OFB
 from cryptography.hazmat.primitives.ciphers import algorithms, base, modes
 
 from ...doubles import DummyMode
@@ -157,7 +158,7 @@ class TestAESModeECB:
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.OFB(b"\x00" * 16)
+        algorithms.AES(b"\x00" * 16), OFB(b"\x00" * 16)
     ),
     skip_message="Does not support AES OFB",
 )
@@ -183,13 +184,13 @@ class TestAESModeOFB:
             "OFBMMT256.rsp",
         ],
         lambda key, **kwargs: algorithms.AES(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.CFB(b"\x00" * 16)
+        algorithms.AES(b"\x00" * 16), CFB(b"\x00" * 16)
     ),
     skip_message="Does not support AES CFB",
 )
@@ -215,13 +216,13 @@ class TestAESModeCFB:
             "CFB128MMT256.rsp",
         ],
         lambda key, **kwargs: algorithms.AES(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.CFB8(b"\x00" * 16)
+        algorithms.AES(b"\x00" * 16), CFB8(b"\x00" * 16)
     ),
     skip_message="Does not support AES CFB8",
 )
@@ -247,7 +248,7 @@ class TestAESModeCFB8:
             "CFB8MMT256.rsp",
         ],
         lambda key, **kwargs: algorithms.AES(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.CFB8(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB8(binascii.unhexlify(iv)),
     )
 
 
@@ -272,9 +273,9 @@ class TestAESModeCTR:
     [
         modes.CBC(bytearray(b"\x00" * 16)),
         modes.CTR(bytearray(b"\x00" * 16)),
-        modes.OFB(bytearray(b"\x00" * 16)),
-        modes.CFB(bytearray(b"\x00" * 16)),
-        modes.CFB8(bytearray(b"\x00" * 16)),
+        OFB(bytearray(b"\x00" * 16)),
+        CFB(bytearray(b"\x00" * 16)),
+        CFB8(bytearray(b"\x00" * 16)),
         modes.XTS(bytearray(b"\x00" * 16)),
         # Add a dummy mode for coverage of the cipher_supported check.
         DummyMode(),
@@ -299,9 +300,9 @@ def test_buffer_protocol_alternate_modes(mode, backend):
         modes.ECB(),
         modes.CBC(bytearray(b"\x00" * 16)),
         modes.CTR(bytearray(b"\x00" * 16)),
-        modes.OFB(bytearray(b"\x00" * 16)),
-        modes.CFB(bytearray(b"\x00" * 16)),
-        modes.CFB8(bytearray(b"\x00" * 16)),
+        OFB(bytearray(b"\x00" * 16)),
+        CFB(bytearray(b"\x00" * 16)),
+        CFB8(bytearray(b"\x00" * 16)),
     ],
 )
 @pytest.mark.parametrize("alg_cls", [algorithms.AES128, algorithms.AES256])

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -8,6 +8,7 @@ import binascii
 import pytest
 
 from cryptography.exceptions import AlreadyFinalized, _Reasons
+from cryptography.hazmat.decrepit.ciphers.modes import CFB, CFB8, OFB
 from cryptography.hazmat.primitives.ciphers import (
     Cipher,
     algorithms,
@@ -157,7 +158,7 @@ class TestModeValidation:
         with pytest.raises(ValueError):
             Cipher(
                 algorithms.AES(b"\x00" * 16),
-                modes.OFB(b"abc"),
+                OFB(b"abc"),
                 backend,
             )
 
@@ -165,7 +166,7 @@ class TestModeValidation:
         with pytest.raises(ValueError):
             Cipher(
                 algorithms.AES(b"\x00" * 16),
-                modes.CFB(b"abc"),
+                CFB(b"abc"),
                 backend,
             )
 
@@ -173,7 +174,7 @@ class TestModeValidation:
         with pytest.raises(ValueError):
             Cipher(
                 algorithms.AES(b"\x00" * 16),
-                modes.CFB8(b"abc"),
+                CFB8(b"abc"),
                 backend,
             )
 
@@ -197,15 +198,15 @@ class TestModesRequireBytes:
 
     def test_cfb(self):
         with pytest.raises(TypeError):
-            modes.CFB([1] * 16)  # type:ignore[arg-type]
+            CFB([1] * 16)  # type:ignore[arg-type]
 
     def test_cfb8(self):
         with pytest.raises(TypeError):
-            modes.CFB8([1] * 16)  # type:ignore[arg-type]
+            CFB8([1] * 16)  # type:ignore[arg-type]
 
     def test_ofb(self):
         with pytest.raises(TypeError):
-            modes.OFB([1] * 16)  # type:ignore[arg-type]
+            OFB([1] * 16)  # type:ignore[arg-type]
 
     def test_ctr(self):
         with pytest.raises(TypeError):

--- a/tests/hazmat/primitives/test_camellia.py
+++ b/tests/hazmat/primitives/test_camellia.py
@@ -8,6 +8,7 @@ import os
 
 import pytest
 
+from cryptography.hazmat.decrepit.ciphers.modes import CFB, OFB
 from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 from ...utils import load_cryptrec_vectors, load_nist_vectors
@@ -52,7 +53,7 @@ class TestCamelliaModeCBC:
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.Camellia(b"\x00" * 16), modes.OFB(b"\x00" * 16)
+        algorithms.Camellia(b"\x00" * 16), OFB(b"\x00" * 16)
     ),
     skip_message="Does not support Camellia OFB",
 )
@@ -62,13 +63,13 @@ class TestCamelliaModeOFB:
         os.path.join("ciphers", "Camellia"),
         ["camellia-ofb.txt"],
         lambda key, **kwargs: algorithms.Camellia(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.Camellia(b"\x00" * 16), modes.CFB(b"\x00" * 16)
+        algorithms.Camellia(b"\x00" * 16), CFB(b"\x00" * 16)
     ),
     skip_message="Does not support Camellia CFB",
 )
@@ -78,5 +79,5 @@ class TestCamelliaModeCFB:
         os.path.join("ciphers", "Camellia"),
         ["camellia-cfb.txt"],
         lambda key, **kwargs: algorithms.Camellia(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -11,6 +11,7 @@ import pytest
 
 from cryptography import utils
 from cryptography.exceptions import AlreadyFinalized
+from cryptography.hazmat.decrepit.ciphers.modes import CFB, CFB8, OFB
 from cryptography.hazmat.primitives import ciphers
 from cryptography.hazmat.primitives.ciphers import modes
 from cryptography.hazmat.primitives.ciphers.algorithms import (
@@ -52,9 +53,7 @@ class TestAES:
 
 
 class TestAESXTS:
-    @pytest.mark.parametrize(
-        "mode", (modes.CBC, modes.CTR, modes.CFB, modes.CFB8, modes.OFB)
-    )
+    @pytest.mark.parametrize("mode", (modes.CBC, modes.CTR, CFB, CFB8, OFB))
     def test_invalid_key_size_with_mode(self, mode, backend):
         with pytest.raises(ValueError):
             ciphers.Cipher(AES(b"0" * 64), mode(b"0" * 16), backend)

--- a/tests/hazmat/primitives/test_sm4.py
+++ b/tests/hazmat/primitives/test_sm4.py
@@ -8,6 +8,7 @@ import os
 import pytest
 
 from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.decrepit.ciphers.modes import CFB, OFB
 from cryptography.hazmat.primitives.ciphers import algorithms, base, modes
 
 from ...utils import load_nist_vectors, load_vectors_from_file
@@ -48,7 +49,7 @@ class TestSM4ModeCBC:
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.SM4(b"\x00" * 16), modes.OFB(b"\x00" * 16)
+        algorithms.SM4(b"\x00" * 16), OFB(b"\x00" * 16)
     ),
     skip_message="Does not support SM4 OFB",
 )
@@ -58,13 +59,13 @@ class TestSM4ModeOFB:
         os.path.join("ciphers", "SM4"),
         ["draft-ribose-cfrg-sm4-10-ofb.txt"],
         lambda key, **kwargs: algorithms.SM4(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.OFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: OFB(binascii.unhexlify(iv)),
     )
 
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.cipher_supported(
-        algorithms.SM4(b"\x00" * 16), modes.CFB(b"\x00" * 16)
+        algorithms.SM4(b"\x00" * 16), CFB(b"\x00" * 16)
     ),
     skip_message="Does not support SM4 CFB",
 )
@@ -74,7 +75,7 @@ class TestSM4ModeCFB:
         os.path.join("ciphers", "SM4"),
         ["draft-ribose-cfrg-sm4-10-cfb.txt"],
         lambda key, **kwargs: algorithms.SM4(binascii.unhexlify(key)),
-        lambda iv, **kwargs: modes.CFB(binascii.unhexlify(iv)),
+        lambda iv, **kwargs: CFB(binascii.unhexlify(iv)),
     )
 
 


### PR DESCRIPTION
These cipher modes are deprecated and moved to the decrepit module. They are re-exported from the original modes module with deprecation warnings.

These modes will be removed from primitives.ciphers.modes in 49.0.0.