### PR TITLE
stop directing people to file issues with us over BER in PKCS#7 and PKCS#12

### DIFF
--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -578,7 +578,7 @@ fn decode_p12(
 
     if let Err(e) = asn1::parse_single::<cryptography_x509::pkcs12::Pfx<'_>>(data.as_bytes()) {
         let warning_cls = pyo3::exceptions::PyUserWarning::type_object(py);
-        let message = std::ffi::CString::new(format!("PKCS#12 bundle could not be parsed as DER, falling back to parsing as BER. Please file an issue at https://github.com/pyca/cryptography/issues explaining how your PKCS#12 bundle was created. In the future, this may become an exception. Error details: {e}")).unwrap();
+        let message = std::ffi::CString::new(format!("PKCS#12 bundle could not be parsed as DER, falling back to parsing as BER. In the future, this may become an exception. Error details: {e}")).unwrap();
         pyo3::PyErr::warn(py, &warning_cls, &message, 1)?;
     }
 

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -845,7 +845,7 @@ fn load_der_pkcs7_certificates(
             if let Err(e) =  load_pkcs7_certificates_rust(py, data) {
                 let err = pyo3::PyErr::from(e);
                 let warning_cls = pyo3::exceptions::PyUserWarning::type_object(py);
-                let message = CString::new(format!("PKCS#7 certificates could not be parsed as DER, falling back to parsing as BER. Please file an issue at https://github.com/pyca/cryptography/issues explaining how your PKCS#7 certificates were created. In the future, this may become an exception. Error details: {err}")).unwrap();
+                let message = CString::new(format!("PKCS#7 certificates could not be parsed as DER, falling back to parsing as BER. In the future, this may become an exception. Error details: {err}")).unwrap();
                 pyo3::PyErr::warn(py, &warning_cls, &message, 1)?;
             }
 


### PR DESCRIPTION
We do not have a particular timeline for removing support for BER, and filing issues with us has been only marginally effective at reducing BER, therefore stop asking people to report issues to us.

Closes #14386
Closes #13671
Closes #12936