### PR TITLE
Reject CRLs with mismatched inner/outer signature algorithms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changelog
 
 * **BACKWARDS INCOMPATIBLE:** Support for Python 3.8 has been removed.
   ``cryptography`` now requires Python 3.9 or later.
+* **BACKWARDS INCOMPATIBLE:** Loading an X.509 CRL whose inner
+  ``TBSCertList.signature`` algorithm does not match the outer
+  ``signatureAlgorithm`` now raises ``ValueError``. Previously, such CRLs
+  were parsed successfully and only rejected during signature validation.
 
 
 .. _v47-0-0:

--- a/src/rust/src/x509/crl.rs
+++ b/src/rust/src/x509/crl.rs
@@ -43,6 +43,16 @@ pub(crate) fn load_der_x509_crl(
         ));
     }
 
+    if owned.borrow_dependent().tbs_cert_list.signature
+        != owned.borrow_dependent().signature_algorithm
+    {
+        return Err(CryptographyError::from(
+            pyo3::exceptions::PyValueError::new_err(
+                "Inner and outer signature algorithms do not match. This is an invalid CRL.",
+            ),
+        ));
+    }
+
     Ok(CertificateRevocationList {
         owned,
         revoked_certs: pyo3::sync::PyOnceLock::new(),
@@ -412,12 +422,6 @@ impl CertificateRevocationList {
         py: pyo3::Python<'p>,
         public_key: pyo3::Bound<'p, pyo3::PyAny>,
     ) -> CryptographyResult<bool> {
-        if slf.owned.borrow_dependent().tbs_cert_list.signature
-            != slf.owned.borrow_dependent().signature_algorithm
-        {
-            return Ok(false);
-        };
-
         // Error on invalid public key -- below we treat any error as just
         // being an invalid signature.
         sign::identify_public_key_type(py, public_key.clone())?;

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -573,11 +573,14 @@ class TestCertificateRevocationList:
         assert isinstance(public_key, rsa.RSAPublicKey)
         assert not crl.is_signature_valid(public_key)
 
-        crl = _load_cert(
+    def test_load_inner_outer_mismatch(self, backend):
+        data = load_vectors_from_file(
             os.path.join("x509", "custom", "crl_inner_outer_mismatch.der"),
-            x509.load_der_x509_crl,
+            lambda f: f.read(),
+            mode="rb",
         )
-        assert not crl.is_signature_valid(public_key)
+        with pytest.raises(ValueError, match="Inner and outer"):
+            x509.load_der_x509_crl(data)
 
     def test_verify_good(self, backend):
         crl = _load_cert(


### PR DESCRIPTION
Validate at parse time that the inner TBSCertList.signature matches the outer signatureAlgorithm, raising ValueError on mismatch. This matches Go's behavior and closes #14267.