### PR TITLE
add an explicit type annotations for Binding.ffi

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -58,7 +58,7 @@ class Binding:
     """
 
     lib: typing.ClassVar[typing.Any] = None
-    ffi = _openssl.ffi
+    ffi: typing.Any = _openssl.ffi
     _lib_loaded = False
     _init_lock = threading.Lock()
 


### PR DESCRIPTION
this removes a whole bunch of ty warnings, and matches the declared type of _openssl.ffi.

See https://github.com/astral-sh/ty/issues/1706 for some context.