### PR TITLE
Use pyo3-build-config for cryptography-cffi build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           - {VERSION: "3.14", NOXSESSION: "rust"}
           - {VERSION: "3.12", NOXSESSION: "docs", OPENSSL: {TYPE: "openssl", VERSION: "4.0.1"}}
           - {VERSION: "3.14t", NOXSESSION: "rust,tests"}
+          - {VERSION: "3.15-dev", NOXSESSION: "rust,tests"}
+          - {VERSION: "3.15t-dev", NOXSESSION: "rust,tests"}
           - {VERSION: "pypy-3.11", NOXSESSION: "tests-nocoverage"}
           - {VERSION: "3.14", NOXSESSION: "tests", OPENSSL: {TYPE: "openssl", VERSION: "4.0.1", CONFIG_FLAGS: "no-engine no-rc2 no-srtp no-ct no-psk"}}
           - {VERSION: "3.14", NOXSESSION: "tests", OPENSSL: {TYPE: "openssl", VERSION: "4.0.1", CONFIG_FLAGS: "no-legacy", NO_LEGACY: "0"}}
@@ -286,6 +288,8 @@ jobs:
           - {VERSION: "3.9", NOXSESSION: "tests"}
           - {VERSION: "3.14", NOXSESSION: "tests"}
           - {VERSION: "3.14t", NOXSESSION: "tests"}
+          - {VERSION: "3.15-dev", NOXSESSION: "tests"}
+          - {VERSION: "3.15t-dev", NOXSESSION: "tests"}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -347,6 +351,8 @@ jobs:
           - {VERSION: "3.9", NOXSESSION: "tests-nocoverage"}
           - {VERSION: "3.14", NOXSESSION: "tests"}
           - {VERSION: "3.14t", NOXSESSION: "tests"}
+          - {VERSION: "3.15-dev", NOXSESSION: "tests"}
+          - {VERSION: "3.15t-dev", NOXSESSION: "tests"}
         include:
           # Windows on ARM is in a stability validation period; the work
           # step uses `continue-on-error` only for this entry so transient

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "cc",
  "openssl-sys",
  "pyo3",
+ "pyo3-build-config",
 ]
 
 [[package]]

--- a/src/rust/cryptography-cffi/Cargo.toml
+++ b/src/rust/cryptography-cffi/Cargo.toml
@@ -13,6 +13,7 @@ openssl-sys.workspace = true
 
 [build-dependencies]
 cc.workspace = true
+pyo3-build-config.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(python_implementation, values("CPython", "PyPy"))'] }

--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -6,6 +6,8 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 
+use pyo3_build_config::{PythonAbiKind, StableAbi};
+
 fn main() {
     let target = env::var("TARGET").unwrap();
     let openssl_static = env::var("OPENSSL_STATIC")
@@ -102,24 +104,31 @@ fn main() {
         build.include(python_include);
     }
 
-    let is_free_threaded = run_python_script(
-        &python,
-        "import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')), end='')",
-    )
-    .unwrap()
-        == "True";
+    // Derive the target ABI from what pyo3 is targeting for this build,
+    // resolved from the abi3/abi3t Cargo features
+    let config = pyo3_build_config::get();
 
-    // Enable abi3 mode if we're not using PyPy or the free-threaded build
-    if !(python_impl == "PyPy" || is_free_threaded) {
-        // cp39 (Python 3.9 to help our grep when we some day drop 3.9 support)
-        build.define("Py_LIMITED_API", "0x030900f0");
+    match config.target_abi().kind() {
+        // GIL-enabled limited API (abi3): a single wheel for CPython 3.9 to 3.14 (not free-threaded)
+        PythonAbiKind::Stable(StableAbi::Abi3) => {
+            // cp39 (Python 3.9 to help our grep when we some day drop 3.9 support)
+            build.define("Py_LIMITED_API", "0x030900f0");
+        }
+        // Free-threaded limited API (abi3t): a single wheel CPython 3.15+.
+        PythonAbiKind::Stable(StableAbi::Abi3t) => {
+            // cp315 (Python 3.15 to help our grep when we some day drop 3.15 support)
+            build.define("Py_LIMITED_API", "0x030f00f0");
+        }
+        // PyPy, or a free-threaded build older than abi3t (e.g. 3.14t):
+        // compile against the full, version-specific ABI.
+        PythonAbiKind::VersionSpecific(_) => {}
     }
 
     if cfg!(windows) {
         build.define("WIN32_LEAN_AND_MEAN", None);
         // python.h doesn't set this on the Windows free-threaded build
         // see https://github.com/python/cpython/issues/127294
-        if is_free_threaded {
+        if config.is_free_threaded() {
             build.define("Py_GIL_DISABLED", "1");
         }
 


### PR DESCRIPTION
Split off from #15063 to land separately from abi3t support.

I could make the match arm for abi3t panic instead of allowing the build but also it seems harmless to me to allow abi3t builds for now but leave them unexercised.