### PR TITLE
Fix publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -51,6 +51,8 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          sparse-checkout: ci-constraints-requirements.txt
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - run: python -m pip install -c ci-constraints-requirements.txt 'uv'

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -49,6 +49,10 @@ jobs:
           python-version: '3.14'
         timeout-minutes: 3
 
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - run: python -m pip install -c ci-constraints-requirements.txt 'uv'
 
       - uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20


### PR DESCRIPTION
https://github.com/pyca/cryptography/actions/runs/25347944931/job/74321055630 failed because `ci-constraints-requirements.txt` wasn't checked out.

This checks it out, which is sad because checkouts are slow. We could possibly make it a sparse checkout to be a little faster, although not sure if it matters in the publish job.