### PR TITLE
Make check_size_constraint take the length as a callable

### DIFF
--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -55,7 +55,7 @@ fn decode_pybytes<'a>(
     annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, pyo3::types::PyBytes>> {
     let value = read_value::<&[u8]>(parser, &annotation.encoding)?;
-    check_size_constraint(&annotation.size, value.len(), "OCTET STRING")?;
+    check_size_constraint(&annotation.size, || value.len(), "OCTET STRING")?;
     Ok(pyo3::types::PyBytes::new(py, value))
 }
 
@@ -67,7 +67,7 @@ fn decode_pystr<'a>(
     let value = read_value::<asn1::Utf8String<'a>>(parser, &annotation.encoding)?;
     check_size_constraint(
         &annotation.size,
-        value.as_str().chars().count(),
+        || value.as_str().chars().count(),
         "UTF8String",
     )?;
     Ok(pyo3::types::PyString::new(py, value.as_str()))
@@ -79,7 +79,7 @@ fn decode_printable_string<'a>(
     annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, PrintableString>> {
     let value = read_value::<asn1::PrintableString<'a>>(parser, &annotation.encoding)?.as_str();
-    check_size_constraint(&annotation.size, value.len(), "PrintableString")?;
+    check_size_constraint(&annotation.size, || value.len(), "PrintableString")?;
     let inner = pyo3::types::PyString::new(py, value).unbind();
     Ok(pyo3::Bound::new(py, PrintableString { inner })?)
 }
@@ -90,7 +90,7 @@ fn decode_ia5_string<'a>(
     annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, IA5String>> {
     let value = read_value::<asn1::IA5String<'a>>(parser, &annotation.encoding)?.as_str();
-    check_size_constraint(&annotation.size, value.len(), "IA5String")?;
+    check_size_constraint(&annotation.size, || value.len(), "IA5String")?;
     let inner = pyo3::types::PyString::new(py, value).unbind();
     Ok(pyo3::Bound::new(py, IA5String { inner })?)
 }
@@ -153,7 +153,7 @@ fn decode_bitstring<'a>(
 ) -> ParseResult<pyo3::Bound<'a, BitString>> {
     let value = read_value::<asn1::BitString<'a>>(parser, &annotation.encoding)?;
     let n_bits = value.as_bytes().len() * 8 - usize::from(value.padding_bits());
-    check_size_constraint(&annotation.size, n_bits, "BIT STRING")?;
+    check_size_constraint(&annotation.size, || n_bits, "BIT STRING")?;
 
     let data = pyo3::types::PyBytes::new(py, value.as_bytes()).unbind();
     Ok(pyo3::Bound::new(
@@ -286,7 +286,7 @@ pub(crate) fn decode_annotated_type<'a>(
                     let val = decode_annotated_type(py, d, inner_ann_type)?;
                     list.append(val)?;
                 }
-                check_size_constraint(&annotation.size, list.len(), "SEQUENCE OF")?;
+                check_size_constraint(&annotation.size, || list.len(), "SEQUENCE OF")?;
                 Ok(list.into_any())
             })?
         }
@@ -315,7 +315,7 @@ pub(crate) fn decode_annotated_type<'a>(
                     let val = decode_annotated_type(py, d, inner_ann_type)?;
                     list.append(val)?;
                 }
-                check_size_constraint(&annotation.size, list.len(), "SET OF")?;
+                check_size_constraint(&annotation.size, || list.len(), "SET OF")?;
                 Ok(pyo3::Bound::new(
                     py,
                     SetOf {

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -74,7 +74,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     })
                     .collect();
 
-                check_size_constraint(&annotation.size, values.len(), "SEQUENCE OF")?;
+                check_size_constraint(&annotation.size, || values.len(), "SEQUENCE OF")?;
 
                 write_value(writer, &asn1::SequenceOfWriter::new(values), encoding)
             }
@@ -107,7 +107,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     })
                     .collect();
 
-                check_size_constraint(&annotation.size, values.len(), "SET OF")?;
+                check_size_constraint(&annotation.size, || values.len(), "SET OF")?;
 
                 write_value(writer, &asn1::SetOfWriter::new(values), encoding)
             }
@@ -191,20 +191,20 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
             }
             Type::PyBytes() => {
                 let val: &[u8] = value.extract()?;
-                check_size_constraint(&annotation.size, val.len(), "OCTET STRING")?;
+                check_size_constraint(&annotation.size, || val.len(), "OCTET STRING")?;
                 Ok(write_value(writer, &val, encoding)?)
             }
             Type::PyStr() => {
                 let val: pyo3::pybacked::PyBackedStr = value.extract()?;
                 let asn1_string: asn1::Utf8String<'_> = asn1::Utf8String::new(&val);
-                check_size_constraint(&annotation.size, val.chars().count(), "UTF8String")?;
+                check_size_constraint(&annotation.size, || val.chars().count(), "UTF8String")?;
                 Ok(write_value(writer, &asn1_string, encoding)?)
             }
             Type::PrintableString() => {
                 let val: &pyo3::Bound<'_, PrintableString> = value.cast()?;
                 // TODO: Switch this to `to_str()` once our minimum version is py310+
                 let inner_str = val.get().inner.to_cow(py)?;
-                check_size_constraint(&annotation.size, inner_str.len(), "PrintableString")?;
+                check_size_constraint(&annotation.size, || inner_str.len(), "PrintableString")?;
                 let printable_string: asn1::PrintableString<'_> =
                     asn1::PrintableString::new(&inner_str).ok_or(CryptographyError::Py(
                         pyo3::exceptions::PyValueError::new_err(
@@ -218,7 +218,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                 let val: &pyo3::Bound<'_, IA5String> = value.cast()?;
                 // TODO: Switch this to `to_str()` once our minimum version is py310+
                 let inner_str = val.get().inner.to_cow(py)?;
-                check_size_constraint(&annotation.size, inner_str.len(), "IA5String")?;
+                check_size_constraint(&annotation.size, || inner_str.len(), "IA5String")?;
                 let ia5_string: asn1::IA5String<'_> = asn1::IA5String::new(&inner_str).ok_or(
                     CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
                         "invalid value for IA5String".to_string(),
@@ -256,7 +256,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                             ),
                         ))?;
                 let n_bits = bitstring.as_bytes().len() * 8 - usize::from(bitstring.padding_bits());
-                check_size_constraint(&annotation.size, n_bits, "BIT STRING")?;
+                check_size_constraint(&annotation.size, || n_bits, "BIT STRING")?;
                 Ok(write_value(writer, &bitstring, encoding)?)
             }
             Type::Tlv() => Err(CryptographyError::Py(

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -678,10 +678,11 @@ pub(crate) fn is_tag_valid_for_type(
 
 pub(crate) fn check_size_constraint(
     size_annotation: &Option<pyo3::Py<Size>>,
-    data_length: usize,
+    data_length: impl FnOnce() -> usize,
     field_type: &str,
 ) -> Result<(), CryptographyError> {
     if let Some(size) = size_annotation {
+        let data_length = data_length();
         let min = size.get().min;
         let max = size.get().max.unwrap_or(usize::MAX);
         if !(min..=max).contains(&data_length) {


### PR DESCRIPTION
`check_size_constraint` now takes `data_length: impl FnOnce() -> usize` and only invokes it when a `Size` annotation is actually present. This lets call sites with expensive length computations — notably the O(n) `chars().count()` for UTF8String in both encode and decode — skip the work entirely for unconstrained values.

All call sites in `encode.rs` and `decode.rs` updated to pass closures.

https://claude.ai/code/session_01TPNsBji87T7ozqNBQAMN2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPNsBji87T7ozqNBQAMN2G)_