### PR TITLE
asn1: Add TODO comment for uses of `PyStringMethods::to_cow`

### DIFF
--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -138,6 +138,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                 let val: &pyo3::Bound<'_, PrintableString> = value
                     .cast()
                     .map_err(|_| asn1::WriteError::AllocationError)?;
+                // TODO: Switch this to `to_str()` once our minimum version is py310+
                 let inner_str = val
                     .get()
                     .inner
@@ -152,6 +153,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                 let val: &pyo3::Bound<'_, IA5String> = value
                     .cast()
                     .map_err(|_| asn1::WriteError::AllocationError)?;
+                // TODO: Switch this to `to_str()` once our minimum version is py310+
                 let inner_str = val
                     .get()
                     .inner

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -143,6 +143,7 @@ impl PrintableString {
     #[new]
     #[pyo3(signature = (inner,))]
     fn new(py: pyo3::Python<'_>, inner: pyo3::Py<pyo3::types::PyString>) -> pyo3::PyResult<Self> {
+        // TODO: Switch this to `to_str()` once our minimum version is py310+
         if Asn1PrintableString::new(&inner.to_cow(py)?).is_none() {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "invalid PrintableString: {inner}"
@@ -176,6 +177,7 @@ impl IA5String {
     #[new]
     #[pyo3(signature = (inner,))]
     fn new(py: pyo3::Python<'_>, inner: pyo3::Py<pyo3::types::PyString>) -> pyo3::PyResult<Self> {
+        // TODO: Switch this to `to_str()` once our minimum version is py310+
         if Asn1IA5String::new(&inner.to_cow(py)?).is_none() {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "invalid IA5String: {inner}"


### PR DESCRIPTION
From https://github.com/pyca/cryptography/pull/13985#issuecomment-3627669112:

> Another follow up: can you have us use to_str() on py310+ and to_cow() only on older Pythons? We do 3.11 wheels, so they'll get the perf win.

Since `pyo3` [already internally uses](https://docs.rs/pyo3/latest/src/pyo3/types/string.rs.html#346-361) `to_str` when calling `to_cow` in Python 3.10+, we just add a comment to migrate once the minimum Python version is sufficient

Part of https://github.com/pyca/cryptography/issues/12283
