### PR TITLE
disable coverage on macos python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
           - {OS: 'macos-15-intel', ARCH: 'x86_64'}
           - {OS: 'macos-15', ARCH: 'arm64'}
         PYTHON:
-          - {VERSION: "3.8", NOXSESSION: "tests"}
+          - {VERSION: "3.8", NOXSESSION: "tests-nocoverage"}
           - {VERSION: "3.14", NOXSESSION: "tests"}
           - {VERSION: "3.14t", NOXSESSION: "tests"}
         exclude:


### PR DESCRIPTION
maybe it's faster, maybe it's not