### PR TITLE
CI: cache the bindgen-cli binary instead of rebuilding it every run

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -19,4 +19,4 @@ runs:
         KEY: "${{ inputs.key }}"
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       with:
-        key: ${{ steps.normalized-key.outputs.key }}-4
+        key: ${{ steps.normalized-key.outputs.key }}-5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,6 @@ jobs:
           echo "CFLAGS=${CFLAGS} -Werror=implicit-function-declaration" >> $GITHUB_ENV
           echo "RUSTFLAGS=-Clink-arg=-Wl,-rpath=${OSSL_PATH}/lib -Clink-arg=-Wl,-rpath=${OSSL_PATH}/lib64" >> $GITHUB_ENV
         if: matrix.PYTHON.OPENSSL
-      - run: rustup run stable cargo install bindgen-cli
-        if: matrix.PYTHON.OPENSSL.TYPE == 'boringssl' || matrix.PYTHON.OPENSSL.TYPE == 'aws-lc'
       - name: Cache rust and pip
         uses: ./.github/actions/cache
         timeout-minutes: 2
@@ -131,6 +129,12 @@ jobs:
           # different Python versions of PyPy that share the same PyPy
           # version number.
           key: "${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.PYTHON.NOXSESSION }}-${{ env.OPENSSL_HASH }}-0"
+      # This must run after the cache action: rust-cache prunes binaries
+      # that already existed in ~/.cargo/bin before it ran, so installing
+      # bindgen first means it never gets cached. When the cache is warm,
+      # cargo sees the binary is already installed and skips the build.
+      - run: rustup run stable cargo install bindgen-cli
+        if: matrix.PYTHON.OPENSSL.TYPE == 'boringssl' || matrix.PYTHON.OPENSSL.TYPE == 'aws-lc'
 
       - run: python -m pip install -c ci-constraints-requirements.txt 'nox[uv]' 'tomli; python_version < "3.11"'
       - name: Create nox environment


### PR DESCRIPTION
## What

Moves `cargo install bindgen-cli` to run *after* the rust-cache step in the `linux` job, and bumps the shared cache key.

## Why

Looking at recent CI timings, every BoringSSL/AWS-LC matrix job (4 jobs per run) spends **~55s compiling bindgen-cli from source on every single run**, despite a warm rust cache.

The cause: `Swatinem/rust-cache` snapshots `~/.cargo/bin` at the start of its main step and, before saving the cache, prunes any binaries that already existed at that point (it assumes they're pre-installed tooling, see [`cleanBin`](https://github.com/Swatinem/rust-cache/blob/c19371144df3bb44fab255c43d04cbc2ab54d1c4/src/cleanup.ts)). Since the `cargo install bindgen-cli` step currently runs *before* the cache action, the binary is pruned from every cache save and rebuilt from scratch on every run.

With the install moved after the cache action:
- rust-cache keeps and caches the binary (`cache-bin` defaults to `true`, which covers `~/.cargo/bin` plus `.crates.toml`/`.crates2.json`)
- on warm caches, `cargo install bindgen-cli` sees the binary is already installed and becomes a quick no-op (just an index check)

The cache key bump (`-4` → `-5`) is needed because rust-cache doesn't re-save on a primary key hit — without it, the existing bindgen-less caches would be restored and never refreshed until the next Cargo.lock rotation.

## Expected impact

~50s saved on each of the 4 boringssl/aws-lc jobs per CI run (these are among the slowest `linux` jobs at 3.4–3.9 min).

Note: the first CI run on this PR is a cold-cache run (key bump), so it will be *slower* than baseline. The second push demonstrates the warm-cache behavior — check the `rustup run stable cargo install bindgen-cli` step duration on the boringssl/aws-lc jobs.

https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb

---
_Generated by [Claude Code](https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb)_