### PR TITLE
Poly1305 is available whenever AWS-LC is backing

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -303,6 +303,8 @@ class Backend:
         )
 
     def poly1305_supported(self) -> bool:
+        if rust_openssl.CRYPTOGRAPHY_IS_AWSLC:
+            return True
         return not self._fips_enabled
 
     def pkcs7_supported(self) -> bool:


### PR DESCRIPTION
Poly1305 is always available when AWS-LC is the backend, regardless of FIPS mode. The Rust backend already handles this correctly - when compiled with CRYPTOGRAPHY_IS_AWSLC, the Poly1305Boring path is used which has no FIPS gate. However, the Python-side poly1305_supported() unconditionally returns False when FIPS is enabled, causing tests to be skipped and the algorithm to appear unsupported.

This aligns the Python backend method with the actual Rust/C behavior.