### PR TITLE
Expose KEM.enc_length() for splitting HPKE enc from ciphertext

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@ Changelog
   signing requests, and certificate revocation lists with
   :doc:`/hazmat/primitives/asymmetric/mldsa` keys, as well as loading
   certificates that contain ML-DSA public keys.
+* Added :meth:`~cryptography.hazmat.primitives.hpke.KEM.enc_length` to
+  :class:`~cryptography.hazmat.primitives.hpke.KEM` so callers can split the
+  encapsulated key from the ciphertext returned by
+  :meth:`~cryptography.hazmat.primitives.hpke.Suite.encrypt`.
 
 .. _v48-0-0:
 

--- a/docs/hazmat/primitives/hpke.rst
+++ b/docs/hazmat/primitives/hpke.rst
@@ -99,6 +99,21 @@ specifying auxiliary authenticated information.
 
     An enumeration of key encapsulation mechanisms.
 
+    .. method:: enc_length()
+
+        .. versionadded:: 49.0.0
+
+        :returns: The length in bytes of the encapsulated key (``enc``)
+            produced by this KEM. The ``enc`` is the prefix of the value
+            returned by :meth:`Suite.encrypt`, so this can be used to split
+            the result into ``enc`` and the AEAD ciphertext::
+
+                ciphertext = suite.encrypt(plaintext, public_key)
+                enc_len = KEM.X25519.enc_length()
+                enc, ct = ciphertext[:enc_len], ciphertext[enc_len:]
+
+        :rtype: int
+
     .. attribute:: X25519
 
         DHKEM(X25519, HKDF-SHA256)

--- a/src/cryptography/hazmat/bindings/_rust/openssl/hpke.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/openssl/hpke.pyi
@@ -14,6 +14,7 @@ class KEM:
     MLKEM1024: KEM
     MLKEM768_X25519: KEM
     MLKEM1024_P384: KEM
+    def enc_length(self) -> int: ...
 
 class KDF:
     HKDF_SHA256: KDF

--- a/src/rust/src/backend/hpke.rs
+++ b/src/rust/src/backend/hpke.rs
@@ -188,19 +188,6 @@ impl KEM {
         }
     }
 
-    fn enc_length(&self) -> usize {
-        match self {
-            KEM::X25519 => kem_params::X25519_NENC,
-            KEM::P256 => kem_params::P256_NENC,
-            KEM::P384 => kem_params::P384_NENC,
-            KEM::P521 => kem_params::P521_NENC,
-            KEM::MLKEM768 => kem_params::MLKEM768_NENC,
-            KEM::MLKEM1024 => kem_params::MLKEM1024_NENC,
-            KEM::MLKEM768_X25519 => kem_params::MLKEM768_X25519_NENC,
-            KEM::MLKEM1024_P384 => kem_params::MLKEM1024_P384_NENC,
-        }
-    }
-
     fn check_public_key(
         &self,
         py: pyo3::Python<'_>,
@@ -627,6 +614,22 @@ impl KEM {
             KEM::MLKEM768 | KEM::MLKEM1024 | KEM::MLKEM768_X25519 | KEM::MLKEM1024_P384 => {
                 unreachable!("ML-KEM does not use a KEM hash algorithm")
             }
+        }
+    }
+}
+
+#[pyo3::pymethods]
+impl KEM {
+    fn enc_length(&self) -> usize {
+        match self {
+            KEM::X25519 => kem_params::X25519_NENC,
+            KEM::P256 => kem_params::P256_NENC,
+            KEM::P384 => kem_params::P384_NENC,
+            KEM::P521 => kem_params::P521_NENC,
+            KEM::MLKEM768 => kem_params::MLKEM768_NENC,
+            KEM::MLKEM1024 => kem_params::MLKEM1024_NENC,
+            KEM::MLKEM768_X25519 => kem_params::MLKEM768_X25519_NENC,
+            KEM::MLKEM1024_P384 => kem_params::MLKEM1024_P384_NENC,
         }
     }
 }

--- a/tests/hazmat/primitives/test_hpke.py
+++ b/tests/hazmat/primitives/test_hpke.py
@@ -101,6 +101,22 @@ class TestHPKE:
         with pytest.raises(TypeError):
             Suite(KEM.X25519, KDF.HKDF_SHA256, "not an aead")  # type: ignore[arg-type]
 
+    @pytest.mark.parametrize(
+        "kem,expected",
+        [
+            (KEM.X25519, X25519_ENC_LENGTH),
+            (KEM.P256, P256_ENC_LENGTH),
+            (KEM.P384, P384_ENC_LENGTH),
+            (KEM.P521, P521_ENC_LENGTH),
+            (KEM.MLKEM768, MLKEM768_ENC_LENGTH),
+            (KEM.MLKEM1024, MLKEM1024_ENC_LENGTH),
+            (KEM.MLKEM768_X25519, MLKEM768_X25519_ENC_LENGTH),
+            (KEM.MLKEM1024_P384, MLKEM1024_P384_ENC_LENGTH),
+        ],
+    )
+    def test_enc_length(self, kem, expected):
+        assert kem.enc_length() == expected
+
     @pytest.mark.parametrize("kem,kdf,aead", SUPPORTED_SUITES)
     def test_roundtrip(self, backend, kem, kdf, aead):
         if kdf == KDF.SHAKE128 and not backend.hash_supported(


### PR DESCRIPTION
Refs #14932.