### PR TITLE
reject trailing data when parsing signed certificate timestamps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Parsing a Signed Certificate Timestamp list now rejects encodings that
+  carry trailing bytes after the list or after an individual SCT, instead of
+  silently ignoring them.
+
 .. _v49-0-0:
 
 49.0.0 - 2026-06-12

--- a/src/rust/src/x509/sct.rs
+++ b/src/rust/src/x509/sct.rs
@@ -223,7 +223,15 @@ pub(crate) fn parse_scts<'p>(
     data: &[u8],
     entry_type: LogEntryType,
 ) -> CryptographyResult<pyo3::Bound<'p, pyo3::PyAny>> {
-    let mut reader = TLSReader::new(data).read_length_prefixed()?;
+    let mut outer = TLSReader::new(data);
+    let mut reader = outer.read_length_prefixed()?;
+    // The length-prefixed list must span the whole input; anything left over
+    // is a malformed encoding rather than a second list.
+    if !outer.is_empty() {
+        return Err(CryptographyError::from(
+            pyo3::exceptions::PyValueError::new_err("Invalid SCT length"),
+        ));
+    }
 
     let py_scts = pyo3::types::PyList::empty(py);
     while !reader.is_empty() {
@@ -243,6 +251,14 @@ pub(crate) fn parse_scts<'p>(
 
         let signature = sct_data.read_length_prefixed()?.data.to_vec();
 
+        // The signature is the final field of an SCT; trailing bytes inside
+        // the length-prefixed entry mean the encoding is malformed.
+        if !sct_data.is_empty() {
+            return Err(CryptographyError::from(
+                pyo3::exceptions::PyValueError::new_err("Invalid SCT length"),
+            ));
+        }
+
         let sct = Sct {
             log_id,
             timestamp,
@@ -261,6 +277,51 @@ pub(crate) fn parse_scts<'p>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Builds a minimal but well-formed SCT body (version, log id, timestamp,
+    // empty extensions, hash/signature algorithm and an empty signature).
+    fn minimal_sct_body() -> Vec<u8> {
+        let mut body = vec![0]; // version
+        body.extend_from_slice(&[0; 32]); // log id
+        body.extend_from_slice(&[0; 8]); // timestamp
+        body.extend_from_slice(&[0, 0]); // extensions (length-prefixed, empty)
+        body.push(4); // hash algorithm (sha256)
+        body.push(3); // signature algorithm (ecdsa)
+        body.extend_from_slice(&[0, 0]); // signature (length-prefixed, empty)
+        body
+    }
+
+    // Wraps `body` as a single entry in a length-prefixed SCT list.
+    fn sct_list(body: &[u8]) -> Vec<u8> {
+        let mut entry = (body.len() as u16).to_be_bytes().to_vec();
+        entry.extend_from_slice(body);
+        let mut list = (entry.len() as u16).to_be_bytes().to_vec();
+        list.extend_from_slice(&entry);
+        list
+    }
+
+    #[test]
+    fn test_parse_scts_rejects_trailing_data() {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            // A well-formed list parses to a single SCT.
+            let data = sct_list(&minimal_sct_body());
+            let scts = parse_scts(py, &data, LogEntryType::Certificate)
+                .ok()
+                .unwrap();
+            assert_eq!(scts.len().unwrap(), 1);
+
+            // A trailing byte inside the SCT entry must be rejected.
+            let mut body = minimal_sct_body();
+            body.push(0);
+            assert!(parse_scts(py, &sct_list(&body), LogEntryType::Certificate).is_err());
+
+            // A trailing byte after the list itself must be rejected.
+            let mut data = sct_list(&minimal_sct_body());
+            data.push(0);
+            assert!(parse_scts(py, &data, LogEntryType::Certificate).is_err());
+        });
+    }
 
     #[test]
     fn test_hash_algorithm_try_from() {

--- a/src/rust/src/x509/sct.rs
+++ b/src/rust/src/x509/sct.rs
@@ -278,51 +278,6 @@ pub(crate) fn parse_scts<'p>(
 mod tests {
     use super::*;
 
-    // Builds a minimal but well-formed SCT body (version, log id, timestamp,
-    // empty extensions, hash/signature algorithm and an empty signature).
-    fn minimal_sct_body() -> Vec<u8> {
-        let mut body = vec![0]; // version
-        body.extend_from_slice(&[0; 32]); // log id
-        body.extend_from_slice(&[0; 8]); // timestamp
-        body.extend_from_slice(&[0, 0]); // extensions (length-prefixed, empty)
-        body.push(4); // hash algorithm (sha256)
-        body.push(3); // signature algorithm (ecdsa)
-        body.extend_from_slice(&[0, 0]); // signature (length-prefixed, empty)
-        body
-    }
-
-    // Wraps `body` as a single entry in a length-prefixed SCT list.
-    fn sct_list(body: &[u8]) -> Vec<u8> {
-        let mut entry = (body.len() as u16).to_be_bytes().to_vec();
-        entry.extend_from_slice(body);
-        let mut list = (entry.len() as u16).to_be_bytes().to_vec();
-        list.extend_from_slice(&entry);
-        list
-    }
-
-    #[test]
-    fn test_parse_scts_rejects_trailing_data() {
-        pyo3::Python::initialize();
-        pyo3::Python::attach(|py| {
-            // A well-formed list parses to a single SCT.
-            let data = sct_list(&minimal_sct_body());
-            let scts = parse_scts(py, &data, LogEntryType::Certificate)
-                .ok()
-                .unwrap();
-            assert_eq!(scts.len().unwrap(), 1);
-
-            // A trailing byte inside the SCT entry must be rejected.
-            let mut body = minimal_sct_body();
-            body.push(0);
-            assert!(parse_scts(py, &sct_list(&body), LogEntryType::Certificate).is_err());
-
-            // A trailing byte after the list itself must be rejected.
-            let mut data = sct_list(&minimal_sct_body());
-            data.push(0);
-            assert!(parse_scts(py, &data, LogEntryType::Certificate).is_err());
-        });
-    }
-
     #[test]
     fn test_hash_algorithm_try_from() {
         for (n, ha) in &[

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -6244,6 +6244,59 @@ class TestPrecertificateSignedCertificateTimestampsExtension:
         assert hash(psct1) == hash(psct2)
         assert hash(psct1) != hash(psct3)
 
+    def test_parse_rejects_trailing_data(
+        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+    ):
+        # The SCT list is read by a small hand-rolled TLS reader, so drive
+        # the trailing-byte rejection through a crafted certificate extension.
+        def sct_list(body: bytes) -> bytes:
+            entry = len(body).to_bytes(2, "big") + body
+            return len(entry).to_bytes(2, "big") + entry
+
+        # version, log id, timestamp, empty extensions, hash and signature
+        # algorithm, and an empty signature.
+        body = (
+            b"\x00"
+            + b"\x00" * 32
+            + b"\x00" * 8
+            + b"\x00\x00"
+            + b"\x04"
+            + b"\x03"
+            + b"\x00\x00"
+        )
+
+        def build(payload: bytes) -> x509.Certificate:
+            ext = x509.UnrecognizedExtension(
+                ExtensionOID.PRECERT_SIGNED_CERTIFICATE_TIMESTAMPS,
+                b"\x04" + bytes([len(payload)]) + payload,
+            )
+            return (
+                _make_certbuilder(rsa_key_2048)
+                .add_extension(ext, critical=False)
+                .sign(rsa_key_2048, hashes.SHA256(), backend)
+            )
+
+        # A well-formed list still parses.
+        cert = build(sct_list(body))
+        scts = cert.extensions.get_extension_for_class(
+            x509.PrecertificateSignedCertificateTimestamps
+        ).value
+        assert len(scts) == 1
+
+        # A trailing byte inside the SCT entry is rejected.
+        cert = build(sct_list(body + b"\x00"))
+        with pytest.raises(ValueError):
+            cert.extensions.get_extension_for_class(
+                x509.PrecertificateSignedCertificateTimestamps
+            )
+
+        # A trailing byte after the list is rejected.
+        cert = build(sct_list(body) + b"\x00")
+        with pytest.raises(ValueError):
+            cert.extensions.get_extension_for_class(
+                x509.PrecertificateSignedCertificateTimestamps
+            )
+
     def test_simple(self, backend):
         cert = _load_cert(
             os.path.join("x509", "badssl-sct.pem"),


### PR DESCRIPTION
Signed Certificate Timestamps embedded in a certificate are parsed by a small hand-rolled TLS reader rather than the DER machinery. The reader walks the length-prefixed list and then each fixed SCT structure, but it never checks that it reached the end of either, so any bytes left over after the list, or after the final signature field inside an individual SCT entry, were quietly discarded. Since the SCT bytes come straight from an untrusted certificate extension, a malformed encoding with appended padding parsed as a valid SCT, and the leftover bytes still ended up in the stored raw data used for equality and hashing. I noticed it while comparing this reader against the DER and SSH parsers, both of which reject leftover input. The fix verifies each reader is empty once the expected fields have been consumed. I kept it inside parse_scts and added a regression test covering both leftover positions.