### PR TITLE
Update build docs to work on OpenBSD

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -224,8 +224,8 @@ dependencies.
     . env/bin/activate
     pip install -U setuptools
     pip install -U wheel pip
-    curl -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-    tar xvf openssl-${OPENSSL_VERSION}.tar.gz
+    curl -LO https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+    tar xzvf openssl-${OPENSSL_VERSION}.tar.gz
     cd openssl-${OPENSSL_VERSION}
     ./config no-shared no-ssl2 no-ssl3 -fPIC --prefix=${CWD}/openssl
     make && make install


### PR DESCRIPTION
Minor documentation updates on how to build cryptography with custom OpenSSL versions :

- the link now redirects to github, add `-L` option to follow redirections.
- tar requires `-z` on OpenBSD, unlike other plateformes. Since it also works on other plateforms, let's just add it