### PR TITLE
Support encode_der for top-level asn1.SetOf

### DIFF
--- a/src/rust/src/declarative_asn1/asn1.rs
+++ b/src/rust/src/declarative_asn1/asn1.rs
@@ -3,7 +3,6 @@
 // for complete details.
 
 use asn1::Asn1Writable;
-use pyo3::types::PyAnyMethods;
 
 use crate::declarative_asn1::decode::decode_annotated_type;
 use crate::declarative_asn1::types as asn1_types;
@@ -13,9 +12,7 @@ pub(crate) fn encode_der<'p>(
     py: pyo3::Python<'p>,
     value: &pyo3::Bound<'p, pyo3::types::PyAny>,
 ) -> pyo3::PyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-    let class = value.get_type();
-
-    let annotated_type = asn1_types::python_class_to_annotated(py, &class)?;
+    let annotated_type = asn1_types::encode_value_to_annotated(py, value)?;
     let object = asn1_types::AnnotatedTypeObject {
         annotated_type: annotated_type.get(),
         value: value.clone(),

--- a/src/rust/src/declarative_asn1/types.rs
+++ b/src/rust/src/declarative_asn1/types.rs
@@ -6,7 +6,7 @@ use asn1::{
     IA5String as Asn1IA5String, PrintableString as Asn1PrintableString, SimpleAsn1Readable,
     UtcTime as Asn1UtcTime,
 };
-use pyo3::types::{PyAnyMethods, PySequenceMethods, PyTzInfoAccess};
+use pyo3::types::{PyAnyMethods, PyListMethods, PySequenceMethods, PyTzInfoAccess};
 use pyo3::{IntoPyObject, PyTypeInfo};
 
 use crate::error::CryptographyError;
@@ -635,6 +635,41 @@ pub(crate) fn python_class_to_annotated<'p>(
         // Handle builtin types
         pyo3::Bound::new(py, non_root_type_to_annotated(py, class)?)
     }
+}
+
+// Builds the `AnnotatedType` used to encode a top-level value passed to
+// `encode_der`.
+pub(crate) fn encode_value_to_annotated<'p>(
+    py: pyo3::Python<'p>,
+    value: &pyo3::Bound<'p, pyo3::types::PyAny>,
+) -> pyo3::PyResult<pyo3::Bound<'p, AnnotatedType>> {
+    if let Ok(setof) = value.cast::<SetOf>() {
+        // SET OF is homogeneous, so we infer the element type from the
+        // first element.
+        let inner = match setof.get().inner.bind(py).iter().next() {
+            Some(first) => {
+                let class = first.get_type();
+                python_class_to_annotated(py, &class)?
+            }
+            // An empty SET OF has no elements to encode, so the inner
+            // type is never used; any type works as a placeholder.
+            None => python_class_to_annotated(py, &Tlv::type_object(py))?,
+        };
+        return pyo3::Bound::new(
+            py,
+            AnnotatedType {
+                inner: pyo3::Py::new(py, Type::SetOf(inner.unbind()))?,
+                annotation: Annotation {
+                    default: None,
+                    encoding: None,
+                    size: None,
+                }
+                .into_pyobject(py)?
+                .unbind(),
+            },
+        );
+    }
+    python_class_to_annotated(py, &value.get_type())
 }
 
 // Checks if encoding `tag_without_encoding` using `encoding` results

--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -1143,6 +1143,19 @@ class TestSet:
         )
 
 
+class TestSetOf:
+    # A top-level `SetOf` can be passed directly to `encode_der`. It cannot
+    # be decoded, since `decode_der` requires a concrete element type.
+    def test_ok_encode_setof(self) -> None:
+        assert (
+            asn1.encode_der(asn1.SetOf([3, 1, 2]))
+            == b"\x31\x09\x02\x01\x01\x02\x01\x02\x02\x01\x03"
+        )
+
+    def test_ok_encode_empty_setof(self) -> None:
+        assert asn1.encode_der(asn1.SetOf([])) == b"\x31\x00"
+
+
 class TestSize:
     def test_ok_sequenceof_size_restriction(self) -> None:
         @asn1.sequence


### PR DESCRIPTION
`asn1.encode_der` previously rejected a bare `SetOf` instance with a `TypeError`, because a `SetOf` carries no information about its element type (e.g. the `int` in `SetOf[int]`), and the encoder only dispatched on a value's Python type.

This infers the element type from the contained values when a `SetOf` is passed directly to `encode_der`, which is enough to encode it as a `SET OF`. This is useful for cases like producing the DER encoding of CMS signed attributes for signing.

```python
from cryptography.hazmat import asn1

asn1.encode_der(asn1.SetOf([3, 1, 2]))
# b'1\t\x02\x01\x01\x02\x01\x02\x02\x01\x03'
```

Decoding a top-level `SetOf` remains unsupported, since `decode_der` needs a concrete element type that a bare `SetOf` doesn't carry.

Closes #15107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3rrycoCFuiUTpM9AodStP)_