### PR TITLE
Add OpenSSL 4.0.0 and LibreSSL 4.3.1 to CI

### DIFF
--- a/.github/workflows/boring-open-awslc-bump.yml
+++ b/.github/workflows/boring-open-awslc-bump.yml
@@ -29,6 +29,16 @@ jobs:
             --comment-pattern 'Latest commit on the BoringSSL main branch.*?\.' \
             --commit-url-template "{repo_url}/+/{version}" \
             --diff-url-template "{repo_url}/+/{old_version}..{new_version}"
+      - id: bump-openssl
+        run: |
+          python3 .github/bin/bump_dependency.py \
+            --name "OpenSSL" \
+            --repo-url "https://github.com/openssl/openssl" \
+            --branch "master" \
+            --file-path ".github/workflows/ci.yml" \
+            --current-version-pattern 'TYPE: "openssl", VERSION: "([a-f0-9]{40})"' \
+            --update-pattern 'TYPE: "openssl", VERSION: "{new_version}"' \
+            --comment-pattern 'Latest commit on the OpenSSL master branch.*?\.'
       - id: bump-awslc
         run: |
           python3 .github/bin/bump_dependency.py \
@@ -48,7 +58,7 @@ jobs:
         with:
           app_id: ${{ secrets.BORINGBOT_APP_ID }}
           private_key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
-        if: steps.bump-boringssl.outputs.HAS_UPDATES == 'true' || steps.bump-awslc.outputs.HAS_UPDATES == 'true'
+        if: steps.bump-boringssl.outputs.HAS_UPDATES == 'true' || steps.bump-openssl.outputs.HAS_UPDATES == 'true' || steps.bump-awslc.outputs.HAS_UPDATES == 'true'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -58,6 +68,7 @@ jobs:
           author: "pyca-boringbot[bot] <pyca-boringbot[bot]+106132319@users.noreply.github.com>"
           body: |
             ${{ steps.bump-boringssl.outputs.COMMIT_MSG }}
+            ${{ steps.bump-openssl.outputs.COMMIT_MSG }}
             ${{ steps.bump-awslc.outputs.COMMIT_MSG }}
           token: ${{ steps.generate-token.outputs.token }}
-        if: steps.bump-boringssl.outputs.HAS_UPDATES == 'true' || steps.bump-awslc.outputs.HAS_UPDATES == 'true'
+        if: steps.bump-boringssl.outputs.HAS_UPDATES == 'true' || steps.bump-openssl.outputs.HAS_UPDATES == 'true' || steps.bump-awslc.outputs.HAS_UPDATES == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,11 @@ jobs:
           - {VERSION: "3.14", NOXSESSION: "tests", OPENSSL: {TYPE: "openssl", VERSION: "3.3.7"}}
           - {VERSION: "3.14", NOXSESSION: "tests", OPENSSL: {TYPE: "openssl", VERSION: "3.4.5"}}
           - {VERSION: "3.14", NOXSESSION: "tests", OPENSSL: {TYPE: "openssl", VERSION: "3.5.6"}}
+          - {VERSION: "3.14", NOXSESSION: "tests", OPENSSL: {TYPE: "openssl", VERSION: "4.0.0"}}
           - {VERSION: "3.14", NOXSESSION: "tests-ssh", OPENSSL: {TYPE: "openssl", VERSION: "3.6.2"}}
           - {VERSION: "3.14", NOXSESSION: "rust,tests", OPENSSL: {TYPE: "libressl", VERSION: "4.1.2"}}
           - {VERSION: "3.14", NOXSESSION: "rust,tests", OPENSSL: {TYPE: "libressl", VERSION: "4.2.1"}}
+          - {VERSION: "3.14", NOXSESSION: "rust,tests", OPENSSL: {TYPE: "libressl", VERSION: "4.3.1"}}
           # Latest commit on the BoringSSL main branch, as of Apr 19, 2026.
           - {VERSION: "3.14", NOXSESSION: "rust,tests", OPENSSL: {TYPE: "boringssl", VERSION: "8313e239e50e4d240ac7fc04c8e1aa05d58ca0fc"}}
           # Latest tag of AWS-LC main branch, as of Apr 14, 2026.


### PR DESCRIPTION
## Summary
- Add OpenSSL 4.0.0 and LibreSSL 4.3.1 entries to the Linux CI matrix
- Revert 0e25c9e to re-enable automated OpenSSL master branch bumping

## Test plan
- [ ] CI passes for the new OpenSSL 4.0.0 job
- [ ] CI passes for the new LibreSSL 4.3.1 job
- [ ] Bump workflow YAML is syntactically valid

https://claude.ai/code/session_01YKcVnYfEFo5HdKpv5HM7tM