### PR TITLE
Fixes #14754 - Builds failing for BoringSSL and AWS-LC using GCC 14+

### DIFF
--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -12,8 +12,8 @@ TYPES = """
 typedef ... CONF;
 
 typedef struct {
-    X509 *issuer_cert;
-    X509 *subject_cert;
+    const X509 *issuer_cert;
+    const X509 *subject_cert;
     ...;
 } X509V3_CTX;
 


### PR DESCRIPTION
This fixes issue #14754.

Starting with GCC 14: "GCC no longer allows implicitly casting all pointer types to all other pointer types." [1]

This change breaks building `cryptography` when using the BoringSSL and AWS-LC backends using GCC 14+. This affects Debian 13 (trixie), Ubuntu 25.10, Ubuntu 26.04, etc..

This matters because the post-quantum cryptography (ML-KEM[2], ML-DSA[3]) are only available using BoringSSL or AWS-LC. So if a user wants to use the post-quantum features, they have to run Debian 12 (oldstable) or Ubuntu 24.04 (old LTS).

The discussion in Issue #14754 plans to remove the cffi binding entirely, which would solve the issue. However, I'd like to ask that in the meantime while that effort is ongoing, this patch unblock users of more recent distros to be able to us the post-quantum features included in `cryptography`.

[1] - https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types
[2] - https://github.com/pyca/cryptography/blob/a8a54203ad906b8af75365885129fd92ce7c6da6/src/cryptography/hazmat/backends/openssl/backend.py#L275
[3] - https://github.com/pyca/cryptography/blob/a8a54203ad906b8af75365885129fd92ce7c6da6/src/cryptography/hazmat/backends/openssl/backend.py#L281
