### PR TITLE
Support HMAC-SHA3 when building against AWS-LC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changelog
   number of unused bits, instead of silently ignoring it.
 * :class:`~cryptography.hazmat.primitives.hashes.XOFHash` is now supported
   when building against AWS-LC.
+* HMAC (and therefore PBKDF2-HMAC) with SHA-3 hashes is now supported when
+  building against AWS-LC.
 * :func:`~cryptography.hazmat.primitives.serialization.load_der_public_key` and
   :func:`~cryptography.hazmat.primitives.serialization.load_pem_public_key` now
   reject Diffie-Hellman public keys whose modulus is smaller than 512 bits,

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -144,6 +144,10 @@ class Backend:
                     hashes.SHA512,
                     hashes.SHA512_224,
                     hashes.SHA512_256,
+                    hashes.SHA3_224,
+                    hashes.SHA3_256,
+                    hashes.SHA3_384,
+                    hashes.SHA3_512,
                 ),
             )
         return self.hash_supported(algorithm)


### PR DESCRIPTION
AWS-LC supports HMAC with SHA-3 digests, but the AWS-LC allowlist in `hmac_supported()` predates that support and incorrectly reported `False` for SHA-3 while the primitive itself worked. This adds `SHA3_224`/`SHA3_256`/`SHA3_384`/`SHA3_512` to the allowlist; `pbkdf2_hmac_supported()` delegates to it and flips too.

Verified against AWS-LC v5.1.0 (the CI-pinned tag):

- At the C level, both the one-shot `HMAC()` API and the `HMAC_CTX_new`/`HMAC_Init_ex` incremental path (the path our Rust `Hmac::new` uses) produce correct results for all four SHA-3 variants, matching references computed independently with CPython's `hmac`/`hashlib`.
- With `cryptography` built against AWS-LC, `hmac.HMAC(key, hashes.SHA3_*())` and `PBKDF2HMAC` with SHA-3 produce matching output through the Python API.
- `tests/hazmat/primitives/test_hmac_vectors.py`, `test_hmac.py`, `test_pbkdf2hmac.py`, and `test_pbkdf2hmac_vectors.py` pass against the AWS-LC build (28 passed; the 2 skips are BLAKE2 vectors, which remain correctly unsupported since AWS-LC lacks those digests entirely).

The Wycheproof HMAC-SHA3 vectors gated on `hmac_supported()` will now also run on AWS-LC CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtVytVEDG14pZZGtgNr5kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtVytVEDG14pZZGtgNr5kL)_