### PR TITLE
feat(ci): switch to uv publish for PyPI uploads

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -51,7 +51,7 @@ jobs:
       - run: |
           find tmpdist/ -type f -name 'cryptography*' -exec mv {} dist/ \;
 
-      - uses: astral-sh/attest-action@2c727738cea36d6c97dd85eb133ea0e0e8fe754b # v0.0.4
+      - uses: astral-sh/attest-action@f35111fb79f1e4f0150a1ee16cfd4399e3151bdb # v0.0.5
         # Do not perform attestation for things for TestPyPI. This is
         # because there's nothing that would prevent a malicious PyPI from
         # serving a signed TestPyPI asset in place of a release intended for

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -43,7 +43,11 @@ jobs:
           echo "PYPI_URL=https://test.pypi.org/legacy/" >> $GITHUB_ENV
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testpypi'
 
-      - uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
+      - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          save-cache: false
+
+      - uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
         with:
           path: tmpdist/
           run_id: ${{ github.event.inputs.run_id || github.event.workflow_run.id }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -47,8 +47,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
-          cache: pip
-          cache-dependency-path: ci-constraints-requirements.txt
         timeout-minutes: 3
 
       - run: python -m pip install -c ci-constraints-requirements.txt 'uv'

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -43,9 +43,15 @@ jobs:
           echo "PYPI_URL=https://test.pypi.org/legacy/" >> $GITHUB_ENV
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testpypi'
 
-      - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+      - name: Setup python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          save-cache: false
+          python-version: '3.14'
+          cache: pip
+          cache-dependency-path: ci-constraints-requirements.txt
+        timeout-minutes: 3
+
+      - run: python -m pip install -c ci-constraints-requirements.txt 'uv'
 
       - uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
         with:
@@ -55,7 +61,7 @@ jobs:
       - run: |
           find tmpdist/ -type f -name 'cryptography*' -exec mv {} dist/ \;
 
-      - uses: astral-sh/attest-action@f35111fb79f1e4f0150a1ee16cfd4399e3151bdb # v0.0.5
+      - uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
         # Do not perform attestation for things for TestPyPI. This is
         # because there's nothing that would prevent a malicious PyPI from
         # serving a signed TestPyPI asset in place of a release intended for
@@ -63,7 +69,6 @@ jobs:
         if: env.PYPI_URL == 'https://upload.pypi.org/legacy/'
 
       - name: Publish package distributions to PyPI
-        # uv is present because attest-action installs it.
         run: |
           uv publish --trusted-publishing=always dist/*
         env:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -53,7 +53,7 @@ jobs:
 
       - run: python -m pip install -c ci-constraints-requirements.txt 'uv'
 
-      - uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+      - uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
           path: tmpdist/
           run_id: ${{ github.event.inputs.run_id || github.event.workflow_run.id }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -51,13 +51,16 @@ jobs:
       - run: |
           find tmpdist/ -type f -name 'cryptography*' -exec mv {} dist/ \;
 
+      - uses: astral-sh/attest-action@2c727738cea36d6c97dd85eb133ea0e0e8fe754b # v0.0.4
+        # Do not perform attestation for things for TestPyPI. This is
+        # because there's nothing that would prevent a malicious PyPI from
+        # serving a signed TestPyPI asset in place of a release intended for
+        # PyPI.
+        if: env.PYPI_URL == 'https://upload.pypi.org/legacy/'
+
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-        with:
-          repository-url: ${{ env.PYPI_URL }}
-          skip-existing: true
-          # Do not perform attestation for things for TestPyPI. This is
-          # because there's nothing that would prevent a malicious PyPI from
-          # serving a signed TestPyPI asset in place of a release intended for
-          # PyPI.
-          attestations: ${{ env.PYPI_URL == 'https://upload.pypi.org/legacy/' }}
+        # uv is present because attest-action installs it.
+        run: |
+          uv publish --trusted-publishing=always dist/*
+        env:
+          UV_PUBLISH_URL: ${{ env.PYPI_URL }}


### PR DESCRIPTION
This switches `pypi-publish.yml` from `gh-action-pypi-publish` to `uv publish`. The upload itself is still through Trusted Publishing, and attestations are preserved through `astral-sh/attest-action` (which can be removed in the medium-term, once `uv publish` itself supports attestation generation).

Noting a few things from conversation with @reaperhulk:

~~- This runs `uv publish` directly, since the uv binary is configured on the `$PATH` implicitly via `astral-sh/attest-action`. This is arguably undesirable, since cryptography otherwise pins uv via a requirements file.~~
~~- Separately, this currently runs the latest uv release at all times, since `astral-sh/attest-action` doesn't attempt to pin it (besides a lower bound for compatibility). This is "ok" from Astral's own trust domain, but it might not be what you want in your release pathway for stability/reproducibility purposes.~~

Both of the above have been addressed: this now uses only the version of `uv` that the rest of the CI is constrained against.

~~TL;DR: This all works, but the current approach may not be what you want in terms of version pinning.~~