### PR TITLE
Add __eq__ methods to hash algorithms and padding classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,10 @@ Changelog
   :class:`~cryptography.hazmat.primitives.asymmetric.mldsa.MLDSAMuHasher` for
   incrementally computing the ML-DSA ``mu`` (message representative) used by
   the external-mu signing and verification APIs.
+* The builtin :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+  classes and the classes in
+  :mod:`~cryptography.hazmat.primitives.asymmetric.padding` can now be
+  compared with ``==`` and hashed.
 
 .. _v49-0-0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,7 @@ Changelog
 * The builtin :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
   classes and the classes in
   :mod:`~cryptography.hazmat.primitives.asymmetric.padding` can now be
-  compared with ``==`` and hashed.
+  compared with ``==``.
 
 .. _v49-0-0:
 

--- a/docs/hazmat/primitives/asymmetric/cloudhsm.rst
+++ b/docs/hazmat/primitives/asymmetric/cloudhsm.rst
@@ -88,7 +88,7 @@ if you only need a subset of functionality.
     ...         Maps the cryptography padding and algorithm to the corresponding KMS signing algorithm.
     ...         This is specific to your implementation.
     ...         """
-    ...         if isinstance(padding, PKCS1v15) and isinstance(algorithm, hashes.SHA256):
+    ...         if padding == PKCS1v15() and algorithm == hashes.SHA256():
     ...             return b"RSA_PKCS1_V1_5_SHA_256"
     ...         else:
     ...             raise NotImplementedError()

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -248,7 +248,7 @@ Loading Certificate Revocation Lists
         >>> from cryptography import x509
         >>> from cryptography.hazmat.primitives import hashes
         >>> crl = x509.load_pem_x509_crl(pem_crl_data)
-        >>> isinstance(crl.signature_hash_algorithm, hashes.SHA256)
+        >>> crl.signature_hash_algorithm == hashes.SHA256()
         True
 
 .. function:: load_der_x509_crl(data)
@@ -287,7 +287,7 @@ Loading Certificate Signing Requests
         >>> from cryptography import x509
         >>> from cryptography.hazmat.primitives import hashes
         >>> csr = x509.load_pem_x509_csr(pem_req_data)
-        >>> isinstance(csr.signature_hash_algorithm, hashes.SHA256)
+        >>> csr.signature_hash_algorithm == hashes.SHA256()
         True
 
 .. function:: load_der_x509_csr(data)
@@ -477,7 +477,7 @@ X.509 Certificate Object
         .. doctest::
 
             >>> from cryptography.hazmat.primitives import hashes
-            >>> isinstance(cert.signature_hash_algorithm, hashes.SHA256)
+            >>> cert.signature_hash_algorithm == hashes.SHA256()
             True
 
     .. attribute:: signature_algorithm_oid
@@ -716,7 +716,7 @@ X.509 CRL (Certificate Revocation List) Object
         .. doctest::
 
             >>> from cryptography.hazmat.primitives import hashes
-            >>> isinstance(crl.signature_hash_algorithm, hashes.SHA256)
+            >>> crl.signature_hash_algorithm == hashes.SHA256()
             True
 
     .. attribute:: signature_algorithm_oid
@@ -1138,7 +1138,7 @@ X.509 CSR (Certificate Signing Request) Object
         .. doctest::
 
             >>> from cryptography.hazmat.primitives import hashes
-            >>> isinstance(csr.signature_hash_algorithm, hashes.SHA256)
+            >>> csr.signature_hash_algorithm == hashes.SHA256()
             True
 
     .. attribute:: signature_algorithm_oid

--- a/src/cryptography/hazmat/primitives/asymmetric/padding.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/padding.py
@@ -22,9 +22,6 @@ class PKCS1v15(AsymmetricPadding):
 
         return True
 
-    def __hash__(self) -> int:
-        return hash(PKCS1v15)
-
 
 class _MaxLength:
     "Sentinel value for `MAX_LENGTH`."
@@ -73,9 +70,6 @@ class PSS(AsymmetricPadding):
             self._mgf == other._mgf and self._salt_length == other._salt_length
         )
 
-    def __hash__(self) -> int:
-        return hash((PSS, self._mgf, self._salt_length))
-
     @property
     def mgf(self) -> MGF:
         return self._mgf
@@ -107,9 +101,6 @@ class OAEP(AsymmetricPadding):
             and self._label == other._label
         )
 
-    def __hash__(self) -> int:
-        return hash((OAEP, self._mgf, self._algorithm, self._label))
-
     @property
     def algorithm(self) -> hashes.HashAlgorithm:
         return self._algorithm
@@ -135,9 +126,6 @@ class MGF1(MGF):
             return NotImplemented
 
         return self._algorithm == other._algorithm
-
-    def __hash__(self) -> int:
-        return hash((MGF1, self._algorithm))
 
 
 def calculate_max_pss_salt_length(

--- a/src/cryptography/hazmat/primitives/asymmetric/padding.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/padding.py
@@ -16,6 +16,15 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 class PKCS1v15(AsymmetricPadding):
     name = "EMSA-PKCS1-v1_5"
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PKCS1v15):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(PKCS1v15)
+
 
 class _MaxLength:
     "Sentinel value for `MAX_LENGTH`."
@@ -56,6 +65,17 @@ class PSS(AsymmetricPadding):
 
         self._salt_length = salt_length
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PSS):
+            return NotImplemented
+
+        return (
+            self._mgf == other._mgf and self._salt_length == other._salt_length
+        )
+
+    def __hash__(self) -> int:
+        return hash((PSS, self._mgf, self._salt_length))
+
     @property
     def mgf(self) -> MGF:
         return self._mgf
@@ -77,6 +97,19 @@ class OAEP(AsymmetricPadding):
         self._algorithm = algorithm
         self._label = label
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, OAEP):
+            return NotImplemented
+
+        return (
+            self._mgf == other._mgf
+            and self._algorithm == other._algorithm
+            and self._label == other._label
+        )
+
+    def __hash__(self) -> int:
+        return hash((OAEP, self._mgf, self._algorithm, self._label))
+
     @property
     def algorithm(self) -> hashes.HashAlgorithm:
         return self._algorithm
@@ -96,6 +129,15 @@ class MGF1(MGF):
             raise TypeError("Expected instance of hashes.HashAlgorithm.")
 
         self._algorithm = algorithm
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MGF1):
+            return NotImplemented
+
+        return self._algorithm == other._algorithm
+
+    def __hash__(self) -> int:
+        return hash((MGF1, self._algorithm))
 
 
 def calculate_max_pss_salt_length(

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -109,9 +109,6 @@ class SHA1(HashAlgorithm):
 
         return True
 
-    def __hash__(self) -> int:
-        return hash(SHA1)
-
 
 class SHA512_224(HashAlgorithm):  # noqa: N801
     name = "sha512-224"
@@ -123,9 +120,6 @@ class SHA512_224(HashAlgorithm):  # noqa: N801
             return NotImplemented
 
         return True
-
-    def __hash__(self) -> int:
-        return hash(SHA512_224)
 
 
 class SHA512_256(HashAlgorithm):  # noqa: N801
@@ -139,9 +133,6 @@ class SHA512_256(HashAlgorithm):  # noqa: N801
 
         return True
 
-    def __hash__(self) -> int:
-        return hash(SHA512_256)
-
 
 class SHA224(HashAlgorithm):
     name = "sha224"
@@ -153,9 +144,6 @@ class SHA224(HashAlgorithm):
             return NotImplemented
 
         return True
-
-    def __hash__(self) -> int:
-        return hash(SHA224)
 
 
 class SHA256(HashAlgorithm):
@@ -169,9 +157,6 @@ class SHA256(HashAlgorithm):
 
         return True
 
-    def __hash__(self) -> int:
-        return hash(SHA256)
-
 
 class SHA384(HashAlgorithm):
     name = "sha384"
@@ -183,9 +168,6 @@ class SHA384(HashAlgorithm):
             return NotImplemented
 
         return True
-
-    def __hash__(self) -> int:
-        return hash(SHA384)
 
 
 class SHA512(HashAlgorithm):
@@ -199,9 +181,6 @@ class SHA512(HashAlgorithm):
 
         return True
 
-    def __hash__(self) -> int:
-        return hash(SHA512)
-
 
 class SHA3_224(HashAlgorithm):  # noqa: N801
     name = "sha3-224"
@@ -213,9 +192,6 @@ class SHA3_224(HashAlgorithm):  # noqa: N801
             return NotImplemented
 
         return True
-
-    def __hash__(self) -> int:
-        return hash(SHA3_224)
 
 
 class SHA3_256(HashAlgorithm):  # noqa: N801
@@ -229,9 +205,6 @@ class SHA3_256(HashAlgorithm):  # noqa: N801
 
         return True
 
-    def __hash__(self) -> int:
-        return hash(SHA3_256)
-
 
 class SHA3_384(HashAlgorithm):  # noqa: N801
     name = "sha3-384"
@@ -244,9 +217,6 @@ class SHA3_384(HashAlgorithm):  # noqa: N801
 
         return True
 
-    def __hash__(self) -> int:
-        return hash(SHA3_384)
-
 
 class SHA3_512(HashAlgorithm):  # noqa: N801
     name = "sha3-512"
@@ -258,9 +228,6 @@ class SHA3_512(HashAlgorithm):  # noqa: N801
             return NotImplemented
 
         return True
-
-    def __hash__(self) -> int:
-        return hash(SHA3_512)
 
 
 class SHAKE128(HashAlgorithm, ExtendableOutputFunction):
@@ -281,9 +248,6 @@ class SHAKE128(HashAlgorithm, ExtendableOutputFunction):
             return NotImplemented
 
         return self._digest_size == other._digest_size
-
-    def __hash__(self) -> int:
-        return hash((SHAKE128, self._digest_size))
 
     @property
     def digest_size(self) -> int:
@@ -309,9 +273,6 @@ class SHAKE256(HashAlgorithm, ExtendableOutputFunction):
 
         return self._digest_size == other._digest_size
 
-    def __hash__(self) -> int:
-        return hash((SHAKE256, self._digest_size))
-
     @property
     def digest_size(self) -> int:
         return self._digest_size
@@ -327,9 +288,6 @@ class MD5(HashAlgorithm):
             return NotImplemented
 
         return True
-
-    def __hash__(self) -> int:
-        return hash(MD5)
 
 
 class BLAKE2b(HashAlgorithm):
@@ -349,9 +307,6 @@ class BLAKE2b(HashAlgorithm):
             return NotImplemented
 
         return self._digest_size == other._digest_size
-
-    def __hash__(self) -> int:
-        return hash((BLAKE2b, self._digest_size))
 
     @property
     def digest_size(self) -> int:
@@ -376,9 +331,6 @@ class BLAKE2s(HashAlgorithm):
 
         return self._digest_size == other._digest_size
 
-    def __hash__(self) -> int:
-        return hash((BLAKE2s, self._digest_size))
-
     @property
     def digest_size(self) -> int:
         return self._digest_size
@@ -394,6 +346,3 @@ class SM3(HashAlgorithm):
             return NotImplemented
 
         return True
-
-    def __hash__(self) -> int:
-        return hash(SM3)

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -103,11 +103,29 @@ class SHA1(HashAlgorithm):
     digest_size = 20
     block_size = 64
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA1):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA1)
+
 
 class SHA512_224(HashAlgorithm):  # noqa: N801
     name = "sha512-224"
     digest_size = 28
     block_size = 128
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA512_224):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA512_224)
 
 
 class SHA512_256(HashAlgorithm):  # noqa: N801
@@ -115,11 +133,29 @@ class SHA512_256(HashAlgorithm):  # noqa: N801
     digest_size = 32
     block_size = 128
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA512_256):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA512_256)
+
 
 class SHA224(HashAlgorithm):
     name = "sha224"
     digest_size = 28
     block_size = 64
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA224):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA224)
 
 
 class SHA256(HashAlgorithm):
@@ -127,11 +163,29 @@ class SHA256(HashAlgorithm):
     digest_size = 32
     block_size = 64
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA256):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA256)
+
 
 class SHA384(HashAlgorithm):
     name = "sha384"
     digest_size = 48
     block_size = 128
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA384):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA384)
 
 
 class SHA512(HashAlgorithm):
@@ -139,11 +193,29 @@ class SHA512(HashAlgorithm):
     digest_size = 64
     block_size = 128
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA512):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA512)
+
 
 class SHA3_224(HashAlgorithm):  # noqa: N801
     name = "sha3-224"
     digest_size = 28
     block_size = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA3_224):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA3_224)
 
 
 class SHA3_256(HashAlgorithm):  # noqa: N801
@@ -151,17 +223,44 @@ class SHA3_256(HashAlgorithm):  # noqa: N801
     digest_size = 32
     block_size = None
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA3_256):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA3_256)
+
 
 class SHA3_384(HashAlgorithm):  # noqa: N801
     name = "sha3-384"
     digest_size = 48
     block_size = None
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA3_384):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA3_384)
+
 
 class SHA3_512(HashAlgorithm):  # noqa: N801
     name = "sha3-512"
     digest_size = 64
     block_size = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHA3_512):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SHA3_512)
 
 
 class SHAKE128(HashAlgorithm, ExtendableOutputFunction):
@@ -176,6 +275,15 @@ class SHAKE128(HashAlgorithm, ExtendableOutputFunction):
             raise ValueError("digest_size must be a positive integer")
 
         self._digest_size = digest_size
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHAKE128):
+            return NotImplemented
+
+        return self._digest_size == other._digest_size
+
+    def __hash__(self) -> int:
+        return hash((SHAKE128, self._digest_size))
 
     @property
     def digest_size(self) -> int:
@@ -195,6 +303,15 @@ class SHAKE256(HashAlgorithm, ExtendableOutputFunction):
 
         self._digest_size = digest_size
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SHAKE256):
+            return NotImplemented
+
+        return self._digest_size == other._digest_size
+
+    def __hash__(self) -> int:
+        return hash((SHAKE256, self._digest_size))
+
     @property
     def digest_size(self) -> int:
         return self._digest_size
@@ -204,6 +321,15 @@ class MD5(HashAlgorithm):
     name = "md5"
     digest_size = 16
     block_size = 64
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MD5):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(MD5)
 
 
 class BLAKE2b(HashAlgorithm):
@@ -217,6 +343,15 @@ class BLAKE2b(HashAlgorithm):
             raise ValueError("Digest size must be 64")
 
         self._digest_size = digest_size
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BLAKE2b):
+            return NotImplemented
+
+        return self._digest_size == other._digest_size
+
+    def __hash__(self) -> int:
+        return hash((BLAKE2b, self._digest_size))
 
     @property
     def digest_size(self) -> int:
@@ -235,6 +370,15 @@ class BLAKE2s(HashAlgorithm):
 
         self._digest_size = digest_size
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BLAKE2s):
+            return NotImplemented
+
+        return self._digest_size == other._digest_size
+
+    def __hash__(self) -> int:
+        return hash((BLAKE2s, self._digest_size))
+
     @property
     def digest_size(self) -> int:
         return self._digest_size
@@ -244,3 +388,12 @@ class SM3(HashAlgorithm):
     name = "sm3"
     digest_size = 32
     block_size = 64
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SM3):
+            return NotImplemented
+
+        return True
+
+    def __hash__(self) -> int:
+        return hash(SM3)

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -225,7 +225,6 @@ class TestHashAlgorithmEquality:
     )
     def test_eq(self, algorithm_cls):
         assert algorithm_cls() == algorithm_cls()
-        assert hash(algorithm_cls()) == hash(algorithm_cls())
         assert algorithm_cls() != DummyHashAlgorithm()
         assert DummyHashAlgorithm() != algorithm_cls()
 
@@ -244,16 +243,12 @@ class TestHashAlgorithmEquality:
     )
     def test_eq_digest_size(self, algorithm_cls, digest_size):
         assert algorithm_cls(digest_size) == algorithm_cls(digest_size)
-        assert hash(algorithm_cls(digest_size)) == hash(
-            algorithm_cls(digest_size)
-        )
         assert algorithm_cls(digest_size) != DummyHashAlgorithm(digest_size)
         assert DummyHashAlgorithm(digest_size) != algorithm_cls(digest_size)
 
     @pytest.mark.parametrize("xof", [hashes.SHAKE128, hashes.SHAKE256])
     def test_eq_different_digest_size(self, xof):
         assert xof(digest_size=32) != xof(digest_size=64)
-        assert hash(xof(digest_size=32)) != hash(xof(digest_size=64))
 
 
 class TestSHAKE:

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -228,9 +228,9 @@ class TestHashAlgorithmEquality:
         assert algorithm_cls() != DummyHashAlgorithm()
         assert DummyHashAlgorithm() != algorithm_cls()
 
-    def test_eq_different_algorithm(self):
+    def test_ne(self):
         assert hashes.SHA256() != hashes.SHA384()
-        assert hashes.SHA256().__eq__(hashes.SHA384()) is NotImplemented
+        assert hashes.SHA256() != object()
 
     @pytest.mark.parametrize(
         ("algorithm_cls", "digest_size"),

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -225,26 +225,6 @@ class TestHashAlgorithmEquality:
     )
     def test_eq(self, algorithm_cls):
         assert algorithm_cls() == algorithm_cls()
-
-    @pytest.mark.parametrize(
-        "algorithm_cls",
-        [
-            hashes.SHA1,
-            hashes.SHA512_224,
-            hashes.SHA512_256,
-            hashes.SHA224,
-            hashes.SHA256,
-            hashes.SHA384,
-            hashes.SHA512,
-            hashes.SHA3_224,
-            hashes.SHA3_256,
-            hashes.SHA3_384,
-            hashes.SHA3_512,
-            hashes.MD5,
-            hashes.SM3,
-        ],
-    )
-    def test_ne(self, algorithm_cls):
         assert algorithm_cls() != DummyHashAlgorithm()
         assert DummyHashAlgorithm() != algorithm_cls()
         assert algorithm_cls() != object()
@@ -263,17 +243,6 @@ class TestHashAlgorithmEquality:
     )
     def test_eq_digest_size(self, algorithm_cls, digest_size):
         assert algorithm_cls(digest_size) == algorithm_cls(digest_size)
-
-    @pytest.mark.parametrize(
-        ("algorithm_cls", "digest_size"),
-        [
-            (hashes.SHAKE128, 32),
-            (hashes.SHAKE256, 32),
-            (hashes.BLAKE2b, 64),
-            (hashes.BLAKE2s, 32),
-        ],
-    )
-    def test_ne_digest_size(self, algorithm_cls, digest_size):
         assert algorithm_cls(digest_size) != DummyHashAlgorithm(digest_size)
         assert DummyHashAlgorithm(digest_size) != algorithm_cls(digest_size)
         assert algorithm_cls(digest_size) != object()

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -204,6 +204,58 @@ class TestHashHash:
         )
 
 
+class TestHashAlgorithmEquality:
+    @pytest.mark.parametrize(
+        "algorithm_cls",
+        [
+            hashes.SHA1,
+            hashes.SHA512_224,
+            hashes.SHA512_256,
+            hashes.SHA224,
+            hashes.SHA256,
+            hashes.SHA384,
+            hashes.SHA512,
+            hashes.SHA3_224,
+            hashes.SHA3_256,
+            hashes.SHA3_384,
+            hashes.SHA3_512,
+            hashes.MD5,
+            hashes.SM3,
+        ],
+    )
+    def test_eq(self, algorithm_cls):
+        assert algorithm_cls() == algorithm_cls()
+        assert hash(algorithm_cls()) == hash(algorithm_cls())
+        assert algorithm_cls() != DummyHashAlgorithm()
+        assert DummyHashAlgorithm() != algorithm_cls()
+
+    def test_eq_different_algorithm(self):
+        assert hashes.SHA256() != hashes.SHA384()
+        assert hashes.SHA256().__eq__(hashes.SHA384()) is NotImplemented
+
+    @pytest.mark.parametrize(
+        ("algorithm_cls", "digest_size"),
+        [
+            (hashes.SHAKE128, 32),
+            (hashes.SHAKE256, 32),
+            (hashes.BLAKE2b, 64),
+            (hashes.BLAKE2s, 32),
+        ],
+    )
+    def test_eq_digest_size(self, algorithm_cls, digest_size):
+        assert algorithm_cls(digest_size) == algorithm_cls(digest_size)
+        assert hash(algorithm_cls(digest_size)) == hash(
+            algorithm_cls(digest_size)
+        )
+        assert algorithm_cls(digest_size) != DummyHashAlgorithm(digest_size)
+        assert DummyHashAlgorithm(digest_size) != algorithm_cls(digest_size)
+
+    @pytest.mark.parametrize("xof", [hashes.SHAKE128, hashes.SHAKE256])
+    def test_eq_different_digest_size(self, xof):
+        assert xof(digest_size=32) != xof(digest_size=64)
+        assert hash(xof(digest_size=32)) != hash(xof(digest_size=64))
+
+
 class TestSHAKE:
     @pytest.mark.parametrize("xof", [hashes.SHAKE128, hashes.SHAKE256])
     def test_invalid_digest_type(self, xof):

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -225,12 +225,32 @@ class TestHashAlgorithmEquality:
     )
     def test_eq(self, algorithm_cls):
         assert algorithm_cls() == algorithm_cls()
+
+    @pytest.mark.parametrize(
+        "algorithm_cls",
+        [
+            hashes.SHA1,
+            hashes.SHA512_224,
+            hashes.SHA512_256,
+            hashes.SHA224,
+            hashes.SHA256,
+            hashes.SHA384,
+            hashes.SHA512,
+            hashes.SHA3_224,
+            hashes.SHA3_256,
+            hashes.SHA3_384,
+            hashes.SHA3_512,
+            hashes.MD5,
+            hashes.SM3,
+        ],
+    )
+    def test_ne(self, algorithm_cls):
         assert algorithm_cls() != DummyHashAlgorithm()
         assert DummyHashAlgorithm() != algorithm_cls()
+        assert algorithm_cls() != object()
 
-    def test_ne(self):
+    def test_ne_different_algorithm(self):
         assert hashes.SHA256() != hashes.SHA384()
-        assert hashes.SHA256() != object()
 
     @pytest.mark.parametrize(
         ("algorithm_cls", "digest_size"),
@@ -243,11 +263,23 @@ class TestHashAlgorithmEquality:
     )
     def test_eq_digest_size(self, algorithm_cls, digest_size):
         assert algorithm_cls(digest_size) == algorithm_cls(digest_size)
+
+    @pytest.mark.parametrize(
+        ("algorithm_cls", "digest_size"),
+        [
+            (hashes.SHAKE128, 32),
+            (hashes.SHAKE256, 32),
+            (hashes.BLAKE2b, 64),
+            (hashes.BLAKE2s, 32),
+        ],
+    )
+    def test_ne_digest_size(self, algorithm_cls, digest_size):
         assert algorithm_cls(digest_size) != DummyHashAlgorithm(digest_size)
         assert DummyHashAlgorithm(digest_size) != algorithm_cls(digest_size)
+        assert algorithm_cls(digest_size) != object()
 
     @pytest.mark.parametrize("xof", [hashes.SHAKE128, hashes.SHAKE256])
-    def test_eq_different_digest_size(self, xof):
+    def test_ne_different_digest_size(self, xof):
         assert xof(digest_size=32) != xof(digest_size=64)
 
 

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1704,8 +1704,6 @@ class TestRSAPKCS1Verification:
 class TestPKCS1v15:
     def test_eq(self):
         assert padding.PKCS1v15() == padding.PKCS1v15()
-
-    def test_ne(self):
         assert padding.PKCS1v15() != padding.PSS(
             mgf=padding.MGF1(hashes.SHA256()), salt_length=32
         )
@@ -1823,8 +1821,6 @@ class TestMGF1:
 
     def test_eq(self):
         assert padding.MGF1(hashes.SHA256()) == padding.MGF1(hashes.SHA256())
-
-    def test_ne(self):
         assert padding.MGF1(hashes.SHA256()) != padding.MGF1(hashes.SHA512())
         assert padding.MGF1(hashes.SHA256()) != DummyMGF()
         assert DummyMGF() != padding.MGF1(hashes.SHA256())

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1704,7 +1704,6 @@ class TestRSAPKCS1Verification:
 class TestPKCS1v15:
     def test_eq(self):
         assert padding.PKCS1v15() == padding.PKCS1v15()
-        assert hash(padding.PKCS1v15()) == hash(padding.PKCS1v15())
         assert padding.PKCS1v15() != padding.PSS(
             mgf=padding.MGF1(hashes.SHA256()), salt_length=32
         )
@@ -1769,7 +1768,6 @@ class TestPSS:
             mgf=padding.MGF1(hashes.SHA256()), salt_length=salt_length
         )
         assert pss1 == pss2
-        assert hash(pss1) == hash(pss2)
 
     @pytest.mark.parametrize(
         "salt_length",
@@ -1821,9 +1819,6 @@ class TestMGF1:
 
     def test_eq(self):
         assert padding.MGF1(hashes.SHA256()) == padding.MGF1(hashes.SHA256())
-        assert hash(padding.MGF1(hashes.SHA256())) == hash(
-            padding.MGF1(hashes.SHA256())
-        )
         assert padding.MGF1(hashes.SHA256()) != padding.MGF1(hashes.SHA512())
         assert padding.MGF1(hashes.SHA256()) != DummyMGF()
         assert DummyMGF() != padding.MGF1(hashes.SHA256())
@@ -1866,7 +1861,6 @@ class TestOAEP:
             label=label,
         )
         assert oaep1 == oaep2
-        assert hash(oaep1) == hash(oaep2)
 
     def test_eq_different_mgf(self):
         assert padding.OAEP(

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1701,6 +1701,15 @@ class TestRSAPKCS1Verification:
     )
 
 
+class TestPKCS1v15:
+    def test_eq(self):
+        assert padding.PKCS1v15() == padding.PKCS1v15()
+        assert hash(padding.PKCS1v15()) == hash(padding.PKCS1v15())
+        assert padding.PKCS1v15() != padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()), salt_length=32
+        )
+
+
 class TestPSS:
     def test_calculate_max_pss_salt_length(self):
         with pytest.raises(TypeError):
@@ -1742,6 +1751,63 @@ class TestPSS:
         assert pss.mgf == mgf
         assert pss.mgf == pss._mgf
 
+    @pytest.mark.parametrize(
+        "salt_length",
+        [
+            1,
+            32,
+            padding.PSS.MAX_LENGTH,
+            padding.PSS.AUTO,
+            padding.PSS.DIGEST_LENGTH,
+        ],
+    )
+    def test_eq(self, salt_length):
+        pss1 = padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()), salt_length=salt_length
+        )
+        pss2 = padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()), salt_length=salt_length
+        )
+        assert pss1 == pss2
+        assert hash(pss1) == hash(pss2)
+
+    @pytest.mark.parametrize(
+        "salt_length",
+        [
+            1,
+            padding.PSS.MAX_LENGTH,
+            padding.PSS.AUTO,
+            padding.PSS.DIGEST_LENGTH,
+        ],
+    )
+    def test_eq_different_salt_length(self, salt_length):
+        mgf = padding.MGF1(hashes.SHA256())
+        assert padding.PSS(mgf=mgf, salt_length=salt_length) != padding.PSS(
+            mgf=mgf, salt_length=32
+        )
+
+    def test_eq_different_sentinel_salt_lengths(self):
+        mgf = padding.MGF1(hashes.SHA256())
+        assert padding.PSS(
+            mgf=mgf, salt_length=padding.PSS.AUTO
+        ) != padding.PSS(mgf=mgf, salt_length=padding.PSS.DIGEST_LENGTH)
+
+    def test_eq_different_mgf(self):
+        assert padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=padding.PSS.AUTO,
+        ) != padding.PSS(
+            mgf=padding.MGF1(hashes.SHA512()),
+            salt_length=padding.PSS.AUTO,
+        )
+
+    def test_eq_different_type(self):
+        pss = padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=padding.PSS.AUTO,
+        )
+        assert pss != padding.MGF1(hashes.SHA256())
+
 
 class TestMGF1:
     def test_invalid_hash_algorithm(self):
@@ -1752,6 +1818,15 @@ class TestMGF1:
         algorithm = hashes.SHA256()
         mgf = padding.MGF1(algorithm)
         assert mgf._algorithm == algorithm
+
+    def test_eq(self):
+        assert padding.MGF1(hashes.SHA256()) == padding.MGF1(hashes.SHA256())
+        assert hash(padding.MGF1(hashes.SHA256())) == hash(
+            padding.MGF1(hashes.SHA256())
+        )
+        assert padding.MGF1(hashes.SHA256()) != padding.MGF1(hashes.SHA512())
+        assert padding.MGF1(hashes.SHA256()) != DummyMGF()
+        assert DummyMGF() != padding.MGF1(hashes.SHA256())
 
 
 class TestOAEP:
@@ -1777,6 +1852,62 @@ class TestOAEP:
         oaep = padding.OAEP(mgf=mgf, algorithm=algorithm, label=None)
         assert oaep.mgf == mgf
         assert oaep.mgf == oaep._mgf
+
+    @pytest.mark.parametrize("label", [None, b"", b"label"])
+    def test_eq(self, label):
+        oaep1 = padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=label,
+        )
+        oaep2 = padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=label,
+        )
+        assert oaep1 == oaep2
+        assert hash(oaep1) == hash(oaep2)
+
+    def test_eq_different_mgf(self):
+        assert padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ) != padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA512()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        )
+
+    def test_eq_different_algorithm(self):
+        assert padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ) != padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA512(),
+            label=None,
+        )
+
+    def test_eq_different_label(self):
+        assert padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ) != padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=b"",
+        )
+
+    def test_eq_different_type(self):
+        oaep = padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        )
+        assert oaep != padding.PKCS1v15()
 
 
 class TestRSADecryption:

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1704,9 +1704,12 @@ class TestRSAPKCS1Verification:
 class TestPKCS1v15:
     def test_eq(self):
         assert padding.PKCS1v15() == padding.PKCS1v15()
+
+    def test_ne(self):
         assert padding.PKCS1v15() != padding.PSS(
             mgf=padding.MGF1(hashes.SHA256()), salt_length=32
         )
+        assert padding.PKCS1v15() != object()
 
 
 class TestPSS:
@@ -1778,19 +1781,19 @@ class TestPSS:
             padding.PSS.DIGEST_LENGTH,
         ],
     )
-    def test_eq_different_salt_length(self, salt_length):
+    def test_ne_different_salt_length(self, salt_length):
         mgf = padding.MGF1(hashes.SHA256())
         assert padding.PSS(mgf=mgf, salt_length=salt_length) != padding.PSS(
             mgf=mgf, salt_length=32
         )
 
-    def test_eq_different_sentinel_salt_lengths(self):
+    def test_ne_different_sentinel_salt_lengths(self):
         mgf = padding.MGF1(hashes.SHA256())
         assert padding.PSS(
             mgf=mgf, salt_length=padding.PSS.AUTO
         ) != padding.PSS(mgf=mgf, salt_length=padding.PSS.DIGEST_LENGTH)
 
-    def test_eq_different_mgf(self):
+    def test_ne_different_mgf(self):
         assert padding.PSS(
             mgf=padding.MGF1(hashes.SHA256()),
             salt_length=padding.PSS.AUTO,
@@ -1799,12 +1802,13 @@ class TestPSS:
             salt_length=padding.PSS.AUTO,
         )
 
-    def test_eq_different_type(self):
+    def test_ne(self):
         pss = padding.PSS(
             mgf=padding.MGF1(hashes.SHA256()),
             salt_length=padding.PSS.AUTO,
         )
         assert pss != padding.MGF1(hashes.SHA256())
+        assert pss != object()
 
 
 class TestMGF1:
@@ -1819,9 +1823,12 @@ class TestMGF1:
 
     def test_eq(self):
         assert padding.MGF1(hashes.SHA256()) == padding.MGF1(hashes.SHA256())
+
+    def test_ne(self):
         assert padding.MGF1(hashes.SHA256()) != padding.MGF1(hashes.SHA512())
         assert padding.MGF1(hashes.SHA256()) != DummyMGF()
         assert DummyMGF() != padding.MGF1(hashes.SHA256())
+        assert padding.MGF1(hashes.SHA256()) != object()
 
 
 class TestOAEP:
@@ -1862,7 +1869,7 @@ class TestOAEP:
         )
         assert oaep1 == oaep2
 
-    def test_eq_different_mgf(self):
+    def test_ne_different_mgf(self):
         assert padding.OAEP(
             mgf=padding.MGF1(hashes.SHA256()),
             algorithm=hashes.SHA256(),
@@ -1873,7 +1880,7 @@ class TestOAEP:
             label=None,
         )
 
-    def test_eq_different_algorithm(self):
+    def test_ne_different_algorithm(self):
         assert padding.OAEP(
             mgf=padding.MGF1(hashes.SHA256()),
             algorithm=hashes.SHA256(),
@@ -1884,7 +1891,7 @@ class TestOAEP:
             label=None,
         )
 
-    def test_eq_different_label(self):
+    def test_ne_different_label(self):
         assert padding.OAEP(
             mgf=padding.MGF1(hashes.SHA256()),
             algorithm=hashes.SHA256(),
@@ -1895,13 +1902,14 @@ class TestOAEP:
             label=b"",
         )
 
-    def test_eq_different_type(self):
+    def test_ne(self):
         oaep = padding.OAEP(
             mgf=padding.MGF1(hashes.SHA256()),
             algorithm=hashes.SHA256(),
             label=None,
         )
         assert oaep != padding.PKCS1v15()
+        assert oaep != object()
 
 
 class TestRSADecryption:


### PR DESCRIPTION
This PR adds equality comparison support to cryptography's hash algorithm and padding classes, allowing them to be compared using the `==` operator.

## Summary

Previously, instances of hash algorithm classes (SHA256, SHA512, etc.) and padding classes (PKCS1v15, PSS, OAEP, MGF1) could not be meaningfully compared for equality. This change implements `__eq__` methods across these classes to enable proper equality testing.

## Key Changes

- **Hash Algorithms** (`src/cryptography/hazmat/primitives/hashes.py`):
  - Added `__eq__` methods to all hash algorithm classes: SHA1, SHA224, SHA256, SHA384, SHA512, SHA512_224, SHA512_256, SHA3_224, SHA3_256, SHA3_384, SHA3_512, MD5, SM3
  - Added `__eq__` methods to parameterized hash algorithms: SHAKE128, SHAKE256, BLAKE2b, BLAKE2s (these compare both type and digest_size)
  - All implementations follow the pattern of returning `NotImplemented` for non-matching types

- **Padding Classes** (`src/cryptography/hazmat/primitives/asymmetric/padding.py`):
  - Added `__eq__` to `PKCS1v15` (always equal to other PKCS1v15 instances)
  - Added `__eq__` to `PSS` (compares MGF and salt_length)
  - Added `__eq__` to `OAEP` (compares MGF, algorithm, and label)
  - Added `__eq__` to `MGF1` (compares algorithm)

- **Tests** (`tests/hazmat/primitives/test_hashes.py` and `tests/hazmat/primitives/test_rsa.py`):
  - Added comprehensive test coverage for equality comparisons across all modified classes
  - Tests verify equality between identical instances, inequality with different types, and inequality with different parameters

- **Documentation** (`docs/x509/reference.rst` and `docs/hazmat/primitives/asymmetric/cloudhsm.rst`):
  - Updated examples to use equality comparison (`==`) instead of `isinstance()` checks where appropriate

- **Changelog** (`CHANGELOG.rst`):
  - Added entry documenting the new equality comparison capability

## Implementation Details

- All `__eq__` implementations return `NotImplemented` when comparing with incompatible types, following Python best practices
- For stateless classes (like SHA256), equality is based solely on type
- For parameterized classes (like SHAKE128 with digest_size), equality includes parameter comparison
- Composite classes (PSS, OAEP) recursively compare their component objects

https://claude.ai/code/session_01WsrSAAABRsHFpHtQxZ1sjs