### PR TITLE
fix type annoations for cffi module

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/_openssl.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/_openssl.pyi
@@ -4,5 +4,5 @@
 
 import typing
 
-lib = typing.Any
-ffi = typing.Any
+lib: typing.Any
+ffi: typing.Any


### PR DESCRIPTION
these are of type typing.Any. they don't have the _value_ typing.Any