### PR TITLE
fix wycheproof JSON loading on Windows

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -992,7 +992,7 @@ class WycheproofTest:
 
 def load_wycheproof_tests(wycheproof: str, test_file: str, subdir: str):
     path = os.path.join(wycheproof, subdir, test_file)
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         data = json.load(f)
         for group in data.pop("testGroups"):
             cases = group.pop("tests")


### PR DESCRIPTION
ML-KEM wycheproof vectors contain non-ASCII bytes that fail to decode with Windows' default cp1252 codec. Open the file as UTF-8 explicitly.


(This doesn't fail yet, but will when we add ML-KEM OpenSSL because then these tests run on Windows)