### PR TITLE
enable cooldowns for GHA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       time: "06:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 1024
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: cargo
     directory: "/"


### PR DESCRIPTION
they are effectively unreviewable due to vendoring, and generally less pressing than cargo/python updates