### PR TITLE
CI: stop recompiling openssl-sys on every Windows/macOS run (pin artifact mtimes)

### DIFF
--- a/.github/actions/windows-tests/action.yml
+++ b/.github/actions/windows-tests/action.yml
@@ -42,6 +42,7 @@ runs:
       shell: bash
 
     - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+      id: ossl-download
       with:
         repo: pyca/infra
         workflow: build-windows-openssl.yml
@@ -50,6 +51,15 @@ runs:
         name: "openssl-${{ inputs.openssl-name }}"
         path: "C:/openssl-${{ inputs.openssl-name }}/"
         github_token: ${{ github.token }}
+    # The fresh extraction gives the headers new mtimes on every run, which
+    # invalidates openssl-sys's cargo fingerprint (it registers
+    # rerun-if-changed on the include dir) despite identical content.
+    - name: Pin OpenSSL artifact mtimes
+      run: python .github/bin/pin_artifact_mtimes.py "C:/openssl-${OPENSSL_NAME}" "${ARTIFACT_CREATED_AT}"
+      env:
+        OPENSSL_NAME: ${{ inputs.openssl-name }}
+        ARTIFACT_CREATED_AT: ${{ fromJSON(steps.ossl-download.outputs.artifacts)[0].created_at }}
+      shell: bash
     - name: Configure
       run: |
           echo "OPENSSL_DIR=C:/openssl-${OPENSSL_NAME}" >> $GITHUB_ENV

--- a/.github/bin/pin_artifact_mtimes.py
+++ b/.github/bin/pin_artifact_mtimes.py
@@ -1,0 +1,32 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+# Set every file in a downloaded artifact to the artifact's own creation
+# time. openssl-sys's build script registers cargo:rerun-if-changed on the
+# OpenSSL include directory, and cargo evaluates that by mtime, so a
+# freshly extracted artifact with identical content would otherwise
+# invalidate the cargo cache on every CI run. Using the artifact's
+# created_at means an unchanged artifact always looks the same, while a
+# rebuilt artifact gets a new timestamp and correctly triggers a rebuild.
+
+import datetime
+import os
+import sys
+
+
+def main(root: str, created_at: str) -> None:
+    mtime = datetime.datetime.fromisoformat(
+        created_at.replace("Z", "+00:00")
+    ).timestamp()
+    count = 0
+    for dirpath, _, filenames in os.walk(root):
+        for filename in filenames:
+            path = os.path.join(dirpath, filename)
+            os.utime(path, (mtime, mtime))
+            count += 1
+    print(f"pinned {count} files in {root} to {created_at}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,7 @@ jobs:
         uses: ./.github/actions/fetch-vectors
 
       - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        id: ossl-download
         with:
           repo: pyca/infra
           workflow: build-macos-openssl.yml
@@ -323,6 +324,13 @@ jobs:
           name: openssl-macos-universal2
           path: "../openssl-macos-universal2/"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      # The fresh extraction gives the headers new mtimes on every run, which
+      # invalidates openssl-sys's cargo fingerprint (it registers
+      # rerun-if-changed on the include dir) despite identical content.
+      - name: Pin OpenSSL artifact mtimes
+        run: python .github/bin/pin_artifact_mtimes.py ../openssl-macos-universal2/ "$ARTIFACT_CREATED_AT"
+        env:
+          ARTIFACT_CREATED_AT: ${{ fromJSON(steps.ossl-download.outputs.artifacts)[0].created_at }}
       - name: Build nox environment
         run: |
           OPENSSL_DIR=$(readlink -f ../openssl-macos-universal2/) \


### PR DESCRIPTION
## What

After downloading the prebuilt OpenSSL artifacts on Windows and macOS, set every extracted file's mtime to the **artifact's `created_at`** (via a small `.github/bin/pin_artifact_mtimes.py`, fed from the download action's `artifacts` output).

## Why

`openssl-sys`'s build script registers [`cargo:rerun-if-changed` on the OpenSSL include directory](https://github.com/sfackler/rust-openssl/blob/openssl-sys-v0.9.116/openssl-sys/build/main.rs), which cargo evaluates **by mtime**. On Windows and macOS the prebuilt OpenSSL is downloaded and extracted fresh on every CI run, so identical headers get brand-new mtimes — and `openssl-sys` (plus everything downstream: `openssl`, `cryptography-openssl`, `cryptography-cffi`) recompiles on every run despite a warm rust-cache. Visible in any windows job log as `Compiling openssl-sys v0.9.116` / `Compiling openssl v0.10.80` (~30–45s of the build step).

The Linux jobs don't have this problem because their custom OpenSSL builds are restored by `actions/cache`, which preserves mtimes — which is exactly why this was a Windows/macOS-only symptom.

## Why the artifact's creation time

It's the semantically right timestamp: an **unchanged artifact always presents identical mtimes** to cargo (cache stays valid), while a **rebuilt artifact gets a new `created_at`** and correctly triggers an `openssl-sys` rebuild — no staleness window, no cache-key coupling, and it's guaranteed to be in the past (a content-derived timestamp would need care not to land in the future, which would make cargo permanently dirty).

## Expected impact

Removes the remaining ~30–45s of redundant compilation from every Windows job's "Build nox environment" step and the macOS equivalent. No cache key bump needed: the pinned mtimes are older than the timestamps recorded in existing cached fingerprints, so existing caches start hitting immediately — the first run on this PR should already show no `Compiling openssl-sys` on windows/macos.

(Complements #14968, which removes the pyo3 chain recompiles; this one targets the openssl-sys side and is independent.)

https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb

---
_Generated by [Claude Code](https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb)_