### PR TITLE
Add client hello callback related functions

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -30,6 +30,7 @@ static const long Cryptography_HAS_CUSTOM_EXT;
 static const long Cryptography_HAS_SRTP;
 static const long Cryptography_HAS_DTLS_GET_DATA_MTU;
 static const long Cryptography_HAS_SSL_GET0_GROUP_NAME;
+static const long Cryptography_HAS_CLIENT_HELLO_CB;
 
 static const long SSL_FILETYPE_PEM;
 static const long SSL_FILETYPE_ASN1;
@@ -390,6 +391,18 @@ long SSL_set_mtu(SSL *, long);
 int DTLSv1_listen(SSL *, BIO_ADDR *);
 size_t DTLS_get_data_mtu(SSL *);
 
+/* Client hello callback support */
+void SSL_CTX_set_client_hello_cb(
+    SSL_CTX *,
+    int (*)(SSL *, int *, void *),
+    void *);
+int SSL_client_hello_get1_extensions_present(
+    SSL *, int **,
+    size_t *);
+int SSL_client_hello_get0_ext(
+    SSL *, unsigned int,
+    const unsigned char **,
+    size_t *);
 
 /* Custom extensions. */
 typedef int (*custom_ext_add_cb)(SSL *, unsigned int,
@@ -676,5 +689,22 @@ static const long Cryptography_HAS_SSL_GET0_GROUP_NAME = 1;
 #else
 static const long Cryptography_HAS_SSL_GET0_GROUP_NAME = 0;
 const char *(*SSL_get0_group_name)(SSL *) = NULL;
+#endif
+
+#if CRYPTOGRAPHY_IS_LIBRESSL || CRYPTOGRAPHY_IS_BORINGSSL
+static const long Cryptography_HAS_CLIENT_HELLO_CB = 0;
+void (*SSL_CTX_set_client_hello_cb)(
+    SSL_CTX *,
+    int (*)(SSL *, int *, void *),
+    void *) = NULL;
+int (*SSL_client_hello_get1_extensions_present)(
+    SSL *, int **,
+    size_t *) = NULL;
+int (*SSL_client_hello_get0_ext)(
+    SSL *s, unsigned int,
+    const unsigned char **,
+    size_t *) = NULL;
+#else
+static const long Cryptography_HAS_CLIENT_HELLO_CB = 1;
 #endif
 """

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -159,6 +159,14 @@ def cryptography_has_ssl_get0_group_name() -> list[str]:
     return ["SSL_get0_group_name"]
 
 
+def cryptography_has_client_hello_cb() -> list[str]:
+    return [
+        "SSL_CTX_set_client_hello_cb",
+        "SSL_client_hello_get1_extensions_present",
+        "SSL_client_hello_get0_ext",
+    ]
+
+
 # This is a mapping of
 # {condition: function-returning-names-dependent-on-that-condition} so we can
 # loop over them and delete unsupported names at runtime. It will be removed
@@ -195,4 +203,5 @@ CONDITIONAL_NAMES = {
     "Cryptography_HAS_SSL_GET0_GROUP_NAME": (
         cryptography_has_ssl_get0_group_name
     ),
+    "Cryptography_HAS_CLIENT_HELLO_CB": cryptography_has_client_hello_cb,
 }


### PR DESCRIPTION
This exposes the OpenSSL functions SSL_CTX_set_client_hello_cb, SSL_client_hello_get0_ext and SSL_client_hello_get1_extensions_present.

These are required to implement to the client hello callback functionality in pyOpenSSL.