### PR TITLE
Fix string interpolation for rust 1.88.0.

### DIFF
--- a/src/rust/cryptography-key-parsing/src/pem.rs
+++ b/src/rust/cryptography-key-parsing/src/pem.rs
@@ -108,7 +108,7 @@ pub fn encrypt_pem(
     let mut pem = pem::Pem::new(tag, encrypted);
     pem.headers_mut().add("Proc-Type", "4,ENCRYPTED").unwrap();
     pem.headers_mut()
-        .add("DEK-Info", &format!("AES-256-CBC,{}", iv_hex))
+        .add("DEK-Info", &format!("AES-256-CBC,{iv_hex}"))
         .unwrap();
 
     Ok(pem::encode_config(&pem, ENCODE_CONFIG).into_bytes())


### PR DESCRIPTION
Greetings,

This fix an error that occur when trying to build the library using rustc 1.88.0.
Following a discussion on IRC the problem was replicated by @alex 

Thank you for this great library!