### PR TITLE
Parallelize test_no_circular_imports across xdist workers

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -7,6 +7,8 @@ import pkgutil
 import subprocess
 import sys
 
+import pytest
+
 import cryptography
 
 
@@ -20,7 +22,8 @@ def find_all_modules() -> list[str]:
     )
 
 
-def test_no_circular_imports(subtests):
+@pytest.mark.parametrize("module", find_all_modules())
+def test_no_circular_imports(module):
     env = os.environ.copy()
     env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
@@ -31,7 +34,5 @@ def test_no_circular_imports(subtests):
     env.pop("COV_CORE_DATAFILE", None)
     env.pop("COV_CORE_SOURCE", None)
 
-    for module in find_all_modules():
-        with subtests.test():
-            argv = [sys.executable, "-c", f"__import__({module!r})"]
-            subprocess.check_call(argv, env=env)
+    argv = [sys.executable, "-c", f"__import__({module!r})"]
+    subprocess.check_call(argv, env=env)


### PR DESCRIPTION
## Summary

Convert `test_no_circular_imports` from a single test that loops via `subtests` into a `@pytest.mark.parametrize` over `find_all_modules()`. Each module's import check is now an individual test case that pytest-xdist (already configured with `-n auto --dist=worksteal` in `nox -e local`) can distribute across workers.

## Performance

Wall-clock for `tests/test_meta.py` via `nox -e local`:

| Version | Tests | Time |
|---|---|---|
| Before (subtests, serial) | 1 | 3.14s |
| After (parametrized, xdist) | 77 | 1.21s |

~2.6× faster. Slowest individual case is now ~0.08s (vs 2.72s in the single old test).

## Test plan

- [x] `nox -e local -- tests/test_meta.py` — 77 passed in 1.21s

https://claude.ai/code/session_011pDeYKpCUdSPQXLMuperTH

---
_Generated by [Claude Code](https://claude.ai/code/session_011pDeYKpCUdSPQXLMuperTH)_