### PR TITLE
Expose DTLS1_COOKIE_LENGTH in cffi bindings

### DIFF
--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -70,6 +70,7 @@ static const long SSL_OP_NETSCAPE_CA_DN_BUG;
 static const long SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG;
 static const long SSL_OP_NO_QUERY_MTU;
 static const long SSL_OP_COOKIE_EXCHANGE;
+static const long DTLS1_COOKIE_LENGTH;
 static const long SSL_OP_NO_TICKET;
 static const long SSL_OP_ALL;
 static const long SSL_OP_SINGLE_ECDH_USE;
@@ -627,6 +628,7 @@ static const long Cryptography_HAS_SSL_VERIFY_CLIENT_POST_HANDSHAKE = 1;
 static const long Cryptography_HAS_SSL_COOKIE = 0;
 
 static const long SSL_OP_COOKIE_EXCHANGE = 0;
+static const long DTLS1_COOKIE_LENGTH = 0;
 int (*DTLSv1_listen)(SSL *, BIO_ADDR *) = NULL;
 void (*SSL_CTX_set_cookie_generate_cb)(SSL_CTX *,
                                        int (*)(

--- a/src/cryptography/hazmat/bindings/openssl/_conditional.py
+++ b/src/cryptography/hazmat/bindings/openssl/_conditional.py
@@ -129,6 +129,7 @@ def cryptography_has_dtls_get_data_mtu() -> list[str]:
 def cryptography_has_ssl_cookie() -> list[str]:
     return [
         "SSL_OP_COOKIE_EXCHANGE",
+        "DTLS1_COOKIE_LENGTH",
         "DTLSv1_listen",
         "SSL_CTX_set_cookie_generate_cb",
         "SSL_CTX_set_cookie_verify_cb",


### PR DESCRIPTION
Add the DTLS1_COOKIE_LENGTH constant to the cffi bindings so it can be accessed from Python. This is grouped with the existing SSL_COOKIE conditional since it is part of the DTLS cookie mechanism.

https://claude.ai/code/session_01Lc6F3gxdtpV5o5HPzeGXsJ