### PR TITLE
count characters not bytes for UTF8String SIZE constraints

### DIFF
--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -65,7 +65,11 @@ fn decode_pystr<'a>(
     annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, pyo3::types::PyString>> {
     let value = read_value::<asn1::Utf8String<'a>>(parser, &annotation.encoding)?;
-    check_size_constraint(&annotation.size, value.as_str().len(), "UTF8String")?;
+    check_size_constraint(
+        &annotation.size,
+        value.as_str().chars().count(),
+        "UTF8String",
+    )?;
     Ok(pyo3::types::PyString::new(py, value.as_str()))
 }
 

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -197,7 +197,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
             Type::PyStr() => {
                 let val: pyo3::pybacked::PyBackedStr = value.extract()?;
                 let asn1_string: asn1::Utf8String<'_> = asn1::Utf8String::new(&val);
-                check_size_constraint(&annotation.size, val.len(), "UTF8String")?;
+                check_size_constraint(&annotation.size, val.chars().count(), "UTF8String")?;
                 Ok(write_value(writer, &asn1_string, encoding)?)
             }
             Type::PrintableString() => {

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -1468,6 +1468,40 @@ class TestSize:
             ]
         )
 
+    def test_ok_string_size_counts_characters(self) -> None:
+        # "é€" is two characters but five UTF-8 bytes, so a SIZE constraint
+        # measured in characters must accept it under max=2.
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[str, asn1.Size(min=1, max=2)]
+
+        assert_roundtrips(
+            [
+                (
+                    Example(a="é€"),
+                    b"\x30\x07\x0c\x05\xc3\xa9\xe2\x82\xac",
+                )
+            ]
+        )
+
+    def test_fail_string_size_counts_characters(self) -> None:
+        # "é€" is two characters; SIZE(min=3) must reject it even though it
+        # is five UTF-8 bytes.
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            a: Annotated[str, asn1.Size(min=3, max=10)]
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("UTF8String has size 2, expected size in [3, 10]"),
+        ):
+            asn1.decode_der(
+                Example,
+                b"\x30\x07\x0c\x05\xc3\xa9\xe2\x82\xac",
+            )
+
     def test_ok_string_size_restriction_no_max(self) -> None:
         @asn1.sequence
         @_comparable_dataclass


### PR DESCRIPTION
decode_pystr and the PyStr encode arm measure SIZE against `str.len()`, which is the UTF-8 byte count rather than the character count X.680 51.5 specifies. A two-character value like "é€" is five bytes, so it slips past `Size(min=3)` on decode and is wrongly rejected under `Size(max=2)` on encode. Count with `chars().count()` instead; BIT STRING already uses bit count and SEQUENCE OF uses element count, and PrintableString/IA5String are ASCII so they're unaffected.