### PR TITLE
Use arm64-only macOS OpenSSL build in CI and wheel builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,11 +317,11 @@ jobs:
         uses: ./.github/actions/fetch-openssl
         with:
           workflow: build-macos-openssl.yml
-          name: openssl-macos-universal2
-          path: "../openssl-macos-universal2/"
+          name: openssl-macos-arm64
+          path: "../openssl-macos-arm64/"
       - name: Build nox environment
         run: |
-          OPENSSL_DIR=$(readlink -f ../openssl-macos-universal2/) \
+          OPENSSL_DIR=$(readlink -f ../openssl-macos-arm64/) \
             OPENSSL_STATIC=1 \
             CFLAGS="-Werror -Wno-error=deprecated-declarations -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=unused-function" \
             nox -v --install-only

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -245,8 +245,8 @@ jobs:
           workflow: build-macos-openssl.yml
           branch: main
           workflow_conclusion: success
-          name: openssl-macos-universal2
-          path: "../openssl-macos-universal2/"
+          name: openssl-macos-arm64
+          path: "../openssl-macos-arm64/"
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
@@ -269,9 +269,9 @@ jobs:
               PY_LIMITED_API="--config-settings=build-args=--features=pyo3/abi3-${{ matrix.PYTHON.ABI_VERSION }}"
           fi
 
-          OPENSSL_DIR="$(readlink -f ../openssl-macos-universal2/)" \
+          OPENSSL_DIR="$(readlink -f ../openssl-macos-arm64/)" \
               OPENSSL_STATIC=1 \
-              uv build --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH $PY_LIMITED_API --config-settings=build-args=--sbom-include="$(readlink -f ../openssl-macos-universal2/sbom.json)" cryptography*.tar.gz -o wheelhouse/
+              uv build --wheel --require-hashes --build-constraint=$BUILD_REQUIREMENTS_PATH $PY_LIMITED_API --config-settings=build-args=--sbom-include="$(readlink -f ../openssl-macos-arm64/sbom.json)" cryptography*.tar.gz -o wheelhouse/
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.PYTHON.DEPLOYMENT_TARGET }}
           ARCHFLAGS: ${{ matrix.PYTHON.ARCHFLAGS }}


### PR DESCRIPTION
All macOS CI and wheel builds target arm64 only (CI runs on `macos-26` and every wheel matrix entry uses `ARCHFLAGS: -arch arm64`), so download the `openssl-macos-arm64` artifact from pyca/infra's `build-macos-openssl.yml` instead of the universal2 bundle.

https://claude.ai/code/session_01AWLNawZ3WFLNSeUfX5yN8E

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWLNawZ3WFLNSeUfX5yN8E)_