### PR TITLE
More misc. zizmor fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,6 @@ updates:
       # Also update indirect dependencies
       - dependency-type: all
     open-pull-requests-limit: 1024
-    cooldown:
-      default-days: 7
 
   - package-ecosystem: uv
     directories:
@@ -39,5 +37,3 @@ updates:
       # Also update indirect dependencies
       - dependency-type: all
     open-pull-requests-limit: 1024
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
Fixes a handful of default-persona zizmor findings. The main ones here are template injections, which aren't exploitable in practice (since the only calls to the action don't allow those inputs to vary at the moment).

I've also added cooldowns to the cargo and uv dep groups in Dependabot, but these could be removed (and optionally suppressed) if you prefer not to have cooldowns on these. (The cooldowns don't affect security updates, only normal bumps.)