### PR TITLE
fix: add -headerpad_max_install_names for macOS wheels

### DIFF
--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -46,4 +46,8 @@ fn main() {
             println!("cargo:rustc-cfg=CRYPTOGRAPHY_OSSLCONF=\"{var}\"");
         }
     }
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg=-Wl,-headerpad_max_install_names");
+    }
 }

--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -47,6 +47,13 @@ fn main() {
         }
     }
 
+    // macOS 15 CI runners use Apple's new linker (ld_prime), which reserves
+    // significantly less Mach-O header padding than the old ld. Tools like
+    // Homebrew use install_name_tool to rewrite dylib paths post-install, and
+    // that requires spare space in the header. Without this flag the relink
+    // fails with "updated load commands do not fit in the header". This was
+    // first observed with cryptography 46.0.4 when wheel builds moved from
+    // macos-13 to macos-15 runners.
     if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
         println!("cargo:rustc-link-arg=-Wl,-headerpad_max_install_names");
     }


### PR DESCRIPTION
## What

Add `-headerpad_max_install_names` to the macOS linker invocation via `build.rs`.

## Why

macOS 15 CI runners use Apple's new linker (`ld_prime`), which reserves significantly less header padding in Mach-O binaries than the old `ld` did. Homebrew's post-install fixup (`install_name_tool`) needs that padding to rewrite dylib paths — when it's absent, the install fails:

```
Error: Failed changing dylib ID of .../_rust.abi3.so
Updated load commands do not fit in the header of .../_rust.abi3.so.
..._rust.abi3.so needs to be relinked, possibly with -headerpad or -headerpad_max_install_names
```

This regressed in `cryptography 46.0.4`, when the wheel-builder CI moved from `macos-13` to `macos-15` runners.

## Prior art

This was discussed in #7847 (2022). At the time, @reaperhulk said:

> "I don't have any issue with adding that flag to our wheel builders going forward."

The regression went away on its own then (a rustc bump changed the default padding). The macOS 15 runner shift has brought it back permanently.

## Fix

Three lines in `build.rs`, gated to macOS:

```rust
if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
    println!("cargo:rustc-link-arg=-Wl,-headerpad_max_install_names");
}
```

`cargo:rustc-link-arg` passes the flag directly to the final `cdylib` link step. This covers published wheels, source builds, and downstream Homebrew formulas in one shot.
