### PR TITLE
call check_length early on AesSiv::encrypt

### DIFF
--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -1135,6 +1135,7 @@ impl AesSiv {
         data: CffiBuf<'_>,
         associated_data: Option<pyo3::Bound<'p, pyo3::types::PyList>>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
+        check_length(data.as_bytes())?;
         Ok(pyo3::types::PyBytes::new_with(
             py,
             data.as_bytes().len() + self.ctx.tag_len,


### PR DESCRIPTION
This is an optimization to early exit before allocating a PyBytes when the buffer is too large and would error inside the encrypt_into (which also calls check_length)