### PR TITLE
Add Diffie-Hellman support for AWS-LC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Changelog
   when building against AWS-LC.
 * HMAC (and therefore PBKDF2-HMAC) with SHA-3 hashes is now supported when
   building against AWS-LC.
+* Diffie-Hellman (:doc:`/hazmat/primitives/asymmetric/dh`) is now supported
+  when building against AWS-LC.
 * :func:`~cryptography.hazmat.primitives.serialization.load_der_public_key` and
   :func:`~cryptography.hazmat.primitives.serialization.load_pem_public_key` now
   reject Diffie-Hellman public keys whose modulus is smaller than 512 bits,

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -256,10 +256,7 @@ class Backend:
         )
 
     def dh_supported(self) -> bool:
-        return (
-            not rust_openssl.CRYPTOGRAPHY_IS_BORINGSSL
-            and not rust_openssl.CRYPTOGRAPHY_IS_AWSLC
-        )
+        return not rust_openssl.CRYPTOGRAPHY_IS_BORINGSSL
 
     def dh_x942_serialization_supported(self) -> bool:
         return self._lib.Cryptography_HAS_EVP_PKEY_DHX == 1

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -154,7 +154,10 @@ fn check_dh_parameters<T: openssl::pkey::HasParams>(
             pyo3::exceptions::PyValueError::new_err("Invalid DH parameters"),
         ));
     }
-    if !dh.check_key()? {
+    // AWS-LC's DH_check returns an error for parameters it considers
+    // fundamentally invalid (e.g. an even modulus), where OpenSSL reports
+    // success with check-result flags set. Treat both as invalid parameters.
+    if !dh.check_key().unwrap_or(false) {
         return Err(CryptographyError::from(
             pyo3::exceptions::PyValueError::new_err("Invalid DH parameters"),
         ));

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -234,7 +234,7 @@ impl DHPrivateKey {
         })
     }
 
-    #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
+    #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
     fn public_key(&self) -> CryptographyResult<DHPublicKey> {
         let orig_dh = self.pkey.dh().unwrap();
         let dh = clone_dh(&orig_dh)?;
@@ -364,7 +364,7 @@ impl DHPublicKey {
 
 #[pyo3::pymethods]
 impl DHParameters {
-    #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
+    #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
     fn generate_private_key(&self) -> CryptographyResult<DHPrivateKey> {
         let dh = clone_dh(&self.dh)?.generate_key()?;
         Ok(DHPrivateKey {
@@ -458,7 +458,7 @@ impl DHPrivateNumbers {
         DHPrivateNumbers { x, public_numbers }
     }
 
-    #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
+    #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
     #[pyo3(signature = (backend=None))]
     fn private_key(
         &self,
@@ -503,7 +503,7 @@ impl DHPublicNumbers {
         }
     }
 
-    #[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]
+    #[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]
     #[pyo3(signature = (backend=None))]
     fn public_key(
         &self,

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -154,9 +154,6 @@ fn check_dh_parameters<T: openssl::pkey::HasParams>(
             pyo3::exceptions::PyValueError::new_err("Invalid DH parameters"),
         ));
     }
-    // AWS-LC's DH_check returns an error for parameters it considers
-    // fundamentally invalid (e.g. an even modulus), where OpenSSL reports
-    // success with check-result flags set. Treat both as invalid parameters.
     if !dh.check_key().unwrap_or(false) {
         return Err(CryptographyError::from(
             pyo3::exceptions::PyValueError::new_err("Invalid DH parameters"),


### PR DESCRIPTION
This PR enables Diffie-Hellman (DH) support when building against AWS-LC, bringing feature parity with BoringSSL support.

## Summary

Previously, DH operations were disabled for both BoringSSL and AWS-LC backends. AWS-LC now has sufficient DH support, so we're enabling it while keeping BoringSSL disabled (which still lacks DH functionality).

## Key Changes

- **Rust backend (`src/rust/src/backend/dh.rs`)**:
  - Changed `dh.check_key()?` to `dh.check_key().unwrap_or(false)` to handle potential errors gracefully
  - Updated four `#[cfg]` attributes from `#[cfg(not(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC)))]` to `#[cfg(not(CRYPTOGRAPHY_IS_BORINGSSL))]` to enable DH methods for AWS-LC:
    - `DHPrivateKey::public_key()`
    - `DHParameters::generate_private_key()`
    - `DHPrivateNumbers::private_key()`
    - `DHPublicNumbers::public_key()`

- **Python backend (`src/cryptography/hazmat/backends/openssl/backend.py`)**:
  - Simplified `dh_supported()` method to only check for BoringSSL, removing the AWS-LC check

- **Documentation (`CHANGELOG.rst`)**:
  - Added entry documenting DH support for AWS-LC

## Implementation Details

The changes maintain the existing error handling pattern while expanding DH functionality to AWS-LC. The `unwrap_or(false)` pattern for `check_key()` ensures graceful degradation if the underlying OpenSSL call fails.

https://claude.ai/code/session_01FtVytVEDG14pZZGtgNr5kL