### PR TITLE
Fix max AAD bytes calculation in GCM mode

### DIFF
--- a/src/cryptography/hazmat/primitives/ciphers/modes.py
+++ b/src/cryptography/hazmat/primitives/ciphers/modes.py
@@ -104,7 +104,7 @@ class CTR(ModeWithNonce):
 class GCM(ModeWithInitializationVector, ModeWithAuthenticationTag):
     name = "GCM"
     _MAX_ENCRYPTED_BYTES = (2**39 - 256) // 8
-    _MAX_AAD_BYTES = (2**64) // 8
+    _MAX_AAD_BYTES = (2**64 - 1) // 8
 
     def __init__(
         self,


### PR DESCRIPTION
https://csrc.nist.rip/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-spec.pdf

"Additional authenticated data (AAD), which is denoted as A. This data is authenticated, but not encrypted, and can have any number of bits between 0 and 2^64"