### PR TITLE
Add ML-DSA signature and public key algorithm OID constants

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,12 +12,6 @@ Changelog
   We now only publish ``arm64`` wheels for macOS.
 * **BACKWARDS INCOMPATIBLE:** Support for 32-bit Windows has been removed.
   Users should move to a 64-bit Python installation.
-* Added :attr:`~cryptography.x509.oid.SignatureAlgorithmOID.ML_DSA_44`,
-  :attr:`~cryptography.x509.oid.SignatureAlgorithmOID.ML_DSA_65`,
-  :attr:`~cryptography.x509.oid.SignatureAlgorithmOID.ML_DSA_87`,
-  :attr:`~cryptography.x509.oid.PublicKeyAlgorithmOID.ML_DSA_44`,
-  :attr:`~cryptography.x509.oid.PublicKeyAlgorithmOID.ML_DSA_65`, and
-  :attr:`~cryptography.x509.oid.PublicKeyAlgorithmOID.ML_DSA_87`.
 
 .. _v48-0-0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,12 @@ Changelog
   We now only publish ``arm64`` wheels for macOS.
 * **BACKWARDS INCOMPATIBLE:** Support for 32-bit Windows has been removed.
   Users should move to a 64-bit Python installation.
+* Added :attr:`~cryptography.x509.oid.SignatureAlgorithmOID.ML_DSA_44`,
+  :attr:`~cryptography.x509.oid.SignatureAlgorithmOID.ML_DSA_65`,
+  :attr:`~cryptography.x509.oid.SignatureAlgorithmOID.ML_DSA_87`,
+  :attr:`~cryptography.x509.oid.PublicKeyAlgorithmOID.ML_DSA_44`,
+  :attr:`~cryptography.x509.oid.PublicKeyAlgorithmOID.ML_DSA_65`, and
+  :attr:`~cryptography.x509.oid.PublicKeyAlgorithmOID.ML_DSA_87`.
 
 .. _v48-0-0:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -3774,6 +3774,27 @@ instances. The following common OIDs are available as constants.
         Corresponds to the dotted string ``"1.3.101.113"``. This is a signature
         using an ed448 key.
 
+    .. attribute:: ML_DSA_44
+
+        .. versionadded:: 49.0.0
+
+        Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.17"``. This is
+        a signature using an ML-DSA-44 key.
+
+    .. attribute:: ML_DSA_65
+
+        .. versionadded:: 49.0.0
+
+        Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.18"``. This is
+        a signature using an ML-DSA-65 key.
+
+    .. attribute:: ML_DSA_87
+
+        .. versionadded:: 49.0.0
+
+        Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.19"``. This is
+        a signature using an ML-DSA-87 key.
+
 
 .. class:: ExtendedKeyUsageOID
     :canonical: cryptography.hazmat._oid.ExtendedKeyUsageOID
@@ -4246,6 +4267,30 @@ instances. The following common OIDs are available as constants.
 
         Corresponds to the dotted string ``"1.3.101.113"``. This is a
         :class:`~cryptography.hazmat.primitives.asymmetric.ed448.Ed448PublicKey`
+        public key.
+
+    .. attribute:: ML_DSA_44
+
+        .. versionadded:: 49.0.0
+
+        Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.17"``. This is
+        a :class:`~cryptography.hazmat.primitives.asymmetric.mldsa.MLDSA44PublicKey`
+        public key.
+
+    .. attribute:: ML_DSA_65
+
+        .. versionadded:: 49.0.0
+
+        Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.18"``. This is
+        a :class:`~cryptography.hazmat.primitives.asymmetric.mldsa.MLDSA65PublicKey`
+        public key.
+
+    .. attribute:: ML_DSA_87
+
+        .. versionadded:: 49.0.0
+
+        Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.19"``. This is
+        a :class:`~cryptography.hazmat.primitives.asymmetric.mldsa.MLDSA87PublicKey`
         public key.
 
 

--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -119,6 +119,9 @@ class SignatureAlgorithmOID:
     DSA_WITH_SHA512 = ObjectIdentifier("2.16.840.1.101.3.4.3.4")
     ED25519 = ObjectIdentifier("1.3.101.112")
     ED448 = ObjectIdentifier("1.3.101.113")
+    ML_DSA_44 = ObjectIdentifier("2.16.840.1.101.3.4.3.17")
+    ML_DSA_65 = ObjectIdentifier("2.16.840.1.101.3.4.3.18")
+    ML_DSA_87 = ObjectIdentifier("2.16.840.1.101.3.4.3.19")
     GOSTR3411_94_WITH_3410_2001 = ObjectIdentifier("1.2.643.2.2.3")
     GOSTR3410_2012_WITH_3411_2012_256 = ObjectIdentifier("1.2.643.7.1.1.3.2")
     GOSTR3410_2012_WITH_3411_2012_512 = ObjectIdentifier("1.2.643.7.1.1.3.3")
@@ -181,6 +184,9 @@ class PublicKeyAlgorithmOID:
     X448 = ObjectIdentifier("1.3.101.111")
     ED25519 = ObjectIdentifier("1.3.101.112")
     ED448 = ObjectIdentifier("1.3.101.113")
+    ML_DSA_44 = ObjectIdentifier("2.16.840.1.101.3.4.3.17")
+    ML_DSA_65 = ObjectIdentifier("2.16.840.1.101.3.4.3.18")
+    ML_DSA_87 = ObjectIdentifier("2.16.840.1.101.3.4.3.19")
 
 
 class ExtendedKeyUsageOID:
@@ -276,6 +282,9 @@ _OID_NAMES = {
     SignatureAlgorithmOID.DSA_WITH_SHA256: "dsa-with-sha256",
     SignatureAlgorithmOID.ED25519: "ed25519",
     SignatureAlgorithmOID.ED448: "ed448",
+    SignatureAlgorithmOID.ML_DSA_44: "ML-DSA-44",
+    SignatureAlgorithmOID.ML_DSA_65: "ML-DSA-65",
+    SignatureAlgorithmOID.ML_DSA_87: "ML-DSA-87",
     SignatureAlgorithmOID.GOSTR3411_94_WITH_3410_2001: (
         "GOST R 34.11-94 with GOST R 34.10-2001"
     ),


### PR DESCRIPTION
## Summary

Adds the ML-DSA (FIPS 204) algorithm OID constants to the public OID classes:

- `SignatureAlgorithmOID.ML_DSA_44` / `ML_DSA_65` / `ML_DSA_87`
- `PublicKeyAlgorithmOID.ML_DSA_44` / `ML_DSA_65` / `ML_DSA_87`

These correspond to the dotted strings `2.16.840.1.101.3.4.3.17`, `.18`, and `.19`. The change also registers their human-readable names in `_OID_NAMES` and documents them in the X.509 reference.

This is a small, purely-additive precursor split out from the larger work to support ML-DSA keys/signatures in X.509 (certificates, CSRs, CRLs), so the constants can be reviewed on their own.

## Test plan

- [ ] `SignatureAlgorithmOID.ML_DSA_{44,65,87}` and `PublicKeyAlgorithmOID.ML_DSA_{44,65,87}` resolve to the correct dotted strings
- [ ] The new OIDs have `_OID_NAMES` entries (`ML-DSA-44`/`-65`/`-87`)
- [ ] `ruff` lint/format pass

https://claude.ai/code/session_01ENDmAD4rsLTkCw1QG9txBL

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENDmAD4rsLTkCw1QG9txBL)_