### PR TITLE
Add ML-DSA support for BoringSSL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,8 +90,7 @@ Changelog
 * Added :doc:`/hazmat/primitives/hpke` support implementing :rfc:`9180` for
   hybrid authenticated encryption.
 * Added new :doc:`/hazmat/primitives/asymmetric/mldsa` module with
-  support for ML-DSA signing and verification with the AWS-LC and BoringSSL
-  backends.
+  support for ML-DSA signing and verification with AWS-LC and BoringSSL.
 * Added new :doc:`/hazmat/asn1/index` module with support for declaratively
   defining custom ASN.1 types and encoding/decoding them.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,7 +90,8 @@ Changelog
 * Added :doc:`/hazmat/primitives/hpke` support implementing :rfc:`9180` for
   hybrid authenticated encryption.
 * Added new :doc:`/hazmat/primitives/asymmetric/mldsa` module with
-  support for ML-DSA signing and verification with the AWS-LC backend.
+  support for ML-DSA signing and verification with the AWS-LC and BoringSSL
+  backends.
 * Added new :doc:`/hazmat/asn1/index` module with support for declaratively
   defining custom ASN.1 types and encoding/decoding them.
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -273,7 +273,10 @@ class Backend:
         )
 
     def mldsa_supported(self) -> bool:
-        return rust_openssl.CRYPTOGRAPHY_IS_AWSLC
+        return (
+            rust_openssl.CRYPTOGRAPHY_IS_AWSLC
+            or rust_openssl.CRYPTOGRAPHY_IS_BORINGSSL
+        )
 
     def ed25519_supported(self) -> bool:
         return True

--- a/src/rust/cryptography-key-parsing/src/pkcs8.rs
+++ b/src/rust/cryptography-key-parsing/src/pkcs8.rs
@@ -35,7 +35,7 @@ pub enum MlDsaPrivateKey {
 /// AWS-LC's `raw_private_key()` returns the expanded key, not the seed.
 /// This function round-trips through the native PKCS#8 encoding to extract it.
 /// https://github.com/aws/aws-lc/issues/3072
-#[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
 pub fn mldsa_seed_from_pkey(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> Result<MlDsaPrivateKey, openssl::error::ErrorStack> {
@@ -501,17 +501,7 @@ pub fn serialize_private_key(key: &ParsedPrivateKey) -> crate::KeySerializationR
             }
             #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
             id if cryptography_openssl::mldsa::is_mldsa_pkey_type(id) => {
-                let seed_key = {
-                    cfg_if::cfg_if! {
-                        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
-                            let seed = cryptography_openssl::mldsa::get_seed(pkey)?;
-                            MlDsaPrivateKey::Seed(seed.try_into().unwrap())
-                        } else {
-                            mldsa_seed_from_pkey(pkey)?
-                        }
-                    }
-                };
-                let private_key_der = asn1::write_single(&seed_key)?;
+                let private_key_der = asn1::write_single(&mldsa_seed_from_pkey(pkey)?)?;
                 let params = match cryptography_openssl::mldsa::MlDsaVariant::from_pkey(pkey) {
                     cryptography_openssl::mldsa::MlDsaVariant::MlDsa44 => {
                         AlgorithmParameters::MlDsa44

--- a/src/rust/cryptography-key-parsing/src/pkcs8.rs
+++ b/src/rust/cryptography-key-parsing/src/pkcs8.rs
@@ -23,14 +23,14 @@ pub struct PrivateKeyInfo<'a> {
 }
 
 // RFC 9881 Section 6.5
-#[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
 #[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub enum MlDsaPrivateKey {
     #[implicit(0)]
     Seed([u8; 32]),
 }
 
-/// Extract the 32-byte ML-DSA-65 seed from a private key.
+/// Extract the 32-byte ML-DSA seed from a private key.
 ///
 /// AWS-LC's `raw_private_key()` returns the expanded key, not the seed.
 /// This function round-trips through the native PKCS#8 encoding to extract it.
@@ -132,7 +132,7 @@ pub fn parse_private_key(data: &[u8]) -> KeyParsingResult<ParsedPrivateKey> {
             Ok(ParsedPrivateKey::Pkey(pkey))
         }
 
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
         AlgorithmParameters::MlDsa44 => {
             let MlDsaPrivateKey::Seed(seed) = asn1::parse_single::<MlDsaPrivateKey>(k.private_key)?;
             Ok(ParsedPrivateKey::Pkey(
@@ -143,7 +143,7 @@ pub fn parse_private_key(data: &[u8]) -> KeyParsingResult<ParsedPrivateKey> {
             ))
         }
 
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
         AlgorithmParameters::MlDsa65 => {
             let MlDsaPrivateKey::Seed(seed) = asn1::parse_single::<MlDsaPrivateKey>(k.private_key)?;
             Ok(ParsedPrivateKey::Pkey(
@@ -154,7 +154,7 @@ pub fn parse_private_key(data: &[u8]) -> KeyParsingResult<ParsedPrivateKey> {
             ))
         }
 
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
         AlgorithmParameters::MlDsa87 => {
             let MlDsaPrivateKey::Seed(seed) = asn1::parse_single::<MlDsaPrivateKey>(k.private_key)?;
             Ok(ParsedPrivateKey::Pkey(
@@ -499,9 +499,19 @@ pub fn serialize_private_key(key: &ParsedPrivateKey) -> crate::KeySerializationR
 
                 (params, private_key_der)
             }
-            #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
-            cryptography_openssl::mldsa::PKEY_ID => {
-                let private_key_der = asn1::write_single(&mldsa_seed_from_pkey(pkey)?)?;
+            #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
+            id if cryptography_openssl::mldsa::is_mldsa_pkey_type(id) => {
+                let seed_key = {
+                    cfg_if::cfg_if! {
+                        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+                            let seed = cryptography_openssl::mldsa::get_seed(pkey)?;
+                            MlDsaPrivateKey::Seed(seed.try_into().unwrap())
+                        } else {
+                            mldsa_seed_from_pkey(pkey)?
+                        }
+                    }
+                };
+                let private_key_der = asn1::write_single(&seed_key)?;
                 let params = match cryptography_openssl::mldsa::MlDsaVariant::from_pkey(pkey) {
                     cryptography_openssl::mldsa::MlDsaVariant::MlDsa44 => {
                         AlgorithmParameters::MlDsa44

--- a/src/rust/cryptography-key-parsing/src/spki.rs
+++ b/src/rust/cryptography-key-parsing/src/spki.rs
@@ -109,7 +109,7 @@ pub fn parse_public_key(data: &[u8]) -> KeyParsingResult<ParsedPublicKey> {
 
             Ok(ParsedPublicKey::Pkey(openssl::pkey::PKey::from_dh(dh)?))
         }
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
         AlgorithmParameters::MlDsa44 => Ok(ParsedPublicKey::Pkey(
             cryptography_openssl::mldsa::new_raw_public_key(
                 cryptography_openssl::mldsa::MlDsaVariant::MlDsa44,
@@ -117,7 +117,7 @@ pub fn parse_public_key(data: &[u8]) -> KeyParsingResult<ParsedPublicKey> {
             )
             .map_err(|_| KeyParsingError::InvalidKey)?,
         )),
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
         AlgorithmParameters::MlDsa65 => Ok(ParsedPublicKey::Pkey(
             cryptography_openssl::mldsa::new_raw_public_key(
                 cryptography_openssl::mldsa::MlDsaVariant::MlDsa65,
@@ -125,7 +125,7 @@ pub fn parse_public_key(data: &[u8]) -> KeyParsingResult<ParsedPublicKey> {
             )
             .map_err(|_| KeyParsingError::InvalidKey)?,
         )),
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
         AlgorithmParameters::MlDsa87 => Ok(ParsedPublicKey::Pkey(
             cryptography_openssl::mldsa::new_raw_public_key(
                 cryptography_openssl::mldsa::MlDsaVariant::MlDsa87,
@@ -248,8 +248,8 @@ pub fn serialize_public_key(
 
             (params, pub_key_der)
         }
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
-        cryptography_openssl::mldsa::PKEY_ID => {
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
+        id if cryptography_openssl::mldsa::is_mldsa_pkey_type(id) => {
             let raw_bytes = pkey.raw_public_key()?;
             let params = match cryptography_openssl::mldsa::MlDsaVariant::from_pkey(pkey) {
                 cryptography_openssl::mldsa::MlDsaVariant::MlDsa44 => AlgorithmParameters::MlDsa44,

--- a/src/rust/cryptography-openssl/src/lib.rs
+++ b/src/rust/cryptography-openssl/src/lib.rs
@@ -9,7 +9,7 @@ pub mod aead;
 pub mod cmac;
 pub mod fips;
 pub mod hmac;
-#[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
 pub mod mldsa;
 #[cfg(any(
     CRYPTOGRAPHY_IS_BORINGSSL,

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -86,13 +86,14 @@ fn set_context_string<T>(
 ) -> OpenSSLResult<()> {
     // SAFETY: EVP_PKEY_CTX_set1_signature_context_string sets the ML-DSA
     // context string on an initialized sign/verify context.
-    unsafe {
-        cvt(ffi::EVP_PKEY_CTX_set1_signature_context_string(
+    let res = unsafe {
+        ffi::EVP_PKEY_CTX_set1_signature_context_string(
             pkey_ctx.as_ptr(),
             context.as_ptr(),
             context.len(),
-        ))?;
-    }
+        )
+    };
+    cvt(res)?;
     Ok(())
 }
 

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -79,40 +79,19 @@ fn evp_pkey_alg(variant: MlDsaVariant) -> *const ffi::EVP_PKEY_ALG {
     }
 }
 
-/// A wrapper around a `PkeyCtxRef` that has been initialized for either a
-/// sign or verify digest operation. The only way to construct one is via
-/// [`InitializedPkeyCtxRef::sign_init`] or [`InitializedPkeyCtxRef::verify_init`],
-/// which perform the underlying `EVP_DigestSignInit`/`EVP_DigestVerifyInit`
-/// call. This lets `set_context_string` assume the underlying context is
-/// already initialized without having to document an implicit precondition.
+/// A marker type for a `PkeyCtxRef` that has been initialized for a sign or
+/// verify operation. Callers explicitly wrap the ref in this type immediately
+/// after calling `digest_sign_init` / `digest_verify_init`, which makes the
+/// precondition required by [`InitializedPkeyCtxRef::set_context_string`]
+/// visible in the source.
 #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
 struct InitializedPkeyCtxRef<'a, T>(&'a mut openssl::pkey_ctx::PkeyCtxRef<T>);
 
 #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
-impl<'a, T> InitializedPkeyCtxRef<'a, T> {
-    fn sign_init(
-        md_ctx: &'a mut openssl::md_ctx::MdCtx,
-        pkey: &openssl::pkey::PKeyRef<T>,
-    ) -> OpenSSLResult<Self>
-    where
-        T: openssl::pkey::HasPrivate,
-    {
-        Ok(Self(md_ctx.digest_sign_init(None, pkey)?))
-    }
-
-    fn verify_init(
-        md_ctx: &'a mut openssl::md_ctx::MdCtx,
-        pkey: &openssl::pkey::PKeyRef<T>,
-    ) -> OpenSSLResult<Self>
-    where
-        T: openssl::pkey::HasPublic,
-    {
-        Ok(Self(md_ctx.digest_verify_init(None, pkey)?))
-    }
-
+impl<T> InitializedPkeyCtxRef<'_, T> {
     fn set_context_string(&mut self, context: &[u8]) -> OpenSSLResult<()> {
-        // SAFETY: By construction, the wrapped pkey_ctx has been initialized
-        // via digest_sign_init or digest_verify_init.
+        // SAFETY: By construction, the caller has wrapped a pkey_ctx that
+        // has been initialized for a sign/verify operation.
         let res = unsafe {
             ffi::EVP_PKEY_CTX_set1_signature_context_string(
                 self.0.as_ptr(),
@@ -262,7 +241,7 @@ pub fn sign(
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
-            let mut pkey_ctx = InitializedPkeyCtxRef::sign_init(&mut md_ctx, pkey)?;
+            let mut pkey_ctx = InitializedPkeyCtxRef(md_ctx.digest_sign_init(None, pkey)?);
             if !context.is_empty() {
                 pkey_ctx.set_context_string(context)?;
             }
@@ -332,7 +311,7 @@ pub fn verify(
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
-            let mut pkey_ctx = InitializedPkeyCtxRef::verify_init(&mut md_ctx, pkey)?;
+            let mut pkey_ctx = InitializedPkeyCtxRef(md_ctx.digest_verify_init(None, pkey)?);
             if !context.is_empty() {
                 pkey_ctx.set_context_string(context)?;
             }

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -228,34 +228,8 @@ pub fn sign(
                     ))?;
                 }
             }
-            // MdCtx::digest_sign is not yet available for BoringSSL builds
-            // in the openssl crate (it's gated on ossl111 only), so we call
-            // EVP_DigestSign directly. MdCtx still handles the EVP_MD_CTX
-            // lifecycle.
-            let mut sig_len = 0;
-            // SAFETY: EVP_DigestSign with null output queries the length.
-            unsafe {
-                cvt(ffi::EVP_DigestSign(
-                    md_ctx.as_ptr(),
-                    std::ptr::null_mut(),
-                    &mut sig_len,
-                    data.as_ptr(),
-                    data.len(),
-                ))?;
-            }
-            let mut sig = vec![0u8; sig_len];
-            // SAFETY: EVP_DigestSign computes the signature into a buffer
-            // that was allocated with sufficient length.
-            unsafe {
-                cvt(ffi::EVP_DigestSign(
-                    md_ctx.as_ptr(),
-                    sig.as_mut_ptr(),
-                    &mut sig_len,
-                    data.as_ptr(),
-                    data.len(),
-                ))?;
-            }
-            sig.truncate(sig_len);
+            let mut sig = vec![];
+            md_ctx.digest_sign_to_vec(data, &mut sig)?;
             Ok(sig)
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
             let raw_key = pkey.raw_private_key()?;
@@ -332,24 +306,7 @@ pub fn verify(
                     ))?;
                 }
             }
-            // MdCtx::digest_verify is not yet available for BoringSSL
-            // builds in the openssl crate (gated on ossl111 only), so we
-            // call EVP_DigestVerify directly.
-            // SAFETY: EVP_DigestVerify verifies the signature against the
-            // data using the initialized verification context.
-            let r = unsafe {
-                ffi::EVP_DigestVerify(
-                    md_ctx.as_ptr(),
-                    signature.as_ptr(),
-                    signature.len(),
-                    data.as_ptr(),
-                    data.len(),
-                )
-            };
-            if r != 1 {
-                let _ = openssl::error::ErrorStack::get();
-            }
-            Ok(r == 1)
+            Ok(md_ctx.digest_verify(data, signature).unwrap_or(false))
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
             let raw_key = pkey.raw_public_key()?;
             let variant = MlDsaVariant::from_pkey(pkey);

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -79,6 +79,23 @@ fn evp_pkey_alg(variant: MlDsaVariant) -> *const ffi::EVP_PKEY_ALG {
     }
 }
 
+#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
+fn set_context_string<T>(
+    pkey_ctx: &mut openssl::pkey_ctx::PkeyCtxRef<T>,
+    context: &[u8],
+) -> OpenSSLResult<()> {
+    // SAFETY: EVP_PKEY_CTX_set1_signature_context_string sets the ML-DSA
+    // context string on an initialized sign/verify context.
+    unsafe {
+        cvt(ffi::EVP_PKEY_CTX_set1_signature_context_string(
+            pkey_ctx.as_ptr(),
+            context.as_ptr(),
+            context.len(),
+        ))?;
+    }
+    Ok(())
+}
+
 #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
 extern "C" {
     // We call ml_dsa_{44,65}_sign/verify directly instead of going through
@@ -218,15 +235,7 @@ pub fn sign(
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
             let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;
             if !context.is_empty() {
-                // SAFETY: EVP_PKEY_CTX_set1_signature_context_string sets the
-                // ML-DSA context string on an initialized signing context.
-                unsafe {
-                    cvt(ffi::EVP_PKEY_CTX_set1_signature_context_string(
-                        pkey_ctx.as_ptr(),
-                        context.as_ptr(),
-                        context.len(),
-                    ))?;
-                }
+                set_context_string(pkey_ctx, context)?;
             }
             let mut sig = vec![];
             md_ctx.digest_sign_to_vec(data, &mut sig)?;
@@ -296,15 +305,7 @@ pub fn verify(
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
             let pkey_ctx = md_ctx.digest_verify_init(None, pkey)?;
             if !context.is_empty() {
-                // SAFETY: EVP_PKEY_CTX_set1_signature_context_string sets the
-                // ML-DSA context string on an initialized verification context.
-                unsafe {
-                    cvt(ffi::EVP_PKEY_CTX_set1_signature_context_string(
-                        pkey_ctx.as_ptr(),
-                        context.as_ptr(),
-                        context.len(),
-                    ))?;
-                }
+                set_context_string(pkey_ctx, context)?;
             }
             Ok(md_ctx.digest_verify(data, signature).unwrap_or(false))
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -4,6 +4,7 @@
 
 use foreign_types_shared::{ForeignType, ForeignTypeRef};
 use openssl_sys as ffi;
+#[cfg(CRYPTOGRAPHY_IS_AWSLC)]
 use std::os::raw::c_int;
 
 use crate::{cvt, cvt_p, OpenSSLResult};
@@ -44,18 +45,13 @@ impl MlDsaVariant {
     ) -> MlDsaVariant {
         cfg_if::cfg_if! {
             if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
-                // SAFETY: EVP_PKEY_id returns the type of a valid EVP_PKEY.
-                let nid = unsafe { ffi::EVP_PKEY_id(pkey.as_ptr()) };
-                match nid {
+                match pkey.id().as_raw() {
                     ffi::NID_ML_DSA_44 => MlDsaVariant::MlDsa44,
                     ffi::NID_ML_DSA_65 => MlDsaVariant::MlDsa65,
                     ffi::NID_ML_DSA_87 => MlDsaVariant::MlDsa87,
                     _ => panic!("Unsupported ML-DSA variant"),
                 }
             } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
-                // AWS-LC: All ML-DSA variants share NID_PQDSA as their EVP
-                // pkey type. EVP_PKEY_pqdsa_get_type returns the specific
-                // variant NID.
                 // SAFETY: EVP_PKEY_pqdsa_get_type returns the NID of the
                 // PQDSA algorithm for a valid PQDSA pkey.
                 let nid = unsafe { ffi::EVP_PKEY_pqdsa_get_type(pkey.as_ptr()) };
@@ -71,45 +67,14 @@ impl MlDsaVariant {
 }
 
 #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
-extern "C" {
-    fn EVP_pkey_ml_dsa_44() -> *const ffi::EVP_PKEY_ALG;
-    fn EVP_pkey_ml_dsa_65() -> *const ffi::EVP_PKEY_ALG;
-    fn EVP_pkey_ml_dsa_87() -> *const ffi::EVP_PKEY_ALG;
-
-    fn EVP_PKEY_from_private_seed(
-        alg: *const ffi::EVP_PKEY_ALG,
-        r#in: *const u8,
-        len: usize,
-    ) -> *mut ffi::EVP_PKEY;
-
-    fn EVP_PKEY_from_raw_public_key(
-        alg: *const ffi::EVP_PKEY_ALG,
-        r#in: *const u8,
-        len: usize,
-    ) -> *mut ffi::EVP_PKEY;
-
-    fn EVP_PKEY_get_private_seed(
-        pkey: *const ffi::EVP_PKEY,
-        out: *mut u8,
-        out_len: *mut usize,
-    ) -> c_int;
-
-    fn EVP_PKEY_CTX_set1_signature_context_string(
-        ctx: *mut ffi::EVP_PKEY_CTX,
-        context: *const u8,
-        context_len: usize,
-    ) -> c_int;
-}
-
-#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
 fn evp_pkey_alg(variant: MlDsaVariant) -> *const ffi::EVP_PKEY_ALG {
     // SAFETY: These functions return static, non-null pointers to the
     // EVP_PKEY_ALG for each ML-DSA variant.
     unsafe {
         match variant {
-            MlDsaVariant::MlDsa44 => EVP_pkey_ml_dsa_44(),
-            MlDsaVariant::MlDsa65 => EVP_pkey_ml_dsa_65(),
-            MlDsaVariant::MlDsa87 => EVP_pkey_ml_dsa_87(),
+            MlDsaVariant::MlDsa44 => ffi::EVP_pkey_ml_dsa_44(),
+            MlDsaVariant::MlDsa65 => ffi::EVP_pkey_ml_dsa_65(),
+            MlDsaVariant::MlDsa87 => ffi::EVP_pkey_ml_dsa_87(),
         }
     }
 }
@@ -189,7 +154,7 @@ pub fn new_raw_private_key(
             // SAFETY: EVP_PKEY_from_private_seed creates a new EVP_PKEY from
             // the seed. evp_pkey_alg returns a valid algorithm pointer.
             unsafe {
-                let pkey = cvt_p(EVP_PKEY_from_private_seed(
+                let pkey = cvt_p(ffi::EVP_PKEY_from_private_seed(
                     evp_pkey_alg(variant),
                     data.as_ptr(),
                     data.len(),
@@ -221,7 +186,7 @@ pub fn new_raw_public_key(
             // SAFETY: EVP_PKEY_from_raw_public_key creates a new EVP_PKEY
             // from raw public key bytes.
             unsafe {
-                let pkey = cvt_p(EVP_PKEY_from_raw_public_key(
+                let pkey = cvt_p(ffi::EVP_PKEY_from_raw_public_key(
                     evp_pkey_alg(variant),
                     data.as_ptr(),
                     data.len(),
@@ -243,29 +208,6 @@ pub fn new_raw_public_key(
     }
 }
 
-#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
-pub fn get_seed(pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>) -> OpenSSLResult<Vec<u8>> {
-    // SAFETY: EVP_PKEY_get_private_seed outputs the seed for ML-DSA keys.
-    // First call with null out gets the length, second call writes the seed.
-    unsafe {
-        let mut seed_len = 0usize;
-        // First call to get the required length.
-        cvt(EVP_PKEY_get_private_seed(
-            pkey.as_ptr(),
-            std::ptr::null_mut(),
-            &mut seed_len,
-        ))?;
-        let mut seed = vec![0u8; seed_len];
-        cvt(EVP_PKEY_get_private_seed(
-            pkey.as_ptr(),
-            seed.as_mut_ptr(),
-            &mut seed_len,
-        ))?;
-        seed.truncate(seed_len);
-        Ok(seed)
-    }
-}
-
 pub fn sign(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
     data: &[u8],
@@ -273,69 +215,46 @@ pub fn sign(
 ) -> OpenSSLResult<Vec<u8>> {
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
-            // SAFETY: Uses EVP_DigestSign with
-            // EVP_PKEY_CTX_set1_signature_context_string for context support.
-            // All pointers come from valid OpenSSL objects. md_ctx is freed
-            // on all paths.
-            unsafe {
-                let md_ctx = ffi::EVP_MD_CTX_new();
-                assert!(!md_ctx.is_null());
-                let mut pctx: *mut ffi::EVP_PKEY_CTX = std::ptr::null_mut();
-                let r = ffi::EVP_DigestSignInit(
-                    md_ctx,
-                    &mut pctx,
-                    std::ptr::null(),
-                    std::ptr::null_mut(),
-                    pkey.as_ptr() as *mut ffi::EVP_PKEY,
-                );
-                if r != 1 {
-                    ffi::EVP_MD_CTX_free(md_ctx);
-                    return Err(openssl::error::ErrorStack::get());
-                }
-
-                if !context.is_empty() {
-                    let r = EVP_PKEY_CTX_set1_signature_context_string(
-                        pctx,
+            let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
+            let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;
+            if !context.is_empty() {
+                // SAFETY: EVP_PKEY_CTX_set1_signature_context_string sets the
+                // ML-DSA context string on an initialized signing context.
+                unsafe {
+                    cvt(ffi::EVP_PKEY_CTX_set1_signature_context_string(
+                        pkey_ctx.as_ptr(),
                         context.as_ptr(),
                         context.len(),
-                    );
-                    if r != 1 {
-                        ffi::EVP_MD_CTX_free(md_ctx);
-                        return Err(openssl::error::ErrorStack::get());
-                    }
+                    ))?;
                 }
-
-                // Get signature length.
-                let mut sig_len: usize = 0;
-                let msg_ptr = if data.is_empty() { std::ptr::null() } else { data.as_ptr() };
-                let r = ffi::EVP_DigestSign(
-                    md_ctx,
+            }
+            // Get signature length.
+            let mut sig_len = 0;
+            // SAFETY: EVP_DigestSign with null output queries the signature
+            // length.
+            unsafe {
+                cvt(ffi::EVP_DigestSign(
+                    md_ctx.as_ptr(),
                     std::ptr::null_mut(),
                     &mut sig_len,
-                    msg_ptr,
+                    data.as_ptr(),
                     data.len(),
-                );
-                if r != 1 {
-                    ffi::EVP_MD_CTX_free(md_ctx);
-                    return Err(openssl::error::ErrorStack::get());
-                }
-
-                let mut sig = vec![0u8; sig_len];
-                let r = ffi::EVP_DigestSign(
-                    md_ctx,
+                ))?;
+            }
+            let mut sig = vec![0u8; sig_len];
+            // SAFETY: EVP_DigestSign writes the signature into the provided
+            // buffer. sig has been allocated with sufficient length.
+            unsafe {
+                cvt(ffi::EVP_DigestSign(
+                    md_ctx.as_ptr(),
                     sig.as_mut_ptr(),
                     &mut sig_len,
-                    msg_ptr,
+                    data.as_ptr(),
                     data.len(),
-                );
-                ffi::EVP_MD_CTX_free(md_ctx);
-                if r != 1 {
-                    return Err(openssl::error::ErrorStack::get());
-                }
-
-                sig.truncate(sig_len);
-                Ok(sig)
+                ))?;
             }
+            sig.truncate(sig_len);
+            Ok(sig)
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
             let raw_key = pkey.raw_private_key()?;
             let variant = MlDsaVariant::from_pkey(pkey);
@@ -398,55 +317,34 @@ pub fn verify(
 ) -> OpenSSLResult<bool> {
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
-            // SAFETY: Uses EVP_DigestVerify with
-            // EVP_PKEY_CTX_set1_signature_context_string for context support.
-            // All pointers come from valid OpenSSL objects. md_ctx is freed
-            // on all paths.
-            unsafe {
-                let md_ctx = ffi::EVP_MD_CTX_new();
-                assert!(!md_ctx.is_null());
-                let mut pctx: *mut ffi::EVP_PKEY_CTX = std::ptr::null_mut();
-                let r = ffi::EVP_DigestVerifyInit(
-                    md_ctx,
-                    &mut pctx,
-                    std::ptr::null(),
-                    std::ptr::null_mut(),
-                    pkey.as_ptr() as *mut ffi::EVP_PKEY,
-                );
-                if r != 1 {
-                    ffi::EVP_MD_CTX_free(md_ctx);
-                    let _ = openssl::error::ErrorStack::get();
-                    return Ok(false);
-                }
-
-                if !context.is_empty() {
-                    let r = EVP_PKEY_CTX_set1_signature_context_string(
-                        pctx,
+            let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
+            let pkey_ctx = md_ctx.digest_verify_init(None, pkey)?;
+            if !context.is_empty() {
+                // SAFETY: EVP_PKEY_CTX_set1_signature_context_string sets the
+                // ML-DSA context string on an initialized verification context.
+                unsafe {
+                    cvt(ffi::EVP_PKEY_CTX_set1_signature_context_string(
+                        pkey_ctx.as_ptr(),
                         context.as_ptr(),
                         context.len(),
-                    );
-                    if r != 1 {
-                        ffi::EVP_MD_CTX_free(md_ctx);
-                        let _ = openssl::error::ErrorStack::get();
-                        return Ok(false);
-                    }
+                    ))?;
                 }
-
-                let msg_ptr = if data.is_empty() { std::ptr::null() } else { data.as_ptr() };
-                let r = ffi::EVP_DigestVerify(
-                    md_ctx,
+            }
+            // SAFETY: EVP_DigestVerify verifies the signature against the
+            // data using the initialized verification context.
+            let r = unsafe {
+                ffi::EVP_DigestVerify(
+                    md_ctx.as_ptr(),
                     signature.as_ptr(),
                     signature.len(),
-                    msg_ptr,
+                    data.as_ptr(),
                     data.len(),
-                );
-                ffi::EVP_MD_CTX_free(md_ctx);
-
-                if r != 1 {
-                    let _ = openssl::error::ErrorStack::get();
-                }
-                Ok(r == 1)
+                )
+            };
+            if r != 1 {
+                let _ = openssl::error::ErrorStack::get();
             }
+            Ok(r == 1)
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
             let raw_key = pkey.raw_public_key()?;
             let variant = MlDsaVariant::from_pkey(pkey);

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -79,22 +79,50 @@ fn evp_pkey_alg(variant: MlDsaVariant) -> *const ffi::EVP_PKEY_ALG {
     }
 }
 
+/// A wrapper around a `PkeyCtxRef` that has been initialized for either a
+/// sign or verify digest operation. The only way to construct one is via
+/// [`InitializedPkeyCtxRef::sign_init`] or [`InitializedPkeyCtxRef::verify_init`],
+/// which perform the underlying `EVP_DigestSignInit`/`EVP_DigestVerifyInit`
+/// call. This lets `set_context_string` assume the underlying context is
+/// already initialized without having to document an implicit precondition.
 #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
-fn set_context_string<T>(
-    pkey_ctx: &mut openssl::pkey_ctx::PkeyCtxRef<T>,
-    context: &[u8],
-) -> OpenSSLResult<()> {
-    // SAFETY: EVP_PKEY_CTX_set1_signature_context_string sets the ML-DSA
-    // context string on an initialized sign/verify context.
-    let res = unsafe {
-        ffi::EVP_PKEY_CTX_set1_signature_context_string(
-            pkey_ctx.as_ptr(),
-            context.as_ptr(),
-            context.len(),
-        )
-    };
-    cvt(res)?;
-    Ok(())
+struct InitializedPkeyCtxRef<'a, T>(&'a mut openssl::pkey_ctx::PkeyCtxRef<T>);
+
+#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
+impl<'a, T> InitializedPkeyCtxRef<'a, T> {
+    fn sign_init(
+        md_ctx: &'a mut openssl::md_ctx::MdCtx,
+        pkey: &openssl::pkey::PKeyRef<T>,
+    ) -> OpenSSLResult<Self>
+    where
+        T: openssl::pkey::HasPrivate,
+    {
+        Ok(Self(md_ctx.digest_sign_init(None, pkey)?))
+    }
+
+    fn verify_init(
+        md_ctx: &'a mut openssl::md_ctx::MdCtx,
+        pkey: &openssl::pkey::PKeyRef<T>,
+    ) -> OpenSSLResult<Self>
+    where
+        T: openssl::pkey::HasPublic,
+    {
+        Ok(Self(md_ctx.digest_verify_init(None, pkey)?))
+    }
+
+    fn set_context_string(&mut self, context: &[u8]) -> OpenSSLResult<()> {
+        // SAFETY: By construction, the wrapped pkey_ctx has been initialized
+        // via digest_sign_init or digest_verify_init.
+        let res = unsafe {
+            ffi::EVP_PKEY_CTX_set1_signature_context_string(
+                self.0.as_ptr(),
+                context.as_ptr(),
+                context.len(),
+            )
+        };
+        cvt(res)?;
+        Ok(())
+    }
 }
 
 #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
@@ -234,9 +262,9 @@ pub fn sign(
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
-            let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;
+            let mut pkey_ctx = InitializedPkeyCtxRef::sign_init(&mut md_ctx, pkey)?;
             if !context.is_empty() {
-                set_context_string(pkey_ctx, context)?;
+                pkey_ctx.set_context_string(context)?;
             }
             let mut sig = vec![];
             md_ctx.digest_sign_to_vec(data, &mut sig)?;
@@ -304,9 +332,9 @@ pub fn verify(
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
-            let pkey_ctx = md_ctx.digest_verify_init(None, pkey)?;
+            let mut pkey_ctx = InitializedPkeyCtxRef::verify_init(&mut md_ctx, pkey)?;
             if !context.is_empty() {
-                set_context_string(pkey_ctx, context)?;
+                pkey_ctx.set_context_string(context)?;
             }
             Ok(md_ctx.digest_verify(data, signature).unwrap_or(false))
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -8,8 +8,6 @@ use std::os::raw::c_int;
 
 use crate::{cvt, cvt_p, OpenSSLResult};
 
-pub const PKEY_ID: openssl::pkey::Id = openssl::pkey::Id::from_raw(ffi::NID_PQDSA);
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MlDsaVariant {
     MlDsa44,
@@ -17,7 +15,22 @@ pub enum MlDsaVariant {
     MlDsa87,
 }
 
+#[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+pub const PKEY_ID: openssl::pkey::Id = openssl::pkey::Id::from_raw(ffi::NID_PQDSA);
+
+pub fn is_mldsa_pkey_type(id: openssl::pkey::Id) -> bool {
+    cfg_if::cfg_if! {
+        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+            let raw = id.as_raw();
+            raw == ffi::NID_ML_DSA_44 || raw == ffi::NID_ML_DSA_65 || raw == ffi::NID_ML_DSA_87
+        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
+            id == PKEY_ID
+        }
+    }
+}
+
 impl MlDsaVariant {
+    #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
     pub fn nid(self) -> c_int {
         match self {
             MlDsaVariant::MlDsa44 => ffi::NID_MLDSA44,
@@ -29,18 +42,79 @@ impl MlDsaVariant {
     pub fn from_pkey<T: openssl::pkey::HasPublic>(
         pkey: &openssl::pkey::PKeyRef<T>,
     ) -> MlDsaVariant {
-        // SAFETY: EVP_PKEY_pqdsa_get_type returns the NID of the PQDSA
-        // algorithm for a valid PQDSA pkey.
-        let nid = unsafe { ffi::EVP_PKEY_pqdsa_get_type(pkey.as_ptr()) };
-        match nid {
-            ffi::NID_MLDSA44 => MlDsaVariant::MlDsa44,
-            ffi::NID_MLDSA65 => MlDsaVariant::MlDsa65,
-            ffi::NID_MLDSA87 => MlDsaVariant::MlDsa87,
-            _ => panic!("Unsupported ML-DSA variant"),
+        cfg_if::cfg_if! {
+            if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+                // SAFETY: EVP_PKEY_id returns the type of a valid EVP_PKEY.
+                let nid = unsafe { ffi::EVP_PKEY_id(pkey.as_ptr()) };
+                match nid {
+                    ffi::NID_ML_DSA_44 => MlDsaVariant::MlDsa44,
+                    ffi::NID_ML_DSA_65 => MlDsaVariant::MlDsa65,
+                    ffi::NID_ML_DSA_87 => MlDsaVariant::MlDsa87,
+                    _ => panic!("Unsupported ML-DSA variant"),
+                }
+            } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
+                // AWS-LC: All ML-DSA variants share NID_PQDSA as their EVP
+                // pkey type. EVP_PKEY_pqdsa_get_type returns the specific
+                // variant NID.
+                // SAFETY: EVP_PKEY_pqdsa_get_type returns the NID of the
+                // PQDSA algorithm for a valid PQDSA pkey.
+                let nid = unsafe { ffi::EVP_PKEY_pqdsa_get_type(pkey.as_ptr()) };
+                match nid {
+                    ffi::NID_MLDSA44 => MlDsaVariant::MlDsa44,
+                    ffi::NID_MLDSA65 => MlDsaVariant::MlDsa65,
+                    ffi::NID_MLDSA87 => MlDsaVariant::MlDsa87,
+                    _ => panic!("Unsupported ML-DSA variant"),
+                }
+            }
         }
     }
 }
 
+#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
+extern "C" {
+    fn EVP_pkey_ml_dsa_44() -> *const ffi::EVP_PKEY_ALG;
+    fn EVP_pkey_ml_dsa_65() -> *const ffi::EVP_PKEY_ALG;
+    fn EVP_pkey_ml_dsa_87() -> *const ffi::EVP_PKEY_ALG;
+
+    fn EVP_PKEY_from_private_seed(
+        alg: *const ffi::EVP_PKEY_ALG,
+        r#in: *const u8,
+        len: usize,
+    ) -> *mut ffi::EVP_PKEY;
+
+    fn EVP_PKEY_from_raw_public_key(
+        alg: *const ffi::EVP_PKEY_ALG,
+        r#in: *const u8,
+        len: usize,
+    ) -> *mut ffi::EVP_PKEY;
+
+    fn EVP_PKEY_get_private_seed(
+        pkey: *const ffi::EVP_PKEY,
+        out: *mut u8,
+        out_len: *mut usize,
+    ) -> c_int;
+
+    fn EVP_PKEY_CTX_set1_signature_context_string(
+        ctx: *mut ffi::EVP_PKEY_CTX,
+        context: *const u8,
+        context_len: usize,
+    ) -> c_int;
+}
+
+#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
+fn evp_pkey_alg(variant: MlDsaVariant) -> *const ffi::EVP_PKEY_ALG {
+    // SAFETY: These functions return static, non-null pointers to the
+    // EVP_PKEY_ALG for each ML-DSA variant.
+    unsafe {
+        match variant {
+            MlDsaVariant::MlDsa44 => EVP_pkey_ml_dsa_44(),
+            MlDsaVariant::MlDsa65 => EVP_pkey_ml_dsa_65(),
+            MlDsaVariant::MlDsa87 => EVP_pkey_ml_dsa_87(),
+        }
+    }
+}
+
+#[cfg(CRYPTOGRAPHY_IS_AWSLC)]
 extern "C" {
     // We call ml_dsa_{44,65}_sign/verify directly instead of going through
     // EVP_DigestSign/EVP_DigestVerify because the EVP PQDSA path hardcodes
@@ -110,15 +184,31 @@ pub fn new_raw_private_key(
     variant: MlDsaVariant,
     data: &[u8],
 ) -> OpenSSLResult<openssl::pkey::PKey<openssl::pkey::Private>> {
-    // SAFETY: EVP_PKEY_pqdsa_new_raw_private_key creates a new EVP_PKEY from
-    // raw key bytes. For ML-DSA, a seed expands into the full keypair.
-    unsafe {
-        let pkey = cvt_p(ffi::EVP_PKEY_pqdsa_new_raw_private_key(
-            variant.nid(),
-            data.as_ptr(),
-            data.len(),
-        ))?;
-        Ok(openssl::pkey::PKey::from_ptr(pkey))
+    cfg_if::cfg_if! {
+        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+            // SAFETY: EVP_PKEY_from_private_seed creates a new EVP_PKEY from
+            // the seed. evp_pkey_alg returns a valid algorithm pointer.
+            unsafe {
+                let pkey = cvt_p(EVP_PKEY_from_private_seed(
+                    evp_pkey_alg(variant),
+                    data.as_ptr(),
+                    data.len(),
+                ))?;
+                Ok(openssl::pkey::PKey::from_ptr(pkey))
+            }
+        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
+            // SAFETY: EVP_PKEY_pqdsa_new_raw_private_key creates a new
+            // EVP_PKEY from raw key bytes. For ML-DSA, a seed expands into
+            // the full keypair.
+            unsafe {
+                let pkey = cvt_p(ffi::EVP_PKEY_pqdsa_new_raw_private_key(
+                    variant.nid(),
+                    data.as_ptr(),
+                    data.len(),
+                ))?;
+                Ok(openssl::pkey::PKey::from_ptr(pkey))
+            }
+        }
     }
 }
 
@@ -126,15 +216,53 @@ pub fn new_raw_public_key(
     variant: MlDsaVariant,
     data: &[u8],
 ) -> OpenSSLResult<openssl::pkey::PKey<openssl::pkey::Public>> {
-    // SAFETY: EVP_PKEY_pqdsa_new_raw_public_key creates a new EVP_PKEY from
-    // raw public key bytes.
+    cfg_if::cfg_if! {
+        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+            // SAFETY: EVP_PKEY_from_raw_public_key creates a new EVP_PKEY
+            // from raw public key bytes.
+            unsafe {
+                let pkey = cvt_p(EVP_PKEY_from_raw_public_key(
+                    evp_pkey_alg(variant),
+                    data.as_ptr(),
+                    data.len(),
+                ))?;
+                Ok(openssl::pkey::PKey::from_ptr(pkey))
+            }
+        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
+            // SAFETY: EVP_PKEY_pqdsa_new_raw_public_key creates a new
+            // EVP_PKEY from raw public key bytes.
+            unsafe {
+                let pkey = cvt_p(ffi::EVP_PKEY_pqdsa_new_raw_public_key(
+                    variant.nid(),
+                    data.as_ptr(),
+                    data.len(),
+                ))?;
+                Ok(openssl::pkey::PKey::from_ptr(pkey))
+            }
+        }
+    }
+}
+
+#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
+pub fn get_seed(pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>) -> OpenSSLResult<Vec<u8>> {
+    // SAFETY: EVP_PKEY_get_private_seed outputs the seed for ML-DSA keys.
+    // First call with null out gets the length, second call writes the seed.
     unsafe {
-        let pkey = cvt_p(ffi::EVP_PKEY_pqdsa_new_raw_public_key(
-            variant.nid(),
-            data.as_ptr(),
-            data.len(),
+        let mut seed_len = 0usize;
+        // First call to get the required length.
+        cvt(EVP_PKEY_get_private_seed(
+            pkey.as_ptr(),
+            std::ptr::null_mut(),
+            &mut seed_len,
         ))?;
-        Ok(openssl::pkey::PKey::from_ptr(pkey))
+        let mut seed = vec![0u8; seed_len];
+        cvt(EVP_PKEY_get_private_seed(
+            pkey.as_ptr(),
+            seed.as_mut_ptr(),
+            &mut seed_len,
+        ))?;
+        seed.truncate(seed_len);
+        Ok(seed)
     }
 }
 
@@ -143,54 +271,123 @@ pub fn sign(
     data: &[u8],
     context: &[u8],
 ) -> OpenSSLResult<Vec<u8>> {
-    let raw_key = pkey.raw_private_key()?;
-    let variant = MlDsaVariant::from_pkey(pkey);
+    cfg_if::cfg_if! {
+        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+            // SAFETY: Uses EVP_DigestSign with
+            // EVP_PKEY_CTX_set1_signature_context_string for context support.
+            // All pointers come from valid OpenSSL objects. md_ctx is freed
+            // on all paths.
+            unsafe {
+                let md_ctx = ffi::EVP_MD_CTX_new();
+                assert!(!md_ctx.is_null());
+                let mut pctx: *mut ffi::EVP_PKEY_CTX = std::ptr::null_mut();
+                let r = ffi::EVP_DigestSignInit(
+                    md_ctx,
+                    &mut pctx,
+                    std::ptr::null(),
+                    std::ptr::null_mut(),
+                    pkey.as_ptr() as *mut ffi::EVP_PKEY,
+                );
+                if r != 1 {
+                    ffi::EVP_MD_CTX_free(md_ctx);
+                    return Err(openssl::error::ErrorStack::get());
+                }
 
-    type SignFn = unsafe extern "C" fn(
-        *const u8,
-        *mut u8,
-        *mut usize,
-        *const u8,
-        usize,
-        *const u8,
-        usize,
-    ) -> c_int;
-    let (signature_bytes, sign_func): (usize, SignFn) = match variant {
-        MlDsaVariant::MlDsa44 => (2420, ml_dsa_44_sign),
-        MlDsaVariant::MlDsa65 => (3309, ml_dsa_65_sign),
-        MlDsaVariant::MlDsa87 => (4627, ml_dsa_87_sign),
-    };
+                if !context.is_empty() {
+                    let r = EVP_PKEY_CTX_set1_signature_context_string(
+                        pctx,
+                        context.as_ptr(),
+                        context.len(),
+                    );
+                    if r != 1 {
+                        ffi::EVP_MD_CTX_free(md_ctx);
+                        return Err(openssl::error::ErrorStack::get());
+                    }
+                }
 
-    let mut sig = vec![0u8; signature_bytes];
-    let mut sig_len: usize = 0;
+                // Get signature length.
+                let mut sig_len: usize = 0;
+                let msg_ptr = if data.is_empty() { std::ptr::null() } else { data.as_ptr() };
+                let r = ffi::EVP_DigestSign(
+                    md_ctx,
+                    std::ptr::null_mut(),
+                    &mut sig_len,
+                    msg_ptr,
+                    data.len(),
+                );
+                if r != 1 {
+                    ffi::EVP_MD_CTX_free(md_ctx);
+                    return Err(openssl::error::ErrorStack::get());
+                }
 
-    let msg_ptr = if data.is_empty() {
-        std::ptr::null()
-    } else {
-        data.as_ptr()
-    };
-    let ctx_ptr = if context.is_empty() {
-        std::ptr::null()
-    } else {
-        context.as_ptr()
-    };
+                let mut sig = vec![0u8; sig_len];
+                let r = ffi::EVP_DigestSign(
+                    md_ctx,
+                    sig.as_mut_ptr(),
+                    &mut sig_len,
+                    msg_ptr,
+                    data.len(),
+                );
+                ffi::EVP_MD_CTX_free(md_ctx);
+                if r != 1 {
+                    return Err(openssl::error::ErrorStack::get());
+                }
 
-    // SAFETY: The sign function takes raw key bytes, message, and context.
-    unsafe {
-        let r = sign_func(
-            raw_key.as_ptr(),
-            sig.as_mut_ptr(),
-            &mut sig_len,
-            msg_ptr,
-            data.len(),
-            ctx_ptr,
-            context.len(),
-        );
-        cvt(r)?;
+                sig.truncate(sig_len);
+                Ok(sig)
+            }
+        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
+            let raw_key = pkey.raw_private_key()?;
+            let variant = MlDsaVariant::from_pkey(pkey);
+
+            type SignFn = unsafe extern "C" fn(
+                *const u8,
+                *mut u8,
+                *mut usize,
+                *const u8,
+                usize,
+                *const u8,
+                usize,
+            ) -> c_int;
+            let (signature_bytes, sign_func): (usize, SignFn) = match variant {
+                MlDsaVariant::MlDsa44 => (2420, ml_dsa_44_sign),
+                MlDsaVariant::MlDsa65 => (3309, ml_dsa_65_sign),
+                MlDsaVariant::MlDsa87 => (4627, ml_dsa_87_sign),
+            };
+
+            let mut sig = vec![0u8; signature_bytes];
+            let mut sig_len: usize = 0;
+
+            let msg_ptr = if data.is_empty() {
+                std::ptr::null()
+            } else {
+                data.as_ptr()
+            };
+            let ctx_ptr = if context.is_empty() {
+                std::ptr::null()
+            } else {
+                context.as_ptr()
+            };
+
+            // SAFETY: The sign function takes raw key bytes, message, and
+            // context.
+            unsafe {
+                let r = sign_func(
+                    raw_key.as_ptr(),
+                    sig.as_mut_ptr(),
+                    &mut sig_len,
+                    msg_ptr,
+                    data.len(),
+                    ctx_ptr,
+                    context.len(),
+                );
+                cvt(r)?;
+            }
+
+            sig.truncate(sig_len);
+            Ok(sig)
+        }
     }
-
-    sig.truncate(sig_len);
-    Ok(sig)
 }
 
 pub fn verify(
@@ -199,56 +396,110 @@ pub fn verify(
     data: &[u8],
     context: &[u8],
 ) -> OpenSSLResult<bool> {
-    let raw_key = pkey.raw_public_key()?;
-    let variant = MlDsaVariant::from_pkey(pkey);
+    cfg_if::cfg_if! {
+        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+            // SAFETY: Uses EVP_DigestVerify with
+            // EVP_PKEY_CTX_set1_signature_context_string for context support.
+            // All pointers come from valid OpenSSL objects. md_ctx is freed
+            // on all paths.
+            unsafe {
+                let md_ctx = ffi::EVP_MD_CTX_new();
+                assert!(!md_ctx.is_null());
+                let mut pctx: *mut ffi::EVP_PKEY_CTX = std::ptr::null_mut();
+                let r = ffi::EVP_DigestVerifyInit(
+                    md_ctx,
+                    &mut pctx,
+                    std::ptr::null(),
+                    std::ptr::null_mut(),
+                    pkey.as_ptr() as *mut ffi::EVP_PKEY,
+                );
+                if r != 1 {
+                    ffi::EVP_MD_CTX_free(md_ctx);
+                    let _ = openssl::error::ErrorStack::get();
+                    return Ok(false);
+                }
 
-    type VerifyFn = unsafe extern "C" fn(
-        *const u8,
-        *const u8,
-        usize,
-        *const u8,
-        usize,
-        *const u8,
-        usize,
-    ) -> c_int;
-    let verify_func: VerifyFn = match variant {
-        MlDsaVariant::MlDsa44 => ml_dsa_44_verify,
-        MlDsaVariant::MlDsa65 => ml_dsa_65_verify,
-        MlDsaVariant::MlDsa87 => ml_dsa_87_verify,
-    };
+                if !context.is_empty() {
+                    let r = EVP_PKEY_CTX_set1_signature_context_string(
+                        pctx,
+                        context.as_ptr(),
+                        context.len(),
+                    );
+                    if r != 1 {
+                        ffi::EVP_MD_CTX_free(md_ctx);
+                        let _ = openssl::error::ErrorStack::get();
+                        return Ok(false);
+                    }
+                }
 
-    let msg_ptr = if data.is_empty() {
-        std::ptr::null()
-    } else {
-        data.as_ptr()
-    };
-    let ctx_ptr = if context.is_empty() {
-        std::ptr::null()
-    } else {
-        context.as_ptr()
-    };
+                let msg_ptr = if data.is_empty() { std::ptr::null() } else { data.as_ptr() };
+                let r = ffi::EVP_DigestVerify(
+                    md_ctx,
+                    signature.as_ptr(),
+                    signature.len(),
+                    msg_ptr,
+                    data.len(),
+                );
+                ffi::EVP_MD_CTX_free(md_ctx);
 
-    // SAFETY: The verify function takes raw key bytes, signature, message,
-    // and context.
-    let r = unsafe {
-        verify_func(
-            raw_key.as_ptr(),
-            signature.as_ptr(),
-            signature.len(),
-            msg_ptr,
-            data.len(),
-            ctx_ptr,
-            context.len(),
-        )
-    };
+                if r != 1 {
+                    let _ = openssl::error::ErrorStack::get();
+                }
+                Ok(r == 1)
+            }
+        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
+            let raw_key = pkey.raw_public_key()?;
+            let variant = MlDsaVariant::from_pkey(pkey);
 
-    if r != 1 {
-        // Clear any errors from the OpenSSL error stack to prevent
-        // leaking errors into subsequent operations.
-        let _ = openssl::error::ErrorStack::get();
+            type VerifyFn = unsafe extern "C" fn(
+                *const u8,
+                *const u8,
+                usize,
+                *const u8,
+                usize,
+                *const u8,
+                usize,
+            ) -> c_int;
+            let verify_func: VerifyFn = match variant {
+                MlDsaVariant::MlDsa44 => ml_dsa_44_verify,
+                MlDsaVariant::MlDsa65 => ml_dsa_65_verify,
+                MlDsaVariant::MlDsa87 => ml_dsa_87_verify,
+            };
+
+            let msg_ptr = if data.is_empty() {
+                std::ptr::null()
+            } else {
+                data.as_ptr()
+            };
+            let ctx_ptr = if context.is_empty() {
+                std::ptr::null()
+            } else {
+                context.as_ptr()
+            };
+
+            // SAFETY: The verify function takes raw key bytes, signature,
+            // message, and context.
+            let r = unsafe {
+                verify_func(
+                    raw_key.as_ptr(),
+                    signature.as_ptr(),
+                    signature.len(),
+                    msg_ptr,
+                    data.len(),
+                    ctx_ptr,
+                    context.len(),
+                )
+            };
+
+            if r != 1 {
+                // Clear any errors from the OpenSSL error stack to prevent
+                // leaking errors into subsequent operations.
+                let _ = openssl::error::ErrorStack::get();
+            }
+
+            Ok(r == 1)
+        }
     }
-
-    Ok(r == 1)
 }
 
 #[cfg(test)]

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -200,16 +200,15 @@ pub fn new_raw_public_key(
 ) -> OpenSSLResult<openssl::pkey::PKey<openssl::pkey::Public>> {
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
-            // SAFETY: EVP_PKEY_from_raw_public_key creates a new EVP_PKEY
-            // from raw public key bytes.
-            unsafe {
-                let pkey = cvt_p(ffi::EVP_PKEY_from_raw_public_key(
-                    evp_pkey_alg(variant),
-                    data.as_ptr(),
-                    data.len(),
-                ))?;
-                Ok(openssl::pkey::PKey::from_ptr(pkey))
-            }
+            let nid = match variant {
+                MlDsaVariant::MlDsa44 => ffi::NID_ML_DSA_44,
+                MlDsaVariant::MlDsa65 => ffi::NID_ML_DSA_65,
+                MlDsaVariant::MlDsa87 => ffi::NID_ML_DSA_87,
+            };
+            openssl::pkey::PKey::public_key_from_raw_bytes(
+                data,
+                openssl::pkey::Id::from_raw(nid),
+            )
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
             // SAFETY: EVP_PKEY_pqdsa_new_raw_public_key creates a new
             // EVP_PKEY from raw public key bytes.

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -228,10 +228,12 @@ pub fn sign(
                     ))?;
                 }
             }
-            // Get signature length.
+            // MdCtx::digest_sign is not yet available for BoringSSL builds
+            // in the openssl crate (it's gated on ossl111 only), so we call
+            // EVP_DigestSign directly. MdCtx still handles the EVP_MD_CTX
+            // lifecycle.
             let mut sig_len = 0;
-            // SAFETY: EVP_DigestSign with null output queries the signature
-            // length.
+            // SAFETY: EVP_DigestSign with null output queries the length.
             unsafe {
                 cvt(ffi::EVP_DigestSign(
                     md_ctx.as_ptr(),
@@ -242,8 +244,8 @@ pub fn sign(
                 ))?;
             }
             let mut sig = vec![0u8; sig_len];
-            // SAFETY: EVP_DigestSign writes the signature into the provided
-            // buffer. sig has been allocated with sufficient length.
+            // SAFETY: EVP_DigestSign computes the signature into a buffer
+            // that was allocated with sufficient length.
             unsafe {
                 cvt(ffi::EVP_DigestSign(
                     md_ctx.as_ptr(),
@@ -330,6 +332,9 @@ pub fn verify(
                     ))?;
                 }
             }
+            // MdCtx::digest_verify is not yet available for BoringSSL
+            // builds in the openssl crate (gated on ossl111 only), so we
+            // call EVP_DigestVerify directly.
             // SAFETY: EVP_DigestVerify verifies the signature against the
             // data using the initialized verification context.
             let r = unsafe {

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -79,29 +79,21 @@ fn evp_pkey_alg(variant: MlDsaVariant) -> *const ffi::EVP_PKEY_ALG {
     }
 }
 
-/// A marker type for a `PkeyCtxRef` that has been initialized for a sign or
-/// verify operation. Callers explicitly wrap the ref in this type immediately
-/// after calling `digest_sign_init` / `digest_verify_init`, which makes the
-/// precondition required by [`InitializedPkeyCtxRef::set_context_string`]
-/// visible in the source.
 #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
-struct InitializedPkeyCtxRef<'a, T>(&'a mut openssl::pkey_ctx::PkeyCtxRef<T>);
-
-#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
-impl<T> InitializedPkeyCtxRef<'_, T> {
-    fn set_context_string(&mut self, context: &[u8]) -> OpenSSLResult<()> {
-        // SAFETY: By construction, the caller has wrapped a pkey_ctx that
-        // has been initialized for a sign/verify operation.
-        let res = unsafe {
-            ffi::EVP_PKEY_CTX_set1_signature_context_string(
-                self.0.as_ptr(),
-                context.as_ptr(),
-                context.len(),
-            )
-        };
-        cvt(res)?;
-        Ok(())
-    }
+fn set_context_string<T>(
+    pkey_ctx: &mut openssl::pkey_ctx::PkeyCtxRef<T>,
+    context: &[u8],
+) -> OpenSSLResult<()> {
+    // SAFETY: pkey_ctx is a valid EVP_PKEY_CTX.
+    let res = unsafe {
+        ffi::EVP_PKEY_CTX_set1_signature_context_string(
+            pkey_ctx.as_ptr(),
+            context.as_ptr(),
+            context.len(),
+        )
+    };
+    cvt(res)?;
+    Ok(())
 }
 
 #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
@@ -241,9 +233,9 @@ pub fn sign(
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
-            let mut pkey_ctx = InitializedPkeyCtxRef(md_ctx.digest_sign_init(None, pkey)?);
+            let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;
             if !context.is_empty() {
-                pkey_ctx.set_context_string(context)?;
+                set_context_string(pkey_ctx, context)?;
             }
             let mut sig = vec![];
             md_ctx.digest_sign_to_vec(data, &mut sig)?;
@@ -311,9 +303,9 @@ pub fn verify(
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
-            let mut pkey_ctx = InitializedPkeyCtxRef(md_ctx.digest_verify_init(None, pkey)?);
+            let pkey_ctx = md_ctx.digest_verify_init(None, pkey)?;
             if !context.is_empty() {
-                pkey_ctx.set_context_string(context)?;
+                set_context_string(pkey_ctx, context)?;
             }
             Ok(md_ctx.digest_verify(data, signature).unwrap_or(false))
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {

--- a/src/rust/src/backend/keys.rs
+++ b/src/rust/src/backend/keys.rs
@@ -180,8 +180,8 @@ fn private_key_from_pkey<'p>(
         openssl::pkey::Id::DHX => Ok(crate::backend::dh::private_key_from_pkey(pkey)
             .into_pyobject(py)?
             .into_any()),
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
-        cryptography_openssl::mldsa::PKEY_ID => {
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
+        id if cryptography_openssl::mldsa::is_mldsa_pkey_type(id) => {
             match cryptography_openssl::mldsa::MlDsaVariant::from_pkey(pkey) {
                 cryptography_openssl::mldsa::MlDsaVariant::MlDsa44 => {
                     Ok(crate::backend::mldsa::mldsa44_private_key_from_pkey(pkey)
@@ -356,8 +356,8 @@ fn public_key_from_pkey<'p>(
             .into_pyobject(py)?
             .into_any()),
 
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
-        cryptography_openssl::mldsa::PKEY_ID => {
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
+        id if cryptography_openssl::mldsa::is_mldsa_pkey_type(id) => {
             match cryptography_openssl::mldsa::MlDsaVariant::from_pkey(pkey) {
                 cryptography_openssl::mldsa::MlDsaVariant::MlDsa44 => {
                     Ok(crate::backend::mldsa::mldsa44_public_key_from_pkey(pkey)

--- a/src/rust/src/backend/mldsa.rs
+++ b/src/rust/src/backend/mldsa.rs
@@ -106,16 +106,9 @@ impl MlDsa44PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        cfg_if::cfg_if! {
-            if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
-                let seed = cryptography_openssl::mldsa::get_seed(&self.pkey)?;
-                Ok(pyo3::types::PyBytes::new(py, &seed))
-            } else {
-                let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-                    cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
-                Ok(pyo3::types::PyBytes::new(py, &seed))
-            }
-        }
+        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
+            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+        Ok(pyo3::types::PyBytes::new(py, &seed))
     }
 
     fn private_bytes<'p>(
@@ -314,16 +307,9 @@ impl MlDsa65PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        cfg_if::cfg_if! {
-            if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
-                let seed = cryptography_openssl::mldsa::get_seed(&self.pkey)?;
-                Ok(pyo3::types::PyBytes::new(py, &seed))
-            } else {
-                let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-                    cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
-                Ok(pyo3::types::PyBytes::new(py, &seed))
-            }
-        }
+        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
+            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+        Ok(pyo3::types::PyBytes::new(py, &seed))
     }
 
     fn private_bytes<'p>(
@@ -525,16 +511,9 @@ impl MlDsa87PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        cfg_if::cfg_if! {
-            if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
-                let seed = cryptography_openssl::mldsa::get_seed(&self.pkey)?;
-                Ok(pyo3::types::PyBytes::new(py, &seed))
-            } else {
-                let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-                    cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
-                Ok(pyo3::types::PyBytes::new(py, &seed))
-            }
-        }
+        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
+            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+        Ok(pyo3::types::PyBytes::new(py, &seed))
     }
 
     fn private_bytes<'p>(

--- a/src/rust/src/backend/mldsa.rs
+++ b/src/rust/src/backend/mldsa.rs
@@ -106,9 +106,16 @@ impl MlDsa44PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
-        Ok(pyo3::types::PyBytes::new(py, &seed))
+        cfg_if::cfg_if! {
+            if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+                let seed = cryptography_openssl::mldsa::get_seed(&self.pkey)?;
+                Ok(pyo3::types::PyBytes::new(py, &seed))
+            } else {
+                let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
+                    cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+                Ok(pyo3::types::PyBytes::new(py, &seed))
+            }
+        }
     }
 
     fn private_bytes<'p>(
@@ -307,9 +314,16 @@ impl MlDsa65PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
-        Ok(pyo3::types::PyBytes::new(py, &seed))
+        cfg_if::cfg_if! {
+            if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+                let seed = cryptography_openssl::mldsa::get_seed(&self.pkey)?;
+                Ok(pyo3::types::PyBytes::new(py, &seed))
+            } else {
+                let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
+                    cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+                Ok(pyo3::types::PyBytes::new(py, &seed))
+            }
+        }
     }
 
     fn private_bytes<'p>(
@@ -511,9 +525,16 @@ impl MlDsa87PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
-        Ok(pyo3::types::PyBytes::new(py, &seed))
+        cfg_if::cfg_if! {
+            if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+                let seed = cryptography_openssl::mldsa::get_seed(&self.pkey)?;
+                Ok(pyo3::types::PyBytes::new(py, &seed))
+            } else {
+                let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
+                    cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+                Ok(pyo3::types::PyBytes::new(py, &seed))
+            }
+        }
     }
 
     fn private_bytes<'p>(

--- a/src/rust/src/backend/mod.rs
+++ b/src/rust/src/backend/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod hmac;
 pub(crate) mod hpke;
 pub(crate) mod kdf;
 pub(crate) mod keys;
-#[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
 pub(crate) mod mldsa;
 pub(crate) mod poly1305;
 pub(crate) mod rand;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -242,7 +242,7 @@ mod _rust {
         use crate::backend::kdf::kdf;
         #[pymodule_export]
         use crate::backend::keys::keys;
-        #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
+        #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
         #[pymodule_export]
         use crate::backend::mldsa::mldsa;
         #[pymodule_export]


### PR DESCRIPTION
## Summary

Extends ML-DSA (FIPS 204) support to BoringSSL. Previously ML-DSA was only enabled when building against AWS-LC; BoringSSL now has ML-DSA support but uses a different API than AWS-LC, so this PR adds conditional compilation paths for both.

## Key differences

**BoringSSL API:**
- `EVP_PKEY_from_private_seed()` / `EVP_PKEY_from_raw_public_key()` with `EVP_pkey_ml_dsa_{44,65,87}()` for key creation
- `EVP_DigestSign` / `EVP_DigestVerify` (via `openssl::md_ctx::MdCtx`) plus `EVP_PKEY_CTX_set1_signature_context_string` for signing/verifying with context strings
- Per-variant NIDs (`NID_ML_DSA_{44,65,87}`) identify ML-DSA keys via `pkey.id()`

**AWS-LC API (unchanged):**
- `EVP_PKEY_pqdsa_new_raw_private_key` / `EVP_PKEY_pqdsa_new_raw_public_key` for key creation
- `ml_dsa_{44,65,87}_sign/verify` direct functions for signing (AWS-LC's EVP PQDSA path hardcodes context to `NULL`, so the low-level functions are needed to preserve context string support)
- Shared `NID_PQDSA` with `EVP_PKEY_pqdsa_get_type` for variant identification

## Implementation notes

- `mldsa_seed_from_pkey` in `cryptography-key-parsing` now works for both backends, since BoringSSL and AWS-LC both serialize ML-DSA private keys as a seed in PKCS#8
- Signing and verification on BoringSSL use `MdCtx::digest_sign_init` / `digest_verify_init` (which return `&mut PkeyCtxRef`) so the ML-DSA context string can be set via a single unsafe call to `EVP_PKEY_CTX_set1_signature_context_string`, and then `digest_sign_to_vec` / `digest_verify` handle the actual operation safely (this requires openssl 0.10.77, which #14644 already bumped to)
- `is_mldsa_pkey_type` helper replaces the single `PKEY_ID` constant, since BoringSSL uses per-variant NIDs for the EVP pkey type

## Test plan

- [x] `OPENSSL_DIR=<boringssl> nox -e local` passes on BoringSSL (3149 passed, 931 skipped)
- [ ] CI: BoringSSL build job
- [ ] CI: AWS-LC build job (confirm no regression)
- [ ] CI: OpenSSL build jobs (confirm no regression — ML-DSA remains unsupported there)

https://claude.ai/code/session_01YVJGsasgsDfKxpkG91NWAw