### PR TITLE
use UnsupportedAlgorithm instead of ValueError for oids we don't support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Changelog
   OpenSSL 3.0.0 or later is now required. LibreSSL, BoringSSL, and AWS-LC
   continue to be supported.
 * **BACKWARDS INCOMPATIBLE:** Dropped support for LibreSSL < 4.1.
+* **BACKWARDS INCOMPATIBLE:** Loading keys with unsupported algorithms or
+  keys with unsupported explicit curve encodings now raises
+  :class:`~cryptography.exceptions.UnsupportedAlgorithm` instead of
+  ``ValueError``. This change affects
+  :func:`~cryptography.hazmat.primitives.serialization.load_pem_private_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_der_private_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_pem_public_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_der_public_key`,
+  and :meth:`~cryptography.x509.Certificate.public_key` when called on
+  certificates with unsupported public key algorithms.
 * Updated the minimum supported Rust version (MSRV) to 1.83.0, from 1.74.0.
 * Added support for loading elliptic curve keys that contain explicit encodings
   of the curves ``secp256r1``, ``secp384r1``, and ``secp521r1``.

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -71,13 +71,15 @@ impl From<cryptography_key_parsing::KeyParsingError> for CryptographyError {
                 CryptographyError::Py(pyo3::exceptions::PyValueError::new_err("Invalid key"))
             }
             cryptography_key_parsing::KeyParsingError::ExplicitCurveUnsupported => {
-                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
+                CryptographyError::Py(exceptions::UnsupportedAlgorithm::new_err((
                     "ECDSA keys with explicit parameters are only supported when they map to secp256r1, secp384r1, or secp521r1. No custom curves are supported.",
-                ))
+                    exceptions::Reasons::UNSUPPORTED_ELLIPTIC_CURVE,
+                )))
             }
             cryptography_key_parsing::KeyParsingError::UnsupportedKeyType(oid) => {
-                CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(format!(
-                    "Unknown key type: {oid}"
+                CryptographyError::Py(exceptions::UnsupportedAlgorithm::new_err((
+                    format!("Unknown key type: {oid}"),
+                    exceptions::Reasons::UNSUPPORTED_PUBLIC_KEY_ALGORITHM,
                 )))
             }
             cryptography_key_parsing::KeyParsingError::UnsupportedEllipticCurve(oid) => {

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -1063,7 +1063,9 @@ class TestECSerialization:
 
     def test_load_private_key_unsupported_explicit_parameters(self):
         # This vector is P256 except the prime field value is wrong
-        with pytest.raises(ValueError, match="explicit parameters"):
+        with pytest.raises(
+            exceptions.UnsupportedAlgorithm, match="explicit parameters"
+        ):
             load_vectors_from_file(
                 os.path.join(
                     "asymmetric", "EC", "explicit_parameters_private_key.pem"
@@ -1074,7 +1076,9 @@ class TestECSerialization:
                 mode="rb",
             )
 
-        with pytest.raises(ValueError, match="explicit parameters"):
+        with pytest.raises(
+            exceptions.UnsupportedAlgorithm, match="explicit parameters"
+        ):
             # This vector encodes SECT233R1 explicitly
             load_vectors_from_file(
                 os.path.join(

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -11,6 +11,7 @@ import textwrap
 
 import pytest
 
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.decrepit.ciphers.algorithms import _DES, ARC4, RC2
 from cryptography.hazmat.primitives.asymmetric import (
@@ -424,7 +425,7 @@ class TestDERSerialization:
             lambda f: f.read(),
             mode="rb",
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedAlgorithm):
             load_der_private_key(data, password=None)
 
     @pytest.mark.skip_fips(reason="3DES is not FIPS")
@@ -1249,7 +1250,7 @@ class TestPEMSerialization:
         ("key_file", "password"), [("bad-oid-dsa-key.pem", None)]
     )
     def test_load_bad_oid_key(self, key_file, password, backend):
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedAlgorithm):
             load_vectors_from_file(
                 os.path.join("asymmetric", "PKCS8", key_file),
                 lambda pemfile: load_pem_private_key(

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -6001,7 +6001,7 @@ class TestOtherCertificate:
             x509.load_pem_x509_certificate,
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedAlgorithm):
             cert.public_key()
 
     def test_bad_time_in_validity(self, backend):


### PR DESCRIPTION
TBD if we want to actually merge this since it's a breaking change (albeit one that should largely only occur during development). fixes #13746 