### PR TITLE
encode arbitrary-precision integers in declarative asn1

### DIFF
--- a/src/rust/src/asn1.rs
+++ b/src/rust/src/asn1.rs
@@ -67,6 +67,37 @@ fn decode_dss_signature<'p>(
         .into_any())
 }
 
+// Encodes a Python `int` of arbitrary size as the minimal big-endian
+// two's complement bytes expected by a DER INTEGER (i.e. suitable for
+// `asn1::BigInt::new`). Unlike `py_uint_to_big_endian_bytes` this accepts
+// negative values, which a general INTEGER field may hold.
+pub(crate) fn py_int_to_der_bytes<'p>(
+    py: pyo3::Python<'p>,
+    v: pyo3::Bound<'p, pyo3::types::PyInt>,
+) -> pyo3::PyResult<PyBackedBytes> {
+    // The number of significant magnitude bits. For negative values we use
+    // `~v` (== `-v - 1`), so that exact negative powers of two (e.g. -128)
+    // get the shorter length their two's complement encoding actually needs.
+    let magnitude = if v.lt(0)? {
+        v.call_method0(pyo3::intern!(py, "__invert__"))?
+    } else {
+        v.clone().into_any()
+    };
+    let bit_length = magnitude
+        .call_method0(pyo3::intern!(py, "bit_length"))?
+        .extract::<usize>()?;
+    // One extra octet leaves room for the sign bit and yields the minimal
+    // DER length once the high bit is accounted for.
+    let length = bit_length / 8 + 1;
+    let kwargs = [("signed", true)].into_py_dict(py)?;
+    Ok(v.call_method(
+        pyo3::intern!(py, "to_bytes"),
+        (length, "big"),
+        Some(&kwargs),
+    )?
+    .extract()?)
+}
+
 pub(crate) fn py_uint_to_big_endian_bytes<'p>(
     py: pyo3::Python<'p>,
     v: pyo3::Bound<'p, pyo3::types::PyInt>,

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -202,13 +202,9 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                 Ok(write_value(writer, &val, encoding)?)
             }
             Type::PyInt() => {
-                let int_value = value.cast::<pyo3::types::PyInt>()?;
-                let bytes = crate::asn1::py_int_to_der_bytes(py, int_value.clone())?;
-                let val = asn1::BigInt::new(&bytes).ok_or_else(|| {
-                    CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
-                        "invalid value for INTEGER",
-                    ))
-                })?;
+                let int_value = value.cast_into::<pyo3::types::PyInt>()?;
+                let bytes = crate::asn1::py_int_to_der_bytes(py, int_value)?;
+                let val = asn1::BigInt::new(&bytes).unwrap();
                 Ok(write_value(writer, &val, encoding)?)
             }
             Type::PyBytes() => {
@@ -361,51 +357,6 @@ mod tests {
 
             let result = asn1::write(|writer| object.write(writer));
             assert!(result.is_err());
-        });
-    }
-
-    #[test]
-    fn test_encode_int_outside_i64() {
-        pyo3::Python::initialize();
-        pyo3::Python::attach(|py| {
-            use pyo3::IntoPyObject;
-
-            let ann_type = AnnotatedType {
-                inner: pyo3::Py::new(py, Type::PyInt()).unwrap(),
-                annotation: pyo3::Py::new(
-                    py,
-                    Annotation {
-                        default: None,
-                        encoding: None,
-                        size: None,
-                    },
-                )
-                .unwrap(),
-            };
-
-            // (value, expected DER). Each case is outside the i64 range that the
-            // encoder previously narrowed to, so the old path raised OverflowError.
-            for (value, expected) in [
-                // 2**63 (i64::MAX + 1)
-                (
-                    (1u64 << 63).into_pyobject(py).unwrap().into_any(),
-                    b"\x02\x09\x00\x80\x00\x00\x00\x00\x00\x00\x00".as_slice(),
-                ),
-                // -(2**63) - 1 (i64::MIN - 1)
-                (
-                    (-(1i128 << 63) - 1).into_pyobject(py).unwrap().into_any(),
-                    b"\x02\x09\xff\x7f\xff\xff\xff\xff\xff\xff\xff".as_slice(),
-                ),
-            ] {
-                let object = AnnotatedTypeObject {
-                    annotated_type: &ann_type,
-                    value,
-                };
-                let result = asn1::write(|writer| object.write(writer))
-                    .map_err(|_| ())
-                    .unwrap();
-                assert_eq!(result, expected);
-            }
         });
     }
 }

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -202,7 +202,13 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                 Ok(write_value(writer, &val, encoding)?)
             }
             Type::PyInt() => {
-                let val: i64 = value.extract()?;
+                let int_value = value.cast::<pyo3::types::PyInt>()?;
+                let bytes = crate::asn1::py_int_to_der_bytes(py, int_value.clone())?;
+                let val = asn1::BigInt::new(&bytes).ok_or_else(|| {
+                    CryptographyError::Py(pyo3::exceptions::PyValueError::new_err(
+                        "invalid value for INTEGER",
+                    ))
+                })?;
                 Ok(write_value(writer, &val, encoding)?)
             }
             Type::PyBytes() => {
@@ -355,6 +361,51 @@ mod tests {
 
             let result = asn1::write(|writer| object.write(writer));
             assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_encode_int_outside_i64() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            use pyo3::IntoPyObject;
+
+            let ann_type = AnnotatedType {
+                inner: pyo3::Py::new(py, Type::PyInt()).unwrap(),
+                annotation: pyo3::Py::new(
+                    py,
+                    Annotation {
+                        default: None,
+                        encoding: None,
+                        size: None,
+                    },
+                )
+                .unwrap(),
+            };
+
+            // (value, expected DER). Each case is outside the i64 range that the
+            // encoder previously narrowed to, so the old path raised OverflowError.
+            for (value, expected) in [
+                // 2**63 (i64::MAX + 1)
+                (
+                    (1u64 << 63).into_pyobject(py).unwrap().into_any(),
+                    b"\x02\x09\x00\x80\x00\x00\x00\x00\x00\x00\x00".as_slice(),
+                ),
+                // -(2**63) - 1 (i64::MIN - 1)
+                (
+                    (-(1i128 << 63) - 1).into_pyobject(py).unwrap().into_any(),
+                    b"\x02\x09\xff\x7f\xff\xff\xff\xff\xff\xff\xff".as_slice(),
+                ),
+            ] {
+                let object = AnnotatedTypeObject {
+                    annotated_type: &ann_type,
+                    value,
+                };
+                let result = asn1::write(|writer| object.write(writer))
+                    .map_err(|_| ())
+                    .unwrap();
+                assert_eq!(result, expected);
+            }
         });
     }
 }

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -84,6 +84,9 @@ class TestInteger:
                 (-1, b"\x02\x01\xff"),
                 (-128, b"\x02\x01\x80"),
                 (-129, b"\x02\x02\xff\x7f"),
+                # Values outside the signed 64-bit range.
+                (2**63, b"\x02\x09\x00\x80\x00\x00\x00\x00\x00\x00\x00"),
+                (-(2**63) - 1, b"\x02\x09\xff\x7f\xff\xff\xff\xff\xff\xff\xff"),
             ],
         )
 

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -86,7 +86,10 @@ class TestInteger:
                 (-129, b"\x02\x02\xff\x7f"),
                 # Values outside the signed 64-bit range.
                 (2**63, b"\x02\x09\x00\x80\x00\x00\x00\x00\x00\x00\x00"),
-                (-(2**63) - 1, b"\x02\x09\xff\x7f\xff\xff\xff\xff\xff\xff\xff"),
+                (
+                    -(2**63) - 1,
+                    b"\x02\x09\xff\x7f\xff\xff\xff\xff\xff\xff\xff",
+                ),
             ],
         )
 


### PR DESCRIPTION
the declarative asn1 decoder reads INTEGER fields as arbitrary-precision values, but the encoder narrows them to an i64, so an integer outside the signed 64-bit range that round-trips through decode_der cannot be re-encoded and instead raises OverflowError. this trips up otherwise valid structures whose integers exceed 64 bits, like RSA moduli or large serial numbers. i've changed the INTEGER arm to emit minimal two's-complement bytes through a BigInt, matching what the decoder already accepts.