### PR TITLE
Removed indirect dependency on OpenSSL from cryptography-x509-verification

### DIFF
--- a/src/rust/cryptography-x509-verification/Cargo.toml
+++ b/src/rust/cryptography-x509-verification/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 asn1.workspace = true
 cryptography-x509 = { path = "../cryptography-x509" }
-cryptography-key-parsing = { path = "../cryptography-key-parsing" }
+pkcs1 = "0.7.5"
 
 [dev-dependencies]
 pem.workspace = true

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 use std::ops::{Deref, Range};
 use std::sync::{Arc, LazyLock};
 
+use pkcs1::der::Decode;
 use asn1::ObjectIdentifier;
-use cryptography_key_parsing::rsa::Pkcs1RsaPublicKey;
 use cryptography_x509::certificate::Certificate;
 use cryptography_x509::common::{
     AlgorithmIdentifier, AlgorithmParameters, EcParameters, RsaPssParameters, Time,
@@ -555,10 +555,13 @@ impl<'a, B: CryptoOps> Policy<'a, B> {
             issuer_spki.algorithm.params,
             AlgorithmParameters::Rsa(_) | AlgorithmParameters::RsaPss(_)
         ) {
-            let rsa_key: Pkcs1RsaPublicKey<'_> =
-                asn1::parse_single(issuer_spki.subject_public_key.as_bytes())?;
+            let rsa_key: pkcs1::RsaPublicKey<'_> = pkcs1::RsaPublicKey::from_der(issuer_spki.subject_public_key.as_bytes()).map_err(|e| {
+                ValidationError::new(ValidationErrorKind::Other(
+                    format!("subject public RSA key could not be parsed: {}", e)
+                ))
+            })?;
 
-            if rsa_key.n.as_bytes().len() * 8 < self.minimum_rsa_modulus {
+            if rsa_key.modulus.as_bytes().len() * 8 < self.minimum_rsa_modulus {
                 return Err(ValidationError::new(ValidationErrorKind::Other(
                     "RSA key is too weak".into(),
                 )));


### PR DESCRIPTION
This PR should decouple `cryptography-x509-verification` from `cryptography-key-parsing` and subsequently OpenSSL.

This makes it possible to (cross-)build the library for targets that would otherwise have difficulties with OpenSSL. It also makes the PKCS#1 parsing pure Rust.

Tests seem to all pass when ran locally.