### PR TITLE
Fixes #14754 - Builds failing for BoringSSL and AWS-LC using GCC 14+

### DIFF
--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -10,14 +10,14 @@ INCLUDES = """
 #include <openssl/x509v3.h>
 """
 
-TYPES = """
+TYPES = f"""
 typedef ... CONF;
 
-typedef struct {
-    X509 *issuer_cert;
-    X509 *subject_cert;
+typedef struct {{
+    {os.environ.get("CONST_X509") or "X509"} *issuer_cert;
+    {os.environ.get("CONST_X509") or "X509"} *subject_cert;
     ...;
-} X509V3_CTX;
+}} X509V3_CTX;
 
 static const int GEN_EMAIL;
 static const int GEN_DNS;
@@ -26,19 +26,15 @@ static const int GEN_URI;
 typedef ... GENERAL_NAMES;
 
 /* Only include the one union element used by pyOpenSSL. */
-typedef struct {
+typedef struct {{
     int type;
-    union {
+    union {{
         ASN1_IA5STRING *ia5;   /* rfc822Name, dNSName, */
                                /*   uniformResourceIdentifier */
-    } d;
+    }} d;
     ...;
-} GENERAL_NAME;
+}} GENERAL_NAME;
 """
-# BoringSSL and AWS-LC use const X509 (OpenSSL does not)
-if os.environ.get("USE_CONST_X509") == "1":
-    TYPES = TYPES.replace("X509 *", "const X509 *")
-
 
 FUNCTIONS = """
 void X509V3_set_ctx(X509V3_CTX *, X509 *, X509 *, X509_REQ *, X509_CRL *, int);

--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -14,8 +14,8 @@ TYPES = f"""
 typedef ... CONF;
 
 typedef struct {{
-    {os.environ.get("CONST_X509") or "X509"} *issuer_cert;
-    {os.environ.get("CONST_X509") or "X509"} *subject_cert;
+    {"const X509" if os.environ.get("USE_CONST_X509") else "X509"} *issuer_cert;
+    {"const X509" if os.environ.get("USE_CONST_X509") else "X509"} *subject_cert;
     ...;
 }} X509V3_CTX;
 

--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import os
+
 INCLUDES = """
 #include <openssl/x509v3.h>
 """
@@ -33,6 +35,9 @@ typedef struct {
     ...;
 } GENERAL_NAME;
 """
+# BoringSSL and AWS-LC use const X509 (OpenSSL does not)
+if os.environ.get("USE_CONST_X509") == "1":
+    TYPES = TYPES.replace("X509 *", "const X509 *");
 
 
 FUNCTIONS = """

--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -37,7 +37,7 @@ typedef struct {
 """
 # BoringSSL and AWS-LC use const X509 (OpenSSL does not)
 if os.environ.get("USE_CONST_X509") == "1":
-    TYPES = TYPES.replace("X509 *", "const X509 *");
+    TYPES = TYPES.replace("X509 *", "const X509 *")
 
 
 FUNCTIONS = """

--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -10,12 +10,14 @@ INCLUDES = """
 #include <openssl/x509v3.h>
 """
 
+USE_CONST_X509 = bool(os.environ.get("USE_CONST_X509"))
+
 TYPES = f"""
 typedef ... CONF;
 
 typedef struct {{
-    {"const X509" if os.environ.get("USE_CONST_X509") else "X509"} *issuer_cert;
-    {"const X509" if os.environ.get("USE_CONST_X509") else "X509"} *subject_cert;
+    {"const X509" if USE_CONST_X509 else "X509"} *issuer_cert;
+    {"const X509" if USE_CONST_X509 else "X509"} *subject_cert;
     ...;
 }} X509V3_CTX;
 

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -23,9 +23,7 @@ fn main() {
     }
 
     // BoringSSL and AWS-LC use const X509 (OpenSSL does not)
-    let is_boringssl = env::var("DEP_OPENSSL_BORINGSSL").is_ok();
-    let is_awslc = env::var("DEP_OPENSSL_AWSLC").is_ok();
-    let const_x509 = if is_boringssl || is_awslc { "const X509" } else { "" };
+    let const_x509 = if env::var("DEP_OPENSSL_BORINGSSL").is_ok() || env::var("DEP_OPENSSL_AWSLC").is_ok() { "const X509" } else { "" };
 
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -33,12 +33,13 @@ fn main() {
     // FIXME: maybe pyo3-build-config should provide a way to do this?
     let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
     println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
-    println!("cargo:rerun-if-env-changed=USE_CONST_X509");
+    println!("cargo:rerun-if-env-changed=DEP_OPENSSL_BORINGSSL");
+    println!("cargo:rerun-if-env-changed=DEP_OPENSSL_AWSLC");
     println!("cargo:rerun-if-changed=../../_cffi_src/");
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)
         .env("OUT_DIR", &out_dir)
-        .env("USE_CONST_X509", &use_const_x509)
+        .env("USE_CONST_X509", use_const_x509)
         .arg("../../_cffi_src/build_openssl.py")
         .output()
         .expect("failed to execute build_openssl.py");

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -23,7 +23,12 @@ fn main() {
     }
 
     // BoringSSL and AWS-LC use const X509 (OpenSSL does not)
-    let const_x509 = if env::var("DEP_OPENSSL_BORINGSSL").is_ok() || env::var("DEP_OPENSSL_AWSLC").is_ok() { "const X509" } else { "" };
+    let use_const_x509 =
+        if env::var("DEP_OPENSSL_BORINGSSL").is_ok() || env::var("DEP_OPENSSL_AWSLC").is_ok() {
+            "1"
+        } else {
+            ""
+        };
 
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?
@@ -33,7 +38,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)
         .env("OUT_DIR", &out_dir)
-        .env("CONST_X509", const_x509)
+        .env("USE_CONST_X509", use_const_x509)
         .arg("../../_cffi_src/build_openssl.py")
         .output()
         .expect("failed to execute build_openssl.py");

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -22,6 +22,12 @@ fn main() {
         }
     }
 
+    // BoringSSL and AWS-LC use const X509 (OpenSSL does not)
+    let mut use_const_x509 = "";
+    if env::var("DEP_OPENSSL_BORINGSSL").is_ok() || env::var("DEP_OPENSSL_AWSLC").is_ok() {
+        use_const_x509 = "1";
+    }
+
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?
     let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
@@ -30,6 +36,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)
         .env("OUT_DIR", &out_dir)
+        .env("USE_CONST_X509", &use_const_x509)
         .arg("../../_cffi_src/build_openssl.py")
         .output()
         .expect("failed to execute build_openssl.py");

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -23,23 +23,19 @@ fn main() {
     }
 
     // BoringSSL and AWS-LC use const X509 (OpenSSL does not)
-    let mut use_const_x509 = "";
-    if env::var("DEP_OPENSSL_BORINGSSL").is_ok() || env::var("DEP_OPENSSL_AWSLC").is_ok() {
-        use_const_x509 = "1";
-        println!("cargo:rustc-cfg=CRYPTOGRAPHY_IS_BORINGSSL_OR_AWSLC");
-    }
+    let is_boringssl = env::var("DEP_OPENSSL_BORINGSSL").is_ok();
+    let is_awslc = env::var("DEP_OPENSSL_AWSLC").is_ok();
+    let const_x509 = if is_boringssl || is_awslc { "const X509" } else { "" };
 
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?
     let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
     println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
-    println!("cargo:rerun-if-env-changed=DEP_OPENSSL_BORINGSSL");
-    println!("cargo:rerun-if-env-changed=DEP_OPENSSL_AWSLC");
     println!("cargo:rerun-if-changed=../../_cffi_src/");
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)
         .env("OUT_DIR", &out_dir)
-        .env("USE_CONST_X509", use_const_x509)
+        .env("CONST_X509", const_x509)
         .arg("../../_cffi_src/build_openssl.py")
         .output()
         .expect("failed to execute build_openssl.py");

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -26,12 +26,14 @@ fn main() {
     let mut use_const_x509 = "";
     if env::var("DEP_OPENSSL_BORINGSSL").is_ok() || env::var("DEP_OPENSSL_AWSLC").is_ok() {
         use_const_x509 = "1";
+        println!("cargo:rustc-cfg=CRYPTOGRAPHY_IS_BORINGSSL_OR_AWSLC");
     }
 
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?
     let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
     println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+    println!("cargo:rerun-if-env-changed=USE_CONST_X509");
     println!("cargo:rerun-if-changed=../../_cffi_src/");
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)


### PR DESCRIPTION
This fixes issue #14754.

Starting with GCC 14: "GCC no longer allows implicitly casting all pointer types to all other pointer types." [1]

This change breaks building `cryptography` when using the BoringSSL and AWS-LC backends using GCC 14+. This affects Debian 13 (trixie), Ubuntu 25.10, Ubuntu 26.04, etc..

This matters because the post-quantum cryptography (ML-KEM[2], ML-DSA[3]) are only available using BoringSSL or AWS-LC. So if a user wants to use the post-quantum features, they have to run Debian 12 (oldstable) or Ubuntu 24.04 (old LTS).

The discussion in Issue #14754 plans to remove the cffi binding entirely, which would solve the issue. However, I'd like to ask that in the meantime while that effort is ongoing, this patch unblock users of more recent distros to be able to us the post-quantum features included in `cryptography`.

The fix is to mark the X509V3_CTX as const or not depending on the backend type (OpenSSL, BoringSSL, AWS-LC).

[1] - https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types
[2] - https://github.com/pyca/cryptography/blob/a8a54203ad906b8af75365885129fd92ce7c6da6/src/cryptography/hazmat/backends/openssl/backend.py#L275
[3] - https://github.com/pyca/cryptography/blob/a8a54203ad906b8af75365885129fd92ce7c6da6/src/cryptography/hazmat/backends/openssl/backend.py#L281
