### PR TITLE
Scope down create-github-app-token permissions in bump workflows

### DIFF
--- a/.github/workflows/boring-open-awslc-bump.yml
+++ b/.github/workflows/boring-open-awslc-bump.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           app-id: ${{ secrets.BORINGBOT_APP_ID }}
           private-key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
         if: steps.bump-boringssl.outputs.HAS_UPDATES == 'true' || steps.bump-openssl.outputs.HAS_UPDATES == 'true' || steps.bump-awslc.outputs.HAS_UPDATES == 'true'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/downstream-version-bump.yml
+++ b/.github/workflows/downstream-version-bump.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           app-id: ${{ secrets.BORINGBOT_APP_ID }}
           private-key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
         if: steps.downstream-bump.outputs.HAS_UPDATES == 'true'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/x509-limbo-version-bump.yml
+++ b/.github/workflows/x509-limbo-version-bump.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           app-id: ${{ secrets.BORINGBOT_APP_ID }}
           private-key: ${{ secrets.BORINGBOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
         if: steps.bump-x509-limbo.outputs.HAS_UPDATES == 'true' || steps.bump-wycheproof.outputs.HAS_UPDATES == 'true'
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
## Summary

`actions/create-github-app-token` mints a token carrying **every** permission the BoringBot app's installation has, by default. In the three daily dependency-bump workflows that token is only used by `peter-evans/create-pull-request` to push a branch and open a PR.

This scopes each generated token down to the minimum required:

- `permission-contents: write`
- `permission-pull-requests: write`

Affected workflows:

- `.github/workflows/downstream-version-bump.yml`
- `.github/workflows/x509-limbo-version-bump.yml`
- `.github/workflows/boring-open-awslc-bump.yml`

This limits blast radius: a compromise of any of these workflow runs can no longer leverage the broader app installation permissions.

## Test plan

- [ ] Confirm `peter-evans/create-pull-request` still succeeds on the next scheduled (or `workflow_dispatch`) run — it requires only `contents: write` and `pull-requests: write`, both of which are granted.

https://claude.ai/code/session_015kWwkXkn8vzX14psMPDtb2

---
_Generated by [Claude Code](https://claude.ai/code/session_015kWwkXkn8vzX14psMPDtb2)_