### PR TITLE
Add HKDF_SHA512 support to the HPKE implementation

### DIFF
--- a/src/cryptography/hazmat/bindings/_rust/openssl/hpke.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/openssl/hpke.pyi
@@ -10,6 +10,7 @@ class KEM:
 
 class KDF:
     HKDF_SHA256: KDF
+    HKDF_SHA512: KDF
 
 class AEAD:
     AES_128_GCM: AEAD

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -308,6 +308,8 @@ pub static SHA1: LazyPyImport =
     LazyPyImport::new("cryptography.hazmat.primitives.hashes", &["SHA1"]);
 pub static SHA256: LazyPyImport =
     LazyPyImport::new("cryptography.hazmat.primitives.hashes", &["SHA256"]);
+pub static SHA512: LazyPyImport =
+    LazyPyImport::new("cryptography.hazmat.primitives.hashes", &["SHA512"]);
 
 pub static NO_DIGEST_INFO: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.asymmetric.utils",

--- a/tests/hazmat/primitives/test_hpke.py
+++ b/tests/hazmat/primitives/test_hpke.py
@@ -24,6 +24,7 @@ X25519_ENC_LENGTH = 32
 SUPPORTED_SUITES = [
     (KEM.X25519, KDF.HKDF_SHA256, AEAD.AES_128_GCM),
     (KEM.X25519, KDF.HKDF_SHA256, AEAD.CHACHA20_POLY1305),
+    (KEM.X25519, KDF.HKDF_SHA512, AEAD.AES_128_GCM),
 ]
 
 
@@ -225,25 +226,28 @@ class TestHPKE:
             lambda f: json.load(f),
         )
 
+        kdf_map = {
+            0x0001: KDF.HKDF_SHA256,
+            0x0003: KDF.HKDF_SHA512,
+        }
         aead_map = {
             0x0001: AEAD.AES_128_GCM,
             0x0003: AEAD.CHACHA20_POLY1305,
         }
 
         for vector in vectors:
-            # Support: mode 0 (Base), X25519, HKDF-SHA256,
-            # AES-128-GCM or ChaCha20Poly1305
             if not (
                 vector["mode"] == 0
                 and vector["kem_id"] == 0x0020
-                and vector["kdf_id"] == 0x0001
+                and vector["kdf_id"] in kdf_map
                 and vector["aead_id"] in aead_map
             ):
                 continue
 
             with subtests.test():
+                kdf = kdf_map[vector["kdf_id"]]
                 aead = aead_map[vector["aead_id"]]
-                suite = Suite(KEM.X25519, KDF.HKDF_SHA256, aead)
+                suite = Suite(KEM.X25519, kdf, aead)
 
                 sk_r_bytes = bytes.fromhex(vector["skRm"])
                 sk_r = x25519.X25519PrivateKey.from_private_bytes(sk_r_bytes)


### PR DESCRIPTION
Extend the HPKE KDF enum with HKDF_SHA512 (ID 0x0003) alongside the existing HKDF_SHA256. The KDF type owns its id() and hash_algorithm() methods, and hkdf_expand takes the hash as an argument so both KEM (SHA256) and HPKE (suite KDF) callers go through the same code path. KEM operations (DHKEM(X25519, HKDF-SHA256)) continue to use SHA-256 per RFC 9180.

https://claude.ai/code/session_013bNoRc1A2vwBFC6NZkxCtS