### PR TITLE
CI: skip llvm-tools-preview install for tests-nocoverage jobs

### DIFF
--- a/.github/actions/windows-tests/action.yml
+++ b/.github/actions/windows-tests/action.yml
@@ -29,8 +29,11 @@ runs:
         architecture: ${{ inputs.arch }}
         cache: pip
         cache-dependency-path: ci-constraints-requirements.txt
+    # llvm-tools is only used to process Rust coverage data, which the
+    # tests-nocoverage session doesn't collect.
     - run: rustup component add llvm-tools-preview
       shell: bash
+      if: ${{ inputs.noxsession != 'tests-nocoverage' }}
     - name: Cache rust and pip
       uses: ./.github/actions/cache
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,10 @@ jobs:
           components: rustfmt,clippy
         if: matrix.PYTHON.RUST
 
+      # llvm-tools is only used to process Rust coverage data, which the
+      # tests-nocoverage session doesn't collect.
       - run: rustup component add llvm-tools-preview
-        if: matrix.PYTHON.NOXSESSION != 'flake' && matrix.PYTHON.NOXSESSION != 'docs'
+        if: matrix.PYTHON.NOXSESSION != 'flake' && matrix.PYTHON.NOXSESSION != 'docs' && matrix.PYTHON.NOXSESSION != 'tests-nocoverage'
       - name: Clone test vectors
         timeout-minutes: 2
         uses: ./.github/actions/fetch-vectors


### PR DESCRIPTION
## What

Skips `rustup component add llvm-tools-preview` when the nox session is `tests-nocoverage` (linux matrix condition + windows-tests composite action).

## Why

`llvm-tools` (`llvm-profdata`/`llvm-cov`) is only used by `process_rust_coverage` in `noxfile.py`, which `tests-nocoverage` never calls (it neither sets `-Cinstrument-coverage` nor processes profraw files).

From recent CI timing data, the **`windows (x64, 3.9, tests-nocoverage)` job is consistently the longest job in the entire CI run** (~6.4 min; the whole run's wall time tracks it), and it spends ~10s downloading/installing this unused component. The `windows-11-arm` and linux `pypy-3.11` tests-nocoverage jobs save the same.

Small, but it comes straight off the critical path of every CI run.

https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb

---
_Generated by [Claude Code](https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb)_