### PR TITLE
Add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Hybrid Python + Rust project. The Python package lives in `src/cryptography/`; t
 
 ## Running tests
 
-Use `nox -e local` to run the full local check: it formats and lints Python (`ruff`) and Rust (`cargo fmt`/`check`/`clippy`), type-checks with `mypy`, then runs the pytest suite and `cargo test`. This is the canonical command — prefer it over invoking `pytest` or `cargo test` directly.
+Use `nox -e local` to run the full local check: it formats and lints Python (`ruff`) and Rust (`cargo fmt`/`check`/`clippy`), type-checks with `mypy`, then runs the pytest suite and `cargo test`. This is the canonical command — never invoke `pytest` or `cargo test` directly.
 
 Other useful sessions: `nox -e tests`, `nox -e tests-nocoverage`, `nox -e rust`, `nox -e docs`, `nox -e flake`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# cryptography
+
+Hybrid Python + Rust project. The Python package lives in `src/cryptography/`; the Rust extension (PyO3) lives in `src/rust/`. CFFI bindings to OpenSSL/BoringSSL/AWS-LC are generated from `src/_cffi_src/`. Test vectors live in `vectors/` (an installable sub-package).
+
+## Running tests
+
+Use `nox -e local` to run the full local check: it formats and lints Python (`ruff`) and Rust (`cargo fmt`/`check`/`clippy`), type-checks with `mypy`, then runs the pytest suite and `cargo test`. This is the canonical command — prefer it over invoking `pytest` or `cargo test` directly.
+
+Other useful sessions: `nox -e tests`, `nox -e tests-nocoverage`, `nox -e rust`, `nox -e docs`, `nox -e flake`.
+
+## Package management
+
+Use `uv`, not `pip`, for any Python package installation or environment management. `noxfile.py` already sets `default_venv_backend = "uv"`.
+
+## Changelog
+
+User-visible changes go in `CHANGELOG.rst` under the unreleased section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,4 +200,6 @@ git-only = [
     "ci-constraints-requirements.txt",
     ".gitattributes",
     ".gitignore",
+    "AGENTS.md",
+    "CLAUDE.md",
 ]


### PR DESCRIPTION
Document project layout and the canonical commands (nox -e local, uv) for agent-based tooling. Exclude both files from the sdist via check-sdist's git-only list.

you're welcome Alex