### PR TITLE
Migrate PublicFormat enum from Python to Rust

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/__init__.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/__init__.pyi
@@ -46,6 +46,14 @@ class PrivateFormat:
     PKCS12: typing.ClassVar[PrivateFormat]
     def encryption_builder(self) -> KeySerializationEncryptionBuilder: ...
 
+class PublicFormat:
+    SubjectPublicKeyInfo: typing.ClassVar[PublicFormat]
+    PKCS1: typing.ClassVar[PublicFormat]
+    OpenSSH: typing.ClassVar[PublicFormat]
+    Raw: typing.ClassVar[PublicFormat]
+    CompressedPoint: typing.ClassVar[PublicFormat]
+    UncompressedPoint: typing.ClassVar[PublicFormat]
+
 class ObjectIdentifier:
     def __init__(self, value: str) -> None: ...
     @property

--- a/src/cryptography/hazmat/primitives/_serialization.py
+++ b/src/cryptography/hazmat/primitives/_serialization.py
@@ -9,6 +9,7 @@ import abc
 from cryptography import utils
 from cryptography.hazmat.bindings._rust import Encoding as Encoding
 from cryptography.hazmat.bindings._rust import PrivateFormat as PrivateFormat
+from cryptography.hazmat.bindings._rust import PublicFormat as PublicFormat
 from cryptography.hazmat.primitives.hashes import HashAlgorithm
 
 # This exists to break an import cycle. These classes are normally accessible
@@ -18,15 +19,6 @@ from cryptography.hazmat.primitives.hashes import HashAlgorithm
 class PBES(utils.Enum):
     PBESv1SHA1And3KeyTripleDESCBC = "PBESv1 using SHA1 and 3-Key TripleDES"
     PBESv2SHA256AndAES256CBC = "PBESv2 using SHA256 PBKDF2 and AES256 CBC"
-
-
-class PublicFormat(utils.Enum):
-    SubjectPublicKeyInfo = "X.509 subjectPublicKeyInfo with PKCS#1"
-    PKCS1 = "Raw PKCS#1"
-    OpenSSH = "OpenSSH"
-    Raw = "Raw"
-    CompressedPoint = "X9.62 Compressed Point"
-    UncompressedPoint = "X9.62 Uncompressed Point"
 
 
 class ParameterFormat(utils.Enum):

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -267,9 +267,9 @@ impl DHPublicKey {
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: crate::serialization::Encoding,
-        format: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: crate::serialization::PublicFormat,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        if !format.is(&types::PUBLIC_FORMAT_SUBJECT_PUBLIC_KEY_INFO.get(py)?) {
+        if format != crate::serialization::PublicFormat::SubjectPublicKeyInfo {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err(
                     "DH public keys support only SubjectPublicKeyInfo serialization",

--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -224,7 +224,7 @@ impl DsaPublicKey {
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: crate::serialization::Encoding,
-        format: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: crate::serialization::PublicFormat,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, false)
     }

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -465,7 +465,7 @@ impl ECPublicKey {
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: crate::serialization::Encoding,
-        format: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: crate::serialization::PublicFormat,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, false)
     }

--- a/src/rust/src/backend/ed25519.rs
+++ b/src/rust/src/backend/ed25519.rs
@@ -156,7 +156,7 @@ impl Ed25519PublicKey {
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: crate::serialization::Encoding,
-        format: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: crate::serialization::PublicFormat,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, true)
     }

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -153,7 +153,7 @@ impl Ed448PublicKey {
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: crate::serialization::Encoding,
-        format: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: crate::serialization::PublicFormat,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, true)
     }

--- a/src/rust/src/backend/rsa.rs
+++ b/src/rust/src/backend/rsa.rs
@@ -563,7 +563,7 @@ impl RsaPublicKey {
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: crate::serialization::Encoding,
-        format: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: crate::serialization::PublicFormat,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, true, false)
     }

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -142,7 +142,7 @@ impl X25519PublicKey {
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: crate::serialization::Encoding,
-        format: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: crate::serialization::PublicFormat,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, false, true)
     }

--- a/src/rust/src/backend/x448.rs
+++ b/src/rust/src/backend/x448.rs
@@ -141,7 +141,7 @@ impl X448PublicKey {
         slf: &pyo3::Bound<'p, Self>,
         py: pyo3::Python<'p>,
         encoding: crate::serialization::Encoding,
-        format: &pyo3::Bound<'p, pyo3::PyAny>,
+        format: crate::serialization::PublicFormat,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         utils::pkey_public_bytes(py, slf, &slf.borrow().pkey, encoding, format, false, true)
     }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -145,7 +145,7 @@ mod _rust {
     #[pymodule_export]
     use crate::pkcs7::pkcs7_mod;
     #[pymodule_export]
-    use crate::serialization::{Encoding, PrivateFormat};
+    use crate::serialization::{Encoding, PrivateFormat, PublicFormat};
     #[pymodule_export]
     use crate::test_support::test_support;
 

--- a/src/rust/src/serialization.rs
+++ b/src/rust/src/serialization.rs
@@ -41,6 +41,23 @@ pub enum PrivateFormat {
     PKCS12,
 }
 
+#[pyo3::pyclass(
+    frozen,
+    eq,
+    hash,
+    from_py_object,
+    module = "cryptography.hazmat.primitives._serialization"
+)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PublicFormat {
+    SubjectPublicKeyInfo,
+    PKCS1,
+    OpenSSH,
+    Raw,
+    CompressedPoint,
+    UncompressedPoint,
+}
+
 #[pyo3::pymethods]
 impl PrivateFormat {
     fn encryption_builder<'p>(

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -47,35 +47,6 @@ pub static DEPRECATED_IN_42: LazyPyImport =
 pub static DEPRECATED_IN_43: LazyPyImport =
     LazyPyImport::new("cryptography.utils", &["DeprecatedIn43"]);
 
-pub static PUBLIC_FORMAT: LazyPyImport = LazyPyImport::new(
-    "cryptography.hazmat.primitives.serialization",
-    &["PublicFormat"],
-);
-pub static PUBLIC_FORMAT_COMPRESSED_POINT: LazyPyImport = LazyPyImport::new(
-    "cryptography.hazmat.primitives.serialization",
-    &["PublicFormat", "CompressedPoint"],
-);
-pub static PUBLIC_FORMAT_OPENSSH: LazyPyImport = LazyPyImport::new(
-    "cryptography.hazmat.primitives.serialization",
-    &["PublicFormat", "OpenSSH"],
-);
-pub static PUBLIC_FORMAT_PKCS1: LazyPyImport = LazyPyImport::new(
-    "cryptography.hazmat.primitives.serialization",
-    &["PublicFormat", "PKCS1"],
-);
-pub static PUBLIC_FORMAT_RAW: LazyPyImport = LazyPyImport::new(
-    "cryptography.hazmat.primitives.serialization",
-    &["PublicFormat", "Raw"],
-);
-pub static PUBLIC_FORMAT_SUBJECT_PUBLIC_KEY_INFO: LazyPyImport = LazyPyImport::new(
-    "cryptography.hazmat.primitives.serialization",
-    &["PublicFormat", "SubjectPublicKeyInfo"],
-);
-pub static PUBLIC_FORMAT_UNCOMPRESSED_POINT: LazyPyImport = LazyPyImport::new(
-    "cryptography.hazmat.primitives.serialization",
-    &["PublicFormat", "UncompressedPoint"],
-);
-
 pub static PARAMETER_FORMAT_PKCS3: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.serialization",
     &["ParameterFormat", "PKCS3"],

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1021,12 +1021,14 @@ pub(crate) fn create_x509_certificate(
         rsa_padding.clone(),
     )?;
 
-    let spki = types::PUBLIC_FORMAT_SUBJECT_PUBLIC_KEY_INFO.get(py)?;
     let spki_bytes = builder
         .getattr(pyo3::intern!(py, "_public_key"))?
         .call_method1(
             pyo3::intern!(py, "public_bytes"),
-            (crate::serialization::Encoding::DER, spki),
+            (
+                crate::serialization::Encoding::DER,
+                crate::serialization::PublicFormat::SubjectPublicKeyInfo,
+            ),
         )?
         .extract::<pyo3::pybacked::PyBackedBytes>()?;
 

--- a/src/rust/src/x509/csr.rs
+++ b/src/rust/src/x509/csr.rs
@@ -255,12 +255,14 @@ pub(crate) fn create_x509_csr(
         rsa_padding.clone(),
     )?;
 
-    let spki = types::PUBLIC_FORMAT_SUBJECT_PUBLIC_KEY_INFO.get(py)?;
     let spki_bytes = private_key
         .call_method0(pyo3::intern!(py, "public_key"))?
         .call_method1(
             pyo3::intern!(py, "public_bytes"),
-            (crate::serialization::Encoding::DER, spki),
+            (
+                crate::serialization::Encoding::DER,
+                crate::serialization::PublicFormat::SubjectPublicKeyInfo,
+            ),
         )?
         .extract::<pyo3::pybacked::PyBackedBytes>()?;
 


### PR DESCRIPTION
Following the same pattern as the Encoding and PrivateFormat migrations, this moves the PublicFormat enum definition from Python to Rust. The enum is defined as a pyo3 pyclass with from_py_object support, allowing pyo3 to handle type checking automatically. All Rust code that previously compared against lazy Python imports now uses native enum comparisons.

https://claude.ai/code/session_01H2PfFsqsejcXsA3kEVRtPv