### PR TITLE
Use a value -> member map for decoding ASN.1 value sets

### DIFF
--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -463,7 +463,17 @@ def value_set(
         inner = declarative_asn1.AnnotatedType(
             rust_type, declarative_asn1.Annotation()
         )
-        root = declarative_asn1.Type.ValueSet(cls, inner)
+        # Map from member value to member, used for O(1) lookups when
+        # decoding.
+        value_map: dict | None
+        try:
+            value_map = {member.value: member for member in members}
+        except TypeError:
+            # Member values that implement `__eq__` but not `__hash__`
+            # (e.g. `Null`) can't be used as dict keys; decoding falls
+            # back to a linear scan over the members.
+            value_map = None
+        root = declarative_asn1.Type.ValueSet(cls, inner, value_map)
 
         setattr(cls, "__asn1_root__", root)
         return cls

--- a/src/cryptography/hazmat/asn1/asn1.py
+++ b/src/cryptography/hazmat/asn1/asn1.py
@@ -464,15 +464,8 @@ def value_set(
             rust_type, declarative_asn1.Annotation()
         )
         # Map from member value to member, used for O(1) lookups when
-        # decoding.
-        value_map: dict | None
-        try:
-            value_map = {member.value: member for member in members}
-        except TypeError:
-            # Member values that implement `__eq__` but not `__hash__`
-            # (e.g. `Null`) can't be used as dict keys; decoding falls
-            # back to a linear scan over the members.
-            value_map = None
+        # decoding. This requires the member values to be hashable.
+        value_map = {member.value: member for member in members}
         root = declarative_asn1.Type.ValueSet(cls, inner, value_map)
 
         setattr(cls, "__asn1_root__", root)

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -262,30 +262,13 @@ fn decode_value_set<'a>(
     parser: &mut Parser<'a>,
     cls: &pyo3::Py<pyo3::types::PyType>,
     inner_type: &AnnotatedType,
-    value_map: &Option<pyo3::Py<pyo3::types::PyDict>>,
+    value_map: &pyo3::Py<pyo3::types::PyDict>,
     annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, pyo3::PyAny>> {
     let inner_ann_type = value_set_inner_type(py, inner_type, annotation)?;
     let decoded = decode_annotated_type(py, parser, &inner_ann_type)?;
-    match value_map {
-        // Common case: look the decoded value up in the value -> member
-        // map.
-        Some(value_map) => {
-            if let Some(member) = value_map.bind(py).get_item(&decoded)? {
-                return Ok(member);
-            }
-        }
-        // The map is `None` when the member values implement `__eq__`
-        // but not `__hash__` (e.g. `Null`), so fall back to a linear
-        // scan over the members.
-        None => {
-            for member in cls.bind(py).try_iter()? {
-                let member = member?;
-                if member.getattr(pyo3::intern!(py, "value"))?.eq(&decoded)? {
-                    return Ok(member);
-                }
-            }
-        }
+    if let Some(member) = value_map.bind(py).get_item(&decoded)? {
+        return Ok(member);
     }
     Err(CryptographyError::Py(
         pyo3::exceptions::PyValueError::new_err(format!(

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -3,7 +3,7 @@
 // for complete details.
 
 use asn1::Parser;
-use pyo3::types::{PyAnyMethods, PyListMethods, PyTypeMethods};
+use pyo3::types::{PyAnyMethods, PyDictMethods, PyListMethods, PyTypeMethods};
 
 use crate::asn1::big_byte_slice_to_py_int;
 use crate::declarative_asn1::types::{
@@ -262,19 +262,29 @@ fn decode_value_set<'a>(
     parser: &mut Parser<'a>,
     cls: &pyo3::Py<pyo3::types::PyType>,
     inner_type: &AnnotatedType,
+    value_map: &Option<pyo3::Py<pyo3::types::PyDict>>,
     annotation: &Annotation,
 ) -> ParseResult<pyo3::Bound<'a, pyo3::PyAny>> {
     let inner_ann_type = value_set_inner_type(py, inner_type, annotation)?;
     let decoded = decode_annotated_type(py, parser, &inner_ann_type)?;
-    // NOTE: This is a linear scan over the members of the enum. If this
-    // ever becomes a performance problem, it could be replaced with a
-    // value -> member map stored in `Type::ValueSet` (keeping in mind
-    // that hash-based lookups won't work for the asn1 wrapper types,
-    // which implement `__eq__` but not `__hash__`).
-    for member in cls.bind(py).try_iter()? {
-        let member = member?;
-        if member.getattr(pyo3::intern!(py, "value"))?.eq(&decoded)? {
-            return Ok(member);
+    match value_map {
+        // Common case: look the decoded value up in the value -> member
+        // map.
+        Some(value_map) => {
+            if let Some(member) = value_map.bind(py).get_item(&decoded)? {
+                return Ok(member);
+            }
+        }
+        // The map is `None` when the member values implement `__eq__`
+        // but not `__hash__` (e.g. `Null`), so fall back to a linear
+        // scan over the members.
+        None => {
+            for member in cls.bind(py).try_iter()? {
+                let member = member?;
+                if member.getattr(pyo3::intern!(py, "value"))?.eq(&decoded)? {
+                    return Ok(member);
+                }
+            }
         }
     }
     Err(CryptographyError::Py(
@@ -452,8 +462,8 @@ pub(crate) fn decode_annotated_type<'a>(
                 ))?
             }
         },
-        Type::ValueSet(cls, inner_type) => {
-            decode_value_set(py, parser, cls, inner_type.get(), annotation)?
+        Type::ValueSet(cls, inner_type, value_map) => {
+            decode_value_set(py, parser, cls, inner_type.get(), value_map, annotation)?
         }
         Type::PyBool() => decode_pybool(py, parser, encoding)?.into_any(),
         Type::PyInt() => decode_pyint(py, parser, encoding)?.into_any(),

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -181,7 +181,7 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     ),
                 ))
             }
-            Type::ValueSet(cls, inner_type) => {
+            Type::ValueSet(cls, inner_type, _) => {
                 if !value.is_instance(cls.bind(py))? {
                     return Err(CryptographyError::Py(
                         pyo3::exceptions::PyTypeError::new_err(format!(

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -39,13 +39,11 @@ pub enum Type {
     /// The first element is the Python enum class, the second
     /// element is the (already converted) underlying type of the
     /// member values, and the third element is a map from member
-    /// value to enum member, used when decoding. The map is `None`
-    /// when the member values are not hashable, in which case
-    /// decoding falls back to a linear scan over the members.
+    /// value to enum member, used when decoding.
     ValueSet(
         pyo3::Py<pyo3::types::PyType>,
         pyo3::Py<AnnotatedType>,
-        Option<pyo3::Py<pyo3::types::PyDict>>,
+        pyo3::Py<pyo3::types::PyDict>,
     ),
 
     // Python types that we map to canonical ASN.1 types

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -38,8 +38,15 @@ pub enum Type {
     /// a single underlying ASN.1 type).
     /// The first element is the Python enum class, the second
     /// element is the (already converted) underlying type of the
-    /// member values.
-    ValueSet(pyo3::Py<pyo3::types::PyType>, pyo3::Py<AnnotatedType>),
+    /// member values, and the third element is a map from member
+    /// value to enum member, used when decoding. The map is `None`
+    /// when the member values are not hashable, in which case
+    /// decoding falls back to a linear scan over the members.
+    ValueSet(
+        pyo3::Py<pyo3::types::PyType>,
+        pyo3::Py<AnnotatedType>,
+        Option<pyo3::Py<pyo3::types::PyDict>>,
+    ),
 
     // Python types that we map to canonical ASN.1 types
     //
@@ -686,7 +693,7 @@ pub(crate) fn is_tag_valid_for_type(
         Type::Choice(variants) => variants.bind(py).into_iter().any(|v| {
             is_tag_valid_for_variant(py, tag, v.cast::<Variant>().unwrap().get(), encoding)
         }),
-        Type::ValueSet(_, t) => is_tag_valid_for_type(py, tag, t.get().inner.get(), encoding),
+        Type::ValueSet(_, t, _) => is_tag_valid_for_type(py, tag, t.get().inner.get(), encoding),
         Type::PyBool() => check_tag_with_encoding(bool::TAG, encoding, tag),
         Type::PyInt() => check_tag_with_encoding(asn1::BigInt::TAG, encoding, tag),
         Type::PyBytes() => {

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -428,7 +428,7 @@ class TestSequenceAPI:
         choice = declarative_asn1.Type.Choice(my_list)
         assert choice._0 is my_list
 
-        my_value_map: dict = dict()
+        my_value_map: dict = {}
         value_set = declarative_asn1.Type.ValueSet(
             type(None), ann_type, my_value_map
         )
@@ -628,13 +628,3 @@ class TestValueSetAPI:
             match="cannot handle type",
         ):
             asn1.value_set(float)
-
-    def test_fail_unhashable_member_values(self) -> None:
-        # Member values must be hashable, since they are used as keys
-        # in the value -> member map used when decoding. `Null`
-        # implements `__eq__` but not `__hash__`.
-        with pytest.raises(TypeError, match="unhashable type"):
-
-            @asn1.value_set(asn1.Null)
-            class Example(enum.Enum):
-                A = asn1.Null()

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -628,3 +628,13 @@ class TestValueSetAPI:
             match="cannot handle type",
         ):
             asn1.value_set(float)
+
+    def test_fail_unhashable_member_values(self) -> None:
+        # Member values must be hashable, since they are used as keys
+        # in the value -> member map used when decoding. `Null`
+        # implements `__eq__` but not `__hash__`.
+        with pytest.raises(TypeError, match="unhashable type"):
+
+            @asn1.value_set(asn1.Null)
+            class Example(enum.Enum):
+                A = asn1.Null()

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -428,9 +428,13 @@ class TestSequenceAPI:
         choice = declarative_asn1.Type.Choice(my_list)
         assert choice._0 is my_list
 
-        value_set = declarative_asn1.Type.ValueSet(type(None), ann_type)
+        my_value_map: dict = dict()
+        value_set = declarative_asn1.Type.ValueSet(
+            type(None), ann_type, my_value_map
+        )
         assert value_set._0 is type(None)
         assert value_set._1 is ann_type
+        assert value_set._2 is my_value_map
 
     def test_fields_of_variant_encoding(self) -> None:
         from cryptography.hazmat.bindings._rust import declarative_asn1

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -2230,6 +2230,20 @@ class TestValueSet:
             ]
         )
 
+    def test_ok_null_value_set(self) -> None:
+        # `Null` implements `__eq__` but not `__hash__`, so decoding
+        # exercises the linear scan fallback (instead of the value ->
+        # member map lookup).
+        @asn1.value_set(asn1.Null)
+        class Marker(enum.Enum):
+            PRESENT = asn1.Null()
+
+        assert_roundtrips(
+            [
+                (Marker.PRESENT, b"\x05\x00"),
+            ]
+        )
+
     def test_fail_decode_non_member_value(self) -> None:
         @asn1.sequence
         @_comparable_dataclass

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -2230,20 +2230,6 @@ class TestValueSet:
             ]
         )
 
-    def test_ok_null_value_set(self) -> None:
-        # `Null` implements `__eq__` but not `__hash__`, so decoding
-        # exercises the linear scan fallback (instead of the value ->
-        # member map lookup).
-        @asn1.value_set(asn1.Null)
-        class Marker(enum.Enum):
-            PRESENT = asn1.Null()
-
-        assert_roundtrips(
-            [
-                (Marker.PRESENT, b"\x05\x00"),
-            ]
-        )
-
     def test_fail_decode_non_member_value(self) -> None:
         @asn1.sequence
         @_comparable_dataclass


### PR DESCRIPTION
Resolves the performance TODO from #14962: value set decoding did a linear scan over the enum members to map the decoded value back to a member.

`Type::ValueSet` now stores a value -> member map (a `PyDict`), built once when the class is decorated, and decoding is a single O(1) dict lookup. This is possible now that the ASN.1 wrapper types implement `__hash__` (#14963).

As a consequence, value set member values must be hashable: an enum whose member values implement `__eq__` but not `__hash__` (e.g. `Null`) now raises `TypeError` at decoration time.

https://claude.ai/code/session_01FrUdGjs6fKGSQ6E6WQPGB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrUdGjs6fKGSQ6E6WQPGB1)_