### PR TITLE
x509-verification: drop cryptography-key-parsing dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,6 @@ name = "cryptography-x509-verification"
 version = "0.1.0"
 dependencies = [
  "asn1",
- "cryptography-key-parsing",
  "cryptography-x509",
  "pem",
 ]

--- a/src/rust/cryptography-key-parsing/src/rsa.rs
+++ b/src/rust/cryptography-key-parsing/src/rsa.rs
@@ -4,11 +4,7 @@
 
 use crate::{KeyParsingError, KeyParsingResult, KeySerializationResult};
 
-#[derive(asn1::Asn1Read, asn1::Asn1Write)]
-pub struct Pkcs1RsaPublicKey<'a> {
-    pub n: asn1::BigUint<'a>,
-    pub e: asn1::BigUint<'a>,
-}
+use cryptography_x509::common::Pkcs1RsaPublicKey;
 
 // RFC 8017, Section A.1.2
 #[derive(asn1::Asn1Read, asn1::Asn1Write)]

--- a/src/rust/cryptography-x509-verification/Cargo.toml
+++ b/src/rust/cryptography-x509-verification/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 [dependencies]
 asn1.workspace = true
 cryptography-x509 = { path = "../cryptography-x509" }
-cryptography-key-parsing = { path = "../cryptography-key-parsing" }
 
 [dev-dependencies]
 pem.workspace = true

--- a/src/rust/cryptography-x509-verification/src/policy/mod.rs
+++ b/src/rust/cryptography-x509-verification/src/policy/mod.rs
@@ -9,8 +9,8 @@ use std::ops::{Deref, Range};
 use std::sync::{Arc, LazyLock};
 
 use asn1::ObjectIdentifier;
-use cryptography_key_parsing::rsa::Pkcs1RsaPublicKey;
 use cryptography_x509::certificate::Certificate;
+use cryptography_x509::common::Pkcs1RsaPublicKey;
 use cryptography_x509::common::{
     AlgorithmIdentifier, AlgorithmParameters, EcParameters, RsaPssParameters, Time,
     PSS_SHA256_HASH_ALG, PSS_SHA256_MASK_GEN_ALG, PSS_SHA384_HASH_ALG, PSS_SHA384_MASK_GEN_ALG,

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -192,6 +192,12 @@ pub struct SubjectPublicKeyInfo<'a> {
     pub subject_public_key: asn1::BitString<'a>,
 }
 
+#[derive(asn1::Asn1Read, asn1::Asn1Write)]
+pub struct Pkcs1RsaPublicKey<'a> {
+    pub n: asn1::BigUint<'a>,
+    pub e: asn1::BigUint<'a>,
+}
+
 #[derive(asn1::Asn1Read, asn1::Asn1Write, PartialEq, Eq, Hash, Clone)]
 pub struct AttributeTypeValue<'a> {
     pub type_id: asn1::ObjectIdentifier,


### PR DESCRIPTION
Move the Pkcs1RsaPublicKey ASN.1 struct into cryptography-x509::common (next to SubjectPublicKeyInfo, where it naturally belongs) so that cryptography-x509-verification no longer depends on cryptography-key-parsing.

This removes the transitive dependency on openssl-sys, making cryptography-x509-verification usable with alternative crypto backends (e.g. aws-lc-rs) without requiring OpenSSL headers or libraries.