### PR TITLE
Add ChaCha20Poly1305 support to HPKE implementation

### DIFF
--- a/docs/hazmat/primitives/hpke.rst
+++ b/docs/hazmat/primitives/hpke.rst
@@ -10,7 +10,7 @@ Mechanism (KEM), a Key Derivation Function (KDF), and an Authenticated
 Encryption with Associated Data (AEAD) scheme. It is defined in :rfc:`9180`.
 
 This implementation supports Base mode with DHKEM(X25519, HKDF-SHA256),
-HKDF-SHA256, and AES-128-GCM.
+HKDF-SHA256, and either AES-128-GCM or ChaCha20Poly1305.
 
 HPKE provides authenticated encryption: the recipient can be certain that the
 message was encrypted by someone who knows the recipient's public key, but
@@ -99,3 +99,7 @@ specifying auxiliary authenticated information.
     .. attribute:: AES_128_GCM
 
         AES-128-GCM
+
+    .. attribute:: CHACHA20_POLY1305
+
+        ChaCha20Poly1305

--- a/src/cryptography/hazmat/bindings/_rust/openssl/hpke.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/openssl/hpke.pyi
@@ -13,6 +13,7 @@ class KDF:
 
 class AEAD:
     AES_128_GCM: AEAD
+    CHACHA20_POLY1305: AEAD
 
 class Suite:
     def __init__(self, kem: KEM, kdf: KDF, aead: AEAD) -> None: ...

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -419,7 +419,7 @@ impl EvpAead {
 }
 
 #[pyo3::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.aead")]
-struct ChaCha20Poly1305 {
+pub(crate) struct ChaCha20Poly1305 {
     #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
     ctx: EvpAead,
     #[cfg(any(CRYPTOGRAPHY_OPENSSL_320_OR_GREATER, CRYPTOGRAPHY_IS_LIBRESSL))]
@@ -436,7 +436,10 @@ struct ChaCha20Poly1305 {
 #[pyo3::pymethods]
 impl ChaCha20Poly1305 {
     #[new]
-    fn new(py: pyo3::Python<'_>, key: pyo3::Py<pyo3::PyAny>) -> CryptographyResult<Self> {
+    pub(crate) fn new(
+        py: pyo3::Python<'_>,
+        key: pyo3::Py<pyo3::PyAny>,
+    ) -> CryptographyResult<Self> {
         let key_buf = key.extract::<CffiBuf<'_>>(py)?;
         if key_buf.as_bytes().len() != 32 {
             return Err(CryptographyError::from(
@@ -495,7 +498,7 @@ impl ChaCha20Poly1305 {
     }
 
     #[pyo3(signature = (nonce, data, associated_data))]
-    fn encrypt<'p>(
+    pub(crate) fn encrypt<'p>(
         &self,
         py: pyo3::Python<'p>,
         nonce: CffiBuf<'_>,
@@ -553,7 +556,7 @@ impl ChaCha20Poly1305 {
     }
 
     #[pyo3(signature = (nonce, data, associated_data))]
-    fn decrypt<'p>(
+    pub(crate) fn decrypt<'p>(
         &self,
         py: pyo3::Python<'p>,
         nonce: CffiBuf<'_>,


### PR DESCRIPTION
Add CHACHA20_POLY1305 as an AEAD option for HPKE (RFC 9180 aead_id 0x0003), alongside the existing AES_128_GCM support.

Changes:
- Add CHACHA20_POLY1305 variant to the HPKE AEAD enum with parameters (Nk=32, Nn=12, Nt=16)
- Make Suite store the selected AEAD and dynamically dispatch to the correct cipher for encrypt/decrypt operations
- Make key_schedule return PyBytes directly to avoid unnecessary allocations when passing to AEAD constructors
- Make ChaCha20Poly1305 struct and its encrypt/decrypt methods pub(crate) so they can be used from the HPKE module
- Update tests to cover ChaCha20Poly1305 roundtrips and RFC 9180 test vector validation
- Update type stubs and documentation

https://claude.ai/code/session_019vzyAZNnzXmtyAnkc9BHZp