### PR TITLE
When serializing EC private keys, ensure the key is padded out to the group degree

### DIFF
--- a/src/rust/cryptography-key-parsing/src/ec.rs
+++ b/src/rust/cryptography-key-parsing/src/ec.rs
@@ -130,7 +130,9 @@ pub fn serialize_pkcs1_private_key(
         None
     };
 
-    let private_key_bytes = ec.private_key().to_vec();
+    let private_key_bytes = ec
+        .private_key()
+        .to_vec_padded(ec.group().order_bits().div_ceil(8).try_into().unwrap())?;
 
     let mut bn_ctx = openssl::bn::BigNumContext::new()?;
     let public_key_bytes = ec.public_key().to_bytes(

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -1237,6 +1237,17 @@ class TestECSerialization:
             == data
         )
 
+    def test_private_bytes_small_key(self):
+        key = ec.derive_private_key(private_value=1, curve=ec.SECP256R1())
+        der = key.private_bytes(
+            serialization.Encoding.DER,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+        # Ensure that serialized keys are always padded to the group order
+        # length.
+        assert (b"\x00" * 31 + b"\x01") in der
+
 
 class TestEllipticCurvePEMPublicKeySerialization:
     @pytest.mark.parametrize(


### PR DESCRIPTION
noticed in conversation with @davidben 