### PR TITLE
asn1.py: treat asn1_string_st as opaque

### DIFF
--- a/src/_cffi_src/openssl/asn1.py
+++ b/src/_cffi_src/openssl/asn1.py
@@ -12,19 +12,11 @@ TYPES = """
 typedef int... time_t;
 
 typedef ... ASN1_INTEGER;
-
-struct asn1_string_st {
-    int length;
-    int type;
-    unsigned char *data;
-    long flags;
-};
-
-typedef struct asn1_string_st ASN1_OCTET_STRING;
-typedef struct asn1_string_st ASN1_IA5STRING;
-typedef struct asn1_string_st ASN1_TIME;
+typedef ... ASN1_OCTET_STRING;
+typedef ... ASN1_IA5STRING;
+typedef ... ASN1_TIME;
 typedef ... ASN1_OBJECT;
-typedef struct asn1_string_st ASN1_STRING;
+typedef ... ASN1_STRING;
 typedef ... ASN1_GENERALIZEDTIME;
 typedef ... ASN1_ENUMERATED;
 


### PR DESCRIPTION
OpenSSL 4 plans to [make ASN1_STRING opaque][1]. Using a forward declaration rather than a redefinition avoids the build breakage in cryptography's cffi when it tries to validate the sizes of the members.

[1]: https://github.com/openssl/openssl/issues/29117