### PR TITLE
fix: mark tests expecting malloc to fail as opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
       - name: Tests
         run: |
-            nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo ${{ matrix.PYTHON.NOXARGS }}
+            nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo --enable-malloc-failure ${{ matrix.PYTHON.NOXARGS }}
         env:
           NOXSESSION: ${{ matrix.PYTHON.NOXSESSION }}
           COLUMNS: 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
       - name: Tests
         run: |
-            nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo --enable-malloc-failure ${{ matrix.PYTHON.NOXARGS }}
+            nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo ${{ matrix.PYTHON.NOXARGS }}
         env:
           NOXSESSION: ${{ matrix.PYTHON.NOXSESSION }}
           COLUMNS: 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ console_output_style = "progress-even-when-capture-no"
 markers = [
     "skip_fips: this test is not executed in FIPS mode",
     "supported: parametrized test requiring only_if and skip_message",
+    "malloc_failure: this test expects malloc to fail under memory pressure and should not be run with overcommit",
 ]
 
 [tool.mypy]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,12 +29,21 @@ def pytest_addoption(parser):
     parser.addoption("--wycheproof-root", default=None)
     parser.addoption("--x509-limbo-root", default=None)
     parser.addoption("--enable-fips", default=False)
+    parser.addoption(
+        "--enable-malloc-failure", action="store_true", default=False
+    )
 
 
 def pytest_runtest_setup(item):
     if openssl_backend._fips_enabled:
         for marker in item.iter_markers(name="skip_fips"):
             pytest.skip(marker.kwargs["reason"])
+    if not item.config.getoption("--enable-malloc-failure"):
+        for _ in item.iter_markers(name="malloc_failure"):
+            pytest.skip(
+                "expects malloc to fail on pressure, "
+                "pass --enable-malloc-failure to run"
+            )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 import contextlib
+import functools
+import mmap
 
 import pytest
 
@@ -25,25 +27,31 @@ def pytest_report_header(config):
     )
 
 
+@functools.cache
+def overcommit_probe() -> bool:
+    # Try to allocate 4TiB of memory, if it succeeds - environment either
+    # has more RAM, or overcommits.
+    try:
+        m = mmap.mmap(-1, (2**32 - 1) * 1024)
+    except (OSError, OverflowError):
+        return False
+    m.close()
+    return True
+
+
 def pytest_addoption(parser):
     parser.addoption("--wycheproof-root", default=None)
     parser.addoption("--x509-limbo-root", default=None)
     parser.addoption("--enable-fips", default=False)
-    parser.addoption(
-        "--enable-malloc-failure", action="store_true", default=False
-    )
 
 
 def pytest_runtest_setup(item):
     if openssl_backend._fips_enabled:
         for marker in item.iter_markers(name="skip_fips"):
             pytest.skip(marker.kwargs["reason"])
-    if not item.config.getoption("--enable-malloc-failure"):
+    if overcommit_probe():
         for _ in item.iter_markers(name="malloc_failure"):
-            pytest.skip(
-                "expects malloc to fail on pressure, "
-                "pass --enable-malloc-failure to run"
-            )
+            pytest.skip("malloc never fails in this environment")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hazmat/primitives/test_argon2.py
+++ b/tests/hazmat/primitives/test_argon2.py
@@ -6,7 +6,6 @@
 import base64
 import binascii
 import os
-import sys
 
 import pytest
 
@@ -141,14 +140,7 @@ class TestArgon2:
                 memory_cost=memory_cost,
             )
 
-    @pytest.mark.skipif(
-        sys.platform == "darwin",
-        reason=(
-            "macOS overcommits the 4 TiB virtual reservation, then the "
-            "subsequent memset triggers an OOM-kill before MemoryError "
-            "can be raised."
-        ),
-    )
+    @pytest.mark.malloc_failure
     def test_argon2_malloc_failure(self, clazz, backend):
         # memory_cost is in KiB, so 2**32 - 1 KiB is ~4 TiB. This should
         # fail to allocate on any reasonable system.

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -96,6 +96,7 @@ class TestScrypt:
                 backend,
             )
 
+    @pytest.mark.malloc_failure
     def test_scrypt_malloc_failure(self, backend):
         password = b"NaCl"
         work_factor = 1024**3


### PR DESCRIPTION
Those tests might overload machines with huge amount of RAM or with overcommit enabled, because of that - one test was already disabled on darwin, which enables overcommit by default.

Because of the potentially destructive overhead, I believe they should be opt-in.

Ref: Read the comments in https://github.com/pyca/cryptography/pull/14782