### PR TITLE
Fix installing stray files into site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,10 +106,10 @@ module-name = "cryptography.hazmat.bindings._rust"
 locked = true
 sdist-generator = "git"
 include = [
-    "CHANGELOG.rst",
-    "CONTRIBUTING.rst",
+    { path = "CHANGELOG.rst", format = "sdist" },
+    { path = "CONTRIBUTING.rst", format = "sdist" },
 
-    "docs/**/*",
+    { path = "docs/**/*", format = "sdist" },
 
     { path = "src/_cffi_src/**/*.py", format = "sdist" },
     { path = "src/_cffi_src/**/*.c", format = "sdist" },
@@ -121,7 +121,7 @@ include = [
     { path = "src/rust/**/Cargo.lock", format = "sdist" },
     { path = "src/rust/**/*.rs", format = "sdist" },
 
-    "tests/**/*.py",
+    { path = "tests/**/*.py", format = "sdist" },
 ]
 exclude = [
     "vectors/**/*",


### PR DESCRIPTION
Fix the `include` pattern in `pyproject.toml` not to install stray files such as `CHANGELOG.rst`, `CONTRIBUTING.rst`, `docs` and `tests` straight into site-packages.  Apparently Maturin did not install them before due to a bug, but it was fixed in maturin 1.12.0, leading to the files being suddenly installed.

Originally reported as https://bugs.gentoo.org/970090.