### PR TITLE
Add support for x509.Name as a field type in the asn1 module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Changelog
 * Parsing a Signed Certificate Timestamp list now rejects encodings that
   carry trailing bytes after the list or after an individual SCT, instead of
   silently ignoring them.
+* Added support for using :class:`~cryptography.x509.Name` as a field type in
+  the :doc:`/hazmat/asn1/index` module.
 
 .. _v49-0-0:
 

--- a/docs/hazmat/asn1/reference.rst
+++ b/docs/hazmat/asn1/reference.rst
@@ -87,6 +87,13 @@ field types. They are encoded by embedding their DER serialization, and
 decoded by parsing the field as the corresponding X.509 object. These
 fields cannot have :class:`Implicit` annotations.
 
+.. versionadded:: 50.0.0
+
+:class:`~cryptography.x509.Name` can also be used as a field type. It is
+encoded and decoded as an X.509 ``Name`` (a ``SEQUENCE OF
+RelativeDistinguishedName``), and supports :class:`Implicit` and
+:class:`Explicit` annotations.
+
 .. code-block:: python
 
     from cryptography import x509

--- a/src/rust/src/declarative_asn1/decode.rs
+++ b/src/rust/src/declarative_asn1/decode.rs
@@ -245,6 +245,15 @@ fn decode_crl<'a>(
     Ok(pyo3::Bound::new(py, crl)?)
 }
 
+fn decode_name<'a>(
+    py: pyo3::Python<'a>,
+    parser: &mut Parser<'a>,
+    encoding: &Option<pyo3::Py<Encoding>>,
+) -> ParseResult<pyo3::Bound<'a, pyo3::PyAny>> {
+    let name = read_value::<cryptography_x509::name::NameReadable<'a>>(parser, encoding)?;
+    crate::x509::common::parse_name(py, &name)
+}
+
 fn decode_null<'a>(
     py: pyo3::Python<'a>,
     parser: &mut Parser<'a>,
@@ -463,6 +472,7 @@ pub(crate) fn decode_annotated_type<'a>(
         Type::Certificate() => decode_certificate(py, parser, encoding)?.into_any(),
         Type::CertificateSigningRequest() => decode_csr(py, parser, encoding)?.into_any(),
         Type::CertificateRevocationList() => decode_crl(py, parser, encoding)?.into_any(),
+        Type::Name() => decode_name(py, parser, encoding)?,
     };
 
     match &ann_type.annotation.get().default {

--- a/src/rust/src/declarative_asn1/encode.rs
+++ b/src/rust/src/declarative_asn1/encode.rs
@@ -307,6 +307,19 @@ impl asn1::Asn1Writable for AnnotatedTypeObject<'_> {
                     encoding,
                 )?)
             }
+            Type::Name() => {
+                if !value.is_instance(&crate::types::NAME.get(py)?)? {
+                    return Err(CryptographyError::Py(
+                        pyo3::exceptions::PyTypeError::new_err(format!(
+                            "Name field must be an instance of x509.Name, got: {}",
+                            value.get_type().name()?,
+                        )),
+                    ));
+                }
+                let ka = cryptography_keepalive::KeepAlive::new();
+                let name = crate::x509::common::encode_name(py, &ka, &value)?;
+                Ok(write_value(writer, &name, encoding)?)
+            }
         }
     }
 }

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -82,6 +82,8 @@ pub enum Type {
     CertificateSigningRequest(),
     /// `x509.CertificateRevocationList`
     CertificateRevocationList(),
+    /// `x509.Name`
+    Name(),
 }
 
 /// A type that we know how to encode/decode, along with any
@@ -579,6 +581,8 @@ pub fn non_root_python_to_rust<'p>(
         Type::CertificateSigningRequest().into_pyobject(py)
     } else if class.is(crate::x509::crl::CertificateRevocationList::type_object(py)) {
         Type::CertificateRevocationList().into_pyobject(py)
+    } else if class.is(&crate::types::NAME.get(py)?) {
+        Type::Name().into_pyobject(py)
     } else {
         Err(pyo3::exceptions::PyTypeError::new_err(format!(
             "cannot handle type: {class:?}"
@@ -723,12 +727,11 @@ pub(crate) fn is_tag_valid_for_type(
             }
         }
         Type::Null() => check_tag_with_encoding(asn1::Null::TAG, encoding, tag),
-        // Certificates, CSRs, and CRLs are all SEQUENCEs
+        // Certificates, CSRs, CRLs, and Names are all SEQUENCEs
         Type::Certificate()
         | Type::CertificateSigningRequest()
-        | Type::CertificateRevocationList() => {
-            check_tag_with_encoding(asn1::Sequence::TAG, encoding, tag)
-        }
+        | Type::CertificateRevocationList()
+        | Type::Name() => check_tag_with_encoding(asn1::Sequence::TAG, encoding, tag),
     }
 }
 

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -2098,6 +2098,107 @@ class TestX509Types:
             asn1.encode_der(Example(cert=9))  # type: ignore[arg-type]
 
 
+class TestName:
+    @pytest.fixture
+    def name(self) -> x509.Name:
+        return x509.Name.from_rfc4514_string("CN=foo,O=bar")
+
+    def test_name(self, name: x509.Name) -> None:
+        assert_roundtrips([(name, name.public_bytes())])
+
+    def test_empty_name(self) -> None:
+        name = x509.Name([])
+        assert_roundtrips([(name, name.public_bytes())])
+
+    def test_fields(self, name: x509.Name) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            name: x509.Name
+
+        inner = name.public_bytes()
+        expected = b"\x30" + _der_length(len(inner)) + inner
+        assert_roundtrips([(Example(name=name), expected)])
+
+    def test_name_explicit(self, name: x509.Name) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            name: Annotated[x509.Name, asn1.Explicit(0)]
+
+        name_der = name.public_bytes()
+        inner = b"\xa0" + _der_length(len(name_der)) + name_der
+        expected = b"\x30" + _der_length(len(inner)) + inner
+        assert_roundtrips([(Example(name=name), expected)])
+
+    def test_name_implicit(self, name: x509.Name) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            name: Annotated[x509.Name, asn1.Implicit(0)]
+
+        name_der = name.public_bytes()
+        # IMPLICIT tagging replaces the outer SEQUENCE tag (0x30) with the
+        # constructed context-specific tag [0] (0xa0).
+        inner = b"\xa0" + name_der[1:]
+        expected = b"\x30" + _der_length(len(inner)) + inner
+        assert_roundtrips([(Example(name=name), expected)])
+
+    def test_optional_name(self, name: x509.Name) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            name: typing.Union[x509.Name, None]
+
+        name_der = name.public_bytes()
+        assert_roundtrips(
+            [
+                (
+                    Example(name=name),
+                    b"\x30" + _der_length(len(name_der)) + name_der,
+                ),
+                (Example(name=None), b"\x30\x00"),
+            ]
+        )
+
+    def test_name_choice(self, name: x509.Name) -> None:
+        @asn1.sequence
+        @_comparable_dataclass
+        class Example:
+            field: typing.Union[x509.Name, int]
+
+        name_der = name.public_bytes()
+        assert_roundtrips(
+            [
+                (
+                    Example(field=name),
+                    b"\x30" + _der_length(len(name_der)) + name_der,
+                ),
+                (
+                    Example(field=9),
+                    b"\x30" + _der_length(3) + b"\x02\x01\x09",
+                ),
+            ]
+        )
+
+    def test_decode_invalid(self) -> None:
+        # Not even a valid TLV
+        with pytest.raises(ValueError):
+            asn1.decode_der(x509.Name, b"")
+
+        # Wrong tag (INTEGER instead of SEQUENCE)
+        with pytest.raises(ValueError):
+            asn1.decode_der(x509.Name, b"\x02\x01\x00")
+
+    def test_encode_wrong_type(self) -> None:
+        @asn1.sequence
+        class Example:
+            name: x509.Name
+
+        with pytest.raises(TypeError):
+            asn1.encode_der(Example(name=9))  # type: ignore[arg-type]
+
+
 @asn1.value_set(x509.ObjectIdentifier)
 class Algorithm(enum.Enum):
     A = x509.ObjectIdentifier("1.2.3.4")

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -2104,11 +2104,15 @@ class TestName:
         return x509.Name.from_rfc4514_string("CN=foo,O=bar")
 
     def test_name(self, name: x509.Name) -> None:
-        assert_roundtrips([(name, name.public_bytes())])
-
-    def test_empty_name(self) -> None:
-        name = x509.Name([])
-        assert_roundtrips([(name, name.public_bytes())])
+        empty = x509.Name([])
+        name_der = name.public_bytes()
+        assert_roundtrips(
+            [
+                # Top-level, both populated and empty.
+                (name, name_der),
+                (empty, empty.public_bytes()),
+            ]
+        )
 
     def test_fields(self, name: x509.Name) -> None:
         @asn1.sequence
@@ -2120,18 +2124,9 @@ class TestName:
         expected = b"\x30" + _der_length(len(inner)) + inner
         assert_roundtrips([(Example(name=name), expected)])
 
-    def test_name_explicit(self, name: x509.Name) -> None:
-        @asn1.sequence
-        @_comparable_dataclass
-        class Example:
-            name: Annotated[x509.Name, asn1.Explicit(0)]
-
-        name_der = name.public_bytes()
-        inner = b"\xa0" + _der_length(len(name_der)) + name_der
-        expected = b"\x30" + _der_length(len(inner)) + inner
-        assert_roundtrips([(Example(name=name), expected)])
-
     def test_name_implicit(self, name: x509.Name) -> None:
+        # Unlike Certificate/CSR/CRL, Name is encoded and decoded through the
+        # asn1 machinery directly, so it supports IMPLICIT annotations.
         @asn1.sequence
         @_comparable_dataclass
         class Example:
@@ -2143,43 +2138,6 @@ class TestName:
         inner = b"\xa0" + name_der[1:]
         expected = b"\x30" + _der_length(len(inner)) + inner
         assert_roundtrips([(Example(name=name), expected)])
-
-    def test_optional_name(self, name: x509.Name) -> None:
-        @asn1.sequence
-        @_comparable_dataclass
-        class Example:
-            name: typing.Union[x509.Name, None]
-
-        name_der = name.public_bytes()
-        assert_roundtrips(
-            [
-                (
-                    Example(name=name),
-                    b"\x30" + _der_length(len(name_der)) + name_der,
-                ),
-                (Example(name=None), b"\x30\x00"),
-            ]
-        )
-
-    def test_name_choice(self, name: x509.Name) -> None:
-        @asn1.sequence
-        @_comparable_dataclass
-        class Example:
-            field: typing.Union[x509.Name, int]
-
-        name_der = name.public_bytes()
-        assert_roundtrips(
-            [
-                (
-                    Example(field=name),
-                    b"\x30" + _der_length(len(name_der)) + name_der,
-                ),
-                (
-                    Example(field=9),
-                    b"\x30" + _der_length(3) + b"\x02\x01\x09",
-                ),
-            ]
-        )
 
     def test_decode_invalid(self) -> None:
         # Not even a valid TLV


### PR DESCRIPTION
Closes #15038.

This follows up on #14893 (released in 49.0.0), which added `Certificate`, `CertificateSigningRequest`, and `CertificateRevocationList` as asn1 field types. `x509.Name` can now be used directly as well:

```python
from cryptography import x509
from cryptography.hazmat import asn1

@asn1.sequence
class Example:
    name: x509.Name
```

It is encoded and decoded as a `SEQUENCE OF RelativeDistinguishedName`.

Unlike the other X.509 types — which embed their DER serialization and are re-parsed through their loaders, and therefore cannot be IMPLICIT (that would rewrite the SEQUENCE tag the loader expects) — `Name` flows through the asn1 reader/writer machinery directly, so it supports both IMPLICIT and EXPLICIT annotations. For that reason it is deliberately not added to the `_X509_TYPES` IMPLICIT restriction in `asn1.py`.

Includes tests, docs, and a changelog entry.

https://claude.ai/code/session_01GKC7MtAKnEdM61Yx8qKBnx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKC7MtAKnEdM61Yx8qKBnx)_