### PR TITLE
Simplify wheel builds using new uv support for 3.14t

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -148,7 +148,7 @@ jobs:
           # docker running on an arm64 CPU
           OPENSSL_DIR="/opt/pyca/cryptography/openssl" \
               OPENSSL_STATIC=1 \
-              manylinux-entrypoint uv build --python=/opt/python/${{ matrix.PYTHON.VERSION }}/bin/python --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH $PY_LIMITED_API cryptography*.tar.gz -o tmpwheelhouse/
+              manylinux-entrypoint uv build --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH $PY_LIMITED_API cryptography*.tar.gz -o tmpwheelhouse/
         env:
           RUSTUP_HOME: /root/.rustup
       - run: auditwheel repair --plat ${{ matrix.MANYLINUX.NAME }} tmpwheelhouse/cryptography*.whl -w wheelhouse/
@@ -162,7 +162,7 @@ jobs:
             exit 0
           fi
 
-      - run: uv venv --python=/opt/python/${{ matrix.PYTHON.VERSION }}/bin/python
+      - run: uv venv
       - run: uv pip install --require-hashes -r $BUILD_REQUIREMENTS_PATH
       - run: uv pip install cryptography --no-index -f wheelhouse/
       - run: |
@@ -285,13 +285,13 @@ jobs:
 
           OPENSSL_DIR="$(readlink -f ../openssl-macos-universal2/)" \
               OPENSSL_STATIC=1 \
-              uv build --python='${{ matrix.PYTHON.BIN_PATH }}' --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH $PY_LIMITED_API cryptography*.tar.gz -o wheelhouse/
+              uv build --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH $PY_LIMITED_API cryptography*.tar.gz -o wheelhouse/
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.PYTHON.DEPLOYMENT_TARGET }}
           ARCHFLAGS: ${{ matrix.PYTHON.ARCHFLAGS }}
           _PYTHON_HOST_PLATFORM: ${{ matrix.PYTHON._PYTHON_HOST_PLATFORM }}
 
-      - run: uv venv --python='${{ matrix.PYTHON.BIN_PATH }}'
+      - run: uv venv
       - run: uv pip install --require-hashes -r $BUILD_REQUIREMENTS_PATH
       - run: uv pip install cryptography --no-index -f wheelhouse/
       - name: Show the wheel's minimum macOS SDK and architectures
@@ -348,7 +348,6 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        id: setup-python
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           architecture: ${{ matrix.WINDOWS.ARCH }}
@@ -381,12 +380,10 @@ jobs:
               PY_LIMITED_API="--config-settings=build-args=--features=pyo3/abi3-${{ matrix.PYTHON.ABI_VERSION }}"
           fi
 
-          uv build --python='${{ steps.setup-python.outputs.python-path }}' --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH cryptography*.tar.gz $PY_LIMITED_API -o wheelhouse/
+          uv build --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH cryptography*.tar.gz $PY_LIMITED_API -o wheelhouse/
         shell: bash
 
-      # the --python argument and setup-python step ID can be removed when uv's
-      # solver no longer considers the free-threaded build to be experimental
-      - run: uv venv --python='${{ steps.setup-python.outputs.python-path }}'
+      - run: uv venv
       - run: uv pip install --require-hashes -r "${BUILD_REQUIREMENTS_PATH}"
         shell: bash
       - run: uv pip install cryptography --no-index -f wheelhouse/


### PR DESCRIPTION
uv 0.9.0 no longer considers 3.14t to be experimental: https://github.com/astral-sh/uv/pull/16142