### PR TITLE
asn1: Add `SIZE` support to `PrintableString`

### DIFF
--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -107,12 +107,13 @@ def _normalize_field_type(
 
     if annotation.size is not None and (
         get_type_origin(field_type) is not builtins.list
-        and field_type not in (builtins.bytes, builtins.str, BitString)
+        and field_type
+        not in (builtins.bytes, builtins.str, BitString, PrintableString)
     ):
         raise TypeError(
             f"field {field_name} has a SIZE annotation, but SIZE annotations "
             f"are only supported for fields of types: [SEQUENCE OF, "
-            "BIT STRING, OCTET STRING, UTF8String]"
+            "BIT STRING, OCTET STRING, UTF8String, PrintableString]"
         )
 
     if hasattr(field_type, "__asn1_root__"):

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -72,9 +72,10 @@ fn decode_pystr<'a>(
 fn decode_printable_string<'a>(
     py: pyo3::Python<'a>,
     parser: &mut Parser<'a>,
-    encoding: &Option<pyo3::Py<Encoding>>,
+    annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, PrintableString>> {
-    let value = read_value::<asn1::PrintableString<'a>>(parser, encoding)?.as_str();
+    let value = read_value::<asn1::PrintableString<'a>>(parser, &annotation.encoding)?.as_str();
+    check_size_constraint(&annotation.size, value.len(), "PrintableString")?;
     let inner = pyo3::types::PyString::new(py, value).unbind();
     Ok(pyo3::Bound::new(py, PrintableString { inner })?)
 }
@@ -219,7 +220,7 @@ pub(crate) fn decode_annotated_type<'a>(
         Type::PyInt() => decode_pyint(py, parser, encoding)?.into_any(),
         Type::PyBytes() => decode_pybytes(py, parser, annotation)?.into_any(),
         Type::PyStr() => decode_pystr(py, parser, annotation)?.into_any(),
-        Type::PrintableString() => decode_printable_string(py, parser, encoding)?.into_any(),
+        Type::PrintableString() => decode_printable_string(py, parser, annotation)?.into_any(),
         Type::IA5String() => decode_ia5_string(py, parser, encoding)?.into_any(),
         Type::UtcTime() => decode_utc_time(py, parser, encoding)?.into_any(),
         Type::GeneralizedTime() => decode_generalized_time(py, parser, encoding)?.into_any(),

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -145,6 +145,8 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     .inner
                     .to_cow(py)
                     .map_err(|_| asn1::WriteError::AllocationError)?;
+                check_size_constraint(&annotation.size, inner_str.len(), "PrintableString")
+                    .map_err(|_| asn1::WriteError::AllocationError)?;
                 let printable_string: asn1::PrintableString<'_> =
                     asn1::PrintableString::new(&inner_str)
                         .ok_or(asn1::WriteError::AllocationError)?;


### PR DESCRIPTION
This PR extends the support for `SIZE` to `PrintableString`


Part of https://github.com/pyca/cryptography/issues/12283