### PR TITLE
Fix InternalError when loading malformed PKCS#8 DSA private key

### DIFF
--- a/src/rust/cryptography-key-parsing/src/pkcs8.rs
+++ b/src/rust/cryptography-key-parsing/src/pkcs8.rs
@@ -69,7 +69,11 @@ pub fn parse_private_key(data: &[u8]) -> KeyParsingResult<ParsedPrivateKey> {
 
             let mut bn_ctx = openssl::bn::BigNumContext::new()?;
             let mut pub_key = openssl::bn::BigNum::new()?;
-            pub_key.mod_exp(&g, &dsa_private_key, &p, &mut bn_ctx)?;
+            // This can fail with malformed parameters (e.g. p == 0), in which
+            // case the key data is invalid.
+            pub_key
+                .mod_exp(&g, &dsa_private_key, &p, &mut bn_ctx)
+                .map_err(|_| KeyParsingError::InvalidKey)?;
 
             let dsa =
                 openssl::dsa::Dsa::from_private_components(p, q, g, dsa_private_key, pub_key)?;

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -797,6 +797,19 @@ class TestDSASerialization:
         priv_num = key.private_numbers()
         assert loaded_priv_num == priv_num
 
+    def test_load_pkcs8_invalid_dsa_parameters(self, backend):
+        # A PKCS8 DSA key with malformed parameters (p == 0) must raise a
+        # ValueError rather than an InternalError. See
+        # https://github.com/pyca/cryptography/issues/15061
+        key_bytes = (
+            b"0D\x02\x01\x000'\x06\x07*\x86H\xce8\x04\x010\x1c\x02\x01\x00"
+            b"\x02\x14*F\x00\x02\x02\x01)\x04\x16\x02\x14<\x06\x01\x00F\x00"
+            b"\x02\x00\x02\x02\x01)\x04\x16\x02\x14<\x06\x01\x00\x00\x00"
+            b"\x86H\xce8\x04\x010\x1c\x02\x14*\x04\xf7\r"
+        )
+        with pytest.raises(ValueError):
+            serialization.load_der_private_key(key_bytes, None, backend)
+
     @pytest.mark.parametrize(
         ("encoding", "fmt"),
         [


### PR DESCRIPTION
Loading a DER PKCS#8 DSA private key with malformed parameters (e.g. a zero modulus `p`) caused an `InternalError` ("Unknown OpenSSL error") instead of a `ValueError`.

The DSA private key path in `pkcs8.rs` recomputes the public key via `pub_key.mod_exp(&g, &dsa_private_key, &p, ...)`. With a zero modulus, OpenSSL's `BN_mod_exp` fails and pushes onto the OpenSSL error stack; that raw `ErrorStack` was propagated and turned into an `InternalError` (which is reserved for "another library dirtied the error stack" cases, not malformed user input). This maps the failure to `KeyParsingError::InvalidKey`, which surfaces as a `ValueError`.

Includes a regression test using the exact bytes from the issue.

Fixes #15061

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgbyMpHukw3e39YnJcRzc3)_