### PR TITLE
Use Mapping for build_conditional_library's conditional_names param

### DIFF
--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import threading
 import types
 import typing
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import cryptography
 from cryptography.exceptions import InternalError
@@ -33,7 +33,7 @@ def _openssl_assert(ok: bool) -> None:
 
 def build_conditional_library(
     lib: typing.Any,
-    conditional_names: dict[str, Callable[[], list[str]]],
+    conditional_names: Mapping[str, Callable[[], list[str]]],
 ) -> typing.Any:
     conditional_lib = types.ModuleType("lib")
     conditional_lib._original_lib = lib  # type: ignore[attr-defined]


### PR DESCRIPTION
`build_conditional_library` only ever iterates over `conditional_names` (via `.items()`), never mutating it, so a covariant `Mapping` is more appropriate than an invariant `dict`.

This also resolves a type error surfaced by ty: passing `CONDITIONAL_NAMES` — a dict whose values are concrete functions (a subtype of `Callable[[], list[str]]`) — fails to type-check against the invariant `dict[str, Callable[[], list[str]]]` parameter, since `dict` is invariant in its value type. `Mapping` is covariant in its value type, so the call type-checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)