### PR TITLE
[CI] Move Windows CI/wheel jobs into composite actions

### DIFF
--- a/.github/actions/windows-tests/action.yml
+++ b/.github/actions/windows-tests/action.yml
@@ -1,0 +1,70 @@
+name: Windows tests
+description: |
+  Runs the cryptography test suite on Windows. Used by ci.yml for both
+  x64 and arm64 jobs to avoid duplication.
+
+inputs:
+  python-version:
+    description: "Python version to test (e.g. 3.9, 3.14, 3.14t)"
+    required: true
+  noxsession:
+    description: "Nox session to run (e.g. tests, tests-nocoverage)"
+    required: true
+  arch:
+    description: "actions/setup-python architecture (x86, x64, arm64)"
+    required: true
+  openssl-name:
+    description: "OpenSSL artifact name suffix (win32, win64, arm64)"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Setup python
+      id: setup-python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: ${{ inputs.python-version }}
+        architecture: ${{ inputs.arch }}
+        cache: pip
+        cache-dependency-path: ci-constraints-requirements.txt
+    - run: rustup component add llvm-tools-preview
+      shell: bash
+    - name: Cache rust and pip
+      uses: ./.github/actions/cache
+      with:
+        key: ${{ inputs.noxsession }}-${{ inputs.arch }}-${{ steps.setup-python.outputs.python-version }}
+    - run: python -m pip install -c ci-constraints-requirements.txt "nox[uv]" "tomli; python_version < '3.11'"
+      shell: bash
+
+    - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+      with:
+        repo: pyca/infra
+        workflow: build-windows-openssl.yml
+        branch: main
+        workflow_conclusion: success
+        name: "openssl-${{ inputs.openssl-name }}"
+        path: "C:/openssl-${{ inputs.openssl-name }}/"
+        github_token: ${{ github.token }}
+    - name: Configure
+      run: |
+          echo "OPENSSL_DIR=C:/openssl-${OPENSSL_NAME}" >> $GITHUB_ENV
+      env:
+        OPENSSL_NAME: ${{ inputs.openssl-name }}
+      shell: bash
+
+    - name: Clone test vectors
+      uses: ./.github/actions/fetch-vectors
+
+    - name: Build nox environment
+      run: nox -v --install-only
+      env:
+        NOXSESSION: ${{ inputs.noxsession }}
+      shell: bash
+    - name: Tests
+      run: nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo
+      env:
+        NOXSESSION: ${{ inputs.noxsession }}
+        COLUMNS: 80
+      shell: bash

--- a/.github/actions/windows-wheel/action.yml
+++ b/.github/actions/windows-wheel/action.yml
@@ -1,0 +1,94 @@
+name: Windows wheel
+description: |
+  Builds (and smoke-tests) a cryptography wheel on Windows. Used by
+  wheel-builder.yml for both x64 and arm64 jobs to avoid duplication.
+
+inputs:
+  python-version:
+    description: "Python version to build for (e.g. 3.14, 3.14t, pypy-3.11)"
+    required: true
+  abi-version:
+    description: "Optional limited-API ABI version (e.g. py39, py311)"
+    required: false
+    default: ""
+  arch:
+    description: "actions/setup-python architecture (x86, x64, arm64)"
+    required: true
+  rust-triple:
+    description: "Rust target triple"
+    required: true
+  openssl-name:
+    description: "OpenSSL artifact name suffix (win32, win64, arm64)"
+    required: true
+  build-requirements-path:
+    description: "Path to build-requirements.txt"
+    required: true
+  uv-requirements-path:
+    description: "Path to uv-requirements.txt"
+    required: true
+  wheel-artifact-name:
+    description: "Name of the uploaded wheel artifact"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: cryptography-sdist
+
+    - name: Setup python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: ${{ inputs.python-version }}
+        architecture: ${{ inputs.arch }}
+    - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+      with:
+        toolchain: stable
+        target: ${{ inputs.rust-triple }}
+
+    - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+      with:
+        repo: pyca/infra
+        workflow: build-windows-openssl.yml
+        branch: main
+        workflow_conclusion: success
+        name: "openssl-${{ inputs.openssl-name }}"
+        path: "C:/openssl-${{ inputs.openssl-name }}/"
+        github_token: ${{ github.token }}
+    - name: Configure OpenSSL
+      run: |
+          echo "OPENSSL_DIR=C:/openssl-${OPENSSL_NAME}" >> $GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $GITHUB_ENV
+      env:
+        OPENSSL_NAME: ${{ inputs.openssl-name }}
+      shell: bash
+
+    - run: pip install -r "${UV_REQUIREMENTS_PATH}"
+      env:
+        UV_REQUIREMENTS_PATH: ${{ inputs.uv-requirements-path }}
+      shell: bash
+    - run: mkdir wheelhouse
+      shell: bash
+    - run: |
+        if [ -n "${ABI_VERSION}" ]; then
+            PY_LIMITED_API="--config-settings=build-args=--features=pyo3/abi3-${ABI_VERSION}"
+        fi
+
+        uv build --wheel --require-hashes --build-constraint="${BUILD_REQUIREMENTS_PATH}" cryptography*.tar.gz $PY_LIMITED_API --config-settings=build-args=--sbom-include="C:/openssl-${OPENSSL_NAME}/sbom.json" -o wheelhouse/
+      env:
+        ABI_VERSION: ${{ inputs.abi-version }}
+        BUILD_REQUIREMENTS_PATH: ${{ inputs.build-requirements-path }}
+        OPENSSL_NAME: ${{ inputs.openssl-name }}
+      shell: bash
+
+    - name: Smoketest
+      uses: ./.github/actions/wheel-smoketest
+      with:
+        build-requirements-path: ${{ inputs.build-requirements-path }}
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.wheel-artifact-name }}
+        path: wheelhouse\

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,50 +351,12 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
-      - name: Setup python
-        id: setup-python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: ./.github/actions/windows-tests
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
-          architecture: ${{ matrix.WINDOWS.ARCH }}
-          cache: pip
-          cache-dependency-path: ci-constraints-requirements.txt
-        timeout-minutes: 3
-      - run: rustup component add llvm-tools-preview
-      - name: Cache rust and pip
-        uses: ./.github/actions/cache
-        timeout-minutes: 2
-        with:
-          key: ${{ matrix.PYTHON.NOXSESSION }}-${{ matrix.WINDOWS.ARCH }}-${{ steps.setup-python.outputs.python-version }}
-      - run: python -m pip install -c ci-constraints-requirements.txt "nox[uv]" "tomli; python_version < '3.11'"
-
-      - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          repo: pyca/infra
-          workflow: build-windows-openssl.yml
-          branch: main
-          workflow_conclusion: success
-          name: "openssl-${{ matrix.WINDOWS.WINDOWS }}"
-          path: "C:/openssl-${{ matrix.WINDOWS.WINDOWS }}/"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Configure
-        run: |
-            echo "OPENSSL_DIR=C:/openssl-${{ matrix.WINDOWS.WINDOWS }}" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Clone test vectors
-        timeout-minutes: 2
-        uses: ./.github/actions/fetch-vectors
-
-      - name: Build nox environment
-        run: nox -v --install-only
-        env:
-          NOXSESSION: ${{ matrix.PYTHON.NOXSESSION }}
-      - name: Tests
-        run: nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo
-        env:
-          NOXSESSION: ${{ matrix.PYTHON.NOXSESSION }}
-          COLUMNS: 80
+          noxsession: ${{ matrix.PYTHON.NOXSESSION }}
+          arch: ${{ matrix.WINDOWS.ARCH }}
+          openssl-name: ${{ matrix.WINDOWS.WINDOWS }}
 
       - uses: ./.github/actions/upload-coverage
 

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -313,56 +313,17 @@ jobs:
           sparse-checkout: |
             ${{ env.BUILD_REQUIREMENTS_PATH }}
             ${{ env.UV_REQUIREMENTS_PATH }}
+            .github/actions/windows-wheel/
             .github/actions/wheel-smoketest/
           sparse-checkout-cone-mode: false
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: cryptography-sdist
-
-      - name: Setup python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: ./.github/actions/windows-wheel
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
-          architecture: ${{ matrix.WINDOWS.ARCH }}
-        timeout-minutes: 3
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
-        with:
-          toolchain: stable
-          target: ${{ matrix.WINDOWS.RUST_TRIPLE }}
-
-      - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          repo: pyca/infra
-          workflow: build-windows-openssl.yml
-          branch: main
-          workflow_conclusion: success
-          name: "openssl-${{ matrix.WINDOWS.WINDOWS }}"
-          path: "C:/openssl-${{ matrix.WINDOWS.WINDOWS }}/"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Configure OpenSSL
-        run: |
-            echo "OPENSSL_DIR=C:/openssl-${{ matrix.WINDOWS.WINDOWS }}" >> $GITHUB_ENV
-            echo "OPENSSL_STATIC=1" >> $GITHUB_ENV
-        shell: bash
-
-      - run: pip install -r "${UV_REQUIREMENTS_PATH}"
-        shell: bash
-      - run: mkdir wheelhouse
-      - run: |
-          if [ -n "${{ matrix.PYTHON.ABI_VERSION }}" ]; then
-              PY_LIMITED_API="--config-settings=build-args=--features=pyo3/abi3-${{ matrix.PYTHON.ABI_VERSION }}"
-          fi
-
-          uv build --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH cryptography*.tar.gz $PY_LIMITED_API --config-settings=build-args=--sbom-include=C:/openssl-${{ matrix.WINDOWS.WINDOWS }}/sbom.json -o wheelhouse/
-        shell: bash
-
-      - name: Smoketest
-        uses: ./.github/actions/wheel-smoketest
-        with:
+          abi-version: ${{ matrix.PYTHON.ABI_VERSION }}
+          arch: ${{ matrix.WINDOWS.ARCH }}
+          rust-triple: ${{ matrix.WINDOWS.RUST_TRIPLE }}
+          openssl-name: ${{ matrix.WINDOWS.WINDOWS }}
           build-requirements-path: ${{ env.BUILD_REQUIREMENTS_PATH }}
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: "cryptography-${{ github.event.inputs.version }}-${{ matrix.WINDOWS.WINDOWS }}-${{ matrix.PYTHON.VERSION }}-${{ matrix.PYTHON.ABI_VERSION }}"
-          path: wheelhouse\
+          uv-requirements-path: ${{ env.UV_REQUIREMENTS_PATH }}
+          wheel-artifact-name: "cryptography-${{ github.event.inputs.version }}-${{ matrix.WINDOWS.WINDOWS }}-${{ matrix.PYTHON.VERSION }}-${{ matrix.PYTHON.ABI_VERSION }}"

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -292,6 +292,7 @@ jobs:
   windows:
     needs: [sdist]
     runs-on: ${{ matrix.WINDOWS.RUNNER }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Extracts the inline step sequences of the `windows` jobs in `ci.yml` and `wheel-builder.yml` into two reusable composite actions:

- `.github/actions/windows-tests/` — setup Python + Rust, fetch OpenSSL, install nox, fetch test vectors, run the test suite.
- `.github/actions/windows-wheel/` — setup Python + Rust, fetch OpenSSL, build the wheel with `uv build`, smoke-test, upload artifact.

The `windows` jobs in both workflows now consist of `checkout` + a single `uses:` step, parameterized by `arch`, `openssl-name`, etc.

### Motivation

Carved out from #14346 per maintainer feedback to keep the refactor and the new arm64 platform as separate changes. Adding a new Windows architecture (or any future variant) becomes a few lines of YAML instead of duplicating ~60–80 lines of steps.

### Notes

- Pure refactor — no behavior change for the existing `x64` matrix.
- Composite actions follow the same convention as existing `.github/actions/cache/`, `fetch-vectors/`, `wheel-smoketest/`, `upload-coverage/`.
- `secrets.GITHUB_TOKEN` is replaced with `github.token` inside the composite actions (composite steps can't read `secrets.*` directly).