### PR TITLE
try marking these fields as const

### DIFF
--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -12,8 +12,8 @@ TYPES = """
 typedef ... CONF;
 
 typedef struct {
-    X509 *issuer_cert;
-    X509 *subject_cert;
+    const X509 *issuer_cert;
+    const X509 *subject_cert;
     ...;
 } X509V3_CTX;
 


### PR DESCRIPTION
they're const in boringssl and aws-lc

fixes #14754