### PR TITLE
Use #[pyclass(generic)] for SetOf in declarative ASN.1

### DIFF
--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -473,7 +473,7 @@ impl Null {
 }
 
 #[derive(pyo3::FromPyObject)]
-#[pyo3::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.asn1")]
+#[pyo3::pyclass(frozen, generic, module = "cryptography.hazmat.bindings._rust.asn1")]
 pub struct SetOf {
     pub(crate) inner: pyo3::Py<pyo3::types::PyList>,
 }
@@ -496,19 +496,6 @@ impl SetOf {
 
     fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
         Ok(format!("SetOf({})", self.inner.bind(py).repr()?))
-    }
-
-    // TODO: replace this manual `__class_getitem__` with
-    // `#[pyclass(generic)]`, which uses `pyo3::types::PyGenericAlias` to
-    // create `types.GenericAlias` objects.
-    #[classmethod]
-    fn __class_getitem__(
-        cls: &pyo3::Bound<'_, pyo3::types::PyType>,
-        py: pyo3::Python<'_>,
-        item: &pyo3::Bound<'_, pyo3::PyAny>,
-    ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
-        let generic_alias = crate::types::TYPES_GENERICALIAS.get(py)?;
-        Ok(generic_alias.call1((cls, item))?.unbind())
     }
 }
 

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -37,7 +37,6 @@ pub static DATETIME_TIMEZONE_UTC: LazyPyImport =
     LazyPyImport::new("datetime", &["timezone", "utc"]);
 pub static IPADDRESS_IPADDRESS: LazyPyImport = LazyPyImport::new("ipaddress", &["ip_address"]);
 pub static IPADDRESS_IPNETWORK: LazyPyImport = LazyPyImport::new("ipaddress", &["ip_network"]);
-pub static TYPES_GENERICALIAS: LazyPyImport = LazyPyImport::new("types", &["GenericAlias"]);
 
 pub static DEPRECATED_IN_36: LazyPyImport =
     LazyPyImport::new("cryptography.utils", &["DeprecatedIn36"]);


### PR DESCRIPTION
PyO3's `generic` pyclass argument auto-generates __class_getitem__ via PyGenericAlias, replacing the manual implementation.