### PR TITLE
Recommend Argon2id over PBKDF2HMAC as KDF

### DIFF
--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -231,7 +231,7 @@ such functions; it is generally recommended to use
     >>> import os
     >>> from cryptography.fernet import Fernet
     >>> from cryptography.hazmat.primitives import hashes
-    >>> from cryptography.hazmat.primitives.kdf.pbkdf2 import Argon2id
+    >>> from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
     >>> password = b"password"
     >>> salt = os.urandom(16)
     >>> kdf = Argon2id(

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -285,4 +285,4 @@ unsuitable for very large files at this time.
 
 .. _`Fernet`: https://github.com/fernet/spec/
 .. _`specification`: https://github.com/fernet/spec/blob/master/Spec.md
- .._`IRTF RFC 9106`: https://datatracker.ietf.org/doc/html/rfc9106#name-parameter-choice
+.. _`IRTF RFC 9106`: https://datatracker.ietf.org/doc/html/rfc9106#name-parameter-choice

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -239,7 +239,7 @@ password through a key derivation function such as
     ...     algorithm=hashes.SHA256(),
     ...     length=32,
     ...     salt=salt,
-    ...     iterations=1_200_000,
+    ...     iterations=1_500_000,
     ... )
     >>> key = base64.urlsafe_b64encode(kdf.derive(password))
     >>> f = Fernet(key)
@@ -253,8 +253,8 @@ In this scheme, the salt has to be stored in a retrievable location in order
 to derive the same key from the password in the future.
 
 The iteration count used should be adjusted to be as high as your server can
-tolerate. A good default is at least 1,200,000 iterations, which is what `Django
-recommends as of January 2025`_.
+tolerate. A good default is at least 1,500,000 iterations, which is what `Django
+recommends as of September 2025`_.
 
 Implementation
 --------------

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -221,10 +221,9 @@ Using passwords with Fernet
 ---------------------------
 
 It is possible to use passwords with Fernet. To do this, you need to run the
-password through a key derivation function such as
-:class:`~cryptography.hazmat.primitives.kdf.pbkdf2.PBKDF2HMAC`,
-:class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id` or
-:class:`~cryptography.hazmat.primitives.kdf.scrypt.Scrypt`.
+password through a key derivation function. ``cryptography`` provides several
+such functions; it is generally recommended to use
+:class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id`.
 
 .. doctest::
 
@@ -232,14 +231,15 @@ password through a key derivation function such as
     >>> import os
     >>> from cryptography.fernet import Fernet
     >>> from cryptography.hazmat.primitives import hashes
-    >>> from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    >>> from cryptography.hazmat.primitives.kdf.pbkdf2 import Argon2id
     >>> password = b"password"
     >>> salt = os.urandom(16)
-    >>> kdf = PBKDF2HMAC(
-    ...     algorithm=hashes.SHA256(),
+    >>> kdf = Argon2id(
+    ...     salt=salt,    
     ...     length=32,
-    ...     salt=salt,
-    ...     iterations=1_500_000,
+    ...     iterations=1,
+    ...     lanes=4,
+    ...     memory_cost=2^21
     ... )
     >>> key = base64.urlsafe_b64encode(kdf.derive(password))
     >>> f = Fernet(key)
@@ -252,9 +252,11 @@ password through a key derivation function such as
 In this scheme, the salt has to be stored in a retrievable location in order
 to derive the same key from the password in the future.
 
-The iteration count used should be adjusted to be as high as your server can
-tolerate. A good default is at least 1,500,000 iterations, which is what `Django
-recommends as of September 2025`_.
+The :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id` parameters
+in the above code example are based on the recommendations of `IRTF RFC 9106`_
+for general applications. For memory-constrained applications, the RFC
+recommends ``iterations=3`` and ``memory_cost=2^16``. See that document for
+more information.
 
 Implementation
 --------------
@@ -282,5 +284,5 @@ unsuitable for very large files at this time.
 
 
 .. _`Fernet`: https://github.com/fernet/spec/
-.. _`Django recommends as of January 2025`: https://github.com/django/django/blob/main/django/contrib/auth/hashers.py
 .. _`specification`: https://github.com/fernet/spec/blob/master/Spec.md
+ .._`IRTF RFC 9106`: https://datatracker.ietf.org/doc/html/rfc9106#name-parameter-choice

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -235,7 +235,7 @@ such functions; it is generally recommended to use
     >>> password = b"password"
     >>> salt = os.urandom(16)
     >>> kdf = Argon2id(
-    ...     salt=salt,    
+    ...     salt=salt,
     ...     length=32,
     ...     iterations=1,
     ...     lanes=4,

--- a/docs/fernet.rst
+++ b/docs/fernet.rst
@@ -239,7 +239,7 @@ such functions; it is generally recommended to use
     ...     length=32,
     ...     iterations=1,
     ...     lanes=4,
-    ...     memory_cost=2^21
+    ...     memory_cost=2**21
     ... )
     >>> key = base64.urlsafe_b64encode(kdf.derive(password))
     >>> f = Fernet(key)
@@ -255,7 +255,7 @@ to derive the same key from the password in the future.
 The :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id` parameters
 in the above code example are based on the recommendations of `IRTF RFC 9106`_
 for general applications. For memory-constrained applications, the RFC
-recommends ``iterations=3`` and ``memory_cost=2^16``. See that document for
+recommends ``iterations=3`` and ``memory_cost=2**16``. See that document for
 more information.
 
 Implementation


### PR DESCRIPTION
Update the recommended PBKDF2HMAC iteration count from 1,200,000 to 1,500,000 to reflect the latest Django recommendations.

Closes: #14723