### PR TITLE
asn1: Add support for `SEQUENCE OF`

### DIFF
--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import builtins
 import dataclasses
 import sys
 import types
@@ -127,6 +128,11 @@ def _normalize_field_type(
             raise TypeError(
                 "union types other than `X | None` are currently not supported"
             )
+    elif get_type_origin(field_type) is builtins.list:
+        inner_type = _normalize_field_type(
+            get_type_args(field_type)[0], field_name
+        )
+        rust_field_type = declarative_asn1.Type.SequenceOf(inner_type)
     else:
         rust_field_type = declarative_asn1.non_root_python_to_rust(field_type)
 

--- a/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
@@ -13,6 +13,7 @@ def non_root_python_to_rust(cls: type) -> Type: ...
 # annotations like this:
 class Type:
     Sequence: typing.ClassVar[type]
+    SequenceOf: typing.ClassVar[type]
     Option: typing.ClassVar[type]
     PyBool: typing.ClassVar[type]
     PyInt: typing.ClassVar[type]

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -19,6 +19,8 @@ pub enum Type {
     /// The first element is the Python class that represents the sequence,
     /// the second element is a dict of the (already converted) fields of the class.
     Sequence(pyo3::Py<pyo3::types::PyType>, pyo3::Py<pyo3::types::PyDict>),
+    /// SEQUENCEOF (`list[`T`]`)
+    SequenceOf(pyo3::Py<AnnotatedType>),
     /// OPTIONAL (`T | None`)
     Option(pyo3::Py<AnnotatedType>),
 
@@ -285,6 +287,7 @@ pub(crate) fn python_class_to_annotated<'p>(
 pub(crate) fn type_to_tag(t: &Type, encoding: &Option<pyo3::Py<Encoding>>) -> asn1::Tag {
     let inner_tag = match t {
         Type::Sequence(_, _) => asn1::Sequence::TAG,
+        Type::SequenceOf(_) => asn1::Sequence::TAG,
         Type::Option(t) => type_to_tag(t.get().inner.get(), encoding),
         Type::PyBool() => bool::TAG,
         Type::PyInt() => asn1::BigInt::TAG,

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -274,6 +274,9 @@ class TestSequenceAPI:
         opt = declarative_asn1.Type.Option(ann_type)
         assert opt._0 == ann_type
 
+        seq_of = declarative_asn1.Type.SequenceOf(ann_type)
+        assert seq_of._0 is ann_type
+
     def test_fields_of_variant_encoding(self) -> None:
         from cryptography.hazmat.bindings._rust import declarative_asn1
 

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -277,6 +277,42 @@ class TestSequence:
             ]
         )
 
+    def test_ok_sequenceof_simple_type(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: typing.List[int]
+
+        assert_roundtrips(
+            [
+                (
+                    Example(a=[1, 2, 3, 4]),
+                    b"\x30\x0e\x30\x0c\x02\x01\x01\x02\x01\x02\x02\x01\x03\x02\x01\x04",
+                )
+            ]
+        )
+
+    def test_ok_sequenceof_user_defined_type(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class MyType:
+            a: int
+            b: bool
+
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: typing.List[MyType]
+
+        assert_roundtrips(
+            [
+                (
+                    Example(a=[MyType(a=1, b=True), MyType(a=2, b=False)]),
+                    b"\x30\x12\x30\x10\x30\x06\x02\x01\x01\x01\x01\xff\x30\x06\x02\x01\x02\x01\x01\x00",
+                )
+            ]
+        )
+
     def test_ok_sequence_with_optionals(self) -> None:
         @asn1.sequence
         @_comparable_dataclass
@@ -350,11 +386,14 @@ class TestSequence:
             d: typing.Union[asn1.PrintableString, None]
             e: typing.Union[asn1.UtcTime, None]
             f: typing.Union[asn1.GeneralizedTime, None]
+            g: typing.Union[typing.List[int], None]
 
         assert_roundtrips(
             [
                 (
-                    Example(a=None, b=None, c=None, d=None, e=None, f=None),
+                    Example(
+                        a=None, b=None, c=None, d=None, e=None, f=None, g=None
+                    ),
                     b"\x30\x00",
                 )
             ]


### PR DESCRIPTION
This PR adds support for `SEQUENCE OF` fields to the ASN.1 API. The fields must be annotated as Python lists:

```python
@asn1.sequence
class Example
  a: typing.List[int]
```

Part of https://github.com/pyca/cryptography/issues/12283