### PR TITLE
Reject critical nameConstraints extensions containing directoryName constraints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,12 +61,13 @@ Changelog
 * Added :meth:`~cryptography.x509.Name.from_bytes` for parsing a
   :class:`~cryptography.x509.Name` from DER bytes, the inverse of
   :meth:`~cryptography.x509.Name.public_bytes`.
-* The X.509 path validator no longer rejects chains containing a
-  ``directoryName`` name constraint outright. Matching ``directoryName``
-  constraints is still not implemented: such a constraint simply never
-  matches, so an excluded ``directoryName`` subtree never excludes anything
-  and a ``directoryName`` SAN can never satisfy a permitted ``directoryName``
-  subtree.
+* The X.509 path validator now rejects ``directoryName`` name constraints
+  when they apply to a subsequent certificate with a non-empty subject.
+  :rfc:`5280` requires ``directoryName`` constraints to be applied to the
+  subject field as well as ``directoryName`` SANs; since matching
+  ``directoryName`` constraints is not implemented, such chains were
+  previously accepted with the constraint silently ignored, unless the
+  certificate also had a ``directoryName`` SAN.
 * Added the ``rsa_padding`` keyword-only parameter to
   :meth:`~cryptography.x509.CertificateBuilder.public_key`. Passing the
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` class

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,17 +61,6 @@ Changelog
 * Added :meth:`~cryptography.x509.Name.from_bytes` for parsing a
   :class:`~cryptography.x509.Name` from DER bytes, the inverse of
   :meth:`~cryptography.x509.Name.public_bytes`.
-* The X.509 path validator now rejects any chain containing a critical
-  ``nameConstraints`` extension with a ``directoryName`` constraint.
-  :rfc:`5280` requires ``directoryName`` constraints to be applied to the
-  subject field as well as ``directoryName`` SANs, and requires applications
-  that cannot process a constraint in a critical ``nameConstraints``
-  extension to reject the certificate. Matching ``directoryName``
-  constraints is not implemented, so previously such chains were accepted
-  with the constraint silently ignored, unless a subsequent certificate
-  had a ``directoryName`` SAN. Non-critical ``directoryName`` constraints
-  continue to be ignored unless a subsequent certificate has a
-  ``directoryName`` SAN, in which case the chain is rejected as before.
 * Added the ``rsa_padding`` keyword-only parameter to
   :meth:`~cryptography.x509.CertificateBuilder.public_key`. Passing the
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` class

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,12 @@ Changelog
 * Added :meth:`~cryptography.x509.Name.from_bytes` for parsing a
   :class:`~cryptography.x509.Name` from DER bytes, the inverse of
   :meth:`~cryptography.x509.Name.public_bytes`.
+* The X.509 path validator no longer rejects chains containing a
+  ``directoryName`` name constraint outright. Matching ``directoryName``
+  constraints is still not implemented: such a constraint simply never
+  matches, so an excluded ``directoryName`` subtree never excludes anything
+  and a ``directoryName`` SAN can never satisfy a permitted ``directoryName``
+  subtree.
 * Added the ``rsa_padding`` keyword-only parameter to
   :meth:`~cryptography.x509.CertificateBuilder.public_key`. Passing the
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` class

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,13 +61,17 @@ Changelog
 * Added :meth:`~cryptography.x509.Name.from_bytes` for parsing a
   :class:`~cryptography.x509.Name` from DER bytes, the inverse of
   :meth:`~cryptography.x509.Name.public_bytes`.
-* The X.509 path validator now rejects ``directoryName`` name constraints
-  when they apply to a subsequent certificate with a non-empty subject.
+* The X.509 path validator now rejects any chain containing a critical
+  ``nameConstraints`` extension with a ``directoryName`` constraint.
   :rfc:`5280` requires ``directoryName`` constraints to be applied to the
-  subject field as well as ``directoryName`` SANs; since matching
-  ``directoryName`` constraints is not implemented, such chains were
-  previously accepted with the constraint silently ignored, unless the
-  certificate also had a ``directoryName`` SAN.
+  subject field as well as ``directoryName`` SANs, and requires applications
+  that cannot process a constraint in a critical ``nameConstraints``
+  extension to reject the certificate. Matching ``directoryName``
+  constraints is not implemented, so previously such chains were accepted
+  with the constraint silently ignored, unless a subsequent certificate
+  had a ``directoryName`` SAN. Non-critical ``directoryName`` constraints
+  continue to be ignored unless a subsequent certificate has a
+  ``directoryName`` SAN, in which case the chain is rejected as before.
 * Added the ``rsa_padding`` keyword-only parameter to
   :meth:`~cryptography.x509.CertificateBuilder.public_key`. Passing the
   :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS` class

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -16,6 +16,7 @@ use std::fmt::Display;
 use std::vec;
 
 use asn1::ObjectIdentifier;
+use cryptography_x509::certificate::Certificate;
 use cryptography_x509::common::Asn1Read;
 use cryptography_x509::extensions::{
     AuthorityKeyIdentifier, DuplicateExtensionsError, Extensions, NameConstraints,
@@ -145,11 +146,13 @@ impl Budget {
 struct NameChain<'a, 'chain> {
     child: Option<&'a NameChain<'a, 'chain>>,
     sans: SubjectAlternativeName<'chain>,
+    non_empty_subject: bool,
 }
 
 impl<'a, 'chain> NameChain<'a, 'chain> {
     fn new<B: CryptoOps>(
         child: Option<&'a NameChain<'a, 'chain>>,
+        certificate: &Certificate<'chain>,
         extensions: &Extensions<'chain>,
         self_issued_intermediate: bool,
     ) -> ValidationResult<'chain, Self, B> {
@@ -163,7 +166,13 @@ impl<'a, 'chain> NameChain<'a, 'chain> {
             _ => asn1::parse_single(b"\x30\x00")?,
         };
 
-        Ok(Self { child, sans })
+        let non_empty_subject = !self_issued_intermediate && !certificate.subject().is_empty();
+
+        Ok(Self {
+            child,
+            sans,
+            non_empty_subject,
+        })
     }
 
     fn evaluate_single_constraint<B: CryptoOps>(
@@ -226,23 +235,10 @@ impl<'a, 'chain> NameChain<'a, 'chain> {
                     )))),
                 }
             }
-            // We don't implement DirectoryName matching, so a DirectoryName
-            // constraint never matches a DirectoryName SAN. For an excluded
-            // subtree that means the SAN is never excluded; for a permitted
-            // subtree it means the SAN can never be permitted (no other
-            // DirectoryName constraint can match either), so we fail
-            // immediately with a dedicated error.
-            (GeneralName::DirectoryName(_), GeneralName::DirectoryName(_)) => match kind {
-                SubtreeKind::Permitted => Err(ValidationError::new(ValidationErrorKind::Other(
-                    "directoryName matching is not implemented, so a SAN cannot \
-                         satisfy a permitted directoryName name constraint"
-                        .to_string(),
-                ))),
-                SubtreeKind::Excluded => Ok(Applied(false)),
-            },
             // All other matching pairs of (constraint, name) are currently unsupported.
             (GeneralName::OtherName(_), GeneralName::OtherName(_))
             | (GeneralName::X400Address(_), GeneralName::X400Address(_))
+            | (GeneralName::DirectoryName(_), GeneralName::DirectoryName(_))
             | (GeneralName::EDIPartyName(_), GeneralName::EDIPartyName(_))
             | (
                 GeneralName::UniformResourceIdentifier(_),
@@ -262,8 +258,46 @@ impl<'a, 'chain> NameChain<'a, 'chain> {
         constraints: &NameConstraints<'chain, Asn1Read>,
         budget: &mut Budget,
     ) -> ValidationResult<'chain, (), B> {
+        // `self` is the certificate containing the name constraints, and
+        // constraints don't apply to the certificate they appear in (per
+        // RFC 5280 6.1.4 they apply to subsequent certificates in the path),
+        // so the subject check starts at our child.
+        self.evaluate_constraints_inner(constraints, budget, false)
+    }
+
+    fn evaluate_constraints_inner<B: CryptoOps>(
+        &self,
+        constraints: &NameConstraints<'chain, Asn1Read>,
+        budget: &mut Budget,
+        constrain_subject: bool,
+    ) -> ValidationResult<'chain, (), B> {
         if let Some(child) = self.child {
-            child.evaluate_constraints(constraints, budget)?;
+            child.evaluate_constraints_inner(constraints, budget, true)?;
+        }
+
+        // RFC 5280 4.2.1.10: directoryName constraints apply to the subject
+        // field (when non-empty) as well as to directoryName SANs. We don't
+        // implement directoryName matching, so any directoryName constraint
+        // that applies to a non-empty subject is an error.
+        if constrain_subject && self.non_empty_subject {
+            for subtrees in [
+                &constraints.permitted_subtrees,
+                &constraints.excluded_subtrees,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                for subtree in subtrees.clone() {
+                    budget.name_constraint_check()?;
+                    if matches!(subtree.base, GeneralName::DirectoryName(_)) {
+                        return Err(ValidationError::new(ValidationErrorKind::Other(
+                            "unsupported name constraint: directoryName constraints \
+                             cannot be applied to a non-empty subject"
+                                .to_string(),
+                        )));
+                    }
+                }
+            }
         }
 
         for san in self.sans.clone() {
@@ -497,6 +531,7 @@ impl<'a, 'chain, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
                         &issuer_extensions,
                         NameChain::new(
                             Some(&name_chain),
+                            issuing_cert_candidate.certificate(),
                             &issuer_extensions,
                             // Per RFC 5280 4.2.1.10: Name constraints are not applied
                             // to subjects in self-issued certificates, *unless* the
@@ -566,7 +601,7 @@ impl<'a, 'chain, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
             leaf,
             0,
             &leaf_extensions,
-            NameChain::new(None, &leaf_extensions, false)?,
+            NameChain::new(None, leaf.certificate(), &leaf_extensions, false)?,
             budget,
         )?;
         // We build the chain in reverse order, fix it now.
@@ -694,7 +729,7 @@ qolIOwIgCaIgj9ipK0Q0p+45UJiq+L/ncrxsweJkFq/UYubzhX0=
             signature_checks: usize::MAX,
         };
 
-        let name_chain = NameChain::new::<NullOps>(None, &ca_exts, false)
+        let name_chain = NameChain::new::<NullOps>(None, &ca, &ca_exts, false)
             .ok()
             .unwrap();
         let err = builder

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -19,7 +19,7 @@ use asn1::ObjectIdentifier;
 use cryptography_x509::common::Asn1Read;
 use cryptography_x509::extensions::{
     AuthorityKeyIdentifier, DuplicateExtensionsError, Extensions, NameConstraints,
-    SubjectAlternativeName,
+    SequenceOfSubtrees, SubjectAlternativeName,
 };
 use cryptography_x509::name::GeneralName;
 use cryptography_x509::oid::{
@@ -426,27 +426,28 @@ impl<'a, 'chain, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
         if let Some(nc) = working_cert_extensions.get_extension(&NAME_CONSTRAINTS_OID) {
             let constraints: NameConstraints<'chain, Asn1Read> = nc.value()?;
 
-            // We don't implement directoryName constraint matching, even
-            // though RFC 5280 4.2.1.10 requires it (applied to both the
-            // subject and any directoryName SANs in subsequent certificates).
-            // Per the same section, an application that cannot process a
-            // constraint imposed by a critical name constraints extension
-            // MUST reject the certificate, so a critical extension containing
-            // any directoryName constraint is a hard error. A non-critical
-            // extension may be (partially) ignored, so its directoryName
-            // constraints fall through to the per-SAN evaluation below.
-            if nc.critical
-                && [
-                    &constraints.permitted_subtrees,
-                    &constraints.excluded_subtrees,
-                ]
-                .into_iter()
-                .flatten()
-                .any(|subtrees| {
+            // RFC 5280 4.2.1.10 requires directoryName constraints to be
+            // applied to the subject field of subsequent certificates, not
+            // just to their directoryName SANs (which the evaluation below
+            // would handle), and requires applications that cannot process
+            // a constraint in a critical name constraints extension to
+            // reject the certificate. We don't implement directoryName
+            // matching, so a critical extension containing any directoryName
+            // constraint is a hard error. A non-critical extension may be
+            // (partially) ignored, so its directoryName constraints fall
+            // through to the per-SAN evaluation below.
+            fn contains_directory_name(
+                subtrees: &Option<SequenceOfSubtrees<'_, Asn1Read>>,
+            ) -> bool {
+                subtrees.as_ref().is_some_and(|subtrees| {
                     subtrees
                         .clone()
                         .any(|subtree| matches!(subtree.base, GeneralName::DirectoryName(_)))
                 })
+            }
+            if nc.critical
+                && (contains_directory_name(&constraints.permitted_subtrees)
+                    || contains_directory_name(&constraints.excluded_subtrees))
             {
                 return Err(ValidationError::new(ValidationErrorKind::FatalError(
                     "critical nameConstraints extension contains an unsupported \

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -226,10 +226,23 @@ impl<'a, 'chain> NameChain<'a, 'chain> {
                     )))),
                 }
             }
+            // We don't implement DirectoryName matching, so a DirectoryName
+            // constraint never matches a DirectoryName SAN. For an excluded
+            // subtree that means the SAN is never excluded; for a permitted
+            // subtree it means the SAN can never be permitted (no other
+            // DirectoryName constraint can match either), so we fail
+            // immediately with a dedicated error.
+            (GeneralName::DirectoryName(_), GeneralName::DirectoryName(_)) => match kind {
+                SubtreeKind::Permitted => Err(ValidationError::new(ValidationErrorKind::Other(
+                    "directoryName matching is not implemented, so a SAN cannot \
+                         satisfy a permitted directoryName name constraint"
+                        .to_string(),
+                ))),
+                SubtreeKind::Excluded => Ok(Applied(false)),
+            },
             // All other matching pairs of (constraint, name) are currently unsupported.
             (GeneralName::OtherName(_), GeneralName::OtherName(_))
             | (GeneralName::X400Address(_), GeneralName::X400Address(_))
-            | (GeneralName::DirectoryName(_), GeneralName::DirectoryName(_))
             | (GeneralName::EDIPartyName(_), GeneralName::EDIPartyName(_))
             | (
                 GeneralName::UniformResourceIdentifier(_),

--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -16,7 +16,6 @@ use std::fmt::Display;
 use std::vec;
 
 use asn1::ObjectIdentifier;
-use cryptography_x509::certificate::Certificate;
 use cryptography_x509::common::Asn1Read;
 use cryptography_x509::extensions::{
     AuthorityKeyIdentifier, DuplicateExtensionsError, Extensions, NameConstraints,
@@ -146,13 +145,11 @@ impl Budget {
 struct NameChain<'a, 'chain> {
     child: Option<&'a NameChain<'a, 'chain>>,
     sans: SubjectAlternativeName<'chain>,
-    non_empty_subject: bool,
 }
 
 impl<'a, 'chain> NameChain<'a, 'chain> {
     fn new<B: CryptoOps>(
         child: Option<&'a NameChain<'a, 'chain>>,
-        certificate: &Certificate<'chain>,
         extensions: &Extensions<'chain>,
         self_issued_intermediate: bool,
     ) -> ValidationResult<'chain, Self, B> {
@@ -166,13 +163,7 @@ impl<'a, 'chain> NameChain<'a, 'chain> {
             _ => asn1::parse_single(b"\x30\x00")?,
         };
 
-        let non_empty_subject = !self_issued_intermediate && !certificate.subject().is_empty();
-
-        Ok(Self {
-            child,
-            sans,
-            non_empty_subject,
-        })
+        Ok(Self { child, sans })
     }
 
     fn evaluate_single_constraint<B: CryptoOps>(
@@ -258,46 +249,8 @@ impl<'a, 'chain> NameChain<'a, 'chain> {
         constraints: &NameConstraints<'chain, Asn1Read>,
         budget: &mut Budget,
     ) -> ValidationResult<'chain, (), B> {
-        // `self` is the certificate containing the name constraints, and
-        // constraints don't apply to the certificate they appear in (per
-        // RFC 5280 6.1.4 they apply to subsequent certificates in the path),
-        // so the subject check starts at our child.
-        self.evaluate_constraints_inner(constraints, budget, false)
-    }
-
-    fn evaluate_constraints_inner<B: CryptoOps>(
-        &self,
-        constraints: &NameConstraints<'chain, Asn1Read>,
-        budget: &mut Budget,
-        constrain_subject: bool,
-    ) -> ValidationResult<'chain, (), B> {
         if let Some(child) = self.child {
-            child.evaluate_constraints_inner(constraints, budget, true)?;
-        }
-
-        // RFC 5280 4.2.1.10: directoryName constraints apply to the subject
-        // field (when non-empty) as well as to directoryName SANs. We don't
-        // implement directoryName matching, so any directoryName constraint
-        // that applies to a non-empty subject is an error.
-        if constrain_subject && self.non_empty_subject {
-            for subtrees in [
-                &constraints.permitted_subtrees,
-                &constraints.excluded_subtrees,
-            ]
-            .into_iter()
-            .flatten()
-            {
-                for subtree in subtrees.clone() {
-                    budget.name_constraint_check()?;
-                    if matches!(subtree.base, GeneralName::DirectoryName(_)) {
-                        return Err(ValidationError::new(ValidationErrorKind::Other(
-                            "unsupported name constraint: directoryName constraints \
-                             cannot be applied to a non-empty subject"
-                                .to_string(),
-                        )));
-                    }
-                }
-            }
+            child.evaluate_constraints(constraints, budget)?;
         }
 
         for san in self.sans.clone() {
@@ -471,7 +424,37 @@ impl<'a, 'chain, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
         budget: &mut Budget,
     ) -> ValidationResult<'chain, Chain<'chain, B>, B> {
         if let Some(nc) = working_cert_extensions.get_extension(&NAME_CONSTRAINTS_OID) {
-            name_chain.evaluate_constraints(&nc.value()?, budget)?;
+            let constraints: NameConstraints<'chain, Asn1Read> = nc.value()?;
+
+            // We don't implement directoryName constraint matching, even
+            // though RFC 5280 4.2.1.10 requires it (applied to both the
+            // subject and any directoryName SANs in subsequent certificates).
+            // Per the same section, an application that cannot process a
+            // constraint imposed by a critical name constraints extension
+            // MUST reject the certificate, so a critical extension containing
+            // any directoryName constraint is a hard error. A non-critical
+            // extension may be (partially) ignored, so its directoryName
+            // constraints fall through to the per-SAN evaluation below.
+            if nc.critical
+                && [
+                    &constraints.permitted_subtrees,
+                    &constraints.excluded_subtrees,
+                ]
+                .into_iter()
+                .flatten()
+                .any(|subtrees| {
+                    subtrees
+                        .clone()
+                        .any(|subtree| matches!(subtree.base, GeneralName::DirectoryName(_)))
+                })
+            {
+                return Err(ValidationError::new(ValidationErrorKind::FatalError(
+                    "critical nameConstraints extension contains an unsupported \
+                     directoryName constraint",
+                )));
+            }
+
+            name_chain.evaluate_constraints(&constraints, budget)?;
         }
 
         // Look in the store's root set to see if the working cert is listed.
@@ -531,7 +514,6 @@ impl<'a, 'chain, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
                         &issuer_extensions,
                         NameChain::new(
                             Some(&name_chain),
-                            issuing_cert_candidate.certificate(),
                             &issuer_extensions,
                             // Per RFC 5280 4.2.1.10: Name constraints are not applied
                             // to subjects in self-issued certificates, *unless* the
@@ -601,7 +583,7 @@ impl<'a, 'chain, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
             leaf,
             0,
             &leaf_extensions,
-            NameChain::new(None, leaf.certificate(), &leaf_extensions, false)?,
+            NameChain::new(None, &leaf_extensions, false)?,
             budget,
         )?;
         // We build the chain in reverse order, fix it now.
@@ -729,7 +711,7 @@ qolIOwIgCaIgj9ipK0Q0p+45UJiq+L/ncrxsweJkFq/UYubzhX0=
             signature_checks: usize::MAX,
         };
 
-        let name_chain = NameChain::new::<NullOps>(None, &ca, &ca_exts, false)
+        let name_chain = NameChain::new::<NullOps>(None, &ca_exts, false)
             .ok()
             .unwrap();
         let err = builder

--- a/tests/x509/verification/test_verification.py
+++ b/tests/x509/verification/test_verification.py
@@ -869,16 +869,11 @@ class TestNameConstraints:
     )
 
     @classmethod
-    def _build_chain(cls, name_constraints, leaf_sans, leaf_subject=None):
+    def _build_chain(cls, name_constraints, leaf_sans, *, nc_critical):
         # Builds a (ca, leaf) chain where the CA carries the given
         # nameConstraints extension and the leaf the given SANs.
         ca_key = ec.generate_private_key(ec.SECP256R1())
         leaf_key = ec.generate_private_key(ec.SECP256R1())
-
-        if leaf_subject is None:
-            leaf_subject = x509.Name(
-                [x509.NameAttribute(NameOID.COMMON_NAME, "example.com")]
-            )
 
         not_before = datetime.datetime(2024, 1, 1)
         not_after = datetime.datetime(2034, 1, 1)
@@ -912,22 +907,24 @@ class TestNameConstraints:
                 ),
                 critical=True,
             )
-            .add_extension(name_constraints, critical=True)
+            .add_extension(name_constraints, critical=nc_critical)
             .sign(ca_key, hashes.SHA256())
         )
 
         leaf = (
             x509.CertificateBuilder()
-            .subject_name(leaf_subject)
+            .subject_name(
+                x509.Name(
+                    [x509.NameAttribute(NameOID.COMMON_NAME, "example.com")]
+                )
+            )
             .issuer_name(ca_name)
             .public_key(leaf_key.public_key())
             .serial_number(x509.random_serial_number())
             .not_valid_before(not_before)
             .not_valid_after(not_after)
-            # The SAN must be critical iff the subject is empty.
             .add_extension(
-                x509.SubjectAlternativeName(leaf_sans),
-                critical=not leaf_subject.rdns,
+                x509.SubjectAlternativeName(leaf_sans), critical=False
             )
             .add_extension(
                 x509.AuthorityKeyIdentifier.from_issuer_public_key(
@@ -946,11 +943,13 @@ class TestNameConstraints:
         return builder.build_client_verifier()
 
     @pytest.mark.parametrize("subtree", ["permitted", "excluded"])
-    def test_dirname_constraint_with_nonempty_subject(self, subtree):
+    def test_critical_dirname_constraint_rejected(self, subtree):
         # Per RFC 5280 4.2.1.10, directoryName constraints apply to the
-        # subject field as well as directoryName SANs. We don't implement
-        # directoryName matching, so a directoryName constraint combined
-        # with a non-empty leaf subject is rejected.
+        # subject field as well as directoryName SANs, and an application
+        # that cannot process a constraint in a critical nameConstraints
+        # extension must reject the certificate. We don't implement
+        # directoryName matching, so a critical extension containing a
+        # directoryName constraint is rejected outright.
         ca, leaf = self._build_chain(
             x509.NameConstraints(
                 permitted_subtrees=(
@@ -961,39 +960,52 @@ class TestNameConstraints:
                 ),
             ),
             [x509.DNSName("example.com")],
+            nc_critical=True,
         )
         with pytest.raises(
             VerificationError,
-            match="directoryName constraints cannot be applied to a "
-            "non-empty subject",
+            match="critical nameConstraints extension contains an "
+            "unsupported directoryName constraint",
         ):
             self._verifier(ca).verify(leaf, [])
 
-    def test_dirname_constraint_with_dirname_san(self):
-        # An empty leaf subject sidesteps the subject check, but a
-        # directoryName constraint applied to a directoryName SAN is
-        # still unsupported.
+    def test_critical_supported_constraint_ok(self):
+        # A critical nameConstraints extension without directoryName
+        # constraints is processed normally.
+        ca, leaf = self._build_chain(
+            x509.NameConstraints(
+                permitted_subtrees=[x509.DNSName("example.com")],
+                excluded_subtrees=None,
+            ),
+            [x509.DNSName("example.com")],
+            nc_critical=True,
+        )
+        self._verifier(ca).verify(leaf, [])
+
+    def test_noncritical_dirname_constraint_with_dirname_san(self):
+        # A non-critical directoryName constraint isn't rejected outright,
+        # but evaluating it against a directoryName SAN is still
+        # unsupported.
         ca, leaf = self._build_chain(
             x509.NameConstraints(
                 permitted_subtrees=[self.dirname], excluded_subtrees=None
             ),
             [x509.DNSName("example.com"), self.dirname],
-            leaf_subject=x509.Name([]),
+            nc_critical=False,
         )
         with pytest.raises(
             VerificationError, match="unsupported name constraint"
         ):
             self._verifier(ca).verify(leaf, [])
 
-    def test_dirname_constraint_inapplicable(self):
-        # A directoryName constraint is allowed when it applies to
-        # nothing: the leaf subject is empty and no SAN is a
-        # directoryName.
+    def test_noncritical_dirname_constraint_ignored(self):
+        # A non-critical directoryName constraint is ignored when no SAN
+        # is a directoryName.
         ca, leaf = self._build_chain(
             x509.NameConstraints(
                 permitted_subtrees=[self.dirname], excluded_subtrees=None
             ),
             [x509.DNSName("example.com")],
-            leaf_subject=x509.Name([]),
+            nc_critical=False,
         )
         self._verifier(ca).verify(leaf, [])

--- a/tests/x509/verification/test_verification.py
+++ b/tests/x509/verification/test_verification.py
@@ -860,3 +860,120 @@ class TestCustomExtensionPolicies:
             builder.build_server_verifier(DNSName("wrong.io")).verify(
                 self.leaf, []
             )
+
+
+class TestNameConstraints:
+    validation_time = datetime.datetime(2025, 1, 1)
+    dirname = x509.DirectoryName(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "PyCA")])
+    )
+
+    @classmethod
+    def _build_chain(cls, name_constraints, leaf_sans):
+        # Builds a (ca, leaf) chain where the CA carries the given
+        # nameConstraints extension and the leaf the given SANs.
+        ca_key = ec.generate_private_key(ec.SECP256R1())
+        leaf_key = ec.generate_private_key(ec.SECP256R1())
+
+        not_before = datetime.datetime(2024, 1, 1)
+        not_after = datetime.datetime(2034, 1, 1)
+
+        ca_name = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, "Test CA")]
+        )
+        ca = (
+            x509.CertificateBuilder()
+            .subject_name(ca_name)
+            .issuer_name(ca_name)
+            .public_key(ca_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_before)
+            .not_valid_after(not_after)
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=False,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(name_constraints, critical=True)
+            .sign(ca_key, hashes.SHA256())
+        )
+
+        leaf = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [x509.NameAttribute(NameOID.COMMON_NAME, "example.com")]
+                )
+            )
+            .issuer_name(ca_name)
+            .public_key(leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_before)
+            .not_valid_after(not_after)
+            .add_extension(
+                x509.SubjectAlternativeName(leaf_sans), critical=False
+            )
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(
+                    ca_key.public_key()
+                ),
+                critical=False,
+            )
+            .sign(ca_key, hashes.SHA256())
+        )
+
+        return ca, leaf
+
+    def _verifier(self, ca):
+        builder = PolicyBuilder().store(Store([ca]))
+        builder = builder.time(self.validation_time)
+        return builder.build_client_verifier()
+
+    def test_dirname_excluded_subtree_never_matches(self):
+        # We don't implement directoryName constraint matching, so an
+        # excluded directoryName subtree never excludes anything.
+        ca, leaf = self._build_chain(
+            x509.NameConstraints(
+                permitted_subtrees=None, excluded_subtrees=[self.dirname]
+            ),
+            [x509.DNSName("example.com"), self.dirname],
+        )
+        self._verifier(ca).verify(leaf, [])
+
+    def test_dirname_permitted_subtree_unsatisfiable(self):
+        # A directoryName SAN can never fall within a permitted
+        # directoryName subtree.
+        ca, leaf = self._build_chain(
+            x509.NameConstraints(
+                permitted_subtrees=[self.dirname], excluded_subtrees=None
+            ),
+            [x509.DNSName("example.com"), self.dirname],
+        )
+        with pytest.raises(
+            VerificationError,
+            match="directoryName matching is not implemented",
+        ):
+            self._verifier(ca).verify(leaf, [])
+
+    def test_dirname_constraint_skipped_for_other_san_types(self):
+        # A directoryName constraint does not apply to SANs of other types.
+        ca, leaf = self._build_chain(
+            x509.NameConstraints(
+                permitted_subtrees=[self.dirname], excluded_subtrees=None
+            ),
+            [x509.DNSName("example.com")],
+        )
+        self._verifier(ca).verify(leaf, [])

--- a/tests/x509/verification/test_verification.py
+++ b/tests/x509/verification/test_verification.py
@@ -869,11 +869,16 @@ class TestNameConstraints:
     )
 
     @classmethod
-    def _build_chain(cls, name_constraints, leaf_sans):
+    def _build_chain(cls, name_constraints, leaf_sans, leaf_subject=None):
         # Builds a (ca, leaf) chain where the CA carries the given
         # nameConstraints extension and the leaf the given SANs.
         ca_key = ec.generate_private_key(ec.SECP256R1())
         leaf_key = ec.generate_private_key(ec.SECP256R1())
+
+        if leaf_subject is None:
+            leaf_subject = x509.Name(
+                [x509.NameAttribute(NameOID.COMMON_NAME, "example.com")]
+            )
 
         not_before = datetime.datetime(2024, 1, 1)
         not_after = datetime.datetime(2034, 1, 1)
@@ -913,18 +918,16 @@ class TestNameConstraints:
 
         leaf = (
             x509.CertificateBuilder()
-            .subject_name(
-                x509.Name(
-                    [x509.NameAttribute(NameOID.COMMON_NAME, "example.com")]
-                )
-            )
+            .subject_name(leaf_subject)
             .issuer_name(ca_name)
             .public_key(leaf_key.public_key())
             .serial_number(x509.random_serial_number())
             .not_valid_before(not_before)
             .not_valid_after(not_after)
+            # The SAN must be critical iff the subject is empty.
             .add_extension(
-                x509.SubjectAlternativeName(leaf_sans), critical=False
+                x509.SubjectAlternativeName(leaf_sans),
+                critical=not leaf_subject.rdns,
             )
             .add_extension(
                 x509.AuthorityKeyIdentifier.from_issuer_public_key(
@@ -942,38 +945,55 @@ class TestNameConstraints:
         builder = builder.time(self.validation_time)
         return builder.build_client_verifier()
 
-    def test_dirname_excluded_subtree_never_matches(self):
-        # We don't implement directoryName constraint matching, so an
-        # excluded directoryName subtree never excludes anything.
+    @pytest.mark.parametrize("subtree", ["permitted", "excluded"])
+    def test_dirname_constraint_with_nonempty_subject(self, subtree):
+        # Per RFC 5280 4.2.1.10, directoryName constraints apply to the
+        # subject field as well as directoryName SANs. We don't implement
+        # directoryName matching, so a directoryName constraint combined
+        # with a non-empty leaf subject is rejected.
         ca, leaf = self._build_chain(
             x509.NameConstraints(
-                permitted_subtrees=None, excluded_subtrees=[self.dirname]
+                permitted_subtrees=(
+                    [self.dirname] if subtree == "permitted" else None
+                ),
+                excluded_subtrees=(
+                    [self.dirname] if subtree == "excluded" else None
+                ),
             ),
-            [x509.DNSName("example.com"), self.dirname],
+            [x509.DNSName("example.com")],
         )
-        self._verifier(ca).verify(leaf, [])
+        with pytest.raises(
+            VerificationError,
+            match="directoryName constraints cannot be applied to a "
+            "non-empty subject",
+        ):
+            self._verifier(ca).verify(leaf, [])
 
-    def test_dirname_permitted_subtree_unsatisfiable(self):
-        # A directoryName SAN can never fall within a permitted
-        # directoryName subtree.
+    def test_dirname_constraint_with_dirname_san(self):
+        # An empty leaf subject sidesteps the subject check, but a
+        # directoryName constraint applied to a directoryName SAN is
+        # still unsupported.
         ca, leaf = self._build_chain(
             x509.NameConstraints(
                 permitted_subtrees=[self.dirname], excluded_subtrees=None
             ),
             [x509.DNSName("example.com"), self.dirname],
+            leaf_subject=x509.Name([]),
         )
         with pytest.raises(
-            VerificationError,
-            match="directoryName matching is not implemented",
+            VerificationError, match="unsupported name constraint"
         ):
             self._verifier(ca).verify(leaf, [])
 
-    def test_dirname_constraint_skipped_for_other_san_types(self):
-        # A directoryName constraint does not apply to SANs of other types.
+    def test_dirname_constraint_inapplicable(self):
+        # A directoryName constraint is allowed when it applies to
+        # nothing: the leaf subject is empty and no SAN is a
+        # directoryName.
         ca, leaf = self._build_chain(
             x509.NameConstraints(
                 permitted_subtrees=[self.dirname], excluded_subtrees=None
             ),
             [x509.DNSName("example.com")],
+            leaf_subject=x509.Name([]),
         )
         self._verifier(ca).verify(leaf, [])


### PR DESCRIPTION
Per RFC 5280 §4.2.1.10:

> Restrictions of the form directoryName MUST be applied to the subject field in the certificate (when the certificate includes a non-empty subject field) and to any names of type directoryName in the subjectAltName extension.

and:

> If a name constraints extension that is marked as critical imposes constraints on a particular name form, and an instance of that name form appears in the subject field or subjectAltName extension of a subsequent certificate, then the application MUST either process the constraint or reject the certificate.

We don't implement directoryName constraint matching, and previously a directoryName constraint was only rejected (as unsupported) when a subsequent certificate had a directoryName *SAN* — the RFC-mandated application to the *subject* field was silently skipped, even for critical extensions.

With this change, when chain building processes a nameConstraints extension that is **critical** and contains a directoryName entry in either `permittedSubtrees` or `excludedSubtrees`, it returns a fatal error (`critical nameConstraints extension contains an unsupported directoryName constraint`) immediately, without inspecting subjects or SANs. Since subjects are essentially always non-empty, the only conforming alternative to actually processing the constraint is rejection, and rejecting unconditionally keeps the logic trivial. The fatal error also short-circuits path building rather than being swallowed into `CandidatesExhausted` and masked by alternate paths.

Caveats / judgment calls:

- **Non-critical nameConstraints with directoryName entries are ignored** (RFC 5280 only mandates process-or-reject for critical extensions; CABF relaxes nameConstraints criticality to MAY) — *except* that the pre-existing per-SAN evaluation still rejects a directoryName constraint evaluated against a directoryName SAN with the generic "unsupported name constraint" error. So non-critical + directoryName SAN still fails; non-critical + no directoryName SANs now validates.
- **rfc822Name has a similar (legacy) subject requirement we still don't implement**: RFC 5280 §4.2.1.10 says that when rfc822Name constraints are imposed and the certificate has *no* subjectAltName, the constraint MUST be applied to an `emailAddress` attribute in the subject DN. That's the only other name form with a subject-field requirement (x400Address/directoryName-in-SAN aside, all other forms apply to SANs only). Under this profile leaves must carry a SAN, so this can only arise for intermediates with `emailAddress` in their subject — left out of scope here, but a critical rfc822Name constraint over such a chain is technically processed incompletely.
- **Practical effect**: chains with critical directoryName constraints fail loudly instead of the subject-side application being silently unenforced. RFC 5280 requires CAs to mark nameConstraints critical, so most real-world directoryName-constrained chains will now be rejected; that's a behavior change for chains that previously validated.
- The `name-constraint-dn` skip in the x509-limbo suite remains, since those testcases expect real DN matching semantics, which this PR deliberately does not implement.

Tests: new `TestNameConstraints` cases cover critical directoryName constraints (permitted and excluded) being rejected, a critical extension with only DNS constraints still validating, and the two non-critical paths (rejected with a directoryName SAN, ignored without one).

https://claude.ai/code/session_01LJgFCNp7irHqqfQ6jXmPhE