### PR TITLE
Improve error message if neither EKU nor anyEKU could be found

### DIFF
--- a/src/rust/cryptography-x509-verification/src/policy/extension.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/extension.rs
@@ -642,7 +642,7 @@ mod ca {
                 Ok(())
             } else {
                 Err(ValidationError::new(ValidationErrorKind::Other(
-                    "EKU and anyEKU not found".to_string(),
+                    "Neither EKU nor anyEKU could be found".to_string(),
                 )))
             }
         } else {


### PR DESCRIPTION
This function also checks for `|| eku == EKU_ANY_KEY_USAGE_OID` so the error message should contain it.