### PR TITLE
bump uv_build to 0.10.0

### DIFF
--- a/vectors/pyproject.toml
+++ b/vectors/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # These requirements must be kept sync with the requirements in
 # ./.github/requirements/build-requirements.{in,txt}
-requires = ["uv_build>=0.7.19,<0.10.0"]
+requires = ["uv_build>=0.7.19,<0.11.0"]
 build-backend = "uv_build"
 
 [project]


### PR DESCRIPTION
uv{,_build} were bumped to `0.10.0`.

I'm a package contributor at Exherbo Linux, I've built it locally and it worked as expected.

Thanks
