### PR TITLE
asn1: Add `SIZE` support to `UTF8String`

### DIFF
--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -107,12 +107,12 @@ def _normalize_field_type(
 
     if annotation.size is not None and (
         get_type_origin(field_type) is not builtins.list
-        and field_type not in (builtins.bytes, BitString)
+        and field_type not in (builtins.bytes, builtins.str, BitString)
     ):
         raise TypeError(
             f"field {field_name} has a SIZE annotation, but SIZE annotations "
             f"are only supported for fields of types: [SEQUENCE OF, "
-            "BIT STRING, OCTET STRING]"
+            "BIT STRING, OCTET STRING, UTF8String]"
         )
 
     if hasattr(field_type, "__asn1_root__"):

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -62,9 +62,10 @@ fn decode_pybytes<'a>(
 fn decode_pystr<'a>(
     py: pyo3::Python<'a>,
     parser: &mut Parser<'a>,
-    encoding: &Option<pyo3::Py<Encoding>>,
+    annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, pyo3::types::PyString>> {
-    let value = read_value::<asn1::Utf8String<'a>>(parser, encoding)?;
+    let value = read_value::<asn1::Utf8String<'a>>(parser, &annotation.encoding)?;
+    check_size_constraint(&annotation.size, value.as_str().len(), "UTF8String")?;
     Ok(pyo3::types::PyString::new(py, value.as_str()))
 }
 
@@ -217,7 +218,7 @@ pub(crate) fn decode_annotated_type<'a>(
         Type::PyBool() => decode_pybool(py, parser, encoding)?.into_any(),
         Type::PyInt() => decode_pyint(py, parser, encoding)?.into_any(),
         Type::PyBytes() => decode_pybytes(py, parser, annotation)?.into_any(),
-        Type::PyStr() => decode_pystr(py, parser, encoding)?.into_any(),
+        Type::PyStr() => decode_pystr(py, parser, annotation)?.into_any(),
         Type::PrintableString() => decode_printable_string(py, parser, encoding)?.into_any(),
         Type::IA5String() => decode_ia5_string(py, parser, encoding)?.into_any(),
         Type::UtcTime() => decode_utc_time(py, parser, encoding)?.into_any(),

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -131,6 +131,8 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     .extract()
                     .map_err(|_| asn1::WriteError::AllocationError)?;
                 let asn1_string: asn1::Utf8String<'_> = asn1::Utf8String::new(&val);
+                check_size_constraint(&annotation.size, val.len(), "UTF8String")
+                    .map_err(|_| asn1::WriteError::AllocationError)?;
                 write_value(writer, &asn1_string, encoding)
             }
             Type::PrintableString() => {


### PR DESCRIPTION
This PR extends the support for `SIZE` to `UTF8String`


Part of https://github.com/pyca/cryptography/issues/12283