### PR TITLE
Add -v to uv pip install in downstream jobs to debug build times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
       - run: python -m pip install -c ci-constraints-requirements.txt 'uv'
       - run: uv venv
       - run: source .venv/bin/activate && ./.github/downstream.d/${{ matrix.DOWNSTREAM }}.sh install
-      - run: uv pip install .
+      - run: uv pip install -v .
       # cryptography main has a version of "(X+1).0.0.dev1" where X is the
       # most recently released major version. A package used by a downstream
       # may depend on cryptography <=X. If you use entrypoints stuff, this can


### PR DESCRIPTION
The `uv pip install .` step in the `linux-downstream` jobs consistently takes 25–63s even when the rust-cache hits (full match, ~32 MB restored). Add `-v` so the logs show where that time is going — cargo invocation, what gets recompiled vs. reused from the restored `target/`, and uv's own overhead.

https://claude.ai/code/session_01YUH4HCt55jz7EM16P8rc2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUH4HCt55jz7EM16P8rc2K)_