### PR TITLE
Bump dependencies in CI constraints file

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -34,7 +34,7 @@ check-sdist==1.3.0 ; python_full_version >= '3.9'
     # via cryptography (pyproject.toml)
 click==8.1.8 ; python_full_version < '3.10'
     # via cryptography (pyproject.toml)
-click==8.3.0 ; python_full_version >= '3.10'
+click==8.3.1 ; python_full_version >= '3.10'
     # via cryptography (pyproject.toml)
 colorama==0.4.6 ; os_name == 'nt' or sys_platform == 'win32'
     # via
@@ -49,7 +49,7 @@ coverage==7.6.1 ; python_full_version < '3.9'
     # via pytest-cov
 coverage==7.10.7 ; python_full_version == '3.9.*'
     # via pytest-cov
-coverage==7.11.3 ; python_full_version >= '3.10'
+coverage==7.12.0 ; python_full_version >= '3.10'
     # via pytest-cov
 dependency-groups==1.3.1
     # via nox


### PR DESCRIPTION
Updates:
- click 8.3.0 -> 8.3.1 for Python >= 3.10
- coverage 7.11.3 -> 7.12.0 for Python >= 3.10