### PR TITLE
Validate `key_to_wrap` length in `aes_key_wrap_with_padding`

### DIFF
--- a/src/cryptography/hazmat/primitives/keywrap.py
+++ b/src/cryptography/hazmat/primitives/keywrap.py
@@ -86,6 +86,9 @@ def aes_key_wrap_with_padding(
     if len(wrapping_key) not in [16, 24, 32]:
         raise ValueError("The wrapping key must be a valid AES key length")
 
+    if not key_to_wrap or len(key_to_wrap) > 2**32:
+        raise ValueError("key_to_wrap must be between 1 and 2^32 bytes")
+
     aiv = b"\xa6\x59\x59\xa6" + len(key_to_wrap).to_bytes(
         length=4, byteorder="big"
     )

--- a/tests/hazmat/primitives/test_keywrap.py
+++ b/tests/hazmat/primitives/test_keywrap.py
@@ -194,6 +194,12 @@ class TestAESKeyWrapWithPadding:
                 b"sixteen_byte_key", b"\x00" * 15, backend
             )
 
+    def test_wrap_empty_key_to_wrap(self, backend):
+        with pytest.raises(
+            ValueError, match="key_to_wrap must be between 1 and 2\\^32 bytes"
+        ):
+            keywrap.aes_key_wrap_with_padding(b"\x00" * 16, b"", backend)
+
     def test_wrap_invalid_key_length(self, backend):
         with pytest.raises(ValueError, match="must be a valid AES key length"):
             keywrap.aes_key_wrap_with_padding(b"badkey", b"\x00", backend)

--- a/tests/wycheproof/test_keywrap.py
+++ b/tests/wycheproof/test_keywrap.py
@@ -17,9 +17,14 @@ def test_keywrap_with_padding(backend, wycheproof):
     key_to_wrap = binascii.unhexlify(wycheproof.testcase["msg"])
     expected = binascii.unhexlify(wycheproof.testcase["ct"])
 
-    result = keywrap.aes_key_wrap_with_padding(
-        wrapping_key, key_to_wrap, backend
-    )
+    try:
+        result = keywrap.aes_key_wrap_with_padding(
+            wrapping_key, key_to_wrap, backend
+        )
+    except ValueError:
+        # Some invalid inputs raise errors during wrapping while others fail
+        # later
+        assert wycheproof.invalid
     if wycheproof.valid or wycheproof.acceptable:
         assert result == expected
 


### PR DESCRIPTION
Hi,

this PR resolves https://github.com/pyca/cryptography/issues/14664:
RFC 5649 specifies that the plaintext must be between 1 and 2^32 octets. Previously, passing an empty key_to_wrap would cause _wrap_core to be called with r=[], which skips all AES operations and just returns an invalid wrapped key.

Wycheproof has a test for this that is marked as "invalid":

https://github.com/C2SP/wycheproof/blob/75ede73a39b8517b2a06c8115dfbcd364479796c/testvectors_v1/aes_kwp_test.json#L839-L849

I've updated the testing harness to allow `aes_key_wrap_with_padding` to return an error in this case. The initial CI run failed in that case. Unfortunately there doesn't seem to be a way to tell if unwrapping or wrapping the key should fail, which is why this wasn't caught by the wycheproof test and why the new logic is somewhat sloppy.

Thanks!