### PR TITLE
asn1: refactor expected tag logic

### DIFF
--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -467,6 +467,10 @@ class TestSequence:
             h: typing.Union[asn1.BitString, None]
             i: typing.Union[asn1.IA5String, None]
             j: typing.Union[x509.ObjectIdentifier, None]
+            k: Annotated[typing.Union[str, None], asn1.Implicit(0)]
+            only_field_present: Annotated[
+                typing.Union[str, None], asn1.Implicit(1)
+            ]
 
         assert_roundtrips(
             [
@@ -482,8 +486,10 @@ class TestSequence:
                         h=None,
                         i=None,
                         j=None,
+                        k=None,
+                        only_field_present="a",
                     ),
-                    b"\x30\x00",
+                    b"\x30\x03\x81\x01a",
                 )
             ]
         )


### PR DESCRIPTION
Split from https://github.com/pyca/cryptography/pull/14201. Refactor the function that returns the expected tag for a type (`type_to_tag()`) to a function that returns if a tag matches a type (`is_tag_valid_for_type`).