### PR TITLE
Build without PEP 517 isolation in nox sessions to keep cargo caches warm

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -19,4 +19,4 @@ runs:
         KEY: "${{ inputs.key }}"
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       with:
-        key: ${{ steps.normalized-key.outputs.key }}-5
+        key: ${{ steps.normalized-key.outputs.key }}-6

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,6 +44,18 @@ def load_pyproject_toml() -> dict:
         return tomllib.load(f)
 
 
+def install_cryptography(session: nox.Session, *args: str) -> None:
+    # Install the build requirements into the session's environment and
+    # then build without PEP 517 build isolation. Build isolation uses a
+    # temporary virtualenv with a randomized path, so PYO3_PYTHON differs
+    # on every build, which defeats cargo's caching of anything whose
+    # build script depends on it.
+    # See https://github.com/PyO3/pyo3/issues/6113
+    pyproject_data = load_pyproject_toml()
+    install(session, *pyproject_data["build-system"]["requires"])
+    install(session, "--no-build-isolation", *args)
+
+
 @nox.session
 @nox.session(name="tests-ssh")
 @nox.session(name="tests-randomorder")
@@ -73,13 +85,13 @@ def tests(session: nox.Session) -> None:
     install_spec = f".[{','.join(extras)}]"
     install(session, "-e", "./vectors")
     if session.name == "tests-rust-debug":
-        install(
+        install_cryptography(
             session,
             "--config-settings-package=cryptography:build-args=--profile=dev",
             install_spec,
         )
     else:
-        install(session, install_spec)
+        install_cryptography(session, install_spec)
 
     install(
         session,
@@ -121,7 +133,7 @@ def tests(session: nox.Session) -> None:
 
 @nox.session
 def docs(session: nox.Session) -> None:
-    install(session, ".[ssh]")
+    install_cryptography(session, ".[ssh]")
     install(
         session,
         "--group",
@@ -192,7 +204,7 @@ def docs(session: nox.Session) -> None:
 
 @nox.session(name="docs-linkcheck")
 def docs_linkcheck(session: nox.Session) -> None:
-    install(session, ".", "--group", "docs")
+    install_cryptography(session, ".", "--group", "docs")
 
     session.run(
         "sphinx-build", "-W", "-b", "linkcheck", "docs", "docs/_build/html"


### PR DESCRIPTION
PEP 517 build isolation creates a temporary virtualenv with a randomized path for every build, so `PYO3_PYTHON` changes on each install. `cryptography-cffi`'s build script registers `rerun-if-env-changed=PYO3_PYTHON`, so `cryptography-cffi` and `cryptography-rust` recompile on every CI job even with a fully warm rust-cache — and on free-threaded (non-abi3) builds the pyo3 crates recompile too, since the maturin-generated interpreter config also embeds the ephemeral path. See https://github.com/PyO3/pyo3/issues/6113 (the upstream `PYO3_BASE_PYTHON` fix is deferred to pyo3 0.30).

This installs the `[build-system].requires` into the session venv (constrained by `ci-constraints-requirements.txt`, same as the `flake` session already does) and passes `--no-build-isolation`, so the build backend runs from the stable `.nox/<session>` interpreter and cargo fingerprints stay valid across runs.

Verified locally: with isolation, every reinstall recompiles the two crates (~30s of cargo on 4 cores); without it, a warm-cache reinstall with identical env compiles nothing (cargo finishes in 0.05s).

Note: this PR also bumps the rust-cache key. PR runs restore main's caches (whose fingerprints contain the old ephemeral paths) and rust-cache skips saving on an exact key hit, so without a key roll the stable-fingerprint cache would never get saved and the win would only appear once caches roll naturally. CI timing comparisons will be posted on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lj3BsMN8xmPQQ89d6nzDcZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj3BsMN8xmPQQ89d6nzDcZ)_