### PR TITLE
Key cffi build-script cache on PYO3_BASE_PYTHON when available

### DIFF
--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -25,7 +25,21 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?
     let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
-    println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+    // PEP 517 build frontends create build isolation venvs at random paths and
+    // point PYO3_PYTHON at them, so keying the build-script cache on PYO3_PYTHON
+    // defeats caching (a rebuild every invocation). When the frontend provides
+    // PYO3_BASE_PYTHON (the stable underlying interpreter, ~sys._base_executable),
+    // key on that instead -- a venv cannot change the implementation, version,
+    // ABI, or headers of its base, which is all this script derives from the
+    // interpreter. We still invoke PYO3_PYTHON to find the binary (it has cffi
+    // installed; the base interpreter may not). When PYO3_BASE_PYTHON is absent,
+    // fall back to keying on PYO3_PYTHON so manual interpreter switches still
+    // trigger a rebuild.
+    if env::var_os("PYO3_BASE_PYTHON").is_some() {
+        println!("cargo:rerun-if-env-changed=PYO3_BASE_PYTHON");
+    } else {
+        println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+    }
     println!("cargo:rerun-if-changed=../../_cffi_src/");
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)


### PR DESCRIPTION
Under PEP 517 build isolation, frontends (pip/uv/build) create venvs at random paths and point `PYO3_PYTHON` at them. Because `cryptography-cffi`'s `build.rs` declares `cargo:rerun-if-env-changed=PYO3_PYTHON`, that path churn makes the build script re-run on every invocation, defeating build caching. This is the same problem tracked upstream in [PyO3/pyo3#6113](https://github.com/PyO3/pyo3/issues/6113), which proposes a stable `PYO3_BASE_PYTHON` (≈ `sys._base_executable`).

This change mirrors the proposed "prefer BASE if present" behavior for this crate's build script: when `PYO3_BASE_PYTHON` is set, key the rerun on it; otherwise fall back to `PYO3_PYTHON`.

Why keying on the base interpreter is sound here: a venv cannot change the implementation (CPython/PyPy), version, ABI (free-threaded vs. not), or C headers of its base — and those are the only interpreter-derived inputs this script has. We still invoke `PYO3_PYTHON` to locate the binary, since `build_openssl.py` needs cffi, which lives in the build venv rather than the base interpreter. The fallback preserves correct rebuild behavior for manual interpreter switches (e.g. setting `PYO3_PYTHON` in a dev checkout) when `PYO3_BASE_PYTHON` is absent.

Note: this is forward-looking — it's harmless until a frontend actually sets `PYO3_BASE_PYTHON`, at which point caching improves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)