### PR TITLE
Add external mu (message representative) support for ML-DSA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,6 +67,10 @@ Changelog
   (not an instance) encodes an RSA subject public key in the certificate's
   ``subjectPublicKeyInfo`` with the ``id-RSASSA-PSS`` OID and no
   parameters.
+* Added external mu (message representative) support to
+  :doc:`/hazmat/primitives/asymmetric/mldsa` via the
+  ``sign_mu`` and ``verify_mu`` methods, which sign and verify a precomputed
+  64-byte ``mu`` as defined in FIPS 204.
 
 .. _v48-0-1:
 

--- a/docs/hazmat/primitives/asymmetric/mldsa.rst
+++ b/docs/hazmat/primitives/asymmetric/mldsa.rst
@@ -100,8 +100,12 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Sign a precomputed ``mu`` (message representative) using ML-DSA-44,
-        the "external mu" variant from FIPS 204. ``mu`` already incorporates
-        the public key and any context string, so no context is accepted here.
+        the "external mu" variant from FIPS 204. ``mu`` is computed as
+        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
+        the context and message; because it already binds the public key and
+        context, no context is accepted here. ``cryptography`` does not
+        currently provide an API to compute ``mu``, so you must compute it
+        yourself.
 
         :param mu: The 64-byte message representative.
         :type mu: :term:`bytes-like`
@@ -247,8 +251,10 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Verify a signature over a precomputed ``mu`` (message representative),
-        the "external mu" variant from FIPS 204. ``mu`` already incorporates
-        the public key and any context string.
+        the "external mu" variant from FIPS 204. ``mu`` is computed as
+        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
+        the context and message. ``cryptography`` does not currently provide an
+        API to compute ``mu``, so you must compute it yourself.
 
         :param signature: The signature to verify.
         :type signature: :term:`bytes-like`
@@ -320,8 +326,12 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Sign a precomputed ``mu`` (message representative) using ML-DSA-65,
-        the "external mu" variant from FIPS 204. ``mu`` already incorporates
-        the public key and any context string, so no context is accepted here.
+        the "external mu" variant from FIPS 204. ``mu`` is computed as
+        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
+        the context and message; because it already binds the public key and
+        context, no context is accepted here. ``cryptography`` does not
+        currently provide an API to compute ``mu``, so you must compute it
+        yourself.
 
         :param mu: The 64-byte message representative.
         :type mu: :term:`bytes-like`
@@ -467,8 +477,10 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Verify a signature over a precomputed ``mu`` (message representative),
-        the "external mu" variant from FIPS 204. ``mu`` already incorporates
-        the public key and any context string.
+        the "external mu" variant from FIPS 204. ``mu`` is computed as
+        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
+        the context and message. ``cryptography`` does not currently provide an
+        API to compute ``mu``, so you must compute it yourself.
 
         :param signature: The signature to verify.
         :type signature: :term:`bytes-like`
@@ -540,8 +552,12 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Sign a precomputed ``mu`` (message representative) using ML-DSA-87,
-        the "external mu" variant from FIPS 204. ``mu`` already incorporates
-        the public key and any context string, so no context is accepted here.
+        the "external mu" variant from FIPS 204. ``mu`` is computed as
+        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
+        the context and message; because it already binds the public key and
+        context, no context is accepted here. ``cryptography`` does not
+        currently provide an API to compute ``mu``, so you must compute it
+        yourself.
 
         :param mu: The 64-byte message representative.
         :type mu: :term:`bytes-like`
@@ -687,8 +703,10 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Verify a signature over a precomputed ``mu`` (message representative),
-        the "external mu" variant from FIPS 204. ``mu`` already incorporates
-        the public key and any context string.
+        the "external mu" variant from FIPS 204. ``mu`` is computed as
+        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
+        the context and message. ``cryptography`` does not currently provide an
+        API to compute ``mu``, so you must compute it yourself.
 
         :param signature: The signature to verify.
         :type signature: :term:`bytes-like`

--- a/docs/hazmat/primitives/asymmetric/mldsa.rst
+++ b/docs/hazmat/primitives/asymmetric/mldsa.rst
@@ -95,6 +95,21 @@ Key interfaces
 
         :raises ValueError: If the context is longer than 255 bytes.
 
+    .. method:: sign_mu(mu)
+
+        .. versionadded:: 49.0.0
+
+        Sign a precomputed ``mu`` (message representative) using ML-DSA-44,
+        the "external mu" variant from FIPS 204. ``mu`` already incorporates
+        the public key and any context string, so no context is accepted here.
+
+        :param mu: The 64-byte message representative.
+        :type mu: :term:`bytes-like`
+
+        :returns bytes: The signature (2420 bytes).
+
+        :raises ValueError: If ``mu`` is not 64 bytes.
+
     .. method:: private_bytes(encoding, format, encryption_algorithm)
 
         Allows serialization of the key to bytes. Encoding (
@@ -227,6 +242,25 @@ Key interfaces
             signature cannot be verified.
         :raises ValueError: If the context is longer than 255 bytes.
 
+    .. method:: verify_mu(signature, mu)
+
+        .. versionadded:: 49.0.0
+
+        Verify a signature over a precomputed ``mu`` (message representative),
+        the "external mu" variant from FIPS 204. ``mu`` already incorporates
+        the public key and any context string.
+
+        :param signature: The signature to verify.
+        :type signature: :term:`bytes-like`
+
+        :param mu: The 64-byte message representative.
+        :type mu: :term:`bytes-like`
+
+        :returns: None
+        :raises cryptography.exceptions.InvalidSignature: Raised when the
+            signature cannot be verified.
+        :raises ValueError: If ``mu`` is not 64 bytes.
+
 .. class:: MLDSA65PrivateKey
 
     .. versionadded:: 47.0.0
@@ -280,6 +314,21 @@ Key interfaces
         :returns bytes: The signature (3309 bytes).
 
         :raises ValueError: If the context is longer than 255 bytes.
+
+    .. method:: sign_mu(mu)
+
+        .. versionadded:: 49.0.0
+
+        Sign a precomputed ``mu`` (message representative) using ML-DSA-65,
+        the "external mu" variant from FIPS 204. ``mu`` already incorporates
+        the public key and any context string, so no context is accepted here.
+
+        :param mu: The 64-byte message representative.
+        :type mu: :term:`bytes-like`
+
+        :returns bytes: The signature (3309 bytes).
+
+        :raises ValueError: If ``mu`` is not 64 bytes.
 
     .. method:: private_bytes(encoding, format, encryption_algorithm)
 
@@ -413,6 +462,25 @@ Key interfaces
             signature cannot be verified.
         :raises ValueError: If the context is longer than 255 bytes.
 
+    .. method:: verify_mu(signature, mu)
+
+        .. versionadded:: 49.0.0
+
+        Verify a signature over a precomputed ``mu`` (message representative),
+        the "external mu" variant from FIPS 204. ``mu`` already incorporates
+        the public key and any context string.
+
+        :param signature: The signature to verify.
+        :type signature: :term:`bytes-like`
+
+        :param mu: The 64-byte message representative.
+        :type mu: :term:`bytes-like`
+
+        :returns: None
+        :raises cryptography.exceptions.InvalidSignature: Raised when the
+            signature cannot be verified.
+        :raises ValueError: If ``mu`` is not 64 bytes.
+
 .. class:: MLDSA87PrivateKey
 
     .. versionadded:: 47.0.0
@@ -466,6 +534,21 @@ Key interfaces
         :returns bytes: The signature (4627 bytes).
 
         :raises ValueError: If the context is longer than 255 bytes.
+
+    .. method:: sign_mu(mu)
+
+        .. versionadded:: 49.0.0
+
+        Sign a precomputed ``mu`` (message representative) using ML-DSA-87,
+        the "external mu" variant from FIPS 204. ``mu`` already incorporates
+        the public key and any context string, so no context is accepted here.
+
+        :param mu: The 64-byte message representative.
+        :type mu: :term:`bytes-like`
+
+        :returns bytes: The signature (4627 bytes).
+
+        :raises ValueError: If ``mu`` is not 64 bytes.
 
     .. method:: private_bytes(encoding, format, encryption_algorithm)
 
@@ -598,6 +681,25 @@ Key interfaces
         :raises cryptography.exceptions.InvalidSignature: Raised when the
             signature cannot be verified.
         :raises ValueError: If the context is longer than 255 bytes.
+
+    .. method:: verify_mu(signature, mu)
+
+        .. versionadded:: 49.0.0
+
+        Verify a signature over a precomputed ``mu`` (message representative),
+        the "external mu" variant from FIPS 204. ``mu`` already incorporates
+        the public key and any context string.
+
+        :param signature: The signature to verify.
+        :type signature: :term:`bytes-like`
+
+        :param mu: The 64-byte message representative.
+        :type mu: :term:`bytes-like`
+
+        :returns: None
+        :raises cryptography.exceptions.InvalidSignature: Raised when the
+            signature cannot be verified.
+        :raises ValueError: If ``mu`` is not 64 bytes.
 
 
 .. _`FIPS 204`: https://csrc.nist.gov/pubs/fips/204/final

--- a/docs/hazmat/primitives/asymmetric/mldsa.rst
+++ b/docs/hazmat/primitives/asymmetric/mldsa.rst
@@ -100,12 +100,8 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Sign a precomputed ``mu`` (message representative) using ML-DSA-44,
-        the "external mu" variant from FIPS 204. ``mu`` is computed as
-        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
-        the context and message; because it already binds the public key and
-        context, no context is accepted here. ``cryptography`` does not
-        currently provide an API to compute ``mu``, so you must compute it
-        yourself.
+        the "external mu" variant from FIPS 204. There is currently no API to
+        compute ``mu``, so you must compute it yourself.
 
         :param mu: The 64-byte message representative.
         :type mu: :term:`bytes-like`
@@ -251,10 +247,8 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Verify a signature over a precomputed ``mu`` (message representative),
-        the "external mu" variant from FIPS 204. ``mu`` is computed as
-        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
-        the context and message. ``cryptography`` does not currently provide an
-        API to compute ``mu``, so you must compute it yourself.
+        the "external mu" variant from FIPS 204. There is currently no API to
+        compute ``mu``, so you must compute it yourself.
 
         :param signature: The signature to verify.
         :type signature: :term:`bytes-like`
@@ -326,12 +320,8 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Sign a precomputed ``mu`` (message representative) using ML-DSA-65,
-        the "external mu" variant from FIPS 204. ``mu`` is computed as
-        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
-        the context and message; because it already binds the public key and
-        context, no context is accepted here. ``cryptography`` does not
-        currently provide an API to compute ``mu``, so you must compute it
-        yourself.
+        the "external mu" variant from FIPS 204. There is currently no API to
+        compute ``mu``, so you must compute it yourself.
 
         :param mu: The 64-byte message representative.
         :type mu: :term:`bytes-like`
@@ -477,10 +467,8 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Verify a signature over a precomputed ``mu`` (message representative),
-        the "external mu" variant from FIPS 204. ``mu`` is computed as
-        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
-        the context and message. ``cryptography`` does not currently provide an
-        API to compute ``mu``, so you must compute it yourself.
+        the "external mu" variant from FIPS 204. There is currently no API to
+        compute ``mu``, so you must compute it yourself.
 
         :param signature: The signature to verify.
         :type signature: :term:`bytes-like`
@@ -552,12 +540,8 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Sign a precomputed ``mu`` (message representative) using ML-DSA-87,
-        the "external mu" variant from FIPS 204. ``mu`` is computed as
-        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
-        the context and message; because it already binds the public key and
-        context, no context is accepted here. ``cryptography`` does not
-        currently provide an API to compute ``mu``, so you must compute it
-        yourself.
+        the "external mu" variant from FIPS 204. There is currently no API to
+        compute ``mu``, so you must compute it yourself.
 
         :param mu: The 64-byte message representative.
         :type mu: :term:`bytes-like`
@@ -703,10 +687,8 @@ Key interfaces
         .. versionadded:: 49.0.0
 
         Verify a signature over a precomputed ``mu`` (message representative),
-        the "external mu" variant from FIPS 204. ``mu`` is computed as
-        ``SHAKE256(SHAKE256(public_key, 64) || M', 64)``, where ``M'`` encodes
-        the context and message. ``cryptography`` does not currently provide an
-        API to compute ``mu``, so you must compute it yourself.
+        the "external mu" variant from FIPS 204. There is currently no API to
+        compute ``mu``, so you must compute it yourself.
 
         :param signature: The signature to verify.
         :type signature: :term:`bytes-like`

--- a/src/cryptography/hazmat/primitives/asymmetric/mldsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/mldsa.py
@@ -56,6 +56,18 @@ class MLDSA44PublicKey(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def verify_mu(
+        self,
+        signature: Buffer,
+        mu: Buffer,
+    ) -> None:
+        """
+        Verify the signature over a precomputed mu (message representative).
+
+        mu must be 64 bytes.
+        """
+
+    @abc.abstractmethod
     def __eq__(self, other: object) -> bool:
         """
         Checks equality.
@@ -139,6 +151,15 @@ class MLDSA44PrivateKey(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def sign_mu(self, mu: Buffer) -> bytes:
+        """
+        Signs a precomputed mu (message representative).
+
+        mu must be 64 bytes and already incorporates the context, so no
+        context is accepted here.
+        """
+
+    @abc.abstractmethod
     def __copy__(self) -> MLDSA44PrivateKey:
         """
         Returns a copy.
@@ -196,6 +217,18 @@ class MLDSA65PublicKey(metaclass=abc.ABCMeta):
     ) -> None:
         """
         Verify the signature.
+        """
+
+    @abc.abstractmethod
+    def verify_mu(
+        self,
+        signature: Buffer,
+        mu: Buffer,
+    ) -> None:
+        """
+        Verify the signature over a precomputed mu (message representative).
+
+        mu must be 64 bytes.
         """
 
     @abc.abstractmethod
@@ -282,6 +315,15 @@ class MLDSA65PrivateKey(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def sign_mu(self, mu: Buffer) -> bytes:
+        """
+        Signs a precomputed mu (message representative).
+
+        mu must be 64 bytes and already incorporates the context, so no
+        context is accepted here.
+        """
+
+    @abc.abstractmethod
     def __copy__(self) -> MLDSA65PrivateKey:
         """
         Returns a copy.
@@ -339,6 +381,18 @@ class MLDSA87PublicKey(metaclass=abc.ABCMeta):
     ) -> None:
         """
         Verify the signature.
+        """
+
+    @abc.abstractmethod
+    def verify_mu(
+        self,
+        signature: Buffer,
+        mu: Buffer,
+    ) -> None:
+        """
+        Verify the signature over a precomputed mu (message representative).
+
+        mu must be 64 bytes.
         """
 
     @abc.abstractmethod
@@ -422,6 +476,15 @@ class MLDSA87PrivateKey(metaclass=abc.ABCMeta):
     def sign(self, data: Buffer, context: Buffer | None = None) -> bytes:
         """
         Signs the data.
+        """
+
+    @abc.abstractmethod
+    def sign_mu(self, mu: Buffer) -> bytes:
+        """
+        Signs a precomputed mu (message representative).
+
+        mu must be 64 bytes and already incorporates the context, so no
+        context is accepted here.
         """
 
     @abc.abstractmethod

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -384,7 +384,10 @@ pub fn sign_mu(
             Ok(sig)
         } else if #[cfg(CRYPTOGRAPHY_OPENSSL_350_OR_GREATER)] {
             // OpenSSL signs an external mu by setting the "mu" parameter and
-            // passing the 64-byte mu in place of the message.
+            // passing the 64-byte mu in place of the message. ML-DSA only
+            // supports the digest-sign flow (EVP_PKEY_sign_init is not
+            // implemented for it), so we cannot use the one-shot PkeyCtx path
+            // the AWS-LC branch uses.
             let _ = variant;
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
             let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -413,9 +413,7 @@ pub fn verify_mu(
                     MlDsaVariant::MlDsa44 => {
                         let mut key = std::mem::MaybeUninit::<ffi::MLDSA44_public_key>::uninit();
                         let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
-                        if cvt(ffi::MLDSA44_parse_public_key(key.as_mut_ptr(), &mut cbs)).is_err() {
-                            return Ok(false);
-                        }
+                        cvt(ffi::MLDSA44_parse_public_key(key.as_mut_ptr(), &mut cbs))?;
                         let key = key.assume_init();
                         Ok(ffi::MLDSA44_verify_message_representative(
                             &key,
@@ -427,9 +425,7 @@ pub fn verify_mu(
                     MlDsaVariant::MlDsa65 => {
                         let mut key = std::mem::MaybeUninit::<ffi::MLDSA65_public_key>::uninit();
                         let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
-                        if cvt(ffi::MLDSA65_parse_public_key(key.as_mut_ptr(), &mut cbs)).is_err() {
-                            return Ok(false);
-                        }
+                        cvt(ffi::MLDSA65_parse_public_key(key.as_mut_ptr(), &mut cbs))?;
                         let key = key.assume_init();
                         Ok(ffi::MLDSA65_verify_message_representative(
                             &key,
@@ -441,9 +437,7 @@ pub fn verify_mu(
                     MlDsaVariant::MlDsa87 => {
                         let mut key = std::mem::MaybeUninit::<ffi::MLDSA87_public_key>::uninit();
                         let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
-                        if cvt(ffi::MLDSA87_parse_public_key(key.as_mut_ptr(), &mut cbs)).is_err() {
-                            return Ok(false);
-                        }
+                        cvt(ffi::MLDSA87_parse_public_key(key.as_mut_ptr(), &mut cbs))?;
                         let key = key.assume_init();
                         Ok(ffi::MLDSA87_verify_message_representative(
                             &key,

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -289,7 +289,7 @@ fn set_mu<T>(pkey_ctx: &mut openssl::pkey_ctx::PkeyCtxRef<T>) -> OpenSSLResult<(
     // OSSL_PARAM_get_int, which accepts an unsigned integer param, so we can
     // build the array on the stack rather than via an allocating
     // OSSL_PARAM_BLD.
-    let mut mu: std::os::raw::c_uint = 1;
+    let mut mu: std::ffi::c_uint = 1;
     // SAFETY: `params` and its backing `mu` value outlive the call into
     // OpenSSL, and the array is terminated with OSSL_PARAM_construct_end().
     unsafe {
@@ -312,6 +312,10 @@ pub fn sign_mu(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
     mu: &[u8],
 ) -> OpenSSLResult<Vec<u8>> {
+    // The BoringSSL path passes `mu` to the low-level API as a bare pointer
+    // that is read for exactly MLDSA_MU_BYTES, so enforce the length here for
+    // soundness rather than relying on callers.
+    assert_eq!(mu.len(), MLDSA_MU_BYTES);
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
             // BoringSSL has no EVP-level external mu support, so we drop down to
@@ -403,6 +407,10 @@ pub fn verify_mu(
     signature: &[u8],
     mu: &[u8],
 ) -> OpenSSLResult<bool> {
+    // The BoringSSL path passes `mu` to the low-level API as a bare pointer
+    // that is read for exactly MLDSA_MU_BYTES, so enforce the length here for
+    // soundness rather than relying on callers.
+    assert_eq!(mu.len(), MLDSA_MU_BYTES);
     cfg_if::cfg_if! {
         if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
             let raw = pkey.raw_public_key()?;
@@ -412,8 +420,12 @@ pub fn verify_mu(
                 match MlDsaVariant::from_pkey(pkey) {
                     MlDsaVariant::MlDsa44 => {
                         let mut key = std::mem::MaybeUninit::<ffi::MLDSA44_public_key>::uninit();
-                        let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
-                        cvt(ffi::MLDSA44_parse_public_key(key.as_mut_ptr(), &mut cbs))?;
+                        let mut cbs = std::mem::MaybeUninit::<ffi::CBS>::uninit();
+                        ffi::CBS_init(cbs.as_mut_ptr(), raw.as_ptr(), raw.len());
+                        cvt(ffi::MLDSA44_parse_public_key(
+                            key.as_mut_ptr(),
+                            cbs.as_mut_ptr(),
+                        ))?;
                         let key = key.assume_init();
                         Ok(ffi::MLDSA44_verify_message_representative(
                             &key,
@@ -424,8 +436,12 @@ pub fn verify_mu(
                     }
                     MlDsaVariant::MlDsa65 => {
                         let mut key = std::mem::MaybeUninit::<ffi::MLDSA65_public_key>::uninit();
-                        let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
-                        cvt(ffi::MLDSA65_parse_public_key(key.as_mut_ptr(), &mut cbs))?;
+                        let mut cbs = std::mem::MaybeUninit::<ffi::CBS>::uninit();
+                        ffi::CBS_init(cbs.as_mut_ptr(), raw.as_ptr(), raw.len());
+                        cvt(ffi::MLDSA65_parse_public_key(
+                            key.as_mut_ptr(),
+                            cbs.as_mut_ptr(),
+                        ))?;
                         let key = key.assume_init();
                         Ok(ffi::MLDSA65_verify_message_representative(
                             &key,
@@ -436,8 +452,12 @@ pub fn verify_mu(
                     }
                     MlDsaVariant::MlDsa87 => {
                         let mut key = std::mem::MaybeUninit::<ffi::MLDSA87_public_key>::uninit();
-                        let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
-                        cvt(ffi::MLDSA87_parse_public_key(key.as_mut_ptr(), &mut cbs))?;
+                        let mut cbs = std::mem::MaybeUninit::<ffi::CBS>::uninit();
+                        ffi::CBS_init(cbs.as_mut_ptr(), raw.as_ptr(), raw.len());
+                        cvt(ffi::MLDSA87_parse_public_key(
+                            key.as_mut_ptr(),
+                            cbs.as_mut_ptr(),
+                        ))?;
                         let key = key.assume_init();
                         Ok(ffi::MLDSA87_verify_message_representative(
                             &key,

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -25,11 +25,7 @@ use std::os::raw::c_int;
     CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
 ))]
 use crate::cvt;
-#[cfg(any(
-    CRYPTOGRAPHY_IS_BORINGSSL,
-    CRYPTOGRAPHY_IS_AWSLC,
-    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
-))]
+#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
 use crate::cvt_p;
 use crate::OpenSSLResult;
 
@@ -288,21 +284,23 @@ pub fn verify(
 /// setting the integer `mu` signature parameter (OSSL_SIGNATURE_PARAM_MU) to 1.
 #[cfg(CRYPTOGRAPHY_OPENSSL_350_OR_GREATER)]
 fn set_mu<T>(pkey_ctx: &mut openssl::pkey_ctx::PkeyCtxRef<T>) -> OpenSSLResult<()> {
-    // SAFETY: We build a one-element OSSL_PARAM array holding the integer "mu"
-    // parameter set to 1 and apply it to the EVP_PKEY_CTX. Every pointer is
-    // valid for the duration of its use and freed before returning.
+    // A fixed OSSL_PARAM array holding the integer "mu" parameter set to 1
+    // enables external mu mode. The provider reads it back with
+    // OSSL_PARAM_get_int, which accepts an unsigned integer param, so we can
+    // build the array on the stack rather than via an allocating
+    // OSSL_PARAM_BLD.
+    let mut mu: std::os::raw::c_uint = 1;
+    // SAFETY: `params` and its backing `mu` value outlive the call into
+    // OpenSSL, and the array is terminated with OSSL_PARAM_construct_end().
     unsafe {
-        let bld = cvt_p(ffi::OSSL_PARAM_BLD_new())?;
-        if ffi::OSSL_PARAM_BLD_push_int(bld, c"mu".as_ptr(), 1) != 1 {
-            ffi::OSSL_PARAM_BLD_free(bld);
-            return Err(openssl::error::ErrorStack::get());
-        }
-        let params = ffi::OSSL_PARAM_BLD_to_param(bld);
-        ffi::OSSL_PARAM_BLD_free(bld);
-        let params = cvt_p(params)?;
-        let res = ffi::EVP_PKEY_CTX_set_params(pkey_ctx.as_ptr(), params);
-        ffi::OSSL_PARAM_free(params);
-        cvt(res)?;
+        let params = [
+            ffi::OSSL_PARAM_construct_uint(c"mu".as_ptr(), &mut mu),
+            ffi::OSSL_PARAM_construct_end(),
+        ];
+        cvt(ffi::EVP_PKEY_CTX_set_params(
+            pkey_ctx.as_ptr(),
+            params.as_ptr(),
+        ))?;
     }
     Ok(())
 }

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -4,16 +4,32 @@
 
 #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
 use foreign_types_shared::ForeignType;
-#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
+#[cfg(any(
+    CRYPTOGRAPHY_IS_BORINGSSL,
+    CRYPTOGRAPHY_IS_AWSLC,
+    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
+))]
 use foreign_types_shared::ForeignTypeRef;
-#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
+#[cfg(any(
+    CRYPTOGRAPHY_IS_BORINGSSL,
+    CRYPTOGRAPHY_IS_AWSLC,
+    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
+))]
 use openssl_sys as ffi;
 #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
 use std::os::raw::c_int;
 
-#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
+#[cfg(any(
+    CRYPTOGRAPHY_IS_BORINGSSL,
+    CRYPTOGRAPHY_IS_AWSLC,
+    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
+))]
 use crate::cvt;
-#[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
+#[cfg(any(
+    CRYPTOGRAPHY_IS_BORINGSSL,
+    CRYPTOGRAPHY_IS_AWSLC,
+    CRYPTOGRAPHY_OPENSSL_350_OR_GREATER
+))]
 use crate::cvt_p;
 use crate::OpenSSLResult;
 
@@ -23,6 +39,10 @@ pub enum MlDsaVariant {
     MlDsa65,
     MlDsa87,
 }
+
+/// The length, in bytes, of an ML-DSA external mu (message representative)
+/// value, as defined in FIPS 204.
+pub const MLDSA_MU_BYTES: usize = 64;
 
 #[cfg(CRYPTOGRAPHY_IS_AWSLC)]
 pub const PKEY_ID: openssl::pkey::Id = openssl::pkey::Id::from_raw(ffi::NID_PQDSA);
@@ -262,6 +282,194 @@ pub fn verify(
         set_context_string(pkey_ctx, context)?;
     }
     Ok(md_ctx.digest_verify(data, signature).unwrap_or(false))
+}
+
+/// Enable "external mu" mode on an OpenSSL signing/verification context by
+/// setting the integer `mu` signature parameter (OSSL_SIGNATURE_PARAM_MU) to 1.
+#[cfg(CRYPTOGRAPHY_OPENSSL_350_OR_GREATER)]
+fn set_mu<T>(pkey_ctx: &mut openssl::pkey_ctx::PkeyCtxRef<T>) -> OpenSSLResult<()> {
+    // SAFETY: We build a one-element OSSL_PARAM array holding the integer "mu"
+    // parameter set to 1 and apply it to the EVP_PKEY_CTX. Every pointer is
+    // valid for the duration of its use and freed before returning.
+    unsafe {
+        let bld = cvt_p(ffi::OSSL_PARAM_BLD_new())?;
+        if ffi::OSSL_PARAM_BLD_push_int(bld, c"mu".as_ptr(), 1) != 1 {
+            ffi::OSSL_PARAM_BLD_free(bld);
+            return Err(openssl::error::ErrorStack::get());
+        }
+        let params = ffi::OSSL_PARAM_BLD_to_param(bld);
+        ffi::OSSL_PARAM_BLD_free(bld);
+        let params = cvt_p(params)?;
+        let res = ffi::EVP_PKEY_CTX_set_params(pkey_ctx.as_ptr(), params);
+        ffi::OSSL_PARAM_free(params);
+        cvt(res)?;
+    }
+    Ok(())
+}
+
+/// Sign a precomputed external mu (message representative). `mu` must be
+/// [`MLDSA_MU_BYTES`] long, and already incorporates any context string, so no
+/// context is accepted here.
+pub fn sign_mu(
+    pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
+    variant: MlDsaVariant,
+    mu: &[u8],
+) -> OpenSSLResult<Vec<u8>> {
+    cfg_if::cfg_if! {
+        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+            // BoringSSL has no EVP-level external mu support, so we drop down to
+            // the low-level ML-DSA API, reconstructing the private key from its
+            // 32-byte seed.
+            let seed = mldsa_seed_raw(pkey)?;
+            // SAFETY: `seed` is a valid 32-byte seed and `mu` is a valid
+            // MLDSA_MU_BYTES buffer; both outlive the calls below.
+            unsafe {
+                match variant {
+                    MlDsaVariant::MlDsa44 => {
+                        let mut key = std::mem::MaybeUninit::<ffi::MLDSA44_private_key>::uninit();
+                        cvt(ffi::MLDSA44_private_key_from_seed(
+                            key.as_mut_ptr(),
+                            seed.as_ptr(),
+                            seed.len(),
+                        ))?;
+                        let key = key.assume_init();
+                        let mut sig = vec![0u8; ffi::MLDSA44_SIGNATURE_BYTES as usize];
+                        cvt(ffi::MLDSA44_sign_message_representative(
+                            sig.as_mut_ptr(),
+                            &key,
+                            mu.as_ptr(),
+                        ))?;
+                        Ok(sig)
+                    }
+                    MlDsaVariant::MlDsa65 => {
+                        let mut key = std::mem::MaybeUninit::<ffi::MLDSA65_private_key>::uninit();
+                        cvt(ffi::MLDSA65_private_key_from_seed(
+                            key.as_mut_ptr(),
+                            seed.as_ptr(),
+                            seed.len(),
+                        ))?;
+                        let key = key.assume_init();
+                        let mut sig = vec![0u8; ffi::MLDSA65_SIGNATURE_BYTES as usize];
+                        cvt(ffi::MLDSA65_sign_message_representative(
+                            sig.as_mut_ptr(),
+                            &key,
+                            mu.as_ptr(),
+                        ))?;
+                        Ok(sig)
+                    }
+                    MlDsaVariant::MlDsa87 => {
+                        let mut key = std::mem::MaybeUninit::<ffi::MLDSA87_private_key>::uninit();
+                        cvt(ffi::MLDSA87_private_key_from_seed(
+                            key.as_mut_ptr(),
+                            seed.as_ptr(),
+                            seed.len(),
+                        ))?;
+                        let key = key.assume_init();
+                        let mut sig = vec![0u8; ffi::MLDSA87_SIGNATURE_BYTES as usize];
+                        cvt(ffi::MLDSA87_sign_message_representative(
+                            sig.as_mut_ptr(),
+                            &key,
+                            mu.as_ptr(),
+                        ))?;
+                        Ok(sig)
+                    }
+                }
+            }
+        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
+            // AWS-LC's EVP_PKEY_sign treats its input as an external mu (the
+            // "ExternalMu" format) for ML-DSA keys.
+            let _ = variant;
+            let mut ctx = openssl::pkey_ctx::PkeyCtx::new(pkey)?;
+            ctx.sign_init()?;
+            let mut sig = vec![];
+            ctx.sign_to_vec(mu, &mut sig)?;
+            Ok(sig)
+        } else if #[cfg(CRYPTOGRAPHY_OPENSSL_350_OR_GREATER)] {
+            // OpenSSL signs an external mu by setting the "mu" parameter and
+            // passing the 64-byte mu in place of the message.
+            let _ = variant;
+            let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
+            let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;
+            set_mu(pkey_ctx)?;
+            let mut sig = vec![];
+            md_ctx.digest_sign_to_vec(mu, &mut sig)?;
+            Ok(sig)
+        }
+    }
+}
+
+/// Verify a signature over a precomputed external mu (message representative).
+/// `mu` must be [`MLDSA_MU_BYTES`] long.
+pub fn verify_mu(
+    pkey: &openssl::pkey::PKeyRef<openssl::pkey::Public>,
+    variant: MlDsaVariant,
+    signature: &[u8],
+    mu: &[u8],
+) -> OpenSSLResult<bool> {
+    cfg_if::cfg_if! {
+        if #[cfg(CRYPTOGRAPHY_IS_BORINGSSL)] {
+            let raw = pkey.raw_public_key()?;
+            // SAFETY: We parse the low-level public key from its encoded form
+            // and verify the signature over the MLDSA_MU_BYTES `mu`.
+            unsafe {
+                match variant {
+                    MlDsaVariant::MlDsa44 => {
+                        let mut key = std::mem::MaybeUninit::<ffi::MLDSA44_public_key>::uninit();
+                        let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
+                        if cvt(ffi::MLDSA44_parse_public_key(key.as_mut_ptr(), &mut cbs)).is_err() {
+                            return Ok(false);
+                        }
+                        let key = key.assume_init();
+                        Ok(ffi::MLDSA44_verify_message_representative(
+                            &key,
+                            signature.as_ptr(),
+                            signature.len(),
+                            mu.as_ptr(),
+                        ) == 1)
+                    }
+                    MlDsaVariant::MlDsa65 => {
+                        let mut key = std::mem::MaybeUninit::<ffi::MLDSA65_public_key>::uninit();
+                        let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
+                        if cvt(ffi::MLDSA65_parse_public_key(key.as_mut_ptr(), &mut cbs)).is_err() {
+                            return Ok(false);
+                        }
+                        let key = key.assume_init();
+                        Ok(ffi::MLDSA65_verify_message_representative(
+                            &key,
+                            signature.as_ptr(),
+                            signature.len(),
+                            mu.as_ptr(),
+                        ) == 1)
+                    }
+                    MlDsaVariant::MlDsa87 => {
+                        let mut key = std::mem::MaybeUninit::<ffi::MLDSA87_public_key>::uninit();
+                        let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
+                        if cvt(ffi::MLDSA87_parse_public_key(key.as_mut_ptr(), &mut cbs)).is_err() {
+                            return Ok(false);
+                        }
+                        let key = key.assume_init();
+                        Ok(ffi::MLDSA87_verify_message_representative(
+                            &key,
+                            signature.as_ptr(),
+                            signature.len(),
+                            mu.as_ptr(),
+                        ) == 1)
+                    }
+                }
+            }
+        } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
+            let _ = variant;
+            let mut ctx = openssl::pkey_ctx::PkeyCtx::new(pkey)?;
+            ctx.verify_init()?;
+            Ok(ctx.verify(mu, signature).unwrap_or(false))
+        } else if #[cfg(CRYPTOGRAPHY_OPENSSL_350_OR_GREATER)] {
+            let _ = variant;
+            let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
+            let pkey_ctx = md_ctx.digest_verify_init(None, pkey)?;
+            set_mu(pkey_ctx)?;
+            Ok(md_ctx.digest_verify(mu, signature).unwrap_or(false))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/rust/cryptography-openssl/src/mldsa.rs
+++ b/src/rust/cryptography-openssl/src/mldsa.rs
@@ -310,7 +310,6 @@ fn set_mu<T>(pkey_ctx: &mut openssl::pkey_ctx::PkeyCtxRef<T>) -> OpenSSLResult<(
 /// context is accepted here.
 pub fn sign_mu(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
-    variant: MlDsaVariant,
     mu: &[u8],
 ) -> OpenSSLResult<Vec<u8>> {
     cfg_if::cfg_if! {
@@ -322,7 +321,7 @@ pub fn sign_mu(
             // SAFETY: `seed` is a valid 32-byte seed and `mu` is a valid
             // MLDSA_MU_BYTES buffer; both outlive the calls below.
             unsafe {
-                match variant {
+                match MlDsaVariant::from_pkey(pkey) {
                     MlDsaVariant::MlDsa44 => {
                         let mut key = std::mem::MaybeUninit::<ffi::MLDSA44_private_key>::uninit();
                         cvt(ffi::MLDSA44_private_key_from_seed(
@@ -376,7 +375,6 @@ pub fn sign_mu(
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
             // AWS-LC's EVP_PKEY_sign treats its input as an external mu (the
             // "ExternalMu" format) for ML-DSA keys.
-            let _ = variant;
             let mut ctx = openssl::pkey_ctx::PkeyCtx::new(pkey)?;
             ctx.sign_init()?;
             let mut sig = vec![];
@@ -388,7 +386,6 @@ pub fn sign_mu(
             // supports the digest-sign flow (EVP_PKEY_sign_init is not
             // implemented for it), so we cannot use the one-shot PkeyCtx path
             // the AWS-LC branch uses.
-            let _ = variant;
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
             let pkey_ctx = md_ctx.digest_sign_init(None, pkey)?;
             set_mu(pkey_ctx)?;
@@ -403,7 +400,6 @@ pub fn sign_mu(
 /// `mu` must be [`MLDSA_MU_BYTES`] long.
 pub fn verify_mu(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Public>,
-    variant: MlDsaVariant,
     signature: &[u8],
     mu: &[u8],
 ) -> OpenSSLResult<bool> {
@@ -413,7 +409,7 @@ pub fn verify_mu(
             // SAFETY: We parse the low-level public key from its encoded form
             // and verify the signature over the MLDSA_MU_BYTES `mu`.
             unsafe {
-                match variant {
+                match MlDsaVariant::from_pkey(pkey) {
                     MlDsaVariant::MlDsa44 => {
                         let mut key = std::mem::MaybeUninit::<ffi::MLDSA44_public_key>::uninit();
                         let mut cbs = ffi::CBS { data: raw.as_ptr(), len: raw.len() };
@@ -459,12 +455,10 @@ pub fn verify_mu(
                 }
             }
         } else if #[cfg(CRYPTOGRAPHY_IS_AWSLC)] {
-            let _ = variant;
             let mut ctx = openssl::pkey_ctx::PkeyCtx::new(pkey)?;
             ctx.verify_init()?;
             Ok(ctx.verify(mu, signature).unwrap_or(false))
         } else if #[cfg(CRYPTOGRAPHY_OPENSSL_350_OR_GREATER)] {
-            let _ = variant;
             let mut md_ctx = openssl::md_ctx::MdCtx::new()?;
             let pkey_ctx = md_ctx.digest_verify_init(None, pkey)?;
             set_mu(pkey_ctx)?;

--- a/src/rust/src/backend/mldsa.rs
+++ b/src/rust/src/backend/mldsa.rs
@@ -105,8 +105,7 @@ impl MlDsa44PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let sig =
-            cryptography_openssl::mldsa::sign_mu(&self.pkey, MlDsaVariant::MlDsa44, mu.as_bytes())?;
+        let sig = cryptography_openssl::mldsa::sign_mu(&self.pkey, mu.as_bytes())?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -173,13 +172,9 @@ impl MlDsa44PublicKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let valid = cryptography_openssl::mldsa::verify_mu(
-            &self.pkey,
-            MlDsaVariant::MlDsa44,
-            signature.as_bytes(),
-            mu.as_bytes(),
-        )
-        .unwrap_or(false);
+        let valid =
+            cryptography_openssl::mldsa::verify_mu(&self.pkey, signature.as_bytes(), mu.as_bytes())
+                .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(
@@ -346,8 +341,7 @@ impl MlDsa65PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let sig =
-            cryptography_openssl::mldsa::sign_mu(&self.pkey, MlDsaVariant::MlDsa65, mu.as_bytes())?;
+        let sig = cryptography_openssl::mldsa::sign_mu(&self.pkey, mu.as_bytes())?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -417,13 +411,9 @@ impl MlDsa65PublicKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let valid = cryptography_openssl::mldsa::verify_mu(
-            &self.pkey,
-            MlDsaVariant::MlDsa65,
-            signature.as_bytes(),
-            mu.as_bytes(),
-        )
-        .unwrap_or(false);
+        let valid =
+            cryptography_openssl::mldsa::verify_mu(&self.pkey, signature.as_bytes(), mu.as_bytes())
+                .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(
@@ -590,8 +580,7 @@ impl MlDsa87PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let sig =
-            cryptography_openssl::mldsa::sign_mu(&self.pkey, MlDsaVariant::MlDsa87, mu.as_bytes())?;
+        let sig = cryptography_openssl::mldsa::sign_mu(&self.pkey, mu.as_bytes())?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -658,13 +647,9 @@ impl MlDsa87PublicKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let valid = cryptography_openssl::mldsa::verify_mu(
-            &self.pkey,
-            MlDsaVariant::MlDsa87,
-            signature.as_bytes(),
-            mu.as_bytes(),
-        )
-        .unwrap_or(false);
+        let valid =
+            cryptography_openssl::mldsa::verify_mu(&self.pkey, signature.as_bytes(), mu.as_bytes())
+                .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(

--- a/src/rust/src/backend/mldsa.rs
+++ b/src/rust/src/backend/mldsa.rs
@@ -95,6 +95,21 @@ impl MlDsa44PrivateKey {
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
+    fn sign_mu<'p>(
+        &self,
+        py: pyo3::Python<'p>,
+        mu: CffiBuf<'_>,
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
+        if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
+            ));
+        }
+        let sig =
+            cryptography_openssl::mldsa::sign_mu(&self.pkey, MlDsaVariant::MlDsa44, mu.as_bytes())?;
+        Ok(pyo3::types::PyBytes::new(py, &sig))
+    }
+
     fn public_key(&self) -> CryptographyResult<MlDsa44PublicKey> {
         let raw_bytes = self.pkey.raw_public_key()?;
         Ok(MlDsa44PublicKey {
@@ -152,6 +167,30 @@ impl MlDsa44PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa44PublicKey {
+    #[pyo3(signature = (signature, mu))]
+    fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
+        if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
+            ));
+        }
+        let valid = cryptography_openssl::mldsa::verify_mu(
+            &self.pkey,
+            MlDsaVariant::MlDsa44,
+            signature.as_bytes(),
+            mu.as_bytes(),
+        )
+        .unwrap_or(false);
+
+        if !valid {
+            return Err(CryptographyError::from(
+                exceptions::InvalidSignature::new_err(()),
+            ));
+        }
+
+        Ok(())
+    }
+
     #[pyo3(signature = (signature, data, context=None))]
     fn verify(
         &self,
@@ -298,6 +337,21 @@ impl MlDsa65PrivateKey {
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
+    fn sign_mu<'p>(
+        &self,
+        py: pyo3::Python<'p>,
+        mu: CffiBuf<'_>,
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
+        if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
+            ));
+        }
+        let sig =
+            cryptography_openssl::mldsa::sign_mu(&self.pkey, MlDsaVariant::MlDsa65, mu.as_bytes())?;
+        Ok(pyo3::types::PyBytes::new(py, &sig))
+    }
+
     fn public_key(&self) -> CryptographyResult<MlDsa65PublicKey> {
         let raw_bytes = self.pkey.raw_public_key()?;
         Ok(MlDsa65PublicKey {
@@ -358,6 +412,30 @@ impl MlDsa65PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa65PublicKey {
+    #[pyo3(signature = (signature, mu))]
+    fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
+        if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
+            ));
+        }
+        let valid = cryptography_openssl::mldsa::verify_mu(
+            &self.pkey,
+            MlDsaVariant::MlDsa65,
+            signature.as_bytes(),
+            mu.as_bytes(),
+        )
+        .unwrap_or(false);
+
+        if !valid {
+            return Err(CryptographyError::from(
+                exceptions::InvalidSignature::new_err(()),
+            ));
+        }
+
+        Ok(())
+    }
+
     #[pyo3(signature = (signature, data, context=None))]
     fn verify(
         &self,
@@ -504,6 +582,21 @@ impl MlDsa87PrivateKey {
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
+    fn sign_mu<'p>(
+        &self,
+        py: pyo3::Python<'p>,
+        mu: CffiBuf<'_>,
+    ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
+        if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
+            ));
+        }
+        let sig =
+            cryptography_openssl::mldsa::sign_mu(&self.pkey, MlDsaVariant::MlDsa87, mu.as_bytes())?;
+        Ok(pyo3::types::PyBytes::new(py, &sig))
+    }
+
     fn public_key(&self) -> CryptographyResult<MlDsa87PublicKey> {
         let raw_bytes = self.pkey.raw_public_key()?;
         Ok(MlDsa87PublicKey {
@@ -561,6 +654,30 @@ impl MlDsa87PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa87PublicKey {
+    #[pyo3(signature = (signature, mu))]
+    fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
+        if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
+            ));
+        }
+        let valid = cryptography_openssl::mldsa::verify_mu(
+            &self.pkey,
+            MlDsaVariant::MlDsa87,
+            signature.as_bytes(),
+            mu.as_bytes(),
+        )
+        .unwrap_or(false);
+
+        if !valid {
+            return Err(CryptographyError::from(
+                exceptions::InvalidSignature::new_err(()),
+            ));
+        }
+
+        Ok(())
+    }
+
     #[pyo3(signature = (signature, data, context=None))]
     fn verify(
         &self,

--- a/src/rust/src/backend/mldsa.rs
+++ b/src/rust/src/backend/mldsa.rs
@@ -167,7 +167,6 @@ impl MlDsa44PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa44PublicKey {
-    #[pyo3(signature = (signature, mu))]
     fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
         if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
             return Err(CryptographyError::from(
@@ -412,7 +411,6 @@ impl MlDsa65PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa65PublicKey {
-    #[pyo3(signature = (signature, mu))]
     fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
         if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
             return Err(CryptographyError::from(
@@ -654,7 +652,6 @@ impl MlDsa87PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa87PublicKey {
-    #[pyo3(signature = (signature, mu))]
     fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
         if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
             return Err(CryptographyError::from(

--- a/tests/hazmat/primitives/test_mldsa.py
+++ b/tests/hazmat/primitives/test_mldsa.py
@@ -32,6 +32,7 @@ from ...utils import (
 
 @dataclasses.dataclass
 class MLDSAVariant:
+    name: str
     private_key_class: type
     public_key_class: type
     pub_key_size: int
@@ -42,6 +43,7 @@ class MLDSAVariant:
 ML_DSA_VARIANTS = [
     pytest.param(
         MLDSAVariant(
+            name="44",
             private_key_class=MLDSA44PrivateKey,
             public_key_class=MLDSA44PublicKey,
             pub_key_size=1312,
@@ -52,6 +54,7 @@ ML_DSA_VARIANTS = [
     ),
     pytest.param(
         MLDSAVariant(
+            name="65",
             private_key_class=MLDSA65PrivateKey,
             public_key_class=MLDSA65PublicKey,
             pub_key_size=1952,
@@ -62,6 +65,7 @@ ML_DSA_VARIANTS = [
     ),
     pytest.param(
         MLDSAVariant(
+            name="87",
             private_key_class=MLDSA87PrivateKey,
             public_key_class=MLDSA87PublicKey,
             pub_key_size=2592,
@@ -286,6 +290,37 @@ class TestMLDSA:
 
                 pub = MLDSA87PublicKey.from_public_bytes(pk)
                 pub.verify(expected_sig, msg, ctx)
+
+    @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
+    def test_kat_vectors_external_mu(self, variant, backend, subtests):
+        # The deterministic pure KAT signatures come from an independent
+        # reference implementation. mu is fully determined by the public key,
+        # context, and message (FIPS 204 Algorithm 2), so deriving it and
+        # checking verify_mu accepts the reference signature exercises the
+        # external-mu path against known-answer data.
+        vectors = load_vectors_from_file(
+            os.path.join(
+                "asymmetric", "MLDSA", f"kat_MLDSA_{variant.name}_det_pure.rsp"
+            ),
+            load_nist_vectors,
+        )
+        for vector in vectors:
+            with subtests.test():
+                pk = binascii.unhexlify(vector["pk"])
+                msg = binascii.unhexlify(vector["msg"])
+                ctx = binascii.unhexlify(vector["ctx"])
+                sm = binascii.unhexlify(vector["sm"])
+                expected_sig = sm[: variant.sig_size]
+                mu = self._compute_mu(pk, msg, ctx)
+
+                pub = variant.public_key_class.from_public_bytes(pk)
+                pub.verify_mu(expected_sig, mu)
+
+                # A signature that is valid for this mu must be rejected for a
+                # different mu.
+                wrong_mu = bytes([mu[0] ^ 0x01]) + mu[1:]
+                with pytest.raises(InvalidSignature):
+                    pub.verify_mu(expected_sig, wrong_mu)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
     def test_private_bytes_raw_round_trip(self, variant, backend):

--- a/tests/hazmat/primitives/test_mldsa.py
+++ b/tests/hazmat/primitives/test_mldsa.py
@@ -6,6 +6,7 @@
 import binascii
 import copy
 import dataclasses
+import hashlib
 import os
 
 import pytest
@@ -162,6 +163,66 @@ class TestMLDSA:
         pub.verify(sig, data, b"")
         sig2 = key.sign(data, b"")
         pub.verify(sig2, data)
+
+    @staticmethod
+    def _compute_mu(pub_raw: bytes, data: bytes, ctx: bytes = b"") -> bytes:
+        # FIPS 204: mu = SHAKE256(SHAKE256(pk, 64) || M', 64) where for pure
+        # ML-DSA M' = 0x00 || len(ctx) || ctx || M.
+        tr = hashlib.shake_256(pub_raw).digest(64)
+        m_prime = b"\x00" + bytes([len(ctx)]) + ctx + data
+        return hashlib.shake_256(tr + m_prime).digest(64)
+
+    @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
+    def test_sign_verify_mu(self, variant, backend):
+        key = variant.private_key_class.generate()
+        pub = key.public_key()
+        data = b"test data"
+        mu = self._compute_mu(pub.public_bytes_raw(), data)
+
+        sig = key.sign_mu(mu)
+        # Round-trips through the external-mu API.
+        pub.verify_mu(sig, mu)
+        # An external-mu signature is an ordinary ML-DSA signature.
+        pub.verify(sig, data)
+        # An ordinary signature verifies through the external-mu API.
+        sig2 = key.sign(data)
+        pub.verify_mu(sig2, mu)
+
+    @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
+    def test_sign_verify_mu_with_context(self, variant, backend):
+        key = variant.private_key_class.generate()
+        pub = key.public_key()
+        data = b"test data"
+        ctx = b"a context"
+        mu = self._compute_mu(pub.public_bytes_raw(), data, ctx)
+
+        sig = key.sign_mu(mu)
+        # The context is folded into mu, so the ordinary verify must supply it.
+        pub.verify(sig, data, ctx)
+        pub.verify_mu(sig, mu)
+
+    @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
+    def test_mu_wrong_length(self, variant, backend):
+        key = variant.private_key_class.generate()
+        pub = key.public_key()
+        with pytest.raises(ValueError):
+            key.sign_mu(b"0" * 63)
+        with pytest.raises(ValueError):
+            key.sign_mu(b"0" * 65)
+        sig = key.sign_mu(b"0" * 64)
+        with pytest.raises(ValueError):
+            pub.verify_mu(sig, b"0" * 63)
+
+    @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
+    def test_verify_mu_invalid(self, variant, backend):
+        key = variant.private_key_class.generate()
+        pub = key.public_key()
+        mu = b"\x01" * 64
+        sig = key.sign_mu(mu)
+        with pytest.raises(InvalidSignature):
+            pub.verify_mu(sig, b"\x02" * 64)
+        with pytest.raises(InvalidSignature):
+            pub.verify_mu(b"0" * variant.sig_size, mu)
 
     def test_kat_vectors_44(self, backend, subtests):
         vectors = load_vectors_from_file(

--- a/tests/wycheproof/test_mldsa.py
+++ b/tests/wycheproof/test_mldsa.py
@@ -3,6 +3,7 @@
 # for complete details.
 
 import binascii
+import hashlib
 
 import pytest
 
@@ -159,6 +160,71 @@ def test_mldsa65_sign_seed(backend, wycheproof):
         with pytest.raises(ValueError):
             assert has_ctx
             key.sign(msg, ctx)
+
+
+def _compute_mu(pub_raw: bytes, msg: bytes, ctx: bytes) -> bytes:
+    # FIPS 204: mu = SHAKE256(SHAKE256(pk, 64) || M', 64) where for pure
+    # ML-DSA M' = 0x00 || len(ctx) || ctx || M.
+    tr = hashlib.shake_256(pub_raw).digest(64)
+    m_prime = b"\x00" + bytes([len(ctx)]) + ctx + msg
+    return hashlib.shake_256(tr + m_prime).digest(64)
+
+
+def _external_mu_test(public_key_class, wycheproof):
+    # The sign vectors carry a precomputed mu ("External Mu") for every case
+    # that has a valid signature, including the "Internal" cases that NIST
+    # provides as bare mu values with no message or context. Those are
+    # skipped by the signing tests above (we don't expose Sign_internal) but
+    # exercise the precomputed-mu verification interface here.
+    if "mu" not in wycheproof.testcase or not wycheproof.valid:
+        return
+
+    pub_raw = binascii.unhexlify(wycheproof.testgroup["publicKey"])
+    pub = public_key_class.from_public_bytes(pub_raw)
+    mu = binascii.unhexlify(wycheproof.testcase["mu"])
+    sig = binascii.unhexlify(wycheproof.testcase["sig"])
+
+    # The signature verifies through the precomputed-mu interface.
+    pub.verify_mu(sig, mu)
+    # And must not verify against a different mu.
+    with pytest.raises(InvalidSignature):
+        pub.verify_mu(bytes(sig), bytes([mu[0] ^ 0x01]) + mu[1:])
+
+    # When the message (and optional context) are also provided, the mu we
+    # derive must match the one in the vector, and the signature is an
+    # ordinary ML-DSA signature over that message.
+    if "msg" in wycheproof.testcase:
+        msg = binascii.unhexlify(wycheproof.testcase["msg"])
+        ctx = binascii.unhexlify(wycheproof.testcase.get("ctx", ""))
+        assert _compute_mu(pub_raw, msg, ctx) == mu
+        pub.verify(sig, msg, ctx)
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.mldsa_supported(),
+    skip_message="Requires a backend with ML-DSA support",
+)
+@wycheproof_tests("mldsa_44_sign_seed_test.json")
+def test_mldsa44_external_mu(backend, wycheproof):
+    _external_mu_test(MLDSA44PublicKey, wycheproof)
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.mldsa_supported(),
+    skip_message="Requires a backend with ML-DSA support",
+)
+@wycheproof_tests("mldsa_65_sign_seed_test.json")
+def test_mldsa65_external_mu(backend, wycheproof):
+    _external_mu_test(MLDSA65PublicKey, wycheproof)
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.mldsa_supported(),
+    skip_message="Requires a backend with ML-DSA support",
+)
+@wycheproof_tests("mldsa_87_sign_seed_test.json")
+def test_mldsa87_external_mu(backend, wycheproof):
+    _external_mu_test(MLDSA87PublicKey, wycheproof)
 
 
 @pytest.mark.supported(

--- a/tests/wycheproof/test_mldsa.py
+++ b/tests/wycheproof/test_mldsa.py
@@ -170,7 +170,23 @@ def _compute_mu(pub_raw: bytes, msg: bytes, ctx: bytes) -> bytes:
     return hashlib.shake_256(tr + m_prime).digest(64)
 
 
-def _external_mu_test(public_key_class, wycheproof):
+_MLDSA_PUBLIC_KEYS = {
+    "ML-DSA-44": MLDSA44PublicKey,
+    "ML-DSA-65": MLDSA65PublicKey,
+    "ML-DSA-87": MLDSA87PublicKey,
+}
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.mldsa_supported(),
+    skip_message="Requires a backend with ML-DSA support",
+)
+@wycheproof_tests(
+    "mldsa_44_sign_seed_test.json",
+    "mldsa_65_sign_seed_test.json",
+    "mldsa_87_sign_seed_test.json",
+)
+def test_mldsa_external_mu(backend, wycheproof):
     # Only some sign vectors carry a precomputed mu ("External Mu"), so we
     # filter out the ones that don't. The ones that do include the "Internal"
     # cases that NIST provides as bare mu values with no message or context;
@@ -181,6 +197,7 @@ def _external_mu_test(public_key_class, wycheproof):
     if "mu" not in wycheproof.testcase or not wycheproof.valid:
         return
 
+    public_key_class = _MLDSA_PUBLIC_KEYS[wycheproof.testfiledata["algorithm"]]
     pub_raw = binascii.unhexlify(wycheproof.testgroup["publicKey"])
     pub = public_key_class.from_public_bytes(pub_raw)
     mu = binascii.unhexlify(wycheproof.testcase["mu"])
@@ -200,33 +217,6 @@ def _external_mu_test(public_key_class, wycheproof):
         ctx = binascii.unhexlify(wycheproof.testcase.get("ctx", ""))
         assert _compute_mu(pub_raw, msg, ctx) == mu
         pub.verify(sig, msg, ctx)
-
-
-@pytest.mark.supported(
-    only_if=lambda backend: backend.mldsa_supported(),
-    skip_message="Requires a backend with ML-DSA support",
-)
-@wycheproof_tests("mldsa_44_sign_seed_test.json")
-def test_mldsa44_external_mu(backend, wycheproof):
-    _external_mu_test(MLDSA44PublicKey, wycheproof)
-
-
-@pytest.mark.supported(
-    only_if=lambda backend: backend.mldsa_supported(),
-    skip_message="Requires a backend with ML-DSA support",
-)
-@wycheproof_tests("mldsa_65_sign_seed_test.json")
-def test_mldsa65_external_mu(backend, wycheproof):
-    _external_mu_test(MLDSA65PublicKey, wycheproof)
-
-
-@pytest.mark.supported(
-    only_if=lambda backend: backend.mldsa_supported(),
-    skip_message="Requires a backend with ML-DSA support",
-)
-@wycheproof_tests("mldsa_87_sign_seed_test.json")
-def test_mldsa87_external_mu(backend, wycheproof):
-    _external_mu_test(MLDSA87PublicKey, wycheproof)
 
 
 @pytest.mark.supported(

--- a/tests/wycheproof/test_mldsa.py
+++ b/tests/wycheproof/test_mldsa.py
@@ -171,11 +171,13 @@ def _compute_mu(pub_raw: bytes, msg: bytes, ctx: bytes) -> bytes:
 
 
 def _external_mu_test(public_key_class, wycheproof):
-    # The sign vectors carry a precomputed mu ("External Mu") for every case
-    # that has a valid signature, including the "Internal" cases that NIST
-    # provides as bare mu values with no message or context. Those are
-    # skipped by the signing tests above (we don't expose Sign_internal) but
-    # exercise the precomputed-mu verification interface here.
+    # Only some sign vectors carry a precomputed mu ("External Mu"), so we
+    # filter out the ones that don't. The ones that do include the "Internal"
+    # cases that NIST provides as bare mu values with no message or context;
+    # those are skipped by the signing tests above (we don't expose
+    # Sign_internal) but exercise the precomputed-mu verification interface
+    # here. We only test cases with a valid signature -- rejection of bad
+    # signatures is covered by the verify tests.
     if "mu" not in wycheproof.testcase or not wycheproof.valid:
         return
 

--- a/tests/wycheproof/test_mldsa.py
+++ b/tests/wycheproof/test_mldsa.py
@@ -2,6 +2,8 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+from __future__ import annotations
+
 import binascii
 import hashlib
 
@@ -170,7 +172,9 @@ def _compute_mu(pub_raw: bytes, msg: bytes, ctx: bytes) -> bytes:
     return hashlib.shake_256(tr + m_prime).digest(64)
 
 
-_MLDSA_PUBLIC_KEYS = {
+_MLDSA_PUBLIC_KEYS: dict[
+    str, type[MLDSA44PublicKey | MLDSA65PublicKey | MLDSA87PublicKey]
+] = {
     "ML-DSA-44": MLDSA44PublicKey,
     "ML-DSA-65": MLDSA65PublicKey,
     "ML-DSA-87": MLDSA87PublicKey,


### PR DESCRIPTION
This PR adds support for the "external mu" variant of ML-DSA signing and verification as defined in FIPS 204. This allows applications to precompute the message representative (mu) and sign/verify it directly, which is useful for protocols that need to work with the intermediate mu value.

## Key Changes

- **New constant**: `MLDSA_MU_BYTES` (64 bytes) defines the length of an ML-DSA external mu value
- **New signing method**: `sign_mu(mu)` on all three private key classes (MlDsa44, MlDsa65, MlDsa87) to sign a precomputed 64-byte mu
- **New verification method**: `verify_mu(signature, mu)` on all three public key classes to verify a signature over a precomputed mu
- **OpenSSL 3.5.0+ support**: Added `CRYPTOGRAPHY_OPENSSL_350_OR_GREATER` to the conditional compilation flags for the new functions
- **Backend implementations**: 
  - BoringSSL: Uses low-level ML-DSA API with private key reconstruction from seed
  - AWS-LC: Uses EVP_PKEY_sign/verify with "ExternalMu" format
  - OpenSSL 3.5.0+: Uses EVP with the "mu" signature parameter
- **Input validation**: Both methods validate that mu is exactly 64 bytes, raising `ValueError` if not
- **Comprehensive tests**: Added unit tests and Wycheproof test vector validation for the external mu interface

## Implementation Details

The external mu interface is implemented with conditional compilation to support three different backends:
- For BoringSSL, the implementation reconstructs the private key from its 32-byte seed and calls the low-level `MLDSA*_sign_message_representative` functions
- For AWS-LC, the EVP interface natively supports external mu through the "ExternalMu" format
- For OpenSSL 3.5.0+, a helper function `set_mu()` configures the signature context with the "mu" parameter before signing/verifying

The external mu signatures are fully compatible with ordinary ML-DSA signatures—a signature produced via `sign_mu()` can be verified with the standard `verify()` method if the message and context are provided, and vice versa.

https://claude.ai/code/session_01MmjphxZ6ookRpjUhQouKjf