### PR TITLE
asn1 : Add support for CHOICE fields

### DIFF
--- a/src/cryptography/hazmat/asn1/__init__.py
+++ b/src/cryptography/hazmat/asn1/__init__.py
@@ -15,6 +15,7 @@ from cryptography.hazmat.asn1.asn1 import (
     decode_der,
     encode_der,
     sequence,
+    variant,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "decode_der",
     "encode_der",
     "sequence",
+    "variant",
 ]

--- a/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/declarative_asn1.pyi
@@ -15,6 +15,7 @@ class Type:
     Sequence: typing.ClassVar[type]
     SequenceOf: typing.ClassVar[type]
     Option: typing.ClassVar[type]
+    Choice: typing.ClassVar[type]
     PyBool: typing.ClassVar[type]
     PyInt: typing.ClassVar[type]
     PyBytes: typing.ClassVar[type]
@@ -59,6 +60,18 @@ class AnnotatedTypeObject:
     def __new__(
         cls, annotated_type: AnnotatedType, value: typing.Any
     ) -> AnnotatedTypeObject: ...
+
+class Variant:
+    python_class: type
+    ann_type: AnnotatedType
+    is_wrapped: bool
+
+    def __new__(
+        cls,
+        python_class: type,
+        ann_type: AnnotatedType,
+        is_wrapped: bool,
+    ) -> Variant: ...
 
 class PrintableString:
     def __new__(cls, inner: str) -> PrintableString: ...

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -7,8 +7,9 @@ use pyo3::types::{PyAnyMethods, PyListMethods};
 
 use crate::asn1::big_byte_slice_to_py_int;
 use crate::declarative_asn1::types::{
-    check_size_constraint, type_to_tag, AnnotatedType, Annotation, BitString, Encoding,
-    GeneralizedTime, IA5String, PrintableString, Type, UtcTime,
+    check_size_constraint, expected_tags_for_type, expected_tags_for_variant, AnnotatedType,
+    Annotation, BitString, Encoding, GeneralizedTime, IA5String, PrintableString, Type, UtcTime,
+    Variant,
 };
 use crate::error::CryptographyError;
 
@@ -160,6 +161,46 @@ fn decode_bitstring<'a>(
     )?)
 }
 
+// Utility function to handle explicit encoding when parsing
+// CHOICE fields.
+fn decode_choice_with_encoding<'a>(
+    py: pyo3::Python<'a>,
+    parser: &mut Parser<'a>,
+    ann_type: &AnnotatedType,
+    encoding: &Encoding,
+) -> ParseResult<pyo3::Bound<'a, pyo3::PyAny>> {
+    match encoding {
+        Encoding::Implicit(_) => Err(CryptographyError::Py(
+            pyo3::exceptions::PyValueError::new_err(
+                "invalid type definition: CHOICE fields cannot be implicitly encoded".to_string(),
+            ),
+        ))?,
+        Encoding::Explicit(n) => {
+            // Since we don't know which of the variants is present for this
+            // CHOICE field, we'll parse this as a generic TLV encoded with
+            // EXPLICIT, so `read_explicit_element` will consume the EXPLICIT
+            // wrapper tag, and the TLV data will contain the variant.
+            let tlv = parser.read_explicit_element::<asn1::Tlv<'_>>(*n)?;
+            let type_without_explicit = AnnotatedType {
+                inner: ann_type.inner.clone_ref(py),
+                annotation: pyo3::Py::new(
+                    py,
+                    Annotation {
+                        default: None,
+                        encoding: None,
+                        size: None,
+                    },
+                )?,
+            };
+            // Parse the TLV data (which contains the field without the EXPLICIT
+            // wrapper)
+            asn1::parse(tlv.full_data(), |d| {
+                decode_annotated_type(py, d, &type_without_explicit)
+            })
+        }
+    }
+}
+
 pub(crate) fn decode_annotated_type<'a>(
     py: pyo3::Python<'a>,
     parser: &mut Parser<'a>,
@@ -172,10 +213,10 @@ pub(crate) fn decode_annotated_type<'a>(
     // Handle DEFAULT annotation if field is not present (by
     // returning the default value)
     if let Some(default) = &ann_type.annotation.get().default {
-        let expected_tag = type_to_tag(inner, encoding);
-        let next_tag = parser.peek_tag();
-        if next_tag != Some(expected_tag) {
-            return Ok(default.clone_ref(py).into_bound(py));
+        let expected_tags = expected_tags_for_type(py, inner, encoding);
+        match parser.peek_tag() {
+            Some(next_tag) if expected_tags.contains(&next_tag) => (),
+            _ => return Ok(default.clone_ref(py).into_bound(py)),
         }
     }
 
@@ -210,9 +251,9 @@ pub(crate) fn decode_annotated_type<'a>(
             })?
         }
         Type::Option(cls) => {
-            let inner_tag = type_to_tag(cls.get().inner.get(), encoding);
+            let expected_tags = expected_tags_for_type(py, cls.get().inner.get(), encoding);
             match parser.peek_tag() {
-                Some(t) if t == inner_tag => {
+                Some(t) if expected_tags.contains(&t) => {
                     // For optional types, annotations will always be associated to the `Optional` type
                     // i.e: `Annotated[Optional[T], annotation]`, as opposed to the inner `T` type.
                     // Therefore, when decoding the inner type `T` we must pass the annotation of the `Optional`
@@ -225,6 +266,35 @@ pub(crate) fn decode_annotated_type<'a>(
                 _ => pyo3::types::PyNone::get(py).to_owned().into_any(),
             }
         }
+        Type::Choice(ts) => match encoding {
+            Some(e) => decode_choice_with_encoding(py, parser, ann_type, e.get())?,
+            None => {
+                for t in ts.bind(py) {
+                    let variant = t.cast::<Variant>()?.get();
+                    let expected_tags = expected_tags_for_variant(py, variant);
+                    match parser.peek_tag() {
+                        Some(tag) if expected_tags.contains(&tag) => {
+                            let decoded_value =
+                                decode_annotated_type(py, parser, variant.ann_type.get())?;
+                            return if variant.is_wrapped {
+                                Ok(variant
+                                    .python_class
+                                    .call1(py, (decoded_value,))?
+                                    .into_bound(py))
+                            } else {
+                                Ok(decoded_value)
+                            };
+                        }
+                        _ => continue,
+                    }
+                }
+                Err(CryptographyError::Py(
+                    pyo3::exceptions::PyValueError::new_err(
+                        "could not find matching variant when parsing CHOICE field".to_string(),
+                    ),
+                ))?
+            }
+        },
         Type::PyBool() => decode_pybool(py, parser, encoding)?.into_any(),
         Type::PyInt() => decode_pyint(py, parser, encoding)?.into_any(),
         Type::PyBytes() => decode_pybytes(py, parser, annotation)?.into_any(),
@@ -244,5 +314,35 @@ pub(crate) fn decode_annotated_type<'a>(
             ),
         )),
         _ => Ok(decoded),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::declarative_asn1::types::{AnnotatedType, Annotation, Encoding, Type, Variant};
+    #[test]
+    fn test_decode_implicit_choice() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let result = asn1::parse(&[], |parser| {
+                let variants: Vec<Variant> = vec![];
+                let choice = Type::Choice(pyo3::types::PyList::new(py, variants)?.unbind());
+                let annotation = Annotation {
+                    default: None,
+                    encoding: None,
+                    size: None,
+                };
+                let ann_type = AnnotatedType {
+                    inner: pyo3::Py::new(py, choice)?,
+                    annotation: pyo3::Py::new(py, annotation)?,
+                };
+                let encoding = Encoding::Implicit(0);
+                super::decode_choice_with_encoding(py, parser, &ann_type, &encoding)
+            });
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(format!("{error}")
+                .contains("invalid type definition: CHOICE fields cannot be implicitly encoded"));
+        });
     }
 }

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -7,7 +7,7 @@ use pyo3::types::{PyAnyMethods, PyListMethods};
 
 use crate::declarative_asn1::types::{
     check_size_constraint, AnnotatedType, AnnotatedTypeObject, BitString, Encoding,
-    GeneralizedTime, IA5String, PrintableString, Type, UtcTime,
+    GeneralizedTime, IA5String, PrintableString, Type, UtcTime, Variant,
 };
 
 fn write_value<T: SimpleAsn1Writable>(
@@ -104,6 +104,41 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     // Missing OPTIONAL values are omitted from DER encoding
                     Ok(())
                 }
+            }
+            Type::Choice(ts) => {
+                for t in ts.bind(py) {
+                    let variant = t
+                        .cast::<Variant>()
+                        .map_err(|_| asn1::WriteError::AllocationError)?
+                        .get();
+                    if value.is_exact_instance(variant.python_class.bind(py)) {
+                        let val = if variant.is_wrapped {
+                            value
+                                .getattr("value")
+                                .map_err(|_| asn1::WriteError::AllocationError)?
+                        } else {
+                            value
+                        };
+                        let object = AnnotatedTypeObject {
+                            annotated_type: variant.ann_type.get(),
+                            value: val,
+                        };
+                        match encoding {
+                            Some(e) => match e.get() {
+                                // CHOICE cannot be encoded as IMPLICIT
+                                Encoding::Implicit(_) => {
+                                    return Err(asn1::WriteError::AllocationError)
+                                }
+                                Encoding::Explicit(n) => {
+                                    return writer.write_explicit_element(&object, *n)
+                                }
+                            },
+                            None => return object.write(writer),
+                        }
+                    }
+                }
+                // No matching variant found
+                Err(asn1::WriteError::AllocationError)
             }
             Type::PyBool() => {
                 let val: bool = value
@@ -210,5 +245,55 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                 write_value(writer, &bitstring, encoding)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::declarative_asn1::types::{
+        AnnotatedType, AnnotatedTypeObject, Annotation, Encoding, Type, Variant,
+    };
+    use asn1::Asn1Writable;
+    use pyo3::PyTypeInfo;
+    #[test]
+    fn test_encode_implicit_choice() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let annotation = Annotation {
+                default: None,
+                encoding: None,
+                size: None,
+            };
+            let ann_type_variant = AnnotatedType {
+                inner: pyo3::Py::new(py, Type::PyInt()).unwrap(),
+                annotation: pyo3::Py::new(py, annotation).unwrap(),
+            };
+            let variant = Variant {
+                python_class: pyo3::types::PyInt::type_object(py).unbind(),
+                ann_type: pyo3::Py::new(py, ann_type_variant).unwrap(),
+                is_wrapped: false,
+            };
+
+            let variants = vec![variant];
+            let choice = Type::Choice(pyo3::types::PyList::new(py, variants).unwrap().unbind());
+            let annotation = Annotation {
+                default: None,
+                encoding: Some(pyo3::Py::new(py, Encoding::Implicit(0)).unwrap()),
+                size: None,
+            };
+            let ann_type = AnnotatedType {
+                inner: pyo3::Py::new(py, choice).unwrap(),
+                annotation: pyo3::Py::new(py, annotation).unwrap(),
+            };
+
+            let value = pyo3::types::PyInt::new(py, 3).into_any();
+            let object = AnnotatedTypeObject {
+                annotated_type: &ann_type,
+                value,
+            };
+
+            let result = asn1::write(|writer| object.write(writer));
+            assert!(result.is_err());
+        });
     }
 }

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -25,6 +25,9 @@ pub enum Type {
     SequenceOf(pyo3::Py<AnnotatedType>),
     /// OPTIONAL (`T | None`)
     Option(pyo3::Py<AnnotatedType>),
+    /// CHOICE (`T | U | ...`)
+    /// The list contains elements of type Variant
+    Choice(pyo3::Py<pyo3::types::PyList>),
 
     // Python types that we map to canonical ASN.1 types
     //
@@ -55,6 +58,7 @@ pub enum Type {
 #[pyo3::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.asn1")]
 #[derive(Debug)]
 pub struct AnnotatedType {
+    #[pyo3(get)]
     pub inner: pyo3::Py<Type>,
     #[pyo3(get)]
     pub annotation: pyo3::Py<Annotation>,
@@ -131,6 +135,32 @@ impl Size {
         Size {
             min: n,
             max: Some(n),
+        }
+    }
+}
+
+#[pyo3::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.asn1")]
+pub struct Variant {
+    #[pyo3(get)]
+    pub python_class: pyo3::Py<pyo3::types::PyType>,
+    #[pyo3(get)]
+    pub ann_type: pyo3::Py<AnnotatedType>,
+    #[pyo3(get)]
+    pub is_wrapped: bool,
+}
+
+#[pyo3::pymethods]
+impl Variant {
+    #[new]
+    fn new(
+        python_class: pyo3::Py<pyo3::types::PyType>,
+        ann_type: pyo3::Py<AnnotatedType>,
+        is_wrapped: bool,
+    ) -> Self {
+        Self {
+            python_class,
+            ann_type,
+            is_wrapped,
         }
     }
 }
@@ -419,29 +449,54 @@ pub(crate) fn python_class_to_annotated<'p>(
     }
 }
 
-pub(crate) fn type_to_tag(t: &Type, encoding: &Option<pyo3::Py<Encoding>>) -> asn1::Tag {
-    let inner_tag = match t {
-        Type::Sequence(_, _) => asn1::Sequence::TAG,
-        Type::SequenceOf(_) => asn1::Sequence::TAG,
-        Type::Option(t) => type_to_tag(t.get().inner.get(), encoding),
-        Type::PyBool() => bool::TAG,
-        Type::PyInt() => asn1::BigInt::TAG,
-        Type::PyBytes() => <&[u8] as SimpleAsn1Readable>::TAG,
-        Type::PyStr() => asn1::Utf8String::TAG,
-        Type::PrintableString() => asn1::PrintableString::TAG,
-        Type::IA5String() => asn1::IA5String::TAG,
-        Type::ObjectIdentifier() => asn1::ObjectIdentifier::TAG,
-        Type::UtcTime() => asn1::UtcTime::TAG,
-        Type::GeneralizedTime() => asn1::GeneralizedTime::TAG,
-        Type::BitString() => asn1::BitString::TAG,
+// Utility function to get the expected tags for an unnanotated variant.
+pub(crate) fn expected_tags_for_variant(py: pyo3::Python<'_>, variant: &Variant) -> Vec<asn1::Tag> {
+    let ann_type = variant.ann_type.get();
+    expected_tags_for_type(
+        py,
+        ann_type.inner.get(),
+        &ann_type.annotation.get().encoding,
+    )
+}
+
+// Given a type, return the set of possible tags that we would expect
+// to see when decoding it. This is usually a single tag per type, except
+// when decoding a CHOICE value.
+pub(crate) fn expected_tags_for_type(
+    py: pyo3::Python<'_>,
+    t: &Type,
+    encoding: &Option<pyo3::Py<Encoding>>,
+) -> Vec<asn1::Tag> {
+    let inner_tags = match t {
+        Type::Sequence(_, _) => vec![asn1::Sequence::TAG],
+        Type::SequenceOf(_) => vec![asn1::Sequence::TAG],
+        Type::Option(t) => expected_tags_for_type(py, t.get().inner.get(), encoding),
+        Type::Choice(variants) => variants
+            .bind(py)
+            .into_iter()
+            .flat_map(|v| expected_tags_for_variant(py, v.cast::<Variant>().unwrap().get()))
+            .collect(),
+        Type::PyBool() => vec![bool::TAG],
+        Type::PyInt() => vec![asn1::BigInt::TAG],
+        Type::PyBytes() => vec![<&[u8] as SimpleAsn1Readable>::TAG],
+        Type::PyStr() => vec![asn1::Utf8String::TAG],
+        Type::PrintableString() => vec![asn1::PrintableString::TAG],
+        Type::IA5String() => vec![asn1::IA5String::TAG],
+        Type::ObjectIdentifier() => vec![asn1::ObjectIdentifier::TAG],
+        Type::UtcTime() => vec![asn1::UtcTime::TAG],
+        Type::GeneralizedTime() => vec![asn1::GeneralizedTime::TAG],
+        Type::BitString() => vec![asn1::BitString::TAG],
     };
 
     match encoding {
         Some(e) => match e.get() {
-            Encoding::Implicit(n) => asn1::implicit_tag(*n, inner_tag),
-            Encoding::Explicit(n) => asn1::explicit_tag(*n),
+            Encoding::Implicit(n) => inner_tags
+                .into_iter()
+                .map(|x| asn1::implicit_tag(*n, x))
+                .collect(),
+            Encoding::Explicit(n) => vec![asn1::explicit_tag(*n)],
         },
-        None => inner_tag,
+        None => inner_tags,
     }
 }
 
@@ -470,12 +525,12 @@ mod tests {
 
     use pyo3::IntoPyObject;
 
-    use super::{type_to_tag, AnnotatedType, Annotation, Type};
+    use super::{expected_tags_for_type, AnnotatedType, Annotation, Type};
 
     #[test]
-    // Needed for coverage of `type_to_tag(Type::Option(..))`, since
-    // `type_to_tag` is never called with an optional value.
-    fn test_option_type_to_tag() {
+    // Needed for coverage of `expected_tags_for_type(Type::Option(..))`, since
+    // `expected_tags_for_type` is never called with an optional value.
+    fn test_option_expected_tags_for_type() {
         pyo3::Python::initialize();
 
         pyo3::Python::attach(|py| {
@@ -509,8 +564,11 @@ mod tests {
                 },
             )
             .unwrap();
-            let expected_tag = type_to_tag(&Type::Option(optional_type), &None);
-            assert_eq!(expected_tag, type_to_tag(&Type::PyInt(), &None))
+            let expected_tags = expected_tags_for_type(py, &Type::Option(optional_type), &None);
+            assert_eq!(
+                expected_tags,
+                expected_tags_for_type(py, &Type::PyInt(), &None)
+            )
         })
     }
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -151,7 +151,7 @@ mod _rust {
         #[pymodule_export]
         use crate::declarative_asn1::types::{
             non_root_python_to_rust, AnnotatedType, Annotation, BitString, Encoding,
-            GeneralizedTime, IA5String, PrintableString, Size, Type, UtcTime,
+            GeneralizedTime, IA5String, PrintableString, Size, Type, UtcTime, Variant,
         };
     }
 


### PR DESCRIPTION

## API

This adds support for CHOICE fields using Python union type annotations.

```python
@asn1.sequence
class Example:
    foo: int | bool | str  # CHOICE field
```

Since unions remove repeated/redundant types, we need a way to represent a CHOICE with multiple variants of the same type.
```python
@asn1.sequence
class Example:
    foo: int | int  # does not work, gets simplified to `foo: int`
```

We do this by creating a trivial wrapper class, so that each variant is a different type:

```python
@asn1.variant
class MyIntA:
    value: int

@asn1.variant
class MyIntB
    value: int
```

These can now be used in a union:
```python
@asn1.sequence
class Example:
    foo: Annotated[MyIntA, asn1.Implicit(0)] | Annotated[MyIntB, asn1.Implicit(1)]
```

And then used to encode/decode:
```python
obj = Example(foo=MyIntA(42))
encoded = encode_der(obj)

decoded = decode(Example, encoded)
assert isinstance(decoded.foo, MyIntA)
assert decoded.foo.value == 42
```


## Details
* Classes annotated with the `@asn1.variant` decorator can only have one field, it must be named `value`, and it should not have any annotations.
* The `@asn1.variant` decorator adds a constructor so that the class can be initialized with just the value (e.g: `MyInt(42)`)
* The internal function `type_to_tag()` was replaced with `expected_tags_for_type()`, which does the same thing except it returns a list of tags. This is due to CHOICE types, where the expected tag can be one of many.


Part of https://github.com/pyca/cryptography/issues/12283