### PR TITLE
Add more robust parameter processing: DH

### DIFF
--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -55,18 +55,20 @@ fn generate_parameters(
 
 pub(crate) fn private_key_from_pkey(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
-) -> DHPrivateKey {
-    DHPrivateKey {
+) -> CryptographyResult<DHPrivateKey> {
+    check_dh_parameters(&pkey.dh()?)?;
+    Ok(DHPrivateKey {
         pkey: pkey.to_owned(),
-    }
+    })
 }
 
 pub(crate) fn public_key_from_pkey(
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Public>,
-) -> DHPublicKey {
-    DHPublicKey {
+) -> CryptographyResult<DHPublicKey> {
+    check_dh_parameters(&pkey.dh()?)?;
+    Ok(DHPublicKey {
         pkey: pkey.to_owned(),
-    }
+    })
 }
 
 #[pyo3::pyfunction]
@@ -85,9 +87,9 @@ fn from_der_parameters(
         .transpose()?;
     let g = openssl::bn::BigNum::from_slice(asn1_params.g.as_bytes())?;
 
-    Ok(DHParameters {
-        dh: openssl::dh::Dh::from_pqg(p, q, g)?,
-    })
+    let dh = openssl::dh::Dh::from_pqg(p, q, g)?;
+    check_dh_parameters(&dh)?;
+    Ok(DHParameters { dh })
 }
 
 #[pyo3::pyfunction]
@@ -119,13 +121,19 @@ fn dh_parameters_from_numbers(
     let g = utils::py_int_to_bn(py, numbers.g.bind(py))?;
 
     let dh = openssl::dh::Dh::from_pqg(p, q, g)?;
+    check_dh_parameters(&dh)?;
+    Ok(dh)
+}
 
+fn check_dh_parameters<T: openssl::pkey::HasParams>(
+    dh: &openssl::dh::Dh<T>,
+) -> CryptographyResult<()> {
     if !dh.check_key()? {
         return Err(CryptographyError::from(
             pyo3::exceptions::PyValueError::new_err("Invalid DH parameters"),
         ));
     }
-    Ok(dh)
+    Ok(())
 }
 
 fn clone_dh<T: openssl::pkey::HasParams>(

--- a/src/rust/src/backend/keys.rs
+++ b/src/rust/src/backend/keys.rs
@@ -168,7 +168,7 @@ fn private_key_from_pkey<'p>(
         openssl::pkey::Id::DSA => Ok(crate::backend::dsa::private_key_from_pkey(pkey)
             .into_pyobject(py)?
             .into_any()),
-        openssl::pkey::Id::DH => Ok(crate::backend::dh::private_key_from_pkey(pkey)
+        openssl::pkey::Id::DH => Ok(crate::backend::dh::private_key_from_pkey(pkey)?
             .into_pyobject(py)?
             .into_any()),
 
@@ -177,7 +177,7 @@ fn private_key_from_pkey<'p>(
             CRYPTOGRAPHY_IS_BORINGSSL,
             CRYPTOGRAPHY_IS_AWSLC
         )))]
-        openssl::pkey::Id::DHX => Ok(crate::backend::dh::private_key_from_pkey(pkey)
+        openssl::pkey::Id::DHX => Ok(crate::backend::dh::private_key_from_pkey(pkey)?
             .into_pyobject(py)?
             .into_any()),
         #[cfg(any(
@@ -366,7 +366,7 @@ fn public_key_from_pkey<'p>(
         openssl::pkey::Id::DSA => Ok(crate::backend::dsa::public_key_from_pkey(pkey)
             .into_pyobject(py)?
             .into_any()),
-        openssl::pkey::Id::DH => Ok(crate::backend::dh::public_key_from_pkey(pkey)
+        openssl::pkey::Id::DH => Ok(crate::backend::dh::public_key_from_pkey(pkey)?
             .into_pyobject(py)?
             .into_any()),
 
@@ -375,7 +375,7 @@ fn public_key_from_pkey<'p>(
             CRYPTOGRAPHY_IS_BORINGSSL,
             CRYPTOGRAPHY_IS_AWSLC
         )))]
-        openssl::pkey::Id::DHX => Ok(crate::backend::dh::public_key_from_pkey(pkey)
+        openssl::pkey::Id::DHX => Ok(crate::backend::dh::public_key_from_pkey(pkey)?
             .into_pyobject(py)?
             .into_any()),
         #[cfg(any(


### PR DESCRIPTION
This PR adds more robust key processing for DH by extending existing heuristic checks on parameter well-formedness to the PEM and DER load paths.

See https://github.com/pyca/cryptography/pull/14992 and https://github.com/pyca/cryptography/pull/15015 for related changes to DSA and RSA processing.