### PR TITLE
CI: pin OpenSSL artifact directory mtimes too (openssl-sys cache, follow-up to #14971)

### DIFF
--- a/.github/actions/fetch-openssl/action.yml
+++ b/.github/actions/fetch-openssl/action.yml
@@ -1,0 +1,40 @@
+name: Download OpenSSL artifact
+description: |
+  Downloads a prebuilt OpenSSL artifact from pyca/infra and pins its
+  mtimes to the artifact's creation time. openssl-sys's build script
+  registers cargo:rerun-if-changed on the OpenSSL include directory,
+  which cargo evaluates by mtime, so a freshly extracted artifact with
+  unchanged content would otherwise invalidate the cargo cache on every
+  run.
+
+inputs:
+  workflow:
+    description: "The pyca/infra workflow that built the artifact"
+    required: true
+  name:
+    description: "The artifact name"
+    required: true
+  path:
+    description: "The directory to extract the artifact to"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+      id: download
+      with:
+        repo: pyca/infra
+        workflow: ${{ inputs.workflow }}
+        branch: main
+        workflow_conclusion: success
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        github_token: ${{ github.token }}
+    - name: Pin artifact mtimes
+      run: python .github/bin/pin_artifact_mtimes.py "$ARTIFACT_PATH" "$ARTIFACT_CREATED_AT"
+      env:
+        ARTIFACT_PATH: ${{ inputs.path }}
+        ARTIFACT_CREATED_AT: ${{ fromJSON(steps.download.outputs.artifacts)[0].created_at }}
+      shell: bash

--- a/.github/actions/windows-tests/action.yml
+++ b/.github/actions/windows-tests/action.yml
@@ -41,25 +41,12 @@ runs:
     - run: python -m pip install -c ci-constraints-requirements.txt "nox[uv]" "tomli; python_version < '3.11'"
       shell: bash
 
-    - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-      id: ossl-download
+    - name: Download OpenSSL
+      uses: ./.github/actions/fetch-openssl
       with:
-        repo: pyca/infra
         workflow: build-windows-openssl.yml
-        branch: main
-        workflow_conclusion: success
         name: "openssl-${{ inputs.openssl-name }}"
         path: "C:/openssl-${{ inputs.openssl-name }}/"
-        github_token: ${{ github.token }}
-    # The fresh extraction gives the headers new mtimes on every run, which
-    # invalidates openssl-sys's cargo fingerprint (it registers
-    # rerun-if-changed on the include dir) despite identical content.
-    - name: Pin OpenSSL artifact mtimes
-      run: python .github/bin/pin_artifact_mtimes.py "C:/openssl-${OPENSSL_NAME}" "${ARTIFACT_CREATED_AT}"
-      env:
-        OPENSSL_NAME: ${{ inputs.openssl-name }}
-        ARTIFACT_CREATED_AT: ${{ fromJSON(steps.ossl-download.outputs.artifacts)[0].created_at }}
-      shell: bash
     - name: Configure
       run: |
           echo "OPENSSL_DIR=C:/openssl-${OPENSSL_NAME}" >> $GITHUB_ENV

--- a/.github/bin/pin_artifact_mtimes.py
+++ b/.github/bin/pin_artifact_mtimes.py
@@ -20,9 +20,12 @@ def main(root: str, created_at: str) -> None:
         created_at.replace("Z", "+00:00")
     ).timestamp()
     count = 0
+    # Directories need pinning too: cargo stats their mtimes as well when
+    # evaluating rerun-if-changed on a directory (that's how it notices
+    # file deletions), and extraction recreates them fresh on every run.
     for dirpath, _, filenames in os.walk(root):
-        for filename in filenames:
-            path = os.path.join(dirpath, filename)
+        for name in (os.curdir, *filenames):
+            path = os.path.join(dirpath, name)
             os.utime(path, (mtime, mtime))
             count += 1
     print(f"pinned {count} files in {root} to {created_at}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,23 +314,12 @@ jobs:
         timeout-minutes: 2
         uses: ./.github/actions/fetch-vectors
 
-      - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        id: ossl-download
+      - name: Download OpenSSL
+        uses: ./.github/actions/fetch-openssl
         with:
-          repo: pyca/infra
           workflow: build-macos-openssl.yml
-          branch: main
-          workflow_conclusion: success
           name: openssl-macos-universal2
           path: "../openssl-macos-universal2/"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      # The fresh extraction gives the headers new mtimes on every run, which
-      # invalidates openssl-sys's cargo fingerprint (it registers
-      # rerun-if-changed on the include dir) despite identical content.
-      - name: Pin OpenSSL artifact mtimes
-        run: python .github/bin/pin_artifact_mtimes.py ../openssl-macos-universal2/ "$ARTIFACT_CREATED_AT"
-        env:
-          ARTIFACT_CREATED_AT: ${{ fromJSON(steps.ossl-download.outputs.artifacts)[0].created_at }}
       - name: Build nox environment
         run: |
           OPENSSL_DIR=$(readlink -f ../openssl-macos-universal2/) \


### PR DESCRIPTION
## What

Follow-up to #14971: pin **directory** mtimes too, not just files.

## Why

The first CI run with #14971 showed the pin step working (`pinned 386 files in C:/openssl-win64 to 2026-05-29T00:46:07Z`) but [`Compiling openssl-sys v0.9.116` still appearing](https://github.com/pyca/cryptography/actions/runs/27095834062) in the windows logs. The reason: cargo's `rerun-if-changed` on a directory stats the directories themselves as well as the files within (that's how it notices file *deletions* — a removed file leaves no mtime behind, but the parent directory's mtime changes). Extraction recreates the directory tree with fresh mtimes every run, so the fingerprint stayed dirty.

With directories pinned to the artifact's `created_at` alongside the files, everything cargo stats under the include dir predates the cached fingerprint, and `openssl-sys` should finally stay cached. Verifiable on this PR's first run: the windows/macos job logs should no longer contain `Compiling openssl-sys`.

https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb

---
_Generated by [Claude Code](https://claude.ai/code/session_014StKTjk7GBcVdiWKimEsQb)_