### PR TITLE
Early error on GCM configuration with short tag length and delayed tag

### DIFF
--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -121,10 +121,10 @@ class GCM(ModeWithInitializationVector, ModeWithAuthenticationTag):
                 "and 1024 bits)."
             )
         self._initialization_vector = initialization_vector
+        if min_tag_length < 4:
+            raise ValueError("min_tag_length must be >= 4")
         if tag is not None:
             utils._check_bytes("tag", tag)
-            if min_tag_length < 4:
-                raise ValueError("min_tag_length must be >= 4")
             if len(tag) < min_tag_length:
                 raise ValueError(
                     f"Authentication tag must be {min_tag_length} bytes or "

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -79,6 +79,13 @@ class TestGCM:
         with pytest.raises(ValueError):
             modes.GCM(b"0" * size)
 
+    @pytest.mark.parametrize("min_tag_length", [0, 1, 2, 3])
+    def test_gcm_rejects_delayed_tag_min_tag_length_too_short(
+        self, min_tag_length
+    ):
+        with pytest.raises(ValueError, match="min_tag_length must be >= 4"):
+            modes.GCM(b"\x00" * 12, min_tag_length=min_tag_length)
+
 
 class TestCamellia:
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR updates the GCM constructor to error immediately for clarity when configuring with an invalid `min_tag_length`, even if the tag itself is deferred.