### PR TITLE
reject undersized modulus for dh public keys in spki loader

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Changelog
   number of unused bits, instead of silently ignoring it.
 * :class:`~cryptography.hazmat.primitives.hashes.XOFHash` is now supported
   when building against AWS-LC.
+* :func:`~cryptography.hazmat.primitives.serialization.load_der_public_key` and
+  :func:`~cryptography.hazmat.primitives.serialization.load_pem_public_key` now
+  reject Diffie-Hellman public keys whose modulus is smaller than 512 bits,
+  matching the minimum already enforced when loading DH private keys and when
+  constructing :class:`~cryptography.hazmat.primitives.asymmetric.dh.DHParameterNumbers`.
 
 .. _v49-0-0:
 

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -145,6 +145,15 @@ fn dh_parameters_from_numbers(
 fn check_dh_parameters<T: openssl::pkey::HasParams>(
     dh: &openssl::dh::Dh<T>,
 ) -> CryptographyResult<()> {
+    // Enforce the modulus minimum ourselves rather than relying on OpenSSL's
+    // DH_check, so an undersized modulus is rejected consistently across every
+    // DH construction path and regardless of backend behaviour. This matches
+    // the minimum already enforced for DH private keys and DHParameterNumbers.
+    if dh.prime_p().num_bits() < cryptography_key_parsing::MIN_DH_MODULUS_SIZE as i32 {
+        return Err(CryptographyError::from(
+            pyo3::exceptions::PyValueError::new_err("Invalid DH parameters"),
+        ));
+    }
     if !dh.check_key()? {
         return Err(CryptographyError::from(
             pyo3::exceptions::PyValueError::new_err("Invalid DH parameters"),

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -393,6 +393,21 @@ class TestDH:
         with pytest.raises(ValueError):
             serialization.load_pem_private_key(data, None, backend)
 
+    def test_load_small_modulus_public_key(self, backend):
+        # SPKI (SubjectPublicKeyInfo) built from the public half of the
+        # 256-bit PKCS#3 DH key in dh_key_256.pem. The group is otherwise
+        # valid, so it clears the DH_check parameter validation, but its
+        # 256-bit modulus is well below the 512-bit minimum already enforced
+        # for private keys and DHParameterNumbers.
+        der = binascii.unhexlify(
+            "305a303306092a864886f70d0103013026022100813e0e814bee676d"
+            "bd3d9d28ed73d36735d21ff6457236f68d3d6145560c0fab02010203"
+            "230002202229529e73a612153eb1d5180040c2ceb50cfcf9bd86d221"
+            "2441626ecf288e06"
+        )
+        with pytest.raises(ValueError):
+            serialization.load_der_public_key(der, backend)
+
     @pytest.mark.parametrize(
         "vector",
         load_vectors_from_file(


### PR DESCRIPTION
Loading a public key currently accepts Diffie-Hellman keys whose modulus is well below 512 bits, even though the private-key DER loader and the DHParameterNumbers constructor already reject anything under that minimum, so the public-key path is the one place a badly undersized group slips through. The check belongs in parse_public_key in the SPKI loader, where both DH OIDs (the X9.42 dhpublicnumber form and the PKCS#3 dhKeyAgreement form) get turned into keys. I've added the same num_bits comparison there for both arms so the behaviour lines up with the other two entry points.