### PR TITLE
Migrate from tibdex/github-app-token to actions/create-github-app-token

### DIFF
--- a/.github/workflows/boring-open-awslc-bump.yml
+++ b/.github/workflows/boring-open-awslc-bump.yml
@@ -53,11 +53,11 @@ jobs:
             --tag-pattern 'v[0-9\.]*'
       - name: Check for updates
         run: git status
-      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app_id: ${{ secrets.BORINGBOT_APP_ID }}
-          private_key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.BORINGBOT_APP_ID }}
+          private-key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
         if: steps.bump-boringssl.outputs.HAS_UPDATES == 'true' || steps.bump-openssl.outputs.HAS_UPDATES == 'true' || steps.bump-awslc.outputs.HAS_UPDATES == 'true'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/downstream-version-bump.yml
+++ b/.github/workflows/downstream-version-bump.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Parse downstream dependencies
         id: downstream-bump
         run: ./.github/bin/bump_downstreams.sh
-      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app_id: ${{ secrets.BORINGBOT_APP_ID }}
-          private_key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.BORINGBOT_APP_ID }}
+          private-key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
         if: steps.downstream-bump.outputs.HAS_UPDATES == 'true'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/x509-limbo-version-bump.yml
+++ b/.github/workflows/x509-limbo-version-bump.yml
@@ -39,11 +39,11 @@ jobs:
             --comment-pattern 'Latest commit on the wycheproof main branch.*?\.'
       - name: Check for updates
         run: git status
-      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app_id: ${{ secrets.BORINGBOT_APP_ID }}
-          private_key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.BORINGBOT_APP_ID }}
+          private-key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
         if: steps.bump-x509-limbo.outputs.HAS_UPDATES == 'true' || steps.bump-wycheproof.outputs.HAS_UPDATES == 'true'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
## Summary

- Replace the unmaintained `tibdex/github-app-token` action with the official `actions/create-github-app-token` in all three version-bump workflows
- Pin to `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3.2.0), matching this repo's SHA-pinning convention
- Rename the inputs `app_id` → `app-id` and `private_key` → `private-key` (the new action uses hyphenated input names); the `outputs.token` name is unchanged so no downstream references needed edits

Files changed:
- `.github/workflows/downstream-version-bump.yml`
- `.github/workflows/x509-limbo-version-bump.yml`
- `.github/workflows/boring-open-awslc-bump.yml`

## Test plan

- [ ] CI passes
- [ ] On next scheduled run, the version-bump workflows successfully generate an app token and open their PRs as `pyca-boringbot[bot]`

https://claude.ai/code/session_013DRNYbEYkxutfjFwFpG3tZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013DRNYbEYkxutfjFwFpG3tZ)_