### PR TITLE
Enable incremental Rust builds in local nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -267,6 +267,9 @@ def rust(session: nox.Session) -> None:
 
 @nox.session
 def local(session: nox.Session):
+    if "CARGO_INCREMENTAL" not in os.environ:
+        session.env["CARGO_INCREMENTAL"] = "1"
+
     pyproject_data = load_pyproject_toml()
     install(session, "-e", "./vectors", verbose=False)
     install(

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -14,8 +14,7 @@ use crate::backend::hmac::Hmac;
 use crate::backend::{cmac, hashes};
 use crate::buf::{CffiBuf, CffiMutBuf};
 use crate::error::{CryptographyError, CryptographyResult};
-use crate::exceptions;
-use crate::types;
+use crate::{exceptions, types};
 
 // NO-COVERAGE-START
 #[pyo3::pyclass(

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -3,8 +3,7 @@
 // for complete details.
 
 use asn1::Parser;
-use pyo3::types::PyAnyMethods;
-use pyo3::types::PyListMethods;
+use pyo3::types::{PyAnyMethods, PyListMethods};
 
 use crate::asn1::big_byte_slice_to_py_int;
 use crate::declarative_asn1::types::{

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -3,8 +3,7 @@
 // for complete details.
 
 use asn1::{SimpleAsn1Writable, Writer};
-use pyo3::types::PyAnyMethods;
-use pyo3::types::PyListMethods;
+use pyo3::types::{PyAnyMethods, PyListMethods};
 
 use crate::declarative_asn1::types::{
     check_size_constraint, AnnotatedType, AnnotatedTypeObject, BitString, Encoding,

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -2,12 +2,11 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use asn1::IA5String as Asn1IA5String;
-use asn1::PrintableString as Asn1PrintableString;
-use asn1::SimpleAsn1Readable;
-use asn1::UtcTime as Asn1UtcTime;
-use pyo3::types::PyAnyMethods;
-use pyo3::types::PyTzInfoAccess;
+use asn1::{
+    IA5String as Asn1IA5String, PrintableString as Asn1PrintableString, SimpleAsn1Readable,
+    UtcTime as Asn1UtcTime,
+};
+use pyo3::types::{PyAnyMethods, PyTzInfoAccess};
 use pyo3::{IntoPyObject, PyTypeInfo};
 
 use crate::error::CryptographyError;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -148,7 +148,6 @@ mod _rust {
     mod declarative_asn1 {
         #[pymodule_export]
         use crate::declarative_asn1::asn1::{decode_der, encode_der};
-
         #[pymodule_export]
         use crate::declarative_asn1::types::{
             non_root_python_to_rust, AnnotatedType, Annotation, BitString, Encoding,


### PR DESCRIPTION
Set CARGO_INCREMENTAL=1 for faster local dev iteration, respecting any externally-set value. Also includes minor rustfmt import cleanups.