### PR TITLE
Replace pretend.stub() with DummyEd25519PublicKey in test

### DIFF
--- a/tests/doubles.py
+++ b/tests/doubles.py
@@ -4,12 +4,13 @@
 
 
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import ed25519, padding
 from cryptography.hazmat.primitives.ciphers import (
     BlockCipherAlgorithm,
     CipherAlgorithm,
 )
 from cryptography.hazmat.primitives.ciphers.modes import Mode
+from cryptography.utils import Buffer
 
 
 class DummyCipherAlgorithm(CipherAlgorithm):
@@ -53,3 +54,35 @@ class DummyKeySerializationEncryption(
 
 class DummyAsymmetricPadding(padding.AsymmetricPadding):
     name = "dummy-padding"
+
+
+class DummyEd25519PublicKey(ed25519.Ed25519PublicKey):
+    """
+    A fake Ed25519PublicKey that returns fixed data from public_bytes().
+    Used for testing invalid key encodings.
+    """
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def public_bytes(
+        self,
+        encoding: serialization.Encoding,
+        format: serialization.PublicFormat,
+    ) -> bytes:
+        return self._data
+
+    def public_bytes_raw(self) -> bytes:
+        raise NotImplementedError
+
+    def verify(self, signature: Buffer, data: Buffer) -> None:
+        raise NotImplementedError
+
+    def __eq__(self, other: object) -> bool:
+        raise NotImplementedError
+
+    def __copy__(self) -> ed25519.Ed25519PublicKey:
+        raise NotImplementedError
+
+    def __deepcopy__(self, memo: dict) -> ed25519.Ed25519PublicKey:
+        raise NotImplementedError

--- a/tests/test_doubles.py
+++ b/tests/test_doubles.py
@@ -1,0 +1,48 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+import copy
+
+import pytest
+
+from cryptography.hazmat.primitives import serialization
+
+from .doubles import DummyEd25519PublicKey
+
+
+class TestDummyEd25519PublicKey:
+    def test_public_bytes(self):
+        key = DummyEd25519PublicKey(b"test data")
+        # The encoding and format arguments are ignored by this dummy
+        assert (
+            key.public_bytes(
+                serialization.Encoding.Raw, serialization.PublicFormat.Raw
+            )
+            == b"test data"
+        )
+
+    def test_public_bytes_raw_not_implemented(self):
+        key = DummyEd25519PublicKey(b"test data")
+        with pytest.raises(NotImplementedError):
+            key.public_bytes_raw()
+
+    def test_verify_not_implemented(self):
+        key = DummyEd25519PublicKey(b"test data")
+        with pytest.raises(NotImplementedError):
+            key.verify(b"sig", b"data")
+
+    def test_eq_not_implemented(self):
+        key = DummyEd25519PublicKey(b"test data")
+        with pytest.raises(NotImplementedError):
+            key == key
+
+    def test_copy_not_implemented(self):
+        key = DummyEd25519PublicKey(b"test data")
+        with pytest.raises(NotImplementedError):
+            copy.copy(key)
+
+    def test_deepcopy_not_implemented(self):
+        key = DummyEd25519PublicKey(b"test data")
+        with pytest.raises(NotImplementedError):
+            copy.deepcopy(key)


### PR DESCRIPTION
The test_invalid_bit_string_padding_from_public_key test was using pretend.stub() to create a mock key object, which doesn't match the type signature of _key_identifier_from_public_key.

This replaces it with DummyEd25519PublicKey in tests/doubles.py that properly implements the Ed25519PublicKey interface. Added coverage tests in tests/test_doubles.py for all methods.