### PR TITLE
Fix HPKE decryption ciphertext length validation

### DIFF
--- a/src/rust/src/backend/hpke.rs
+++ b/src/rust/src/backend/hpke.rs
@@ -28,6 +28,7 @@ mod aead_params {
     pub const AES_128_GCM_ID: u16 = 0x0001;
     pub const AES_128_GCM_NK: usize = 16;
     pub const AES_128_GCM_NN: usize = 12;
+    pub const AES_128_GCM_NT: usize = 16;
 }
 
 #[allow(clippy::upper_case_acronyms)]
@@ -336,7 +337,7 @@ impl Suite {
         aad: Option<CffiBuf<'_>>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let ct_bytes = ciphertext.as_bytes();
-        if ct_bytes.len() < kem_params::X25519_NENC {
+        if ct_bytes.len() < kem_params::X25519_NENC + aead_params::AES_128_GCM_NT {
             return Err(CryptographyError::from(exceptions::InvalidTag::new_err(())));
         }
 


### PR DESCRIPTION
## Summary
This PR fixes the ciphertext length validation in HPKE decryption to account for the authentication tag size.

## Key Changes
- Added `AES_128_GCM_NT` constant (16 bytes) to `aead_params` module to represent the AES-128-GCM authentication tag length
- Updated the ciphertext length check in `Suite::decrypt()` to validate that the ciphertext is at least `X25519_NENC + AES_128_GCM_NT` bytes, rather than just `X25519_NENC` bytes

## Details
The previous validation was insufficient as it only checked for the encapsulated key size but did not account for the authentication tag that must be present in the ciphertext. This could allow invalid ciphertexts to pass the length check and potentially cause issues during decryption. The fix ensures the ciphertext contains both the encapsulated key and the authentication tag before attempting decryption.

https://claude.ai/code/session_01EGLxxnHUgfiStRV9BzFJxo