### PR TITLE
CI: stop recompiling pyo3 on every run (pin PYO3_CONFIG_FILE in tests sessions)

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -19,4 +19,4 @@ runs:
         KEY: "${{ inputs.key }}"
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       with:
-        key: ${{ steps.normalized-key.outputs.key }}-5
+        key: ${{ steps.normalized-key.outputs.key }}-7

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,6 +112,12 @@ def pin_pyo3_config(session: nox.Session) -> None:
     config_path.write_text(content)
     os.utime(config_path, (0, 0))
     session.env["PYO3_CONFIG_FILE"] = str(config_path)
+    # When PYO3_CONFIG_FILE is set, maturin doesn't export PYO3_PYTHON to
+    # cargo, but cryptography-cffi's build script needs an interpreter
+    # (with the build requirements available) to run
+    # _cffi_src/build_openssl.py. Point it at the session's interpreter;
+    # the path is stable, so this doesn't reintroduce cache churn.
+    session.env["PYO3_PYTHON"] = str(python)
 
 
 @nox.session
@@ -142,6 +148,12 @@ def tests(session: nox.Session) -> None:
 
     install_spec = f".[{','.join(extras)}]"
     pin_pyo3_config(session)
+    # The build requirements must be importable by the PYO3_PYTHON
+    # interpreter that pin_pyo3_config points at the session venv (see
+    # there); they are not otherwise used, since the build itself still
+    # runs in an isolated environment.
+    pyproject_data = load_pyproject_toml()
+    install(session, *pyproject_data["build-system"]["requires"])
     install(session, "-e", "./vectors")
     if session.name == "tests-rust-debug":
         install(

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,6 +82,25 @@ def pin_pyo3_config(session: nox.Session) -> None:
                 break
             config_lines.append(line)
     assert config_lines, f"failed to extract PyO3 config from:\n{output}"
+    # maturin also reads PYO3_CONFIG_FILE, and additionally needs
+    # ext_suffix (mandatory on Windows) and abiflags (for the free-threaded
+    # wheel tag), neither of which PyO3 emits (it ignores unknown keys
+    # with a warning).
+    info = session.run_install(
+        str(python),
+        "-c",
+        "import sys, sysconfig;"
+        'print(sysconfig.get_config_var("EXT_SUFFIX"));'
+        'print(getattr(sys, "abiflags", "") or'
+        ' ("t" if sysconfig.get_config_var("Py_GIL_DISABLED") else ""))',
+        silent=True,
+        external=True,
+    )
+    assert isinstance(info, str)
+    ext_suffix, abiflags = info.splitlines()
+    config_lines.append(f"ext_suffix={ext_suffix}")
+    if abiflags:
+        config_lines.append(f"abiflags={abiflags}")
     content = "\n".join(config_lines) + "\n"
     # The file name is content-addressed and the mtime is pinned: cargo
     # treats both a changed PYO3_CONFIG_FILE value and a fresh mtime on

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import glob
+import hashlib
 import itertools
 import json
 import os
@@ -44,6 +45,56 @@ def load_pyproject_toml() -> dict:
         return tomllib.load(f)
 
 
+def pin_pyo3_config(session: nox.Session) -> None:
+    # PEP 517 builds run in a randomly-named temporary environment, and
+    # PyO3's build script fingerprints the interpreter path it is given.
+    # That makes cargo recompile pyo3 (and everything downstream of it) on
+    # every CI run, despite an otherwise warm cache. Resolve the PyO3
+    # build config once, against this session's interpreter (whose path is
+    # stable from run to run), and pin it via PYO3_CONFIG_FILE so the
+    # build is independent of the ephemeral build environment.
+    venv = pathlib.Path(session.virtualenv.location)
+    python = venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    output = session.run_install(
+        "cargo",
+        "check",
+        "-p",
+        "pyo3-ffi",
+        external=True,
+        silent=True,
+        success_codes=[0, 101],
+        env={"PYO3_PRINT_CONFIG": "1", "PYO3_PYTHON": str(python)},
+    )
+    # None on --no-install invocations, where the config file (and the
+    # build it is for) already exists.
+    if output is None:
+        return
+    assert isinstance(output, str)
+    config_lines = []
+    in_config = False
+    for line in output.splitlines():
+        line = line.strip()
+        if "PYO3_PRINT_CONFIG=1 is set" in line:
+            in_config = True
+            continue
+        if in_config:
+            if line.startswith("note:") or "=" not in line:
+                break
+            config_lines.append(line)
+    assert config_lines, f"failed to extract PyO3 config from:\n{output}"
+    content = "\n".join(config_lines) + "\n"
+    # The file name is content-addressed and the mtime is pinned: cargo
+    # treats both a changed PYO3_CONFIG_FILE value and a fresh mtime on
+    # the file it points to as reasons to recompile pyo3. This way a
+    # regenerated-but-identical config (e.g. a fresh CI run) never looks
+    # changed, while a genuinely different config gets a new path.
+    digest = hashlib.sha256(content.encode()).hexdigest()[:16]
+    config_path = venv / f"pyo3-config-{digest}.txt"
+    config_path.write_text(content)
+    os.utime(config_path, (0, 0))
+    session.env["PYO3_CONFIG_FILE"] = str(config_path)
+
+
 @nox.session
 @nox.session(name="tests-ssh")
 @nox.session(name="tests-randomorder")
@@ -71,6 +122,7 @@ def tests(session: nox.Session) -> None:
         )
 
     install_spec = f".[{','.join(extras)}]"
+    pin_pyo3_config(session)
     install(session, "-e", "./vectors")
     if session.name == "tests-rust-debug":
         install(


### PR DESCRIPTION
## What

In the `tests*` nox sessions, resolve the PyO3 build config once — against the session venv's interpreter, whose path is stable from run to run — and pin it via `PYO3_CONFIG_FILE` for the build of cryptography itself. **Build isolation stays fully enabled.** Bumps the shared rust cache key so caches get re-saved with the new fingerprints.

(Earlier revision of this PR used `--no-build-isolation`; reworked per review feedback.)

## Why

CI logs show **every run recompiles `pyo3-build-config`, `pyo3-ffi`, `pyo3`, `pyo3-macros-backend`, and `pyo3-macros`** (and on Windows, `openssl-sys`/`openssl` too) despite a rust-cache hit — e.g. [this main run](https://github.com/pyca/cryptography/actions/runs/27081559238).

Mechanism: PEP 517 builds run in a randomly-named temporary environment (`~/.cache/uv/builds-v0/.tmpXXXX`), and maturin points PyO3 at that environment's interpreter via `PYO3_PYTHON`. PyO3's build scripts emit `cargo:rerun-if-env-changed` for the env vars they actually consult, and the resolved config embeds the interpreter path — so a different temp path every run dirties the whole chain.

`PYO3_CONFIG_FILE` takes priority over `PYO3_PYTHON`: when it's set, PyO3 never consults (and therefore never fingerprints) the volatile variables. We generate the config using **pyo3's own discovery** (`PYO3_PRINT_CONFIG=1` against the session interpreter), so it's correct across CPython/PyPy/free-threaded/Windows without hand-rolling sysconfig logic.

Three details to make this work:
- the config file's **name is content-addressed** — a genuinely different config changes the `PYO3_CONFIG_FILE` value and correctly triggers a rebuild;
- its **mtime is pinned** — a regenerated-but-identical file (every fresh CI run) doesn't trip `cargo:rerun-if-changed`, which compares mtimes;
- **`ext_suffix` and `abiflags` are appended**: maturin also reads `PYO3_CONFIG_FILE` as the authoritative target description — it [requires `ext_suffix` on Windows and uses `abiflags` for the wheel tag](https://github.com/PyO3/maturin/blob/v1.13.3/src/python_interpreter/config.rs) (without it, free-threaded wheels get tagged `cp314` instead of `cp314t` and the installer rejects them). PyO3 ignores unknown config keys with a warning, so appending both is safe.

## Verified locally

With a warm `target/`, removing `.nox` entirely and re-running `nox -e tests-nocoverage --install-only`:

- **before**: `Compiling pyo3-build-config / pyo3-ffi / pyo3-macros-backend / pyo3 / pyo3-macros` + workspace crates, every time
- **after**: `Finished release [optimized] target(s) in 0.04s` — zero recompiles

Also verified that churning `PYO3_PYTHON`/`VIRTUAL_ENV` across fake temp envs with `PYO3_CONFIG_FILE` set recompiles nothing in the pyo3 chain.

## Expected CI impact

Same as measured for the previous revision of this PR ([warm run](https://github.com/pyca/cryptography/actions/runs/27082958417) vs [baseline](https://github.com/pyca/cryptography/actions/runs/27081559238)): windows build step 1m48s → ~1m04s, the critical-path `windows (3.9, tests-nocoverage)` job 6.4m → ~4.1m; linux saves the CPU of the pyo3 chain. The first run on each revision is cold (key bump); the following push demonstrates warm behavior.

## Behavior notes

- Generation runs via `session.run_install`, so it executes during `nox --install-only` (CI's "create env" step) and is skipped under `--no-install` (CI's "tests" step, where the build already exists).
- The `PYO3_PRINT_CONFIG` cargo invocation is the documented mechanism for producing config files and costs a few seconds (cached dev-profile artifacts).
- `nox -e flake` passes locally.

https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb

---
_Generated by [Claude Code](https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb)_