### PR TITLE
Update copyright year from 2025 to 2026

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Cryptography"
-copyright = "2013-2025, Individual Contributors"
+copyright = "2013-2026, Individual Contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -14,4 +14,4 @@ __version__ = "47.0.0.dev1"
 
 
 __author__ = "The Python Cryptographic Authority and individual contributors"
-__copyright__ = f"Copyright 2013-2025 {__author__}"
+__copyright__ = f"Copyright 2013-2026 {__author__}"


### PR DESCRIPTION
Update copyright statements in project-owned files to reflect the new year.