### PR TITLE
fixes #14084 -- Fix IndexError when loading malformed ECDSA SSH key with empty point

### DIFF
--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -472,6 +472,8 @@ class _SSHFormatECDSA:
         point, data = _get_sshstr(data)
         if curve != self.ssh_curve_name:
             raise ValueError("Curve name mismatch")
+        if len(point) == 0:
+            raise ValueError("Invalid EC point: empty data")
         if point[0] != 4:
             raise NotImplementedError("Need uncompressed point")
         return (curve, point), data

--- a/tests/hazmat/primitives/test_ssh.py
+++ b/tests/hazmat/primitives/test_ssh.py
@@ -1119,6 +1119,16 @@ class TestECDSASSHSerialization:
         with pytest.raises(NotImplementedError):
             load_ssh_public_key(ssh_key, backend)
 
+    def test_load_ssh_public_key_ecdsa_nist_p256_empty_point(self, backend):
+        # Malformed key with empty point data should raise ValueError,
+        # not IndexError.
+        ssh_key = (
+            b"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAy"
+            b"NTYAAAAA"
+        )
+        with pytest.raises(ValueError):
+            load_ssh_public_key(ssh_key, backend)
+
     def test_load_ssh_public_key_ecdsa_nist_p256_bad_curve_name(self, backend):
         ssh_key = (
             # The curve name in here is changed to be "nistp255".


### PR DESCRIPTION
When parsing an SSH ECDSA public key with empty point data, the code was accessing point[0] without first checking if the point is empty, causing an IndexError. This change adds a check for empty point data before accessing point[0], raising a ValueError instead.