### PR TITLE
Raise MemoryError on Argon2 allocation failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Changelog
   ``TBSCertList.signature`` algorithm does not match the outer
   ``signatureAlgorithm`` now raises ``ValueError``. Previously, such CRLs
   were parsed successfully and only rejected during signature validation.
+* :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id`,
+  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2i`, and
+  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2d` now raise
+  ``MemoryError`` when there is insufficient memory to derive a key with the
+  chosen ``memory_cost`` parameter, instead of an opaque ``InternalError``.
 
 
 .. _v47-0-0:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,6 @@ Changelog
   ``TBSCertList.signature`` algorithm does not match the outer
   ``signatureAlgorithm`` now raises ``ValueError``. Previously, such CRLs
   were parsed successfully and only rejected during signature validation.
-* :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id`,
-  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2i`, and
-  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2d` now raise
-  ``MemoryError`` when there is insufficient memory to derive a key with the
-  chosen ``memory_cost`` parameter, instead of an opaque ``InternalError``.
 
 
 .. _v47-0-0:

--- a/docs/hazmat/primitives/key-derivation-functions.rst
+++ b/docs/hazmat/primitives/key-derivation-functions.rst
@@ -119,6 +119,9 @@ Each of the classes constructors and parameters are the same; only details of Ar
         :return bytes: the derived key.
         :raises TypeError: This exception is raised if ``key_material`` is not
                            ``bytes``.
+        :raises MemoryError: This exception is raised if there is insufficient
+                             memory to derive the key with the chosen
+                             ``memory_cost``.
         :raises cryptography.exceptions.AlreadyFinalized: This is raised when
                                                           :meth:`derive`,
                                                           :meth:`derive_into`,
@@ -142,6 +145,9 @@ Each of the classes constructors and parameters are the same; only details of Ar
                            ``bytes``.
         :raises ValueError: This exception is raised if the buffer is too small
                            for the derived key.
+        :raises MemoryError: This exception is raised if there is insufficient
+                             memory to derive the key with the chosen
+                             ``memory_cost``.
         :raises cryptography.exceptions.AlreadyFinalized: This is raised when
                                                           :meth:`derive`,
                                                           :meth:`derive_into`,

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -375,7 +375,12 @@ impl BaseArgon2 {
             self.memory_cost,
             output,
         )
-        .map_err(CryptographyError::from)?;
+        .map_err(|_| {
+            CryptographyError::from(pyo3::exceptions::PyMemoryError::new_err(format!(
+                "Not enough memory to derive key. These parameters require {}KiB of memory.",
+                self.memory_cost
+            )))
+        })?;
 
         Ok(self.length)
     }

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -378,7 +378,10 @@ impl BaseArgon2 {
         .map_err(|e| {
             // ERR_R_MALLOC_FAILURE = 256, PROV_R_INVALID_MEMORY_SIZE = 235.
             // OpenSSL's argon2 provider raises one or both when it can't
-            // allocate the memory matrix.
+            // allocate the memory matrix. In theory other init issues
+            // (e.g. PROV_R_INVALID_THREAD_POOL_SIZE on builds without
+            // thread-pool support) can also occur, but we strictly map
+            // these reason codes to MemoryError.
             if e.errors()
                 .iter()
                 .any(|err| matches!(err.reason_code(), 256 | 235))

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -375,24 +375,15 @@ impl BaseArgon2 {
             self.memory_cost,
             output,
         )
-        .map_err(|e| {
-            // ERR_R_MALLOC_FAILURE = 256, PROV_R_INVALID_MEMORY_SIZE = 235.
-            // OpenSSL's argon2 provider raises one or both when it can't
-            // allocate the memory matrix. In theory other init issues
-            // (e.g. PROV_R_INVALID_THREAD_POOL_SIZE on builds without
-            // thread-pool support) can also occur, but we strictly map
-            // these reason codes to MemoryError.
-            if e.errors()
-                .iter()
-                .any(|err| matches!(err.reason_code(), 256 | 235))
-            {
-                CryptographyError::from(pyo3::exceptions::PyMemoryError::new_err(format!(
-                    "Not enough memory to derive key. These parameters require {}KiB of memory.",
-                    self.memory_cost
-                )))
-            } else {
-                CryptographyError::from(e)
-            }
+        .map_err(|_| {
+            // In theory other init issues (e.g. PROV_R_INVALID_THREAD_POOL_SIZE
+            // on builds without thread-pool support) can also occur here, but
+            // in practice failures from OpenSSL's argon2 provider at this point
+            // are memory-allocation failures, so we strictly map to MemoryError.
+            CryptographyError::from(pyo3::exceptions::PyMemoryError::new_err(format!(
+                "Not enough memory to derive key. These parameters require {}KiB of memory.",
+                self.memory_cost
+            )))
         })?;
 
         Ok(self.length)

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -375,11 +375,21 @@ impl BaseArgon2 {
             self.memory_cost,
             output,
         )
-        .map_err(|_| {
-            CryptographyError::from(pyo3::exceptions::PyMemoryError::new_err(format!(
-                "Not enough memory to derive key. These parameters require {}KiB of memory.",
-                self.memory_cost
-            )))
+        .map_err(|e| {
+            // ERR_R_MALLOC_FAILURE = 256, PROV_R_INVALID_MEMORY_SIZE = 235.
+            // OpenSSL's argon2 provider raises one or both when it can't
+            // allocate the memory matrix.
+            if e.errors()
+                .iter()
+                .any(|err| matches!(err.reason_code(), 256 | 235))
+            {
+                CryptographyError::from(pyo3::exceptions::PyMemoryError::new_err(format!(
+                    "Not enough memory to derive key. These parameters require {}KiB of memory.",
+                    self.memory_cost
+                )))
+            } else {
+                CryptographyError::from(e)
+            }
         })?;
 
         Ok(self.length)

--- a/tests/hazmat/primitives/test_argon2.py
+++ b/tests/hazmat/primitives/test_argon2.py
@@ -140,6 +140,19 @@ class TestArgon2:
                 memory_cost=memory_cost,
             )
 
+    def test_argon2_malloc_failure(self, clazz, backend):
+        # memory_cost is in KiB, so 2**32 - 1 KiB is ~4 TiB. This should
+        # fail to allocate on any reasonable system.
+        argon2 = clazz(
+            salt=b"salt" * 2,
+            length=32,
+            iterations=1,
+            lanes=1,
+            memory_cost=2**32 - 1,
+        )
+        with pytest.raises(MemoryError):
+            argon2.derive(b"password")
+
     def test_already_finalized(self, clazz, backend):
         argon2id = clazz(
             salt=b"salt" * 2, length=32, iterations=1, lanes=1, memory_cost=32

--- a/tests/hazmat/primitives/test_argon2.py
+++ b/tests/hazmat/primitives/test_argon2.py
@@ -6,6 +6,7 @@
 import base64
 import binascii
 import os
+import sys
 
 import pytest
 
@@ -140,6 +141,14 @@ class TestArgon2:
                 memory_cost=memory_cost,
             )
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin",
+        reason=(
+            "macOS overcommits the 4 TiB virtual reservation, then the "
+            "subsequent memset triggers an OOM-kill before MemoryError "
+            "can be raised."
+        ),
+    )
     def test_argon2_malloc_failure(self, clazz, backend):
         # memory_cost is in KiB, so 2**32 - 1 KiB is ~4 TiB. This should
         # fail to allocate on any reasonable system.


### PR DESCRIPTION
Closes #14778.

Argon2 derivations that exceed available memory (e.g. when running under `mlockall` with a low max-locked-memory ulimit, or when given an unreasonably large `memory_cost`) currently surface as an opaque `InternalError` like:

```
cryptography.exceptions.InternalError: Unknown OpenSSL error. ... (error:078C0100:common libcrypto routines::malloc failure:providers/implementations/kdfs/argon2.c:736:, error:1C8000EB:Provider routines:initialize:invalid memory size:providers/implementations/kdfs/argon2.c:743:cannot allocate required memory)
```

This mirrors `Scrypt`'s behavior: any error from the OpenSSL argon2 derive call is mapped to `MemoryError` with a message that includes the configured `memory_cost`, so callers can handle the failure programmatically.

In theory other init failures (e.g. `PROV_R_INVALID_THREAD_POOL_SIZE` on builds without thread-pool support) can also reach this path, but in practice the only realistic failure mode after our constructor validation is memory allocation, so the unconditional mapping matches what `Scrypt` does.

## Test plan

- [x] `cargo build` and `cargo clippy` clean
- [x] Added `test_argon2_malloc_failure` parameterized over Argon2d/i/id, modeled on `test_scrypt_malloc_failure`, using `memory_cost=2**32 - 1` (~4 TiB)
- [ ] CI exercises the new test on an OpenSSL build with argon2 support (local OpenSSL is 3.0.13)
- [x] Documented `MemoryError` in the `derive` / `derive_into` raises sections


---
_Generated by [Claude Code](https://claude.ai/code/session_01N5DJsHxpAxRpiNHnDGBfxT)_