### PR TITLE
Fix benchmark workflow to use dependency group instead of removed [test] extra

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,14 +44,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install uv
+        run: pip install -c ./cryptography-pr/ci-constraints-requirements.txt uv
       - name: Create virtualenv (base)
         run: |
-          python -m venv .venv-base
-          .venv-base/bin/pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base:test
+          uv venv .venv-base
+          . .venv-base/bin/activate
+          uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base:test
       - name: Create virtualenv (PR)
         run: |
-          python -m venv .venv-pr
-          .venv-pr/bin/pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr:test
+          uv venv .venv-pr
+          . .venv-pr/bin/activate
+          uv pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr:test
 
       - name: Run benchmarks (base)
         run: .venv-base/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-base.json --x509-limbo-root=x509-limbo/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,12 +50,12 @@ jobs:
         run: |
           uv venv .venv-base
           . .venv-base/bin/activate
-          uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base:test
+          uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base/pyproject.toml:test
       - name: Create virtualenv (PR)
         run: |
           uv venv .venv-pr
           . .venv-pr/bin/activate
-          uv pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr:test
+          uv pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr/pyproject.toml:test
 
       - name: Run benchmarks (base)
         run: .venv-base/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-base.json --x509-limbo-root=x509-limbo/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,11 +47,11 @@ jobs:
       - name: Create virtualenv (base)
         run: |
           python -m venv .venv-base
-          .venv-base/bin/pip install -v -c ./cryptography-base/ci-constraints-requirements.txt "./cryptography-base[test]" ./cryptography-base/vectors/
+          .venv-base/bin/pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base:test
       - name: Create virtualenv (PR)
         run: |
           python -m venv .venv-pr
-          .venv-pr/bin/pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt "./cryptography-pr[test]" ./cryptography-pr/vectors/
+          .venv-pr/bin/pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr:test
 
       - name: Run benchmarks (base)
         run: .venv-base/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-base.json --x509-limbo-root=x509-limbo/


### PR DESCRIPTION
## Summary
- The `[test]` extra was converted to a dependency group in #14638, but the benchmark workflow still referenced `[test]`, causing pytest to not be installed in the venv
- Use `--group path:test` syntax to install the test dependency group

## Test plan
- [ ] Benchmark workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)