### PR TITLE
asn1: Add `SIZE` support to `IA5String`

### DIFF
--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -108,12 +108,18 @@ def _normalize_field_type(
     if annotation.size is not None and (
         get_type_origin(field_type) is not builtins.list
         and field_type
-        not in (builtins.bytes, builtins.str, BitString, PrintableString)
+        not in (
+            builtins.bytes,
+            builtins.str,
+            BitString,
+            IA5String,
+            PrintableString,
+        )
     ):
         raise TypeError(
             f"field {field_name} has a SIZE annotation, but SIZE annotations "
             f"are only supported for fields of types: [SEQUENCE OF, "
-            "BIT STRING, OCTET STRING, UTF8String, PrintableString]"
+            "BIT STRING, OCTET STRING, UTF8String, PrintableString, IA5String]"
         )
 
     if hasattr(field_type, "__asn1_root__"):

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -83,9 +83,10 @@ fn decode_printable_string<'a>(
 fn decode_ia5_string<'a>(
     py: pyo3::Python<'a>,
     parser: &mut Parser<'a>,
-    encoding: &Option<pyo3::Py<Encoding>>,
+    annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, IA5String>> {
-    let value = read_value::<asn1::IA5String<'a>>(parser, encoding)?.as_str();
+    let value = read_value::<asn1::IA5String<'a>>(parser, &annotation.encoding)?.as_str();
+    check_size_constraint(&annotation.size, value.len(), "IA5String")?;
     let inner = pyo3::types::PyString::new(py, value).unbind();
     Ok(pyo3::Bound::new(py, IA5String { inner })?)
 }
@@ -221,7 +222,7 @@ pub(crate) fn decode_annotated_type<'a>(
         Type::PyBytes() => decode_pybytes(py, parser, annotation)?.into_any(),
         Type::PyStr() => decode_pystr(py, parser, annotation)?.into_any(),
         Type::PrintableString() => decode_printable_string(py, parser, annotation)?.into_any(),
-        Type::IA5String() => decode_ia5_string(py, parser, encoding)?.into_any(),
+        Type::IA5String() => decode_ia5_string(py, parser, annotation)?.into_any(),
         Type::UtcTime() => decode_utc_time(py, parser, encoding)?.into_any(),
         Type::GeneralizedTime() => decode_generalized_time(py, parser, encoding)?.into_any(),
         Type::BitString() => decode_bitstring(py, parser, annotation)?.into_any(),

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -162,6 +162,8 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     .inner
                     .to_cow(py)
                     .map_err(|_| asn1::WriteError::AllocationError)?;
+                check_size_constraint(&annotation.size, inner_str.len(), "IA5String")
+                    .map_err(|_| asn1::WriteError::AllocationError)?;
                 let ia5_string: asn1::IA5String<'_> =
                     asn1::IA5String::new(&inner_str).ok_or(asn1::WriteError::AllocationError)?;
                 write_value(writer, &ia5_string, encoding)

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -1027,6 +1027,111 @@ class TestSize:
         ):
             asn1.encode_der(Example(a=asn1.PrintableString("abcd")))
 
+    def test_ok_ia5string_size_restriction(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[asn1.IA5String, asn1.Size(min=1, max=4)]
+
+        assert_roundtrips(
+            [
+                (
+                    Example(a=asn1.IA5String("abcd")),
+                    b"\x30\x06\x16\x04abcd",
+                )
+            ]
+        )
+
+    def test_ok_ia5string_size_restriction_no_max(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[asn1.IA5String, asn1.Size(min=1, max=None)]
+
+        assert_roundtrips(
+            [
+                (
+                    Example(a=asn1.IA5String("abcd")),
+                    b"\x30\x06\x16\x04abcd",
+                )
+            ]
+        )
+
+    def test_ok_ia5string_size_restriction_exact(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[asn1.IA5String, asn1.Size.exact(4)]
+
+        assert_roundtrips(
+            [
+                (
+                    Example(a=asn1.IA5String("abcd")),
+                    b"\x30\x06\x16\x04abcd",
+                )
+            ]
+        )
+
+    def test_fail_ia5string_size_too_big(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[asn1.IA5String, asn1.Size(min=1, max=2)]
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("IA5String has size 4, expected size in [1, 2]"),
+        ):
+            asn1.decode_der(
+                Example,
+                b"\x30\x06\x16\x04abcd",
+            )
+
+        with pytest.raises(
+            ValueError,
+        ):
+            asn1.encode_der(Example(a=asn1.IA5String("abcd")))
+
+    def test_fail_ia5string_size_too_small(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[asn1.IA5String, asn1.Size(min=5, max=6)]
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("IA5String has size 4, expected size in [5, 6]"),
+        ):
+            asn1.decode_der(
+                Example,
+                b"\x30\x06\x16\x04abcd",
+            )
+
+        with pytest.raises(
+            ValueError,
+        ):
+            asn1.encode_der(Example(a=asn1.IA5String("abcd")))
+
+    def test_fail_ia5string_size_not_exact(self) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[asn1.IA5String, asn1.Size.exact(5)]
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("IA5String has size 4, expected size in [5, 5]"),
+        ):
+            asn1.decode_der(
+                Example,
+                b"\x30\x06\x16\x04abcd",
+            )
+
+        with pytest.raises(
+            ValueError,
+        ):
+            asn1.encode_der(Example(a=asn1.IA5String("abcd")))
+
     def test_ok_bitstring_size_restriction_no_max(self) -> None:
         @asn1.sequence
         @_comparable_dataclass


### PR DESCRIPTION
This PR extends the support for `SIZE` to `IA5String`

Part of https://github.com/pyca/cryptography/issues/12283