### PR TITLE
Add AWS-LC support for XOFHash

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changelog
 * Loading a public key or an EC private key now rejects DER where the
   ``subjectPublicKey`` (or EC ``publicKey``) ``BIT STRING`` declares a non-zero
   number of unused bits, instead of silently ignoring it.
+* :class:`~cryptography.hazmat.primitives.hashes.XOFHash` is now supported
+  when building against AWS-LC.
 
 .. _v49-0-0:
 

--- a/src/rust/src/backend/hashes.rs
+++ b/src/rust/src/backend/hashes.rs
@@ -189,14 +189,10 @@ impl XOFHash {
         algorithm: &pyo3::Bound<'_, pyo3::PyAny>,
     ) -> CryptographyResult<XOFHash> {
         cfg_if::cfg_if! {
-            if #[cfg(any(
-                CRYPTOGRAPHY_IS_LIBRESSL,
-                CRYPTOGRAPHY_IS_BORINGSSL,
-                not(any(
-                    CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
-                    CRYPTOGRAPHY_IS_AWSLC
-                ))
-            ))] {
+            if #[cfg(not(any(
+                CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
+                CRYPTOGRAPHY_IS_AWSLC
+            )))] {
                 let _ = py;
                 let _ = algorithm;
                 Err(CryptographyError::from(
@@ -237,14 +233,7 @@ impl XOFHash {
         }
         self.update_bytes(data.as_bytes())
     }
-    #[cfg(any(
-        CRYPTOGRAPHY_IS_AWSLC,
-        all(
-            CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
-            not(CRYPTOGRAPHY_IS_LIBRESSL),
-            not(CRYPTOGRAPHY_IS_BORINGSSL),
-        )
-    ))]
+    #[cfg(any(CRYPTOGRAPHY_OPENSSL_330_OR_GREATER, CRYPTOGRAPHY_IS_AWSLC))]
     fn squeeze<'p>(
         &mut self,
         py: pyo3::Python<'p>,

--- a/src/rust/src/backend/hashes.rs
+++ b/src/rust/src/backend/hashes.rs
@@ -192,13 +192,16 @@ impl XOFHash {
             if #[cfg(any(
                 CRYPTOGRAPHY_IS_LIBRESSL,
                 CRYPTOGRAPHY_IS_BORINGSSL,
-                not(CRYPTOGRAPHY_OPENSSL_330_OR_GREATER)
+                not(any(
+                    CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
+                    CRYPTOGRAPHY_IS_AWSLC
+                ))
             ))] {
                 let _ = py;
                 let _ = algorithm;
                 Err(CryptographyError::from(
                     exceptions::UnsupportedAlgorithm::new_err((
-                        "Extendable output functions are not supported on LibreSSL or BoringSSL.",
+                        "Extendable output functions are not supported on this backend.",
                     )),
                 ))
             } else {
@@ -234,10 +237,13 @@ impl XOFHash {
         }
         self.update_bytes(data.as_bytes())
     }
-    #[cfg(all(
-        CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
-        not(CRYPTOGRAPHY_IS_LIBRESSL),
-        not(CRYPTOGRAPHY_IS_BORINGSSL),
+    #[cfg(any(
+        CRYPTOGRAPHY_IS_AWSLC,
+        all(
+            CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
+            not(CRYPTOGRAPHY_IS_LIBRESSL),
+            not(CRYPTOGRAPHY_IS_BORINGSSL),
+        )
     ))]
     fn squeeze<'p>(
         &mut self,

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -8,7 +8,6 @@ import binascii
 import pytest
 
 from cryptography.exceptions import AlreadyFinalized, _Reasons
-from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.primitives import hashes
 
 from ...doubles import DummyHashAlgorithm
@@ -192,10 +191,12 @@ class TestHashHash:
             hashes.Hash.hash(DummyHashAlgorithm(), b"data")
 
     @pytest.mark.supported(
-        only_if=lambda _: rust_openssl.CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
+        only_if=lambda backend: backend.hash_supported(
+            hashes.SHAKE256(digest_size=32)
+        ),
         skip_message="Requires backend with XOF support",
     )
-    def test_hash_xof(self):
+    def test_hash_xof(self, backend):
         digest = hashes.Hash.hash(hashes.SHAKE256(32), b"data")
         assert digest == (
             b"\xc7=\xbe\xd8R\x7fZ\xe0V\x86y\xf3\x0e\xcc\\\xb6\x97\x8b!\x08"

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -196,7 +196,7 @@ class TestHashHash:
         ),
         skip_message="Requires backend with XOF support",
     )
-    def test_hash_xof(self, backend):
+    def test_hash_xof(self):
         digest = hashes.Hash.hash(hashes.SHAKE256(32), b"data")
         assert digest == (
             b"\xc7=\xbe\xd8R\x7fZ\xe0V\x86y\xf3\x0e\xcc\\\xb6\x97\x8b!\x08"

--- a/tests/hazmat/primitives/test_xofhash.py
+++ b/tests/hazmat/primitives/test_xofhash.py
@@ -18,22 +18,25 @@ from ...utils import load_nist_vectors
 from .utils import _load_all_params
 
 
+def _xof_supported() -> bool:
+    return (
+        rust_openssl.CRYPTOGRAPHY_OPENSSL_330_OR_GREATER
+        and not rust_openssl.CRYPTOGRAPHY_IS_LIBRESSL
+        and not rust_openssl.CRYPTOGRAPHY_IS_BORINGSSL
+    ) or rust_openssl.CRYPTOGRAPHY_IS_AWSLC
+
+
 @pytest.mark.supported(
-    only_if=lambda backend: (
-        not rust_openssl.CRYPTOGRAPHY_OPENSSL_330_OR_GREATER
-        or rust_openssl.CRYPTOGRAPHY_IS_LIBRESSL
-        or rust_openssl.CRYPTOGRAPHY_IS_BORINGSSL
-        or rust_openssl.CRYPTOGRAPHY_IS_AWSLC
-    ),
+    only_if=lambda backend: not _xof_supported(),
     skip_message="Requires backend without XOF support",
 )
-def test_unsupported_boring_libre(backend):
+def test_unsupported_xof(backend):
     with pytest.raises(UnsupportedAlgorithm):
         hashes.XOFHash(hashes.SHAKE128(digest_size=32))
 
 
 @pytest.mark.supported(
-    only_if=lambda backend: rust_openssl.CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
+    only_if=lambda backend: _xof_supported(),
     skip_message="Requires backend with XOF support",
 )
 class TestXOFHash:
@@ -77,7 +80,7 @@ class TestXOFHash:
 
 
 @pytest.mark.supported(
-    only_if=lambda backend: rust_openssl.CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
+    only_if=lambda backend: _xof_supported(),
     skip_message="Requires backend with XOF support",
 )
 class TestXOFSHAKE128:
@@ -105,7 +108,7 @@ class TestXOFSHAKE128:
 
 
 @pytest.mark.supported(
-    only_if=lambda backend: rust_openssl.CRYPTOGRAPHY_OPENSSL_330_OR_GREATER,
+    only_if=lambda backend: _xof_supported(),
     skip_message="Requires backend with XOF support",
 )
 class TestXOFSHAKE256:

--- a/tests/hazmat/primitives/test_xofhash.py
+++ b/tests/hazmat/primitives/test_xofhash.py
@@ -21,9 +21,8 @@ from .utils import _load_all_params
 def _xof_supported() -> bool:
     return (
         rust_openssl.CRYPTOGRAPHY_OPENSSL_330_OR_GREATER
-        and not rust_openssl.CRYPTOGRAPHY_IS_LIBRESSL
-        and not rust_openssl.CRYPTOGRAPHY_IS_BORINGSSL
-    ) or rust_openssl.CRYPTOGRAPHY_IS_AWSLC
+        or rust_openssl.CRYPTOGRAPHY_IS_AWSLC
+    )
 
 
 @pytest.mark.supported(


### PR DESCRIPTION
This PR extends XOFHash (Extendable Output Function) support to AWS-LC, in addition to the existing OpenSSL 3.3.0+ support.

## Summary

Previously, XOFHash was only supported on OpenSSL 3.3.0 or greater. This change adds support for AWS-LC while maintaining backward compatibility with existing backends.

## Key Changes

- **Rust backend (`src/rust/src/backend/hashes.rs`)**:
  - Updated the XOF support check to include AWS-LC alongside OpenSSL 3.3.0+
  - Simplified the conditional compilation logic by inverting the check: now enables XOF when `CRYPTOGRAPHY_OPENSSL_330_OR_GREATER` OR `CRYPTOGRAPHY_IS_AWSLC` is true
  - Updated error message to be backend-agnostic ("not supported on this backend" instead of specifically mentioning LibreSSL/BoringSSL)

- **Python tests (`tests/hazmat/primitives/test_xofhash.py`)**:
  - Extracted XOF support detection into a reusable `_xof_supported()` helper function
  - Updated all test markers to use the new helper function for consistency
  - Renamed `test_unsupported_boring_libre` to `test_unsupported_xof` to reflect the more general nature of the test

- **Hash tests (`tests/hazmat/primitives/test_hashes.py`)**:
  - Updated `test_hash_xof` to use the backend's `hash_supported()` method instead of directly checking OpenSSL version
  - Removed direct dependency on `rust_openssl` module in this test file

- **Changelog**: Added entry documenting XOFHash support for AWS-LC

## Implementation Details

The changes consolidate the XOF support logic by using a positive check (backends that support XOF) rather than a negative check (backends that don't support it). This makes the code more maintainable and easier to extend to additional backends in the future.

https://claude.ai/code/session_01SCjKRh9sZ4qXDfoVm5YAJ3