### PR TITLE
 Fix EC point-at-infinity key loading raising InternalError on AWS-LC

### DIFF
--- a/src/rust/cryptography-key-parsing/src/spki.rs
+++ b/src/rust/cryptography-key-parsing/src/spki.rs
@@ -22,7 +22,8 @@ pub fn parse_public_key(data: &[u8]) -> KeyParsingResult<ParsedPublicKey> {
                 &mut bn_ctx,
             )
             .map_err(|_| KeyParsingError::InvalidKey)?;
-            let ec_key = openssl::ec::EcKey::from_public_key(&group, &ec_point)?;
+            let ec_key = openssl::ec::EcKey::from_public_key(&group, &ec_point)
+                .map_err(|_| KeyParsingError::InvalidKey)?;
             let pkey = openssl::pkey::PKey::from_ec_key(ec_key)?;
             Ok(ParsedPublicKey::Pkey(pkey))
         }


### PR DESCRIPTION
When updating #14598 to AWS-LC 1.72.0, an unrelated error appeared when running the test suite:


```
E           cryptography.exceptions.InternalError: Unknown OpenSSL error. This error is commonly encountered
E                               when another library is not cleaning up the OpenSSL error
E                               stack. If you are using cryptography with another library
E                               that uses OpenSSL try disabling it before reporting a bug.
E                               Otherwise please file an issue at
E                               https://github.com/pyca/cryptography/issues with
E                               information on how to reproduce this. (error:0F000077:elliptic curve routines:OPENSSL_internal:POINT_AT_INFINITY:/tmp/aws-lc/crypto/fipsmodule/ec/ec_key.c:210:)

```

I believe this was caused by the fix in https://github.com/aws/aws-lc/pull/3101


