### PR TITLE
drop building and testing against windows arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,13 +341,13 @@ jobs:
       - uses: ./.github/actions/upload-coverage
 
   windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.WINDOWS.RUNNER }}
     strategy:
       fail-fast: false
       matrix:
         WINDOWS:
-          - {ARCH: 'x86', WINDOWS: 'win32'}
-          - {ARCH: 'x64', WINDOWS: 'win64'}
+          - {ARCH: 'x86', WINDOWS: 'win32', RUNNER: 'windows-latest'}
+          - {ARCH: 'x64', WINDOWS: 'win64', RUNNER: 'windows-latest'}
         PYTHON:
           - {VERSION: "3.8", NOXSESSION: "tests-nocoverage"}
           - {VERSION: "3.14", NOXSESSION: "tests"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,22 +341,17 @@ jobs:
       - uses: ./.github/actions/upload-coverage
 
   windows:
-    runs-on: ${{ matrix.WINDOWS.RUNNER }}
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         WINDOWS:
-          - {ARCH: 'x86', WINDOWS: 'win32', RUNNER: 'windows-latest'}
-          - {ARCH: 'x64', WINDOWS: 'win64', RUNNER: 'windows-latest'}
+          - {ARCH: 'x86', WINDOWS: 'win32'}
+          - {ARCH: 'x64', WINDOWS: 'win64'}
         PYTHON:
           - {VERSION: "3.8", NOXSESSION: "tests-nocoverage"}
           - {VERSION: "3.14", NOXSESSION: "tests"}
           - {VERSION: "3.14t", NOXSESSION: "tests"}
-        include:
-          # Not in the main matrix because we want tests-nocoverage on Python
-          # 3.14
-          - PYTHON: {VERSION: "3.14", NOXSESSION: "tests-nocoverage"}
-            WINDOWS: {ARCH: 'arm64', WINDOWS: 'arm64', RUNNER: 'windows-11-arm'}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -308,13 +308,13 @@ jobs:
 
   windows:
     needs: [sdist]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.WINDOWS.RUNNER }}
     strategy:
       fail-fast: false
       matrix:
         WINDOWS:
-          - {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc'}
-          - {ARCH: 'x64', WINDOWS: 'win64', RUST_TRIPLE: 'x86_64-pc-windows-msvc'}
+          - {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc', RUNNER: 'windows-latest'}
+          - {ARCH: 'x64', WINDOWS: 'win64', RUST_TRIPLE: 'x86_64-pc-windows-msvc', RUNNER: 'windows-latest'}
         PYTHON:
           - {VERSION: "3.14", "ABI_VERSION": "py38"}
           - {VERSION: "3.14", "ABI_VERSION": "py311"}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -308,14 +308,13 @@ jobs:
 
   windows:
     needs: [sdist]
-    runs-on: ${{ matrix.WINDOWS.RUNNER }}
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         WINDOWS:
-          - {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc', RUNNER: 'windows-latest'}
-          - {ARCH: 'x64', WINDOWS: 'win64', RUST_TRIPLE: 'x86_64-pc-windows-msvc', RUNNER: 'windows-latest'}
-          - {ARCH: 'arm64', WINDOWS: 'arm64', RUST_TRIPLE: 'aarch64-pc-windows-msvc', RUNNER: 'windows-11-arm'}
+          - {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc'}
+          - {ARCH: 'x64', WINDOWS: 'win64', RUST_TRIPLE: 'x86_64-pc-windows-msvc'}
         PYTHON:
           - {VERSION: "3.14", "ABI_VERSION": "py38"}
           - {VERSION: "3.14", "ABI_VERSION": "py311"}
@@ -324,9 +323,6 @@ jobs:
         exclude:
           # We need to exclude the below configuration because there is no 32-bit pypy3
           - WINDOWS: {ARCH: 'x86', WINDOWS: 'win32', RUST_TRIPLE: 'i686-pc-windows-msvc'}
-            PYTHON: {VERSION: "pypy-3.11"}
-          # We need to exclude the below configuration because there is no ARM64 pypy3
-          - WINDOWS: {ARCH: 'arm64', WINDOWS: 'arm64', RUST_TRIPLE: 'aarch64-pc-windows-msvc', RUNNER: 'windows-11-arm'}
             PYTHON: {VERSION: "pypy-3.11"}
     name: "${{ matrix.PYTHON.VERSION }} ${{ matrix.WINDOWS.WINDOWS }} ${{ matrix.PYTHON.ABI_VERSION }}"
     steps:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,7 +32,6 @@ operating systems.
 * x86-64 Debian Bookworm (12.x), Trixie (13.x), and Sid (unstable)
 * x86-64 and ARM64 Alpine (latest)
 * 32-bit and 64-bit Python on 64-bit Windows Server 2022
-* ARM64 Windows 11
 
 We test compiling with ``clang`` as well as ``gcc`` and use the following
 OpenSSL releases in addition to distribution provided releases from the


### PR DESCRIPTION
When we originally added win arm64 wheels part of our decision was that we would remove it if the underlying CI infrastructure proved problematic. Unfortunately, that time has already arrived. We need to do a release today for an OpenSSL security release and the arm64 windows image has been [broken with Python 3.14t for over two weeks](
https://github.com/actions/runner-images/issues/14058). Working around issues like this in our CI is not desirable or acceptable. Accordingly, we are removing wheels effective with our next point release.

Our apologies to the users of these wheels, but the most effective thing you can do is advocate with GitHub to have windows arm64 treated like a first class citizen in Actions.