### PR TITLE
Remove unused CFFI bindings without specific consumer

### DIFF
--- a/src/_cffi_src/openssl/asn1.py
+++ b/src/_cffi_src/openssl/asn1.py
@@ -43,7 +43,6 @@ void ASN1_GENERALIZEDTIME_free(ASN1_GENERALIZEDTIME *);
 
 int ASN1_STRING_type(const ASN1_STRING *);
 int ASN1_STRING_to_UTF8(unsigned char **, const ASN1_STRING *);
-int i2a_ASN1_INTEGER(BIO *, const ASN1_INTEGER *);
 
 ASN1_GENERALIZEDTIME *ASN1_TIME_to_generalizedtime(const ASN1_TIME *,
                                                    ASN1_GENERALIZEDTIME **);

--- a/src/_cffi_src/openssl/nid.py
+++ b/src/_cffi_src/openssl/nid.py
@@ -10,8 +10,6 @@ INCLUDES = """
 
 TYPES = """
 static const int NID_undef;
-
-static const int NID_subject_alt_name;
 """
 
 FUNCTIONS = """

--- a/src/_cffi_src/openssl/ssl.py
+++ b/src/_cffi_src/openssl/ssl.py
@@ -22,7 +22,6 @@ static const long Cryptography_HAS_KEYLOG;
 static const long Cryptography_HAS_SSL_COOKIE;
 
 static const long Cryptography_HAS_SSL_OP_IGNORE_UNEXPECTED_EOF;
-static const long Cryptography_HAS_ALPN;
 static const long Cryptography_HAS_NEXTPROTONEG;
 static const long Cryptography_HAS_SET_CERT_CB;
 static const long Cryptography_HAS_GET_EXTMS_SUPPORT;
@@ -460,7 +459,6 @@ static const long Cryptography_HAS_VERIFIED_CHAIN = 1;
 static const long Cryptography_HAS_KEYLOG = 1;
 
 static const long Cryptography_HAS_NEXTPROTONEG = 0;
-static const long Cryptography_HAS_ALPN = 1;
 
 #ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
 static const long Cryptography_HAS_SSL_OP_IGNORE_UNEXPECTED_EOF = 1;

--- a/src/_cffi_src/openssl/x509.py
+++ b/src/_cffi_src/openssl/x509.py
@@ -22,12 +22,9 @@ typedef ... Cryptography_STACK_OF_X509;
 
 typedef ... X509_ALGOR;
 typedef ... X509_EXTENSION;
-typedef ... X509_EXTENSIONS;
 typedef ... X509_REQ;
 typedef ... X509_CRL;
 typedef ... X509;
-
-typedef void (*sk_X509_EXTENSION_freefunc)(X509_EXTENSION *);
 """
 
 FUNCTIONS = """
@@ -55,12 +52,6 @@ int X509_set_subject_name(X509 *, X509_NAME *);
 
 int X509_set_issuer_name(X509 *, X509_NAME *);
 
-int X509_add_ext(X509 *, X509_EXTENSION *, int);
-X509_EXTENSION *X509_EXTENSION_dup(X509_EXTENSION *);
-
-ASN1_OBJECT *X509_EXTENSION_get_object(X509_EXTENSION *);
-void X509_EXTENSION_free(X509_EXTENSION *);
-
 int X509_REQ_set_version(X509_REQ *, long);
 X509_REQ *X509_REQ_new(void);
 void X509_REQ_free(X509_REQ *);
@@ -69,11 +60,6 @@ int X509_REQ_sign(X509_REQ *, EVP_PKEY *, const EVP_MD *);
 int X509_REQ_verify(X509_REQ *, EVP_PKEY *);
 EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *);
 int X509_REQ_print_ex(BIO *, X509_REQ *, unsigned long, unsigned long);
-int X509_REQ_add_extensions(X509_REQ *, X509_EXTENSIONS *);
-X509_EXTENSIONS *X509_REQ_get_extensions(X509_REQ *);
-
-int X509V3_EXT_print(BIO *, X509_EXTENSION *, unsigned long, int);
-ASN1_OCTET_STRING *X509_EXTENSION_get_data(X509_EXTENSION *);
 
 X509_CRL *d2i_X509_CRL_bio(BIO *, X509_CRL **);
 void X509_CRL_free(X509_CRL *);
@@ -99,11 +85,8 @@ const char *X509_get_default_cert_dir(void);
 const char *X509_get_default_cert_file(void);
 
 int X509_get_ext_count(const X509 *);
-X509_EXTENSION *X509_get_ext(const X509 *, int);
 X509_NAME *X509_get_subject_name(const X509 *);
 X509_NAME *X509_get_issuer_name(const X509 *);
-
-int X509_EXTENSION_get_critical(const X509_EXTENSION *);
 
 const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *);
 
@@ -120,13 +103,6 @@ void sk_X509_free(Cryptography_STACK_OF_X509 *);
 int sk_X509_num(Cryptography_STACK_OF_X509 *);
 int sk_X509_push(Cryptography_STACK_OF_X509 *, X509 *);
 X509 *sk_X509_value(Cryptography_STACK_OF_X509 *, int);
-
-X509_EXTENSIONS *sk_X509_EXTENSION_new_null(void);
-int sk_X509_EXTENSION_num(X509_EXTENSIONS *);
-X509_EXTENSION *sk_X509_EXTENSION_value(X509_EXTENSIONS *, int);
-int sk_X509_EXTENSION_push(X509_EXTENSIONS *, X509_EXTENSION *);
-void sk_X509_EXTENSION_free(X509_EXTENSIONS *);
-void sk_X509_EXTENSION_pop_free(X509_EXTENSIONS *, sk_X509_EXTENSION_freefunc);
 
 void X509_ALGOR_get0(const ASN1_OBJECT **, int *, const void **,
                      const X509_ALGOR *);

--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -131,7 +131,6 @@ int X509_STORE_add_cert(X509_STORE *, X509 *);
 int X509_STORE_add_crl(X509_STORE *, X509_CRL *);
 int X509_STORE_load_locations(X509_STORE *, const char *, const char *);
 int X509_STORE_set1_param(X509_STORE *, X509_VERIFY_PARAM *);
-int X509_STORE_set_default_paths(X509_STORE *);
 int X509_STORE_set_flags(X509_STORE *, unsigned long);
 /* Included due to external consumer, see
    https://github.com/pyca/pyopenssl/issues/1031 */
@@ -141,7 +140,6 @@ void X509_STORE_free(X509_STORE *);
 
 /* X509_STORE_CTX */
 X509_STORE_CTX *X509_STORE_CTX_new(void);
-void X509_STORE_CTX_cleanup(X509_STORE_CTX *);
 void X509_STORE_CTX_free(X509_STORE_CTX *);
 int X509_STORE_CTX_init(X509_STORE_CTX *, X509_STORE *, X509 *,
                         Cryptography_STACK_OF_X509 *);
@@ -157,12 +155,6 @@ X509_VERIFY_PARAM *X509_VERIFY_PARAM_new(void);
 int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *, unsigned long);
 void X509_VERIFY_PARAM_set_time(X509_VERIFY_PARAM *, time_t);
 void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *);
-
-int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *, const char *,
-                                size_t);
-void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *, unsigned int);
-int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *, const unsigned char *,
-                              size_t);
 
 int sk_X509_OBJECT_num(Cryptography_STACK_OF_X509_OBJECT *);
 Cryptography_STACK_OF_X509_OBJECT *X509_STORE_get0_objects(X509_STORE *);

--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -156,6 +156,13 @@ int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *, unsigned long);
 void X509_VERIFY_PARAM_set_time(X509_VERIFY_PARAM *, time_t);
 void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *);
 
+/* Included due to external consumer (mitmproxy) */
+int X509_VERIFY_PARAM_set1_host(X509_VERIFY_PARAM *, const char *,
+                                size_t);
+void X509_VERIFY_PARAM_set_hostflags(X509_VERIFY_PARAM *, unsigned int);
+int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *, const unsigned char *,
+                              size_t);
+
 int sk_X509_OBJECT_num(Cryptography_STACK_OF_X509_OBJECT *);
 Cryptography_STACK_OF_X509_OBJECT *X509_STORE_get0_objects(X509_STORE *);
 

--- a/src/_cffi_src/openssl/x509name.py
+++ b/src/_cffi_src/openssl/x509name.py
@@ -20,7 +20,6 @@ typedef ... Cryptography_STACK_OF_X509_NAME;
 """
 
 FUNCTIONS = """
-X509_NAME *X509_NAME_new(void);
 void X509_NAME_free(X509_NAME *);
 
 unsigned long X509_NAME_hash(X509_NAME *);

--- a/src/_cffi_src/openssl/x509v3.py
+++ b/src/_cffi_src/openssl/x509v3.py
@@ -4,52 +4,25 @@
 
 from __future__ import annotations
 
-import os
-
 INCLUDES = """
 #include <openssl/x509v3.h>
 """
 
-USE_CONST_X509 = bool(os.environ.get("USE_CONST_X509"))
-
-TYPES = f"""
-typedef ... CONF;
-
-typedef struct {{
-    {"const X509" if USE_CONST_X509 else "X509"} *issuer_cert;
-    {"const X509" if USE_CONST_X509 else "X509"} *subject_cert;
-    ...;
-}} X509V3_CTX;
-
-static const int GEN_EMAIL;
-static const int GEN_DNS;
-static const int GEN_URI;
-
+TYPES = """
 typedef ... GENERAL_NAMES;
 
 /* Only include the one union element used by pyOpenSSL. */
-typedef struct {{
+typedef struct {
     int type;
-    union {{
+    union {
         ASN1_IA5STRING *ia5;   /* rfc822Name, dNSName, */
                                /*   uniformResourceIdentifier */
-    }} d;
+    } d;
     ...;
-}} GENERAL_NAME;
+} GENERAL_NAME;
 """
 
 FUNCTIONS = """
-void X509V3_set_ctx(X509V3_CTX *, X509 *, X509 *, X509_REQ *, X509_CRL *, int);
-int GENERAL_NAME_print(BIO *, GENERAL_NAME *);
-void GENERAL_NAMES_free(GENERAL_NAMES *);
-void *X509V3_EXT_d2i(X509_EXTENSION *);
-X509_EXTENSION *X509V3_EXT_nconf(CONF *, X509V3_CTX *, const char *,
-                                 const char *);
-
-void X509V3_set_ctx_nodb(X509V3_CTX *);
-
-int sk_GENERAL_NAME_num(GENERAL_NAMES *);
-GENERAL_NAME *sk_GENERAL_NAME_value(GENERAL_NAMES *, int);
 """
 
 CUSTOMIZATIONS = """

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -22,14 +22,6 @@ fn main() {
         }
     }
 
-    // BoringSSL and AWS-LC use const X509 (OpenSSL does not)
-    let use_const_x509 =
-        if env::var("DEP_OPENSSL_BORINGSSL").is_ok() || env::var("DEP_OPENSSL_AWSLC").is_ok() {
-            "1"
-        } else {
-            ""
-        };
-
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?
     let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
@@ -38,7 +30,6 @@ fn main() {
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)
         .env("OUT_DIR", &out_dir)
-        .env("USE_CONST_X509", use_const_x509)
         .arg("../../_cffi_src/build_openssl.py")
         .output()
         .expect("failed to execute build_openssl.py");


### PR DESCRIPTION
Drops bindings whose git history shows no specific user/consumer request — they were added in bulk during the cffi 1.0 conversion or as generic library setup, and are no longer referenced by cryptography itself. Bindings that were explicitly requested by external consumers (pyOpenSSL, mitmproxy, Tribler, etc.) are retained.

Also removes the now-unused USE_CONST_X509 env var plumbing in build.rs, since the X509V3_CTX struct that depended on it is gone.