### PR TITLE
Add brainpoolP320r1 elliptic curve

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/ec.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/ec.py
@@ -23,6 +23,7 @@ class EllipticCurveOID:
     SECP384R1 = ObjectIdentifier("1.3.132.0.34")
     SECP521R1 = ObjectIdentifier("1.3.132.0.35")
     BRAINPOOLP256R1 = ObjectIdentifier("1.3.36.3.3.2.8.1.1.7")
+    BRAINPOOLP320R1 = ObjectIdentifier("1.3.36.3.3.2.8.1.1.9")
     BRAINPOOLP384R1 = ObjectIdentifier("1.3.36.3.3.2.8.1.1.11")
     BRAINPOOLP512R1 = ObjectIdentifier("1.3.36.3.3.2.8.1.1.13")
 
@@ -265,6 +266,12 @@ class BrainpoolP256R1(EllipticCurve):
     )
 
 
+class BrainpoolP320R1(EllipticCurve):
+    name = "brainpoolP320r1"
+    key_size = 320
+    group_order = 0xD35E472036BC4FB7E13C785ED201E065F98FCFA5B68F12A32D482EC7EE8658E98691555B44C59311  # noqa: E501
+
+
 class BrainpoolP384R1(EllipticCurve):
     name = "brainpoolP384r1"
     key_size = 384
@@ -287,6 +294,7 @@ _CURVE_TYPES: dict[str, EllipticCurve] = {
     "secp521r1": SECP521R1(),
     "secp256k1": SECP256K1(),
     "brainpoolP256r1": BrainpoolP256R1(),
+    "brainpoolP320r1": BrainpoolP320R1(),
     "brainpoolP384r1": BrainpoolP384R1(),
     "brainpoolP512r1": BrainpoolP512R1(),
 }
@@ -354,6 +362,7 @@ _OID_TO_CURVE = {
     EllipticCurveOID.SECP384R1: SECP384R1,
     EllipticCurveOID.SECP521R1: SECP521R1,
     EllipticCurveOID.BRAINPOOLP256R1: BrainpoolP256R1,
+    EllipticCurveOID.BRAINPOOLP320R1: BrainpoolP320R1,
     EllipticCurveOID.BRAINPOOLP384R1: BrainpoolP384R1,
     EllipticCurveOID.BRAINPOOLP512R1: BrainpoolP512R1,
 }

--- a/src/rust/cryptography-key-parsing/src/ec.rs
+++ b/src/rust/cryptography-key-parsing/src/ec.rs
@@ -32,6 +32,8 @@ pub(crate) fn group_to_curve_oid(
         #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
         openssl::nid::Nid::BRAINPOOL_P256R1 => Some(cryptography_x509::oid::EC_BRAINPOOLP256R1),
         #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
+        openssl::nid::Nid::BRAINPOOL_P320R1 => Some(cryptography_x509::oid::EC_BRAINPOOLP320R1),
+        #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
         openssl::nid::Nid::BRAINPOOL_P384R1 => Some(cryptography_x509::oid::EC_BRAINPOOLP384R1),
         #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
         openssl::nid::Nid::BRAINPOOL_P512R1 => Some(cryptography_x509::oid::EC_BRAINPOOLP512R1),
@@ -55,6 +57,8 @@ pub(crate) fn ec_params_to_group(
 
                 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
                 &cryptography_x509::oid::EC_BRAINPOOLP256R1 => openssl::nid::Nid::BRAINPOOL_P256R1,
+                #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
+                &cryptography_x509::oid::EC_BRAINPOOLP320R1 => openssl::nid::Nid::BRAINPOOL_P320R1,
                 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
                 &cryptography_x509::oid::EC_BRAINPOOLP384R1 => openssl::nid::Nid::BRAINPOOL_P384R1,
                 #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -60,6 +60,7 @@ pub const EC_SECP521R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 35);
 pub const EC_SECP256K1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 132, 0, 10);
 
 pub const EC_BRAINPOOLP256R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3, 2, 8, 1, 1, 7);
+pub const EC_BRAINPOOLP320R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3, 2, 8, 1, 1, 9);
 pub const EC_BRAINPOOLP384R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3, 2, 8, 1, 1, 11);
 pub const EC_BRAINPOOLP512R1: asn1::ObjectIdentifier = asn1::oid!(1, 3, 36, 3, 3, 2, 8, 1, 1, 13);
 

--- a/src/rust/src/backend/ec.rs
+++ b/src/rust/src/backend/ec.rs
@@ -50,6 +50,8 @@ fn curve_from_py_curve(
         #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
         "brainpoolP256r1" => openssl::nid::Nid::BRAINPOOL_P256R1,
         #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
+        "brainpoolP320r1" => openssl::nid::Nid::BRAINPOOL_P320R1,
+        #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
         "brainpoolP384r1" => openssl::nid::Nid::BRAINPOOL_P384R1,
         #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
         "brainpoolP512r1" => openssl::nid::Nid::BRAINPOOL_P512R1,


### PR DESCRIPTION
## Summary

Add brainpoolP320r1 as a named elliptic curve. It is defined in [RFC 5639](https://datatracker.ietf.org/doc/html/rfc5639) and fully supported by OpenSSL (NID 929).

## Motivation

[ICAO Doc 9303](https://www.icao.int/sites/default/files/publications/DocSeries/9303_p12_cons_en.pdf) (the international standard for machine-readable travel documents / ePassports), Part 12, Section 4.1.6.3 recommends [BSI TR-03111](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03111/BSI-TR-03111_V-2-1_pdf.pdf?__blob=publicationFile&v=1) for elliptic curve selection. TR-03111 includes brainpoolP320r1 as an approved curve for ePassport use.

This curve is deployed in production:

- **Netherlands** uses brainpoolP320r1 for DG15 Active Authentication keys in ePassport documents

### Addressing #4767

I'm aware that a generic request to add Brainpool curves was declined in #4767 as lacking a concrete use case. This request is different: it is driven by a specific international standard (ICAO 9303), backed by real-world data from production ePassport PKI deployments.

### Security

brainpoolP320r1 provides 160-bit security, between secp256r1 and secp384r1. ICAO considers it adequate for ePassport documents with 10-year validity.

## What this PR does

- Adds `BrainpoolP320R1` curve class to the Python API (`ec.py`)
- Adds OID constant to `oid.rs` (1.3.36.3.3.2.8.1.1.9)
- Adds NID mappings in the Rust key-parsing and backend modules (`ec.rs`), gated behind `#[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]`
- Registers curve in `_CURVE_TYPES`, `_OID_TO_CURVE`, and `EllipticCurveOID`

## What this PR does NOT do

- Does not add brainpoolP224r1 (deferred — requires NID addition to the `openssl` Rust crate first)
- Does not add explicit-parameter-to-named-curve mapping (that is handled separately in #14905)
- Does not change any behavior for BoringSSL or AWS-LC builds

## References

- [RFC 5639](https://datatracker.ietf.org/doc/html/rfc5639) — Elliptic Curve Cryptography (ECC) Brainpool Standard Curves and Curve Generation
- [ICAO Doc 9303 Part 12](https://www.icao.int/sites/default/files/publications/DocSeries/9303_p12_cons_en.pdf) — Public Key Infrastructure for MRTDs (Section 4.1.6.3)
- [BSI TR-03111 v2.10](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03111/BSI-TR-03111_V-2-1_pdf.pdf?__blob=publicationFile&v=1) — Elliptic Curve Cryptography (recommended by ICAO 9303)
- [Dutch CSCA Master List](https://www.npkd.nl/files/ml/NL_MASTERLIST.mls) — from the country using brainpoolP320r1
- [#4767](https://github.com/pyca/cryptography/issues/4767) — previous curve addition request (rejected for lack of concrete use case)
- [#14905](https://github.com/pyca/cryptography/pull/14905) — companion PR adding explicit parameter mapping for existing Brainpool curves