### PR TITLE
Include exact error details in PKCS#12 DER parsing warning

### DIFF
--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -567,10 +567,10 @@ fn decode_p12(
         .parse2(password)
         .map_err(|_| pyo3::exceptions::PyValueError::new_err("Invalid password or PKCS12 data"))?;
 
-    if asn1::parse_single::<cryptography_x509::pkcs12::Pfx<'_>>(data.as_bytes()).is_err() {
+    if let Err(e) = asn1::parse_single::<cryptography_x509::pkcs12::Pfx<'_>>(data.as_bytes()) {
         let warning_cls = pyo3::exceptions::PyUserWarning::type_object(py);
-        let message = c"PKCS#12 bundle could not be parsed as DER, falling back to parsing as BER. Please file an issue at https://github.com/pyca/cryptography/issues explaining how your PKCS#12 bundle was created. In the future, this may become an exception.";
-        pyo3::PyErr::warn(py, &warning_cls, message, 1)?;
+        let message = std::ffi::CString::new(format!("PKCS#12 bundle could not be parsed as DER, falling back to parsing as BER. Please file an issue at https://github.com/pyca/cryptography/issues explaining how your PKCS#12 bundle was created. In the future, this may become an exception. Error details: {e}")).unwrap();
+        pyo3::PyErr::warn(py, &warning_cls, &message, 1)?;
     }
 
     Ok(parsed)


### PR DESCRIPTION
Updates the PKCS#12 warning message to include the specific error details when DER parsing fails, matching the recent improvement made to PKCS#7 warnings. This provides users with more actionable information about why their PKCS#12 bundle couldn't be parsed as DER.

The warning now captures and displays the actual parsing error instead of just indicating that parsing failed.