### PR TITLE
Bump Rust workspace crate versions as part of bump-version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cryptography-cffi"
-version = "0.1.0"
+version = "0.49.0"
 dependencies = [
  "cc",
  "openssl-sys",
@@ -62,21 +62,21 @@ dependencies = [
 
 [[package]]
 name = "cryptography-crypto"
-version = "0.1.0"
+version = "0.49.0"
 dependencies = [
  "openssl",
 ]
 
 [[package]]
 name = "cryptography-keepalive"
-version = "0.1.0"
+version = "0.49.0"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "cryptography-key-parsing"
-version = "0.1.0"
+version = "0.49.0"
 dependencies = [
  "asn1",
  "cfg-if",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography-openssl"
-version = "0.1.0"
+version = "0.49.0"
 dependencies = [
  "cfg-if",
  "foreign-types",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography-rust"
-version = "0.1.0"
+version = "0.49.0"
 dependencies = [
  "asn1",
  "base64",
@@ -124,14 +124,14 @@ dependencies = [
 
 [[package]]
 name = "cryptography-x509"
-version = "0.1.0"
+version = "0.49.0"
 dependencies = [
  "asn1",
 ]
 
 [[package]]
 name = "cryptography-x509-verification"
-version = "0.1.0"
+version = "0.49.0"
 dependencies = [
  "asn1",
  "cryptography-x509",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cryptography-cffi"
-version = "0.49.0"
+version = "0.49.0-dev1"
 dependencies = [
  "cc",
  "openssl-sys",
@@ -62,21 +62,21 @@ dependencies = [
 
 [[package]]
 name = "cryptography-crypto"
-version = "0.49.0"
+version = "0.49.0-dev1"
 dependencies = [
  "openssl",
 ]
 
 [[package]]
 name = "cryptography-keepalive"
-version = "0.49.0"
+version = "0.49.0-dev1"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "cryptography-key-parsing"
-version = "0.49.0"
+version = "0.49.0-dev1"
 dependencies = [
  "asn1",
  "cfg-if",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography-openssl"
-version = "0.49.0"
+version = "0.49.0-dev1"
 dependencies = [
  "cfg-if",
  "foreign-types",
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography-rust"
-version = "0.49.0"
+version = "0.49.0-dev1"
 dependencies = [
  "asn1",
  "base64",
@@ -124,14 +124,14 @@ dependencies = [
 
 [[package]]
 name = "cryptography-x509"
-version = "0.49.0"
+version = "0.49.0-dev1"
 dependencies = [
  "asn1",
 ]
 
 [[package]]
 name = "cryptography-x509-verification"
-version = "0.49.0"
+version = "0.49.0-dev1"
 dependencies = [
  "asn1",
  "cryptography-x509",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.49.0"
+version = "0.49.0-dev1"
 authors = ["The cryptography developers <cryptography-dev@python.org>"]
 edition = "2021"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.49.0"
 authors = ["The cryptography developers <cryptography-dev@python.org>"]
 edition = "2021"
 publish = false

--- a/release.py
+++ b/release.py
@@ -88,21 +88,12 @@ def rust_version(version: Version) -> str:
 
 
 def bump_rust_versions(base_dir: pathlib.Path, new_version: str) -> None:
-    crate_version = rust_version(Version(new_version))
-
-    with (base_dir / "Cargo.toml").open("rb") as f:
-        workspace = tomllib.load(f)["workspace"]
-
-    replace_version(base_dir / "Cargo.toml", "version", crate_version)
-
-    for member in workspace["members"]:
-        with (base_dir / member / "Cargo.toml").open("rb") as f:
-            crate_name = tomllib.load(f)["package"]["name"]
-        replace_pattern(
-            base_dir / "Cargo.lock",
-            rf'^name = "{crate_name}"\nversion = ".*?"$',
-            f'name = "{crate_name}"\nversion = "{crate_version}"',
-        )
+    # All crates in the workspace inherit the workspace version, so we only
+    # need to update it in one place, then sync Cargo.lock.
+    replace_version(
+        base_dir / "Cargo.toml", "version", rust_version(Version(new_version))
+    )
+    run("cargo", "update", "--workspace")
 
 
 @cli.command()

--- a/release.py
+++ b/release.py
@@ -68,6 +68,34 @@ def replace_version(
     )
 
 
+def rust_version(version: Version) -> str:
+    # The Rust crates use a version that maps to the cryptography version,
+    # but pre-1.0: cryptography X.0.Z is version 0.X.Z of the crates.
+    if version.minor != 0:
+        raise ValueError(
+            f"Can't map {version} to a crate version, minor must be 0"
+        )
+    return f"0.{version.major}.{version.micro}"
+
+
+def bump_rust_versions(base_dir: pathlib.Path, new_version: str) -> None:
+    crate_version = rust_version(Version(new_version))
+
+    with (base_dir / "Cargo.toml").open("rb") as f:
+        workspace = tomllib.load(f)["workspace"]
+
+    replace_version(base_dir / "Cargo.toml", "version", crate_version)
+
+    for member in workspace["members"]:
+        with (base_dir / member / "Cargo.toml").open("rb") as f:
+            crate_name = tomllib.load(f)["package"]["name"]
+        replace_pattern(
+            base_dir / "Cargo.lock",
+            rf'^name = "{crate_name}"\nversion = ".*?"$',
+            f'name = "{crate_name}"\nversion = "{crate_version}"',
+        )
+
+
 @cli.command()
 @click.argument("new_version")
 def bump_version(new_version: str) -> None:
@@ -100,6 +128,8 @@ def bump_version(new_version: str) -> None:
             r'"cryptography_vectors(==.*?)?"',
             f'"cryptography_vectors=={new_version}"',
         )
+
+    bump_rust_versions(base_dir, new_version)
 
 
 if __name__ == "__main__":

--- a/release.py
+++ b/release.py
@@ -70,12 +70,21 @@ def replace_version(
 
 def rust_version(version: Version) -> str:
     # The Rust crates use a version that maps to the cryptography version,
-    # but pre-1.0: cryptography X.0.Z is version 0.X.Z of the crates.
+    # but pre-1.0: cryptography X.0.Z is version 0.X.Z of the crates, and
+    # pre-releases map to semver pre-releases (49.0.0.dev1 is 0.49.0-dev1).
     if version.minor != 0:
         raise ValueError(
             f"Can't map {version} to a crate version, minor must be 0"
         )
-    return f"0.{version.major}.{version.micro}"
+    crate_version = f"0.{version.major}.{version.micro}"
+    pre_parts = []
+    if version.pre is not None:
+        pre_parts.append(f"{version.pre[0]}{version.pre[1]}")
+    if version.dev is not None:
+        pre_parts.append(f"dev{version.dev}")
+    if pre_parts:
+        crate_version += "-" + ".".join(pre_parts)
+    return crate_version
 
 
 def bump_rust_versions(base_dir: pathlib.Path, new_version: str) -> None:


### PR DESCRIPTION
refs https://github.com/pyca/cryptography/issues/14002

`release.py bump-version` now also bumps the Rust workspace crates to a version mapping to the cryptography version, but pre-1.0:

- cryptography `X.0.Z` is version `0.X.Z` of the crates (e.g. `47.0.0` → `0.47.0`, `47.0.2` → `0.47.2`)
- pre-releases map to semver pre-releases (`49.0.0.dev1` → `0.49.0-dev1`, `48.0.0b1` → `0.48.0-b1`)
- raises if the minor component is ever nonzero, since the mapping would be ambiguous

Since all crates inherit `[workspace.package] version`, only the root `Cargo.toml` is edited; `Cargo.lock` is then synced via `cargo update --workspace` (the lockfile records workspace member versions, so skipping this would break `--locked` builds).

Also applies the new mapping for the current `49.0.0.dev1`, moving the crates from `0.1.0` to `0.49.0-dev1`.

https://claude.ai/code/session_01Y2akSbEJx924SCRsr2yRDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2akSbEJx924SCRsr2yRDw)_