### PR TITLE
Use PyString::from_fmt to avoid intermediate String allocations

### DIFF
--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -465,12 +465,16 @@ impl DsaPublicNumbers {
                 .eq(other.parameter_numbers.bind(py))?)
     }
 
-    fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+    fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
         let y = self.y.bind(py);
         let parameter_numbers = self.parameter_numbers.bind(py).repr()?;
-        Ok(format!(
-            "<DSAPublicNumbers(y={y}, parameter_numbers={parameter_numbers})>"
-        ))
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!("<DSAPublicNumbers(y={y}, parameter_numbers={parameter_numbers})>"),
+        )
     }
 }
 
@@ -514,11 +518,17 @@ impl DsaParameterNumbers {
             && (**self.g.bind(py)).eq(other.g.bind(py))?)
     }
 
-    fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+    fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
         let p = self.p.bind(py);
         let q = self.q.bind(py);
         let g = self.g.bind(py);
-        Ok(format!("<DSAParameterNumbers(p={p}, q={q}, g={g})>"))
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!("<DSAParameterNumbers(p={p}, q={q}, g={g})>"),
+        )
     }
 }
 

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -673,13 +673,17 @@ impl EllipticCurvePublicNumbers {
         Ok(hasher.finish())
     }
 
-    fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+    fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
         let x = self.x.bind(py);
         let y = self.y.bind(py);
         let curve_name = self.curve.bind(py).getattr(pyo3::intern!(py, "name"))?;
-        Ok(format!(
-            "<EllipticCurvePublicNumbers(curve={curve_name}, x={x}, y={y})>"
-        ))
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!("<EllipticCurvePublicNumbers(curve={curve_name}, x={x}, y={y})>"),
+        )
     }
 }
 

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -514,13 +514,13 @@ impl BaseArgon2 {
             Argon2Variant::Argon2id => "argon2id",
         };
 
-        // Format the PHC string
-        let phc_string = format!(
-            "${}$v=19$m={},t={},p={}${}${}",
-            variant_id, self.memory_cost, self.iterations, self.lanes, salt_b64, hash_b64
-        );
-
-        Ok(pyo3::types::PyString::new(py, &phc_string))
+        Ok(pyo3::types::PyString::from_fmt(
+            py,
+            format_args!(
+                "${}$v=19$m={},t={},p={}${}${}",
+                variant_id, self.memory_cost, self.iterations, self.lanes, salt_b64, hash_b64
+            ),
+        )?)
     }
 
     #[cfg(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER)]

--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -852,10 +852,13 @@ impl RsaPublicNumbers {
         Ok(hasher.finish())
     }
 
-    fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+    fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
         let e = self.e.bind(py);
         let n = self.n.bind(py);
-        Ok(format!("<RSAPublicNumbers(e={e}, n={n})>"))
+        pyo3::types::PyString::from_fmt(py, format_args!("<RSAPublicNumbers(e={e}, n={n})>"))
     }
 }
 

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -201,8 +201,14 @@ impl PrintableString {
         (**self.inner.bind(py)).eq(other.inner.bind(py))
     }
 
-    pub fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
-        Ok(format!("PrintableString({})", self.inner.bind(py).repr()?))
+    pub fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!("PrintableString({})", self.inner.bind(py).repr()?),
+        )
     }
 }
 
@@ -242,8 +248,14 @@ impl IA5String {
         (**self.inner.bind(py)).eq(other.inner.bind(py))
     }
 
-    pub fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
-        Ok(format!("IA5String({})", self.inner.bind(py).repr()?))
+    pub fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!("IA5String({})", self.inner.bind(py).repr()?),
+        )
     }
 }
 
@@ -288,8 +300,14 @@ impl UtcTime {
         (**self.inner.bind(py)).eq(other.inner.bind(py))
     }
 
-    pub fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
-        Ok(format!("UtcTime({})", self.inner.bind(py).repr()?))
+    pub fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!("UtcTime({})", self.inner.bind(py).repr()?),
+        )
     }
 }
 
@@ -327,8 +345,14 @@ impl GeneralizedTime {
         (**self.inner.bind(py)).eq(other.inner.bind(py))
     }
 
-    pub fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
-        Ok(format!("GeneralizedTime({})", self.inner.bind(py).repr()?))
+    pub fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!("GeneralizedTime({})", self.inner.bind(py).repr()?),
+        )
     }
 }
 
@@ -370,11 +394,17 @@ impl BitString {
             && self.padding_bits == other.padding_bits)
     }
 
-    pub fn __repr__(&self) -> pyo3::PyResult<String> {
-        Ok(format!(
-            "BitString(data={}, padding_bits={})",
-            self.data, self.padding_bits,
-        ))
+    pub fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!(
+                "BitString(data={}, padding_bits={})",
+                self.data, self.padding_bits,
+            ),
+        )
     }
 }
 

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -284,14 +284,20 @@ impl OpenSSLError {
         self.e.reason().unwrap_or("").as_bytes()
     }
 
-    fn __repr__(&self) -> pyo3::PyResult<String> {
-        Ok(format!(
-            "<OpenSSLError(code={}, lib={}, reason={}, reason_text={})>",
-            self.e.code(),
-            self.e.library_code(),
-            self.e.reason_code(),
-            self.e.reason().unwrap_or("")
-        ))
+    fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!(
+                "<OpenSSLError(code={}, lib={}, reason={}, reason_text={})>",
+                self.e.code(),
+                self.e.library_code(),
+                self.e.reason_code(),
+                self.e.reason().unwrap_or("")
+            ),
+        )
     }
 }
 

--- a/src/rust/src/oid.rs
+++ b/src/rust/src/oid.rs
@@ -46,13 +46,19 @@ impl ObjectIdentifier {
         slf
     }
 
-    fn __repr__(slf: &pyo3::Bound<'_, Self>, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+    fn __repr__<'py>(
+        slf: &pyo3::Bound<'py, Self>,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
         let name = Self::_name(slf.borrow(), py)?;
-        Ok(format!(
-            "<ObjectIdentifier(oid={}, name={})>",
-            slf.get().oid,
-            name.extract::<pyo3::pybacked::PyBackedStr>()?
-        ))
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!(
+                "<ObjectIdentifier(oid={}, name={})>",
+                slf.get().oid,
+                name.extract::<pyo3::pybacked::PyBackedStr>()?
+            ),
+        )
     }
 
     fn __eq__(&self, other: pyo3::PyRef<'_, ObjectIdentifier>) -> bool {

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -63,7 +63,10 @@ impl PKCS12Certificate {
         Ok(hasher.finish())
     }
 
-    fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+    fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
         let py_friendly_name_repr;
         let friendly_name_repr = match &self.friendly_name {
             Some(v) => {
@@ -75,11 +78,14 @@ impl PKCS12Certificate {
             }
             None => "None",
         };
-        Ok(format!(
-            "<PKCS12Certificate({}, friendly_name={})>",
-            self.certificate.bind(py).str()?,
-            friendly_name_repr
-        ))
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!(
+                "<PKCS12Certificate({}, friendly_name={})>",
+                self.certificate.bind(py).str()?,
+                friendly_name_repr
+            ),
+        )
     }
 }
 

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -55,10 +55,16 @@ impl Certificate {
         self.raw.borrow_dependent() == other.raw.borrow_dependent()
     }
 
-    fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+    fn __repr__<'py>(
+        &self,
+        py: pyo3::Python<'py>,
+    ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyString>> {
         let subject = self.subject(py)?;
         let subject_repr = subject.repr()?.extract::<pyo3::pybacked::PyBackedStr>()?;
-        Ok(format!("<Certificate(subject={subject_repr}, ...)>"))
+        pyo3::types::PyString::from_fmt(
+            py,
+            format_args!("<Certificate(subject={subject_repr}, ...)>"),
+        )
     }
 
     fn __deepcopy__(


### PR DESCRIPTION
Replace `format!` + String with `PyString::from_fmt` + `format_args!` in __repr__ methods and one PyString::new call, writing directly to a Python string buffer (1 alloc) instead of going through format!() -> String -> PyString (2 allocs + copy). This optimization is only effective on Python 3.14+.