### PR TITLE
Lower cffi version requirement from >=2.0.0 to >=1.16

### DIFF
--- a/.github/requirements/build-requirements.in
+++ b/.github/requirements/build-requirements.in
@@ -1,6 +1,7 @@
 # Must be kept sync with build-system.requires at pyproject.toml
 setuptools!=74.0.0
-cffi>=2.0.0; platform_python_implementation != 'PyPy'
+cffi>=1.16; python_version < '3.13' and platform_python_implementation != 'PyPy'
+cffi>=2.0.0; python_version >= '3.13' and platform_python_implementation != 'PyPy'
 maturin>=1,<2
 
 # Must be kept sync with build-system.requires at vectors/pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ requires = [
     "maturin>=1.9.4,<2,!=1.12.0",
 
     # Must be kept in sync with `project.dependencies`
-    "cffi>=2.0.0; platform_python_implementation != 'PyPy'",
+    "cffi>=1.16; python_version < '3.13' and platform_python_implementation != 'PyPy'",
+    "cffi>=2.0.0; python_version >= '3.13' and platform_python_implementation != 'PyPy'",
     # Used by cffi (which import distutils, and in Python 3.12, distutils has
     # been removed from the stdlib, but installing setuptools puts it back) as
     # well as our build.rs for the rust/cffi bridge.
@@ -49,7 +50,8 @@ classifiers = [
 requires-python = ">=3.9,!=3.9.0,!=3.9.1"
 dependencies = [
     # Must be kept in sync with `build-system.requires`
-    "cffi>=2.0.0; platform_python_implementation != 'PyPy'",
+    "cffi>=1.16; python_version < '3.13' and platform_python_implementation != 'PyPy'",
+    "cffi>=2.0.0; python_version >= '3.13' and platform_python_implementation != 'PyPy'",
     # Must be kept in sync with ./.github/requirements/build-requirements.{in,txt}
     "typing-extensions>=4.13.2; python_version < '3.11'",
 ]


### PR DESCRIPTION
Some distros don't have cffi >= 2.0.0 yet.  v1.16 still works, so
reduce the lower bound.