### PR TITLE
Fix windows free-threaded cryptography-cffi linking

### DIFF
--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -93,6 +93,11 @@ fn main() {
 
     if cfg!(windows) {
         build.define("WIN32_LEAN_AND_MEAN", None);
+        // python.h doesn't set this on the Windows free-threaded build
+        // see https://github.com/python/cpython/issues/127294
+        if is_free_threaded {
+            build.define("Py_GIL_DISABLED", "1");
+        }
     }
 
     build.compile("_openssl.a");


### PR DESCRIPTION
Fixes #13946.

See the CPython issue I linked in the comment for more details about why we need to do this. Normally maturin and/or setuptools handles this but for this extension we're hand-building a C extension, so we need to do all this manually.

I'm honestly not sure how this works at all on CI currently or how I missed this when we initially added free-threaded support. Somehow cryptography_cffi is being built as a GIL-enabled extension on Windows, but then everything works out in the end?