### PR TITLE
Simplify ML-DSA and ML-KEM AWS-LC paths using AWS-LC 1.73.0 APIs

### DIFF
--- a/src/rust/cryptography-key-parsing/src/pkcs8.rs
+++ b/src/rust/cryptography-key-parsing/src/pkcs8.rs
@@ -46,32 +46,6 @@ pub enum MlDsaPrivateKey {
     Seed([u8; 32]),
 }
 
-/// Extract the ML-KEM seed from a private key.
-#[cfg(any(
-    CRYPTOGRAPHY_IS_BORINGSSL,
-    CRYPTOGRAPHY_IS_AWSLC,
-    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
-))]
-pub fn mlkem_seed_from_pkey(
-    pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
-) -> Result<MlKemPrivateKey, openssl::error::ErrorStack> {
-    let seed = cryptography_openssl::mlkem::mlkem_seed_raw(pkey)?;
-    Ok(MlKemPrivateKey::Seed(seed))
-}
-
-/// Extract the 32-byte ML-DSA seed from a private key.
-#[cfg(any(
-    CRYPTOGRAPHY_IS_BORINGSSL,
-    CRYPTOGRAPHY_IS_AWSLC,
-    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
-))]
-pub fn mldsa_seed_from_pkey(
-    pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
-) -> Result<MlDsaPrivateKey, openssl::error::ErrorStack> {
-    let seed = cryptography_openssl::mldsa::mldsa_seed_raw(pkey)?;
-    Ok(MlDsaPrivateKey::Seed(seed))
-}
-
 pub fn parse_private_key(data: &[u8]) -> KeyParsingResult<ParsedPrivateKey> {
     let k = asn1::parse_single::<PrivateKeyInfo<'_>>(data)?;
     if k.version != 0 {
@@ -572,7 +546,8 @@ pub fn serialize_private_key(key: &ParsedPrivateKey) -> crate::KeySerializationR
                 CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
             ))]
             _ if cryptography_openssl::mlkem::is_mlkem_pkey(pkey) => {
-                let private_key_der = asn1::write_single(&mlkem_seed_from_pkey(pkey)?)?;
+                let seed = cryptography_openssl::mlkem::mlkem_seed_raw(pkey)?;
+                let private_key_der = asn1::write_single(&MlKemPrivateKey::Seed(seed))?;
                 let params = match cryptography_openssl::mlkem::MlKemVariant::from_pkey(pkey) {
                     cryptography_openssl::mlkem::MlKemVariant::MlKem768 => {
                         AlgorithmParameters::MlKem768
@@ -589,7 +564,8 @@ pub fn serialize_private_key(key: &ParsedPrivateKey) -> crate::KeySerializationR
                 CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
             ))]
             _ if cryptography_openssl::mldsa::is_mldsa_pkey(pkey) => {
-                let private_key_der = asn1::write_single(&mldsa_seed_from_pkey(pkey)?)?;
+                let seed = cryptography_openssl::mldsa::mldsa_seed_raw(pkey)?;
+                let private_key_der = asn1::write_single(&MlDsaPrivateKey::Seed(seed))?;
                 let params = match cryptography_openssl::mldsa::MlDsaVariant::from_pkey(pkey) {
                     cryptography_openssl::mldsa::MlDsaVariant::MlDsa44 => {
                         AlgorithmParameters::MlDsa44

--- a/src/rust/cryptography-key-parsing/src/pkcs8.rs
+++ b/src/rust/cryptography-key-parsing/src/pkcs8.rs
@@ -47,14 +47,6 @@ pub enum MlDsaPrivateKey {
 }
 
 /// Extract the ML-KEM seed from a private key.
-///
-/// For BoringSSL and OpenSSL 3.5+, calls the library's seed extraction API
-/// directly (`EVP_PKEY_get_private_seed` / `PKey::seed_into`).
-///
-/// For AWS-LC, round-trips through PKCS#8 encoding because
-/// `raw_private_key()` returns the 2400-byte expanded key. Since AWS-LC
-/// 1.72.0, `private_key_to_pkcs8()` produces RFC 9935 seed-format PKCS#8
-/// when the key was created from a seed.
 #[cfg(any(
     CRYPTOGRAPHY_IS_BORINGSSL,
     CRYPTOGRAPHY_IS_AWSLC,
@@ -63,26 +55,11 @@ pub enum MlDsaPrivateKey {
 pub fn mlkem_seed_from_pkey(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> Result<MlKemPrivateKey, openssl::error::ErrorStack> {
-    cfg_if::cfg_if! {
-        if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
-            let pkcs8_der = pkey.private_key_to_pkcs8()?;
-            let pki = asn1::parse_single::<PrivateKeyInfo<'_>>(&pkcs8_der).unwrap();
-            Ok(asn1::parse_single::<MlKemPrivateKey>(pki.private_key).unwrap())
-        } else {
-            let seed = cryptography_openssl::mlkem::mlkem_seed_raw(pkey)?;
-            Ok(MlKemPrivateKey::Seed(seed))
-        }
-    }
+    let seed = cryptography_openssl::mlkem::mlkem_seed_raw(pkey)?;
+    Ok(MlKemPrivateKey::Seed(seed))
 }
 
 /// Extract the 32-byte ML-DSA seed from a private key.
-///
-/// For BoringSSL and OpenSSL 3.5+, calls the library's seed extraction API
-/// directly (`EVP_PKEY_get_private_seed` / `PKey::seed_into`).
-///
-/// For AWS-LC, round-trips through PKCS#8 encoding because
-/// `raw_private_key()` returns the expanded key, not the seed
-/// (https://github.com/aws/aws-lc/issues/3072).
 #[cfg(any(
     CRYPTOGRAPHY_IS_BORINGSSL,
     CRYPTOGRAPHY_IS_AWSLC,
@@ -91,16 +68,8 @@ pub fn mlkem_seed_from_pkey(
 pub fn mldsa_seed_from_pkey(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> Result<MlDsaPrivateKey, openssl::error::ErrorStack> {
-    cfg_if::cfg_if! {
-        if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
-            let pkcs8_der = pkey.private_key_to_pkcs8()?;
-            let pki = asn1::parse_single::<PrivateKeyInfo<'_>>(&pkcs8_der).unwrap();
-            Ok(asn1::parse_single::<MlDsaPrivateKey>(pki.private_key).unwrap())
-        } else {
-            let seed = cryptography_openssl::mldsa::mldsa_seed_raw(pkey)?;
-            Ok(MlDsaPrivateKey::Seed(seed))
-        }
-    }
+    let seed = cryptography_openssl::mldsa::mldsa_seed_raw(pkey)?;
+    Ok(MlDsaPrivateKey::Seed(seed))
 }
 
 pub fn parse_private_key(data: &[u8]) -> KeyParsingResult<ParsedPrivateKey> {

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -136,16 +136,17 @@ fn set_context_string<T>(
 }
 
 /// Extract the raw 32-byte seed from an ML-DSA private key.
-///
-/// Avoids the PKCS#8 round-trip that vanilla OpenSSL 3.5 encodes
-/// differently from BoringSSL/AWS-LC.
-#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_OPENSSL_350_OR_GREATER))]
+#[cfg(any(
+    CRYPTOGRAPHY_IS_BORINGSSL,
+    CRYPTOGRAPHY_IS_AWSLC,
+    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
+))]
 pub fn mldsa_seed_raw(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> OpenSSLResult<[u8; 32]> {
     let mut seed = [0u8; 32];
     cfg_if::cfg_if! {
-        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+        if #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))] {
             let mut seed_len = seed.len();
             // SAFETY: pkey is a valid EVP_PKEY and seed is a 32-byte buffer.
             unsafe {

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -136,11 +136,6 @@ fn set_context_string<T>(
 }
 
 /// Extract the raw 32-byte seed from an ML-DSA private key.
-#[cfg(any(
-    CRYPTOGRAPHY_IS_BORINGSSL,
-    CRYPTOGRAPHY_IS_AWSLC,
-    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
-))]
 pub fn mldsa_seed_raw(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> OpenSSLResult<[u8; 32]> {

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -113,13 +113,12 @@ fn evp_pkey_alg(variant: MlDsaVariant) -> *const ffi::EVP_PKEY_ALG {
     }
 }
 
-#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_OPENSSL_350_OR_GREATER))]
 fn set_context_string<T>(
     pkey_ctx: &mut openssl::pkey_ctx::PkeyCtxRef<T>,
     context: &[u8],
 ) -> OpenSSLResult<()> {
     cfg_if::cfg_if! {
-        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+        if #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))] {
             // SAFETY: pkey_ctx is a valid EVP_PKEY_CTX.
             let res = unsafe {
                 ffi::EVP_PKEY_CTX_set1_signature_context_string(
@@ -134,72 +133,6 @@ fn set_context_string<T>(
         }
     }
     Ok(())
-}
-
-#[cfg(CRYPTOGRAPHY_IS_AWSLC)]
-extern "C" {
-    // We call ml_dsa_{44,65}_sign/verify directly instead of going through
-    // EVP_DigestSign/EVP_DigestVerify because the EVP PQDSA path hardcodes
-    // context to (NULL, 0), so we'd lose context string support.
-    fn ml_dsa_44_sign(
-        private_key: *const u8,
-        sig: *mut u8,
-        sig_len: *mut usize,
-        message: *const u8,
-        message_len: usize,
-        ctx_string: *const u8,
-        ctx_string_len: usize,
-    ) -> c_int;
-
-    fn ml_dsa_44_verify(
-        public_key: *const u8,
-        sig: *const u8,
-        sig_len: usize,
-        message: *const u8,
-        message_len: usize,
-        ctx_string: *const u8,
-        ctx_string_len: usize,
-    ) -> c_int;
-
-    fn ml_dsa_65_sign(
-        private_key: *const u8,
-        sig: *mut u8,
-        sig_len: *mut usize,
-        message: *const u8,
-        message_len: usize,
-        ctx_string: *const u8,
-        ctx_string_len: usize,
-    ) -> c_int;
-
-    fn ml_dsa_65_verify(
-        public_key: *const u8,
-        sig: *const u8,
-        sig_len: usize,
-        message: *const u8,
-        message_len: usize,
-        ctx_string: *const u8,
-        ctx_string_len: usize,
-    ) -> c_int;
-
-    fn ml_dsa_87_sign(
-        private_key: *const u8,
-        sig: *mut u8,
-        sig_len: *mut usize,
-        message: *const u8,
-        message_len: usize,
-        ctx_string: *const u8,
-        ctx_string_len: usize,
-    ) -> c_int;
-
-    fn ml_dsa_87_verify(
-        public_key: *const u8,
-        sig: *const u8,
-        sig_len: usize,
-        message: *const u8,
-        message_len: usize,
-        ctx_string: *const u8,
-        ctx_string_len: usize,
-    ) -> c_int;
 }
 
 /// Extract the raw 32-byte seed from an ML-DSA private key.
@@ -311,68 +244,14 @@ pub fn sign(
     data: &[u8],
     context: &[u8],
 ) -> OpenSSLResult<Vec<u8>> {
-    cfg_if::cfg_if! {
-        if #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_OPENSSL_350_OR_GREATER))] {
-            let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
-            let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;
-            if !context.is_empty() {
-                set_context_string(pkey_ctx, context)?;
-            }
-            let mut sig = vec![];
-            md_ctx.digest_sign_to_vec(data, &mut sig)?;
-            Ok(sig)
-        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
-            let raw_key = pkey.raw_private_key()?;
-            let variant = MlDsaVariant::from_pkey(pkey);
-
-            type SignFn = unsafe extern "C" fn(
-                *const u8,
-                *mut u8,
-                *mut usize,
-                *const u8,
-                usize,
-                *const u8,
-                usize,
-            ) -> c_int;
-            let (signature_bytes, sign_func): (usize, SignFn) = match variant {
-                MlDsaVariant::MlDsa44 => (2420, ml_dsa_44_sign),
-                MlDsaVariant::MlDsa65 => (3309, ml_dsa_65_sign),
-                MlDsaVariant::MlDsa87 => (4627, ml_dsa_87_sign),
-            };
-
-            let mut sig = vec![0u8; signature_bytes];
-            let mut sig_len: usize = 0;
-
-            let msg_ptr = if data.is_empty() {
-                std::ptr::null()
-            } else {
-                data.as_ptr()
-            };
-            let ctx_ptr = if context.is_empty() {
-                std::ptr::null()
-            } else {
-                context.as_ptr()
-            };
-
-            // SAFETY: The sign function takes raw key bytes, message, and
-            // context.
-            unsafe {
-                let r = sign_func(
-                    raw_key.as_ptr(),
-                    sig.as_mut_ptr(),
-                    &mut sig_len,
-                    msg_ptr,
-                    data.len(),
-                    ctx_ptr,
-                    context.len(),
-                );
-                cvt(r)?;
-            }
-
-            sig.truncate(sig_len);
-            Ok(sig)
-        }
+    let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
+    let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;
+    if !context.is_empty() {
+        set_context_string(pkey_ctx, context)?;
     }
+    let mut sig = vec![];
+    md_ctx.digest_sign_to_vec(data, &mut sig)?;
+    Ok(sig)
 }
 
 pub fn verify(
@@ -381,67 +260,12 @@ pub fn verify(
     data: &[u8],
     context: &[u8],
 ) -> OpenSSLResult<bool> {
-    cfg_if::cfg_if! {
-        if #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_OPENSSL_350_OR_GREATER))] {
-            let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
-            let pkey_ctx = md_ctx.digest_verify_init(None, pkey)?;
-            if !context.is_empty() {
-                set_context_string(pkey_ctx, context)?;
-            }
-            Ok(md_ctx.digest_verify(data, signature).unwrap_or(false))
-        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
-            let raw_key = pkey.raw_public_key()?;
-            let variant = MlDsaVariant::from_pkey(pkey);
-
-            type VerifyFn = unsafe extern "C" fn(
-                *const u8,
-                *const u8,
-                usize,
-                *const u8,
-                usize,
-                *const u8,
-                usize,
-            ) -> c_int;
-            let verify_func: VerifyFn = match variant {
-                MlDsaVariant::MlDsa44 => ml_dsa_44_verify,
-                MlDsaVariant::MlDsa65 => ml_dsa_65_verify,
-                MlDsaVariant::MlDsa87 => ml_dsa_87_verify,
-            };
-
-            let msg_ptr = if data.is_empty() {
-                std::ptr::null()
-            } else {
-                data.as_ptr()
-            };
-            let ctx_ptr = if context.is_empty() {
-                std::ptr::null()
-            } else {
-                context.as_ptr()
-            };
-
-            // SAFETY: The verify function takes raw key bytes, signature,
-            // message, and context.
-            let r = unsafe {
-                verify_func(
-                    raw_key.as_ptr(),
-                    signature.as_ptr(),
-                    signature.len(),
-                    msg_ptr,
-                    data.len(),
-                    ctx_ptr,
-                    context.len(),
-                )
-            };
-
-            if r != 1 {
-                // Clear any errors from the OpenSSL error stack to prevent
-                // leaking errors into subsequent operations.
-                let _ = openssl::error::ErrorStack::get();
-            }
-
-            Ok(r == 1)
-        }
+    let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
+    let pkey_ctx = md_ctx.digest_verify_init(None, pkey)?;
+    if !context.is_empty() {
+        set_context_string(pkey_ctx, context)?;
     }
+    Ok(md_ctx.digest_verify(data, signature).unwrap_or(false))
 }
 
 #[cfg(test)]

--- a/src/rust/cryptography-openssl/src/mlkem.rs
+++ b/src/rust/cryptography-openssl/src/mlkem.rs
@@ -116,11 +116,6 @@ extern "C" {
 }
 
 /// Extract the raw 64-byte seed from an ML-KEM private key.
-#[cfg(any(
-    CRYPTOGRAPHY_IS_BORINGSSL,
-    CRYPTOGRAPHY_IS_AWSLC,
-    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
-))]
 pub fn mlkem_seed_raw(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> OpenSSLResult<[u8; 64]> {

--- a/src/rust/cryptography-openssl/src/mlkem.rs
+++ b/src/rust/cryptography-openssl/src/mlkem.rs
@@ -116,16 +116,17 @@ extern "C" {
 }
 
 /// Extract the raw 64-byte seed from an ML-KEM private key.
-///
-/// Avoids the PKCS#8 round-trip that vanilla OpenSSL 3.5 encodes
-/// differently from BoringSSL/AWS-LC.
-#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_OPENSSL_350_OR_GREATER))]
+#[cfg(any(
+    CRYPTOGRAPHY_IS_BORINGSSL,
+    CRYPTOGRAPHY_IS_AWSLC,
+    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
+))]
 pub fn mlkem_seed_raw(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> OpenSSLResult<[u8; 64]> {
     let mut seed = [0u8; 64];
     cfg_if::cfg_if! {
-        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+        if #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))] {
             let mut seed_len = seed.len();
             // SAFETY: pkey is a valid EVP_PKEY and seed is a 64-byte buffer.
             unsafe {

--- a/src/rust/cryptography-openssl/src/mlkem.rs
+++ b/src/rust/cryptography-openssl/src/mlkem.rs
@@ -3,7 +3,7 @@
 // for complete details.
 
 use foreign_types_shared::ForeignType;
-#[cfg(CRYPTOGRAPHY_IS_BORINGSSL)]
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
 use foreign_types_shared::ForeignTypeRef;
 use openssl_sys as ffi;
 #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
@@ -67,16 +67,12 @@ impl MlKemVariant {
                     _ => panic!("Unsupported ML-KEM variant"),
                 }
             } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
-                // AWS-LC is missing the equivalent `EVP_PKEY_pqdsa_get_type`,
-                // so we are using the key size as a discriminator to find the
-                // variant.
-                let len = pkey
-                    .raw_public_key()
-                    .expect("valid ML-KEM public key")
-                    .len();
-                match len {
-                    1184 => MlKemVariant::MlKem768,
-                    1568 => MlKemVariant::MlKem1024,
+                // SAFETY: EVP_PKEY_kem_get_type returns the NID of the KEM
+                // algorithm for a valid KEM pkey.
+                let nid = unsafe { ffi::EVP_PKEY_kem_get_type(pkey.as_ptr()) };
+                match nid {
+                    ffi::NID_MLKEM768 => MlKemVariant::MlKem768,
+                    ffi::NID_MLKEM1024 => MlKemVariant::MlKem1024,
                     _ => panic!("Unsupported ML-KEM variant"),
                 }
             } else if #[cfg(CRYPTOGRAPHY_OPENSSL_350_OR_GREATER)] {

--- a/src/rust/src/backend/mldsa.rs
+++ b/src/rust/src/backend/mldsa.rs
@@ -109,8 +109,7 @@ impl MlDsa44PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+        let seed = cryptography_openssl::mldsa::mldsa_seed_raw(&self.pkey)?;
         Ok(pyo3::types::PyBytes::new(py, &seed))
     }
 
@@ -313,8 +312,7 @@ impl MlDsa65PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+        let seed = cryptography_openssl::mldsa::mldsa_seed_raw(&self.pkey)?;
         Ok(pyo3::types::PyBytes::new(py, &seed))
     }
 
@@ -520,8 +518,7 @@ impl MlDsa87PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        let cryptography_key_parsing::pkcs8::MlDsaPrivateKey::Seed(seed) =
-            cryptography_key_parsing::pkcs8::mldsa_seed_from_pkey(&self.pkey)?;
+        let seed = cryptography_openssl::mldsa::mldsa_seed_raw(&self.pkey)?;
         Ok(pyo3::types::PyBytes::new(py, &seed))
     }
 

--- a/src/rust/src/backend/mlkem.rs
+++ b/src/rust/src/backend/mlkem.rs
@@ -124,8 +124,7 @@ impl MlKem768PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        let cryptography_key_parsing::pkcs8::MlKemPrivateKey::Seed(seed) =
-            cryptography_key_parsing::pkcs8::mlkem_seed_from_pkey(&self.pkey)?;
+        let seed = cryptography_openssl::mlkem::mlkem_seed_raw(&self.pkey)?;
         Ok(pyo3::types::PyBytes::new(py, &seed))
     }
 
@@ -275,8 +274,7 @@ impl MlKem1024PrivateKey {
         &self,
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-        let cryptography_key_parsing::pkcs8::MlKemPrivateKey::Seed(seed) =
-            cryptography_key_parsing::pkcs8::mlkem_seed_from_pkey(&self.pkey)?;
+        let seed = cryptography_openssl::mlkem::mlkem_seed_raw(&self.pkey)?;
         Ok(pyo3::types::PyBytes::new(py, &seed))
     }
 


### PR DESCRIPTION
AWS-LC 1.73.0 added three APIs that let us drop AWS-LC-specific
workarounds in our ML-DSA and ML-KEM code. CI is already pinned to
v1.73.0.

* **`EVP_PKEY_CTX_set1_signature_context_string`** ([aws/aws-lc#3135](https://github.com/aws/aws-lc/pull/3135)) for ML-DSA
  EVP sign/verify. Previously the EVP PQDSA path hardcoded the context
  to `(NULL, 0)`, so AWS-LC had to call the raw `ml_dsa_{44,65,87}_sign`
  / `_verify` functions directly. AWS-LC now joins the BoringSSL /
  OpenSSL 3.5 `EVP_DigestSign` / `EVP_DigestVerify` path, removing
  ~150 lines of `extern "C"` declarations, hardcoded signature-size
  tables and manual error-stack draining.

* **`EVP_PKEY_kem_get_type`** ([aws/aws-lc#3179](https://github.com/aws/aws-lc/pull/3179)) returns the KEM key NID, so
  `MlKemVariant::from_pkey` can do a direct NID lookup on AWS-LC
  instead of discriminating ML-KEM-768 vs ML-KEM-1024 by public-key
  byte length.

* **`EVP_PKEY_get_private_seed`** ([aws/aws-lc#3200](https://github.com/aws/aws-lc/pull/3200)) for KEM and PQDSA
  keys, with the same signature as BoringSSL's. The AWS-LC PKCS#8
  round-trip in `mldsa_seed_from_pkey` / `mlkem_seed_from_pkey` is
  gone — both wrappers fold into a single helper call. Since the
  five backend callers only need the raw seed bytes, the wrappers are
  removed entirely; the two ASN.1 serialization sites construct
  `MlKemPrivateKey::Seed(...)` / `MlDsaPrivateKey::Seed(...)` inline.

Net change across the three commits: **+45 / −283**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZKqdgDtqU9eSf3Xsv2cVF)_