### PR TITLE
asn1: Add `SIZE` support to `OCTET STRING`

### DIFF
--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -107,12 +107,12 @@ def _normalize_field_type(
 
     if annotation.size is not None and (
         get_type_origin(field_type) is not builtins.list
-        and field_type is not BitString
+        and field_type not in (builtins.bytes, BitString)
     ):
         raise TypeError(
             f"field {field_name} has a SIZE annotation, but SIZE annotations "
             f"are only supported for fields of types: [SEQUENCE OF, "
-            "BIT STRING]"
+            "BIT STRING, OCTET STRING]"
         )
 
     if hasattr(field_type, "__asn1_root__"):

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -52,9 +52,10 @@ fn decode_pyint<'a>(
 fn decode_pybytes<'a>(
     py: pyo3::Python<'a>,
     parser: &mut Parser<'a>,
-    encoding: &Option<pyo3::Py<Encoding>>,
+    annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, pyo3::types::PyBytes>> {
-    let value = read_value::<&[u8]>(parser, encoding)?;
+    let value = read_value::<&[u8]>(parser, &annotation.encoding)?;
+    check_size_constraint(&annotation.size, value.len(), "OCTET STRING")?;
     Ok(pyo3::types::PyBytes::new(py, value))
 }
 
@@ -215,7 +216,7 @@ pub(crate) fn decode_annotated_type<'a>(
         }
         Type::PyBool() => decode_pybool(py, parser, encoding)?.into_any(),
         Type::PyInt() => decode_pyint(py, parser, encoding)?.into_any(),
-        Type::PyBytes() => decode_pybytes(py, parser, encoding)?.into_any(),
+        Type::PyBytes() => decode_pybytes(py, parser, annotation)?.into_any(),
         Type::PyStr() => decode_pystr(py, parser, encoding)?.into_any(),
         Type::PrintableString() => decode_printable_string(py, parser, encoding)?.into_any(),
         Type::IA5String() => decode_ia5_string(py, parser, encoding)?.into_any(),

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -122,6 +122,8 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                 let val: &[u8] = value
                     .extract()
                     .map_err(|_| asn1::WriteError::AllocationError)?;
+                check_size_constraint(&annotation.size, val.len(), "OCTET STRING")
+                    .map_err(|_| asn1::WriteError::AllocationError)?;
                 write_value(writer, &val, encoding)
             }
             Type::PyStr() => {


### PR DESCRIPTION
This PR extends the support for `SIZE` to `OCTET STRING`


Part of https://github.com/pyca/cryptography/issues/12283