### PR TITLE
Add rsa_padding parameter to CertificateBuilder.public_key()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,9 +63,8 @@ Changelog
   :meth:`~cryptography.x509.Name.public_bytes`.
 * Added the ``rsa_padding`` keyword-only parameter to
   :meth:`~cryptography.x509.CertificateBuilder.public_key`. Passing the
-  uninstantiated
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` class
-  encodes an RSA subject public key in the certificate's
+  (not an instance) encodes an RSA subject public key in the certificate's
   ``subjectPublicKeyInfo`` with the ``id-RSASSA-PSS`` OID and no
   parameters.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,13 @@ Changelog
 * Added :meth:`~cryptography.x509.Name.from_bytes` for parsing a
   :class:`~cryptography.x509.Name` from DER bytes, the inverse of
   :meth:`~cryptography.x509.Name.public_bytes`.
+* Added the ``rsa_padding`` keyword-only parameter to
+  :meth:`~cryptography.x509.CertificateBuilder.public_key`. Passing the
+  uninstantiated
+  :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` class
+  encodes an RSA subject public key with the ``id-RSASSA-PSS`` OID
+  (and absent parameters) in the certificate's ``subjectPublicKeyInfo``,
+  as required by the ``rsa_pss_pss_*`` signature schemes in TLS 1.3.
 
 .. _v48-0-0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,8 +54,9 @@ Changelog
   :meth:`~cryptography.x509.CertificateBuilder.public_key`. Passing the
   uninstantiated
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` class
-  encodes an RSA subject public key with the ``id-RSASSA-PSS`` OID
-  (and absent parameters) in the certificate's ``subjectPublicKeyInfo``.
+  encodes an RSA subject public key in the certificate's
+  ``subjectPublicKeyInfo`` with the ``id-RSASSA-PSS`` OID and no
+  parameters.
 
 .. _v48-0-0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,8 +55,7 @@ Changelog
   uninstantiated
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` class
   encodes an RSA subject public key with the ``id-RSASSA-PSS`` OID
-  (and absent parameters) in the certificate's ``subjectPublicKeyInfo``,
-  as required by the ``rsa_pss_pss_*`` signature schemes in TLS 1.3.
+  (and absent parameters) in the certificate's ``subjectPublicKeyInfo``.
 
 .. _v48-0-0:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -164,6 +164,7 @@ tunable
 Ubuntu
 unencrypted
 unicode
+uninstantiated
 unpadded
 unpadding
 unsafety

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -959,16 +959,15 @@ X.509 Certificate Builder
         :param public_key: The subject's public key. This can be one of
             :data:`~cryptography.hazmat.primitives.asymmetric.types.CertificatePublicKeyTypes`.
 
-        :param rsa_padding: The
-            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
-            class itself (not an instance), only valid with
+        :param rsa_padding: This keyword argument is only valid with
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`.
-            When set, the certificate's ``subjectPublicKeyInfo`` encodes the
-            key with the ``id-RSASSA-PSS`` OID and no parameters (the
-            unrestricted form from :rfc:`4055`) instead of ``rsaEncryption``,
-            marking the key as usable only for RSASSA-PSS signatures. It does
-            not change how this certificate itself is signed; use the
-            ``rsa_padding`` parameter of :meth:`sign` to control that.
+            The caller can pass an uninstantiated
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+            class or ``None``. If ``PSS`` is passed the ``id-RSASSA-PSS`` OID
+            (with no parameters) will be encoded into the public key, which
+            marks it as usable for only PSS signatures. This does not affect
+            the certificate's signature, only the public key encoding within
+            the certificate.
 
         :return: A new :class:`CertificateBuilder` with the updated public key.
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -948,12 +948,29 @@ X.509 Certificate Builder
 
         :return: A new :class:`CertificateBuilder` with the updated subject name.
 
-    .. method:: public_key(public_key)
+    .. method:: public_key(public_key, *, rsa_padding=None)
 
         Sets the subject's public key.
 
+        .. versionchanged:: 49.0.0
+
+            Added the ``rsa_padding`` keyword-only parameter.
+
         :param public_key: The subject's public key. This can be one of
             :data:`~cryptography.hazmat.primitives.asymmetric.types.CertificatePublicKeyTypes`.
+
+        :param rsa_padding: The uninstantiated
+            :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
+            class (not an instance), only valid with
+            :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`.
+            When set, the certificate's ``subjectPublicKeyInfo`` encodes the
+            key with the ``id-RSASSA-PSS`` OID and the parameters absent (the
+            unrestricted form from :rfc:`4055`) instead of ``rsaEncryption``,
+            marking the key as usable only for RSASSA-PSS signatures. This is
+            the encoding required by the ``rsa_pss_pss_*`` signature schemes
+            in TLS 1.3. It does not change how this certificate itself is
+            signed; use the ``rsa_padding`` parameter of :meth:`sign` to
+            control that.
 
         :return: A new :class:`CertificateBuilder` with the updated public key.
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -966,11 +966,9 @@ X.509 Certificate Builder
             When set, the certificate's ``subjectPublicKeyInfo`` encodes the
             key with the ``id-RSASSA-PSS`` OID and no parameters (the
             unrestricted form from :rfc:`4055`) instead of ``rsaEncryption``,
-            marking the key as usable only for RSASSA-PSS signatures. This is
-            the encoding required by the ``rsa_pss_pss_*`` signature schemes
-            in TLS 1.3. It does not change how this certificate itself is
-            signed; use the ``rsa_padding`` parameter of :meth:`sign` to
-            control that.
+            marking the key as usable only for RSASSA-PSS signatures. It does
+            not change how this certificate itself is signed; use the
+            ``rsa_padding`` parameter of :meth:`sign` to control that.
 
         :return: A new :class:`CertificateBuilder` with the updated public key.
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -959,9 +959,9 @@ X.509 Certificate Builder
         :param public_key: The subject's public key. This can be one of
             :data:`~cryptography.hazmat.primitives.asymmetric.types.CertificatePublicKeyTypes`.
 
-        :param rsa_padding: The uninstantiated
+        :param rsa_padding: The
             :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
-            class (not an instance), only valid with
+            class itself (not an instance), only valid with
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`.
             When set, the certificate's ``subjectPublicKeyInfo`` encodes the
             key with the ``id-RSASSA-PSS`` OID and no parameters (the

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -964,7 +964,7 @@ X.509 Certificate Builder
             class (not an instance), only valid with
             :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`.
             When set, the certificate's ``subjectPublicKeyInfo`` encodes the
-            key with the ``id-RSASSA-PSS`` OID and the parameters absent (the
+            key with the ``id-RSASSA-PSS`` OID and no parameters (the
             unrestricted form from :rfc:`4055`) instead of ``rsaEncryption``,
             marking the key as usable only for RSASSA-PSS signatures. This is
             the encoding required by the ``rsa_pss_pss_*`` signature schemes

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -302,6 +302,7 @@ class CertificateBuilder:
         not_valid_before: datetime.datetime | None = None,
         not_valid_after: datetime.datetime | None = None,
         extensions: list[Extension[ExtensionType]] = [],
+        public_key_rsa_padding: type[padding.PSS] | None = None,
     ) -> None:
         self._version = Version.v3
         self._issuer_name = issuer_name
@@ -311,6 +312,7 @@ class CertificateBuilder:
         self._not_valid_before = not_valid_before
         self._not_valid_after = not_valid_after
         self._extensions = extensions
+        self._public_key_rsa_padding = public_key_rsa_padding
 
     def issuer_name(self, name: Name) -> CertificateBuilder:
         """
@@ -328,6 +330,7 @@ class CertificateBuilder:
             self._not_valid_before,
             self._not_valid_after,
             self._extensions,
+            self._public_key_rsa_padding,
         )
 
     def subject_name(self, name: Name) -> CertificateBuilder:
@@ -346,11 +349,14 @@ class CertificateBuilder:
             self._not_valid_before,
             self._not_valid_after,
             self._extensions,
+            self._public_key_rsa_padding,
         )
 
     def public_key(
         self,
         key: CertificatePublicKeyTypes,
+        *,
+        rsa_padding: type[padding.PSS] | None = None,
     ) -> CertificateBuilder:
         """
         Sets the requestor's public key (as found in the signing request).
@@ -377,6 +383,15 @@ class CertificateBuilder:
                 " MLDSA87PublicKey, X25519PublicKey, or "
                 "X448PublicKey."
             )
+        if rsa_padding is not None:
+            if rsa_padding is not padding.PSS:
+                raise TypeError(
+                    "rsa_padding must be the PSS class, not an instance"
+                )
+            if not isinstance(key, rsa.RSAPublicKey):
+                raise TypeError(
+                    "rsa_padding is only supported with RSA public keys"
+                )
         if self._public_key is not None:
             raise ValueError("The public key may only be set once.")
         return CertificateBuilder(
@@ -387,6 +402,7 @@ class CertificateBuilder:
             self._not_valid_before,
             self._not_valid_after,
             self._extensions,
+            rsa_padding,
         )
 
     def serial_number(self, number: int) -> CertificateBuilder:
@@ -414,6 +430,7 @@ class CertificateBuilder:
             self._not_valid_before,
             self._not_valid_after,
             self._extensions,
+            self._public_key_rsa_padding,
         )
 
     def not_valid_before(self, time: datetime.datetime) -> CertificateBuilder:
@@ -443,6 +460,7 @@ class CertificateBuilder:
             time,
             self._not_valid_after,
             self._extensions,
+            self._public_key_rsa_padding,
         )
 
     def not_valid_after(self, time: datetime.datetime) -> CertificateBuilder:
@@ -474,6 +492,7 @@ class CertificateBuilder:
             self._not_valid_before,
             time,
             self._extensions,
+            self._public_key_rsa_padding,
         )
 
     def add_extension(
@@ -496,6 +515,7 @@ class CertificateBuilder:
             self._not_valid_before,
             self._not_valid_after,
             [*self._extensions, extension],
+            self._public_key_rsa_padding,
         )
 
     def sign(

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -704,13 +704,21 @@ impl asn1::SimpleAsn1Writable for Utf8StoredBMPString<'_> {
 
 #[derive(Clone)]
 pub struct WithTlv<'a, T> {
-    tlv: asn1::Tlv<'a>,
+    tlv: Option<asn1::Tlv<'a>>,
     value: T,
 }
 
 impl<'a, T> WithTlv<'a, T> {
+    /// Constructs a value that was not parsed, and therefore has no TLV.
+    /// Calling `tlv()` on it will panic.
+    pub fn new(value: T) -> Self {
+        Self { tlv: None, value }
+    }
+
     pub fn tlv(&self) -> &asn1::Tlv<'a> {
-        &self.tlv
+        self.tlv
+            .as_ref()
+            .expect("tlv() may only be called on parsed values")
     }
 }
 
@@ -726,7 +734,7 @@ impl<'a, T: asn1::Asn1Readable<'a>> asn1::Asn1Readable<'a> for WithTlv<'a, T> {
     fn parse(p: &mut asn1::Parser<'a>) -> asn1::ParseResult<Self> {
         let tlv = p.read_element::<asn1::Tlv<'a>>()?;
         Ok(Self {
-            tlv,
+            tlv: Some(tlv),
             value: tlv.parse()?,
         })
     }

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1065,13 +1065,7 @@ pub(crate) fn create_x509_certificate(
     let spki_der: &[u8] = if py_public_key_rsa_padding.is_none() {
         &spki_bytes
     } else {
-        if !py_public_key_rsa_padding.is(&types::PSS.get(py)?) {
-            return Err(CryptographyError::from(
-                pyo3::exceptions::PyTypeError::new_err(
-                    "rsa_padding must be the PSS class, not an instance",
-                ),
-            ));
-        }
+        // The Python layer ensures this is only ever the PSS class.
         let spki = asn1::parse_single::<common::SubjectPublicKeyInfo<'_>>(&spki_bytes)?;
         // id-RSASSA-PSS with the parameters absent (the unrestricted form
         // from RFC 4055), which is the encoding required for the TLS 1.3

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1059,6 +1059,33 @@ pub(crate) fn create_x509_certificate(
         )?
         .extract::<pyo3::pybacked::PyBackedBytes>()?;
 
+    let py_public_key_rsa_padding =
+        builder.getattr(pyo3::intern!(py, "_public_key_rsa_padding"))?;
+    let pss_spki_bytes;
+    let spki_der: &[u8] = if py_public_key_rsa_padding.is_none() {
+        &spki_bytes
+    } else {
+        if !py_public_key_rsa_padding.is(&types::PSS.get(py)?) {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyTypeError::new_err(
+                    "rsa_padding must be the PSS class, not an instance",
+                ),
+            ));
+        }
+        let spki = asn1::parse_single::<common::SubjectPublicKeyInfo<'_>>(&spki_bytes)?;
+        // id-RSASSA-PSS with the parameters absent (the unrestricted form
+        // from RFC 4055), which is the encoding required for the TLS 1.3
+        // rsa_pss_pss_* signature schemes.
+        pss_spki_bytes = asn1::write_single(&common::SubjectPublicKeyInfo {
+            algorithm: common::AlgorithmIdentifier {
+                oid: asn1::DefinedByMarker::marker(),
+                params: AlgorithmParameters::RsaPss(None),
+            },
+            subject_public_key: spki.subject_public_key,
+        })?;
+        &pss_spki_bytes
+    };
+
     let py_serial = builder
         .getattr(pyo3::intern!(py, "_serial_number"))?
         .extract()?;
@@ -1092,7 +1119,7 @@ pub(crate) fn create_x509_certificate(
             not_after: time_from_py(py, &py_not_after)?,
         },
         subject: x509::common::encode_name(py, &ka, &py_subject_name)?,
-        spki: asn1::parse_single(&spki_bytes)?,
+        spki: asn1::parse_single(spki_der)?,
         issuer_unique_id: None,
         subject_unique_id: None,
         raw_extensions: x509::common::encode_extensions(

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1029,23 +1029,20 @@ pub(crate) fn create_x509_certificate(
 
     let py_public_key_rsa_padding =
         builder.getattr(pyo3::intern!(py, "_public_key_rsa_padding"))?;
-    let pss_spki_bytes;
-    let spki_der: &[u8] = if py_public_key_rsa_padding.is_none() {
-        &spki_bytes
+    let spki = if py_public_key_rsa_padding.is_none() {
+        asn1::parse_single(&spki_bytes)?
     } else {
         // The Python layer ensures this is only ever the PSS class.
         let spki = asn1::parse_single::<common::SubjectPublicKeyInfo<'_>>(&spki_bytes)?;
         // id-RSASSA-PSS with the parameters absent (the unrestricted form
-        // from RFC 4055), which is the encoding required for the TLS 1.3
-        // rsa_pss_pss_* signature schemes.
-        pss_spki_bytes = asn1::write_single(&common::SubjectPublicKeyInfo {
+        // from RFC 4055).
+        common::WithTlv::new(common::SubjectPublicKeyInfo {
             algorithm: common::AlgorithmIdentifier {
                 oid: asn1::DefinedByMarker::marker(),
-                params: AlgorithmParameters::RsaPss(None),
+                params: common::AlgorithmParameters::RsaPss(None),
             },
             subject_public_key: spki.subject_public_key,
-        })?;
-        &pss_spki_bytes
+        })
     };
 
     let py_serial = builder
@@ -1081,7 +1078,7 @@ pub(crate) fn create_x509_certificate(
             not_after: time_from_py(py, &py_not_after)?,
         },
         subject: x509::common::encode_name(py, &ka, &py_subject_name)?,
-        spki: asn1::parse_single(spki_der)?,
+        spki,
         issuer_unique_id: None,
         subject_unique_id: None,
         raw_extensions: x509::common::encode_extensions(

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -3139,6 +3139,73 @@ class TestCertificateBuilder:
         with pytest.raises(ValueError):
             builder.public_key(public_key)
 
+    def test_public_key_rsa_pss_spki(
+        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+    ):
+        private_key = rsa_key_2048
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+            )
+            .issuer_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+            )
+            .public_key(
+                private_key.public_key(),
+                rsa_padding=padding.PSS,
+            )
+            .serial_number(777)
+            .not_valid_before(datetime.datetime(2020, 1, 1))
+            .not_valid_after(datetime.datetime(2030, 1, 1))
+            .sign(
+                private_key,
+                hashes.SHA256(),
+                rsa_padding=padding.PSS(
+                    mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.DIGEST_LENGTH,
+                ),
+            )
+        )
+        assert (
+            cert.public_key_algorithm_oid == PublicKeyAlgorithmOID.RSASSA_PSS
+        )
+        public_key = cert.public_key()
+        assert isinstance(public_key, rsa.RSAPublicKey)
+        assert public_key == private_key.public_key()
+        # The SPKI AlgorithmIdentifier must be id-RSASSA-PSS with the
+        # parameters absent.
+        assert bytes.fromhex(
+            "300b06092a864886f70d01010a"
+        ) in cert.public_bytes(serialization.Encoding.DER)
+        cert.verify_directly_issued_by(cert)
+
+    def test_public_key_rsa_padding_must_be_pss_class(
+        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+    ):
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder().public_key(
+                rsa_key_2048.public_key(),
+                rsa_padding=padding.PSS(  # type: ignore[arg-type]
+                    mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.DIGEST_LENGTH,
+                ),
+            )
+
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder().public_key(
+                rsa_key_2048.public_key(),
+                rsa_padding=padding.PKCS1v15,  # type: ignore[arg-type]
+            )
+
+    def test_public_key_rsa_padding_requires_rsa_key(self, backend):
+        private_key = ec.generate_private_key(ec.SECP256R1())
+        with pytest.raises(TypeError):
+            x509.CertificateBuilder().public_key(
+                private_key.public_key(),
+                rsa_padding=padding.PSS,
+            )
+
     def test_serial_number_must_be_an_integer_type(self):
         with pytest.raises(TypeError):
             x509.CertificateBuilder().serial_number(


### PR DESCRIPTION
## Summary

Adds support for encoding RSA public keys in X.509 certificates with the `id-RSASSA-PSS` OID and no parameters (the unrestricted form from RFC 4055), which marks the key as usable only for RSASSA-PSS signatures. This is required for TLS 1.3 `rsa_pss_pss_*` signature schemes.

## Changes

- **Python API**: Added `rsa_padding` keyword-only parameter to `CertificateBuilder.public_key()` that accepts the uninstantiated `PSS` class (not an instance). When provided with an RSA public key, the certificate's `subjectPublicKeyInfo` is encoded with the `id-RSASSA-PSS` OID and no parameters instead of the standard `rsaEncryption` OID.

- **Validation**: Added type checking to ensure:
  - `rsa_padding` must be the `PSS` class itself, not an instance
  - `rsa_padding` is only valid with `RSAPublicKey` types
  - Appropriate `TypeError` exceptions are raised for invalid usage

- **Rust implementation**: Modified certificate creation to detect when PSS padding is specified and rewrite the SPKI (SubjectPublicKeyInfo) structure with the `id-RSASSA-PSS` OID and absent parameters, while preserving the actual public key material.

- **State management**: Updated `CertificateBuilder.__init__()` and all builder methods to properly thread the `_public_key_rsa_padding` state through the builder chain.

- **Documentation**: Updated reference documentation and CHANGELOG to describe the new parameter and its behavior.

## Implementation Details

- The `rsa_padding` parameter does not affect how the certificate itself is signed; it only controls the encoding of the subject public key in the certificate. The `rsa_padding` parameter of the `sign()` method continues to control the certificate's signature algorithm.
- The implementation parses the standard SPKI structure and rewrites it with the PSS OID and no parameters, maintaining the original public key bits.
- Three new test cases validate: successful PSS SPKI encoding, proper type validation of the `rsa_padding` parameter, and rejection of `rsa_padding` with non-RSA keys.

https://claude.ai/code/session_01HBR1P3RLnJ6r2avs6DZxUy