### PR TITLE
Replace invalid-type "type: ignore" comments with typing.cast in tests

### DIFF
--- a/tests/hazmat/asn1/test_serialization.py
+++ b/tests/hazmat/asn1/test_serialization.py
@@ -863,7 +863,7 @@ class TestSequence:
         with pytest.raises(
             ValueError,
         ):
-            asn1.encode_der(Example(foo=3))  # type: ignore[arg-type]
+            asn1.encode_der(Example(foo=typing.cast(typing.Any, 3)))
 
     def test_sequence_with_explicit_choice(self) -> None:
         @asn1.sequence
@@ -2122,7 +2122,7 @@ class TestX509Types:
             cert: x509.Certificate
 
         with pytest.raises(TypeError):
-            asn1.encode_der(Example(cert=9))  # type: ignore[arg-type]
+            asn1.encode_der(Example(cert=typing.cast(typing.Any, 9)))
 
 
 class TestName:
@@ -2181,7 +2181,7 @@ class TestName:
             name: x509.Name
 
         with pytest.raises(TypeError):
-            asn1.encode_der(Example(name=9))  # type: ignore[arg-type]
+            asn1.encode_der(Example(name=typing.cast(typing.Any, 9)))
 
 
 @asn1.value_set(x509.ObjectIdentifier)
@@ -2355,7 +2355,11 @@ class TestValueSet:
             "got: ObjectIdentifier",
         ):
             asn1.encode_der(
-                Example(algorithm=x509.ObjectIdentifier("1.2.3.4"))  # type: ignore[arg-type]
+                Example(
+                    algorithm=typing.cast(
+                        typing.Any, x509.ObjectIdentifier("1.2.3.4")
+                    )
+                )
             )
 
 

--- a/tests/hazmat/primitives/decrepit/test_algorithms.py
+++ b/tests/hazmat/primitives/decrepit/test_algorithms.py
@@ -5,6 +5,7 @@
 
 import binascii
 import os
+import typing
 
 import pytest
 
@@ -49,7 +50,7 @@ class TestARC4:
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            ARC4("0" * 10)  # type: ignore[arg-type]
+            ARC4(typing.cast(typing.Any, "0" * 10))
 
 
 def test_invalid_mode_algorithm():
@@ -83,7 +84,7 @@ class TestTripleDES:
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            TripleDES("0" * 16)  # type: ignore[arg-type]
+            TripleDES(typing.cast(typing.Any, "0" * 16))
 
     def test_single_key_deprecated(self):
         with pytest.warns(utils.DeprecatedIn47):
@@ -111,7 +112,7 @@ class TestBlowfish:
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            Blowfish("0" * 8)  # type: ignore[arg-type]
+            Blowfish(typing.cast(typing.Any, "0" * 8))
 
 
 @pytest.mark.supported(
@@ -193,7 +194,7 @@ class TestCAST5:
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            CAST5("0" * 10)  # type: ignore[arg-type]
+            CAST5(typing.cast(typing.Any, "0" * 10))
 
 
 @pytest.mark.supported(
@@ -271,7 +272,7 @@ class TestIDEA:
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            IDEA("0" * 16)  # type: ignore[arg-type]
+            IDEA(typing.cast(typing.Any, "0" * 16))
 
 
 @pytest.mark.supported(
@@ -349,7 +350,7 @@ class TestSEED:
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            SEED("0" * 16)  # type: ignore[arg-type]
+            SEED(typing.cast(typing.Any, "0" * 16))
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -7,6 +7,7 @@ import binascii
 import mmap
 import os
 import sys
+import typing
 
 import pytest
 
@@ -81,7 +82,7 @@ class TestChaCha20Poly1305:
 
     def test_bad_key(self, backend):
         with pytest.raises(TypeError):
-            ChaCha20Poly1305(object())  # type:ignore[arg-type]
+            ChaCha20Poly1305(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             ChaCha20Poly1305(b"0" * 31)
@@ -308,7 +309,7 @@ class TestAESCCM:
             AESCCM(key, tag_length=2)
 
         with pytest.raises(TypeError):
-            AESCCM(key, tag_length="notanint")  # type:ignore[arg-type]
+            AESCCM(key, tag_length=typing.cast(typing.Any, "notanint"))
 
     def test_invalid_nonce_length(self, backend):
         key = AESCCM.generate_key(128)
@@ -402,14 +403,14 @@ class TestAESCCM:
 
     def test_bad_key(self, backend):
         with pytest.raises(TypeError):
-            AESCCM(object())  # type:ignore[arg-type]
+            AESCCM(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESCCM(b"0" * 31)
 
     def test_bad_generate_key(self, backend):
         with pytest.raises(TypeError):
-            AESCCM.generate_key(object())  # type:ignore[arg-type]
+            AESCCM.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESCCM.generate_key(129)
@@ -642,14 +643,14 @@ class TestAESGCM:
 
     def test_bad_key(self, backend):
         with pytest.raises(TypeError):
-            AESGCM(object())  # type:ignore[arg-type]
+            AESGCM(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESGCM(b"0" * 31)
 
     def test_bad_generate_key(self, backend):
         with pytest.raises(TypeError):
-            AESGCM.generate_key(object())  # type:ignore[arg-type]
+            AESGCM.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESGCM.generate_key(129)
@@ -915,14 +916,14 @@ class TestAESOCB3:
 
     def test_bad_key(self, backend):
         with pytest.raises(TypeError):
-            AESOCB3(object())  # type:ignore[arg-type]
+            AESOCB3(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESOCB3(b"0" * 31)
 
     def test_bad_generate_key(self, backend):
         with pytest.raises(TypeError):
-            AESOCB3.generate_key(object())  # type:ignore[arg-type]
+            AESOCB3.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESOCB3.generate_key(129)
@@ -1144,14 +1145,14 @@ class TestAESSIV:
 
     def test_bad_key(self, backend):
         with pytest.raises(TypeError):
-            AESSIV(object())  # type:ignore[arg-type]
+            AESSIV(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESSIV(b"0" * 31)
 
     def test_bad_generate_key(self, backend):
         with pytest.raises(TypeError):
-            AESSIV.generate_key(object())  # type:ignore[arg-type]
+            AESSIV.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESSIV.generate_key(128)
@@ -1404,7 +1405,7 @@ class TestAESGCMSIV:
 
     def test_bad_key(self, backend):
         with pytest.raises(TypeError):
-            AESGCMSIV(object())  # type:ignore[arg-type]
+            AESGCMSIV(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESGCMSIV(b"0" * 31)
@@ -1418,7 +1419,7 @@ class TestAESGCMSIV:
 
     def test_bad_generate_key(self, backend):
         with pytest.raises(TypeError):
-            AESGCMSIV.generate_key(object())  # type:ignore[arg-type]
+            AESGCMSIV.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESGCMSIV.generate_key(129)

--- a/tests/hazmat/primitives/test_asym_utils.py
+++ b/tests/hazmat/primitives/test_asym_utils.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import typing
+
 import pytest
 
 from cryptography.hazmat.primitives import hashes
@@ -36,19 +38,25 @@ def test_dss_signature():
 
 def test_encode_dss_non_integer():
     with pytest.raises(TypeError):
-        encode_dss_signature("h", 3)  # type: ignore[arg-type]
+        encode_dss_signature(typing.cast(typing.Any, "h"), 3)
 
     with pytest.raises(TypeError):
-        encode_dss_signature("3", "2")  # type: ignore[arg-type]
+        encode_dss_signature(
+            typing.cast(typing.Any, "3"), typing.cast(typing.Any, "2")
+        )
 
     with pytest.raises(TypeError):
-        encode_dss_signature(3, "h")  # type: ignore[arg-type]
+        encode_dss_signature(3, typing.cast(typing.Any, "h"))
 
     with pytest.raises(TypeError):
-        encode_dss_signature(3.3, 1.2)  # type: ignore[arg-type]
+        encode_dss_signature(
+            typing.cast(typing.Any, 3.3), typing.cast(typing.Any, 1.2)
+        )
 
     with pytest.raises(TypeError):
-        encode_dss_signature("hello", "world")  # type: ignore[arg-type]
+        encode_dss_signature(
+            typing.cast(typing.Any, "hello"), typing.cast(typing.Any, "world")
+        )
 
 
 def test_encode_dss_negative():
@@ -76,7 +84,7 @@ def test_decode_dss_invalid_asn1():
 
 def test_pass_invalid_prehashed_arg():
     with pytest.raises(TypeError):
-        Prehashed(object())  # type: ignore[arg-type]
+        Prehashed(typing.cast(typing.Any, object()))
 
 
 def test_prehashed_digest_size():

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -4,6 +4,7 @@
 
 
 import binascii
+import typing
 
 import pytest
 
@@ -45,7 +46,7 @@ class TestCipher:
         algorithm = object()
         with pytest.raises(TypeError):
             Cipher(
-                algorithm,  # type: ignore[arg-type]
+                typing.cast(typing.Any, algorithm),
                 mode=None,
                 backend=backend,
             )
@@ -194,28 +195,28 @@ class TestModeValidation:
 class TestModesRequireBytes:
     def test_cbc(self):
         with pytest.raises(TypeError):
-            modes.CBC([1] * 16)  # type:ignore[arg-type]
+            modes.CBC(typing.cast(typing.Any, [1] * 16))
 
     def test_cfb(self):
         with pytest.raises(TypeError):
-            CFB([1] * 16)  # type:ignore[arg-type]
+            CFB(typing.cast(typing.Any, [1] * 16))
 
     def test_cfb8(self):
         with pytest.raises(TypeError):
-            CFB8([1] * 16)  # type:ignore[arg-type]
+            CFB8(typing.cast(typing.Any, [1] * 16))
 
     def test_ofb(self):
         with pytest.raises(TypeError):
-            OFB([1] * 16)  # type:ignore[arg-type]
+            OFB(typing.cast(typing.Any, [1] * 16))
 
     def test_ctr(self):
         with pytest.raises(TypeError):
-            modes.CTR([1] * 16)  # type:ignore[arg-type]
+            modes.CTR(typing.cast(typing.Any, [1] * 16))
 
     def test_gcm_iv(self):
         with pytest.raises(TypeError):
-            modes.GCM([1] * 16)  # type:ignore[arg-type]
+            modes.GCM(typing.cast(typing.Any, [1] * 16))
 
     def test_gcm_tag(self):
         with pytest.raises(TypeError):
-            modes.GCM(b"\x00" * 16, [1] * 16)  # type:ignore[arg-type]
+            modes.GCM(b"\x00" * 16, typing.cast(typing.Any, [1] * 16))

--- a/tests/hazmat/primitives/test_chacha20.py
+++ b/tests/hazmat/primitives/test_chacha20.py
@@ -6,6 +6,7 @@
 import binascii
 import os
 import struct
+import typing
 
 import pytest
 
@@ -129,11 +130,11 @@ class TestChaCha20:
             algorithms.ChaCha20(b"0" * 32, b"0")
 
         with pytest.raises(TypeError):
-            algorithms.ChaCha20(b"0" * 32, object())  # type:ignore[arg-type]
+            algorithms.ChaCha20(b"0" * 32, typing.cast(typing.Any, object()))
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            algorithms.ChaCha20("0" * 32, b"0" * 16)  # type:ignore[arg-type]
+            algorithms.ChaCha20(typing.cast(typing.Any, "0" * 32), b"0" * 16)
 
     def test_partial_blocks(self, backend):
         # Test that partial blocks and counter increments are handled

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -6,6 +6,7 @@
 import binascii
 import os
 import sys
+import typing
 
 import pytest
 
@@ -51,7 +52,7 @@ class TestAES:
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            AES("0" * 32)  # type: ignore[arg-type]
+            AES(typing.cast(typing.Any, "0" * 32))
 
 
 class TestAESXTS:
@@ -62,7 +63,7 @@ class TestAESXTS:
 
     def test_xts_tweak_not_bytes(self):
         with pytest.raises(TypeError):
-            modes.XTS(32)  # type: ignore[arg-type]
+            modes.XTS(typing.cast(typing.Any, 32))
 
     def test_xts_tweak_too_small(self):
         with pytest.raises(ValueError):
@@ -102,7 +103,7 @@ class TestCamellia:
 
     def test_invalid_key_type(self):
         with pytest.raises(TypeError, match="key must be bytes"):
-            Camellia("0" * 32)  # type: ignore[arg-type]
+            Camellia(typing.cast(typing.Any, "0" * 32))
 
 
 @pytest.mark.supported(
@@ -247,9 +248,9 @@ class TestCipherUpdateInto:
         c = ciphers.Cipher(AES(key), modes.GCM(b"\x00" * 12), backend)
         encryptor = c.encryptor()
         with pytest.raises(TypeError, match=r"bytestring instead\?"):
-            encryptor.update("hello")  # type: ignore[arg-type]
+            encryptor.update(typing.cast(typing.Any, "hello"))
         with pytest.raises(TypeError, match="instance to a buffer"):
-            encryptor.update(object)  # type: ignore[arg-type]
+            encryptor.update(typing.cast(typing.Any, object))
 
 
 @pytest.mark.skipif(

--- a/tests/hazmat/primitives/test_cmac.py
+++ b/tests/hazmat/primitives/test_cmac.py
@@ -4,6 +4,7 @@
 
 
 import binascii
+import typing
 
 import pytest
 
@@ -142,7 +143,7 @@ class TestCMAC:
     def test_invalid_algorithm(self, backend):
         key = b"0102030405"
         with pytest.raises(TypeError):
-            CMAC(ARC4(key), backend)  # type: ignore[arg-type]
+            CMAC(typing.cast(typing.Any, ARC4(key)), backend)
 
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
             CMAC(DummyBlockCipherAlgorithm(b"bad"), backend)
@@ -181,10 +182,10 @@ class TestCMAC:
         cmac = CMAC(AES(key), backend)
 
         with pytest.raises(TypeError):
-            cmac.update("")  # type: ignore[arg-type]
+            cmac.update(typing.cast(typing.Any, ""))
 
         with pytest.raises(TypeError):
-            cmac.verify("")  # type: ignore[arg-type]
+            cmac.verify(typing.cast(typing.Any, ""))
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.cmac_algorithm_supported(

--- a/tests/hazmat/primitives/test_concatkdf.py
+++ b/tests/hazmat/primitives/test_concatkdf.py
@@ -5,6 +5,7 @@
 
 import binascii
 import sys
+import typing
 
 import pytest
 
@@ -100,7 +101,7 @@ class TestConcatKDFHash:
             ConcatKDFHash(
                 hashes.SHA256(),
                 16,
-                otherinfo="foo",  # type: ignore[arg-type]
+                otherinfo=typing.cast(typing.Any, "foo"),
                 backend=backend,
             )
 
@@ -109,21 +110,21 @@ class TestConcatKDFHash:
                 hashes.SHA256(), 16, otherinfo=None, backend=backend
             )
 
-            ckdf.derive("foo")  # type: ignore[arg-type]
+            ckdf.derive(typing.cast(typing.Any, "foo"))
 
         with pytest.raises(TypeError):
             ckdf = ConcatKDFHash(
                 hashes.SHA256(), 16, otherinfo=None, backend=backend
             )
 
-            ckdf.verify("foo", b"bar")  # type: ignore[arg-type]
+            ckdf.verify(typing.cast(typing.Any, "foo"), b"bar")
 
         with pytest.raises(TypeError):
             ckdf = ConcatKDFHash(
                 hashes.SHA256(), 16, otherinfo=None, backend=backend
             )
 
-            ckdf.verify(b"foo", "bar")  # type: ignore[arg-type]
+            ckdf.verify(b"foo", typing.cast(typing.Any, "bar"))
 
     def test_derive_into(self, backend):
         prk = binascii.unhexlify(
@@ -279,7 +280,7 @@ class TestConcatKDFHMAC:
             ConcatKDFHMAC(
                 hashes.SHA256(),
                 16,
-                salt="foo",  # type: ignore[arg-type]
+                salt=typing.cast(typing.Any, "foo"),
                 otherinfo=None,
                 backend=backend,
             )
@@ -289,7 +290,7 @@ class TestConcatKDFHMAC:
                 hashes.SHA256(),
                 16,
                 salt=None,
-                otherinfo="foo",  # type: ignore[arg-type]
+                otherinfo=typing.cast(typing.Any, "foo"),
                 backend=backend,
             )
 
@@ -298,21 +299,21 @@ class TestConcatKDFHMAC:
                 hashes.SHA256(), 16, salt=None, otherinfo=None, backend=backend
             )
 
-            ckdf.derive("foo")  # type: ignore[arg-type]
+            ckdf.derive(typing.cast(typing.Any, "foo"))
 
         with pytest.raises(TypeError):
             ckdf = ConcatKDFHMAC(
                 hashes.SHA256(), 16, salt=None, otherinfo=None, backend=backend
             )
 
-            ckdf.verify("foo", b"bar")  # type: ignore[arg-type]
+            ckdf.verify(typing.cast(typing.Any, "foo"), b"bar")
 
         with pytest.raises(TypeError):
             ckdf = ConcatKDFHMAC(
                 hashes.SHA256(), 16, salt=None, otherinfo=None, backend=backend
             )
 
-            ckdf.verify(b"foo", "bar")  # type: ignore[arg-type]
+            ckdf.verify(b"foo", typing.cast(typing.Any, "bar"))
 
     def test_unsupported_hash_algorithm(self, backend):
         # ConcatKDF requires a hash algorithm with an internal block size.

--- a/tests/hazmat/primitives/test_constant_time.py
+++ b/tests/hazmat/primitives/test_constant_time.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import typing
+
 import pytest
 
 from cryptography.hazmat.primitives import constant_time
@@ -11,13 +13,15 @@ from cryptography.hazmat.primitives import constant_time
 class TestConstantTimeBytesEq:
     def test_reject_unicode(self):
         with pytest.raises(TypeError):
-            constant_time.bytes_eq(b"foo", "foo")  # type: ignore[arg-type]
+            constant_time.bytes_eq(b"foo", typing.cast(typing.Any, "foo"))
 
         with pytest.raises(TypeError):
-            constant_time.bytes_eq("foo", b"foo")  # type: ignore[arg-type]
+            constant_time.bytes_eq(typing.cast(typing.Any, "foo"), b"foo")
 
         with pytest.raises(TypeError):
-            constant_time.bytes_eq("foo", "foo")  # type: ignore[arg-type]
+            constant_time.bytes_eq(
+                typing.cast(typing.Any, "foo"), typing.cast(typing.Any, "foo")
+            )
 
     def test_compares(self):
         assert constant_time.bytes_eq(b"foo", b"foo") is True

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -46,13 +46,15 @@ def test_dh_parameternumbers():
     assert params.g == 2
 
     with pytest.raises(TypeError):
-        dh.DHParameterNumbers(None, 2)  # type: ignore[arg-type]
+        dh.DHParameterNumbers(typing.cast(typing.Any, None), 2)
 
     with pytest.raises(TypeError):
-        dh.DHParameterNumbers(P_1536, None)  # type: ignore[arg-type]
+        dh.DHParameterNumbers(P_1536, typing.cast(typing.Any, None))
 
     with pytest.raises(TypeError):
-        dh.DHParameterNumbers(None, None)  # type: ignore[arg-type]
+        dh.DHParameterNumbers(
+            typing.cast(typing.Any, None), typing.cast(typing.Any, None)
+        )
 
     with pytest.raises(ValueError):
         dh.DHParameterNumbers(P_1536, 1)
@@ -68,7 +70,7 @@ def test_dh_parameternumbers():
     assert params.q == 1245
 
     with pytest.raises(TypeError):
-        dh.DHParameterNumbers(P_1536, 2, "hello")  # type: ignore[arg-type]
+        dh.DHParameterNumbers(P_1536, 2, typing.cast(typing.Any, "hello"))
 
 
 @pytest.mark.skip_fips(reason="RHEL8 FIPS doesn't like this")
@@ -88,10 +90,10 @@ def test_dh_numbers():
     assert public.y == 1
 
     with pytest.raises(TypeError):
-        dh.DHPublicNumbers(1, None)  # type: ignore[arg-type]
+        dh.DHPublicNumbers(1, typing.cast(typing.Any, None))
 
     with pytest.raises(TypeError):
-        dh.DHPublicNumbers(None, params)  # type:ignore[arg-type]
+        dh.DHPublicNumbers(typing.cast(typing.Any, None), params)
 
     private = dh.DHPrivateNumbers(1, public)
 
@@ -99,10 +101,10 @@ def test_dh_numbers():
     assert private.x == 1
 
     with pytest.raises(TypeError):
-        dh.DHPrivateNumbers(1, None)  # type: ignore[arg-type]
+        dh.DHPrivateNumbers(1, typing.cast(typing.Any, None))
 
     with pytest.raises(TypeError):
-        dh.DHPrivateNumbers(None, public)  # type:ignore[arg-type]
+        dh.DHPrivateNumbers(typing.cast(typing.Any, None), public)
 
 
 def test_dh_parameter_numbers_equality():
@@ -286,7 +288,7 @@ class TestDH:
         parameters = FFDH3072_P.parameters(backend)
         key1 = parameters.generate_private_key()
         with pytest.raises(TypeError):
-            key1.exchange(b"invalidtype")  # type: ignore[arg-type]
+            key1.exchange(typing.cast(typing.Any, b"invalidtype"))
 
     def test_exchange(self, backend):
         parameters = FFDH3072_P.parameters(backend)
@@ -708,7 +710,7 @@ class TestDHPrivateKeySerialization:
         key = parameters.generate_private_key()
         with pytest.raises(TypeError):
             key.private_bytes(
-                "notencoding",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption(),
             )
@@ -719,7 +721,7 @@ class TestDHPrivateKeySerialization:
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "invalidformat"),
                 serialization.NoEncryption(),
             )
 
@@ -730,7 +732,7 @@ class TestDHPrivateKeySerialization:
             key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.PKCS8,
-                "notanencalg",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanencalg"),
             )
 
     def test_private_bytes_unsupported_encryption_type(self, backend):
@@ -876,7 +878,7 @@ class TestDHPublicKeySerialization:
         key = parameters.generate_private_key().public_key()
         with pytest.raises(TypeError):
             key.public_bytes(
-                "notencoding",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.PublicFormat.SubjectPublicKeyInfo,
             )
 
@@ -1041,7 +1043,7 @@ class TestDHParameterSerialization:
         parameters = FFDH3072_P.parameters(backend)
         with pytest.raises(TypeError):
             parameters.parameter_bytes(
-                "notencoding",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.ParameterFormat.PKCS3,
             )
 
@@ -1050,7 +1052,7 @@ class TestDHParameterSerialization:
         with pytest.raises(TypeError):
             parameters.parameter_bytes(
                 serialization.Encoding.PEM,
-                "notformat",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notformat"),
             )
 
     def test_parameter_bytes_openssh_unsupported(self, backend):

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -631,13 +631,13 @@ class TestDSANumbers:
 
     def test_dsa_parameter_numbers_invalid_types(self):
         with pytest.raises(TypeError):
-            dsa.DSAParameterNumbers(p=None, q=2, g=3)  # type: ignore[arg-type]
+            dsa.DSAParameterNumbers(p=typing.cast(typing.Any, None), q=2, g=3)
 
         with pytest.raises(TypeError):
-            dsa.DSAParameterNumbers(p=1, q=None, g=3)  # type: ignore[arg-type]
+            dsa.DSAParameterNumbers(p=1, q=typing.cast(typing.Any, None), g=3)
 
         with pytest.raises(TypeError):
-            dsa.DSAParameterNumbers(p=1, q=2, g=None)  # type: ignore[arg-type]
+            dsa.DSAParameterNumbers(p=1, q=2, g=typing.cast(typing.Any, None))
 
     def test_dsa_public_numbers(self):
         parameter_numbers = dsa.DSAParameterNumbers(p=1, q=2, g=3)
@@ -651,13 +651,13 @@ class TestDSANumbers:
         with pytest.raises(TypeError):
             dsa.DSAPublicNumbers(
                 y=4,
-                parameter_numbers=None,  # type: ignore[arg-type]
+                parameter_numbers=typing.cast(typing.Any, None),
             )
 
         with pytest.raises(TypeError):
             parameter_numbers = dsa.DSAParameterNumbers(p=1, q=2, g=3)
             dsa.DSAPublicNumbers(
-                y=None,  # type: ignore[arg-type]
+                y=typing.cast(typing.Any, None),
                 parameter_numbers=parameter_numbers,
             )
 
@@ -680,12 +680,12 @@ class TestDSANumbers:
         with pytest.raises(TypeError):
             dsa.DSAPrivateNumbers(
                 x=4,
-                public_numbers=None,  # type: ignore[arg-type]
+                public_numbers=typing.cast(typing.Any, None),
             )
 
         with pytest.raises(TypeError):
             dsa.DSAPrivateNumbers(
-                x=None,  # type: ignore[arg-type]
+                x=typing.cast(typing.Any, None),
                 public_numbers=public_numbers,
             )
 
@@ -950,7 +950,7 @@ class TestDSASerialization:
         )
         with pytest.raises(TypeError):
             key.private_bytes(
-                "notencoding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption(),
             )
@@ -965,7 +965,7 @@ class TestDSASerialization:
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "invalidformat"),
                 serialization.NoEncryption(),
             )
 
@@ -980,7 +980,7 @@ class TestDSASerialization:
             key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.TraditionalOpenSSL,
-                "notanencalg",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notanencalg"),
             )
 
     def test_private_bytes_unsupported_encryption_type(self, backend):
@@ -1065,7 +1065,7 @@ class TestDSAPEMPublicKeySerialization:
         key = DSA_KEY_2048.private_key(backend).public_key()
         with pytest.raises(TypeError):
             key.public_bytes(
-                "notencoding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.PublicFormat.SubjectPublicKeyInfo,
             )
 
@@ -1074,7 +1074,7 @@ class TestDSAPEMPublicKeySerialization:
         with pytest.raises(TypeError):
             key.public_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "invalidformat"),
             )
 
     def test_public_bytes_pkcs1_unsupported(self, backend):

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -7,6 +7,7 @@ import copy
 import itertools
 import os
 import textwrap
+import typing
 from binascii import hexlify
 
 import pytest
@@ -129,10 +130,10 @@ def test_derive_private_key_errors(backend):
     _skip_curve_unsupported(backend, curve)
 
     with pytest.raises(TypeError):
-        ec.derive_private_key("one", curve, backend)  # type: ignore[arg-type]
+        ec.derive_private_key(typing.cast(typing.Any, "one"), curve, backend)
 
     with pytest.raises(TypeError):
-        ec.derive_private_key(10, "five", backend)  # type: ignore[arg-type]
+        ec.derive_private_key(10, typing.cast(typing.Any, "five"), backend)
 
     with pytest.raises(ValueError):
         ec.derive_private_key(-7, curve, backend)
@@ -196,7 +197,7 @@ def test_invalid_ec_numbers_args(private_value, x, y, curve):
 
 def test_invalid_private_numbers_public_numbers():
     with pytest.raises(TypeError):
-        ec.EllipticCurvePrivateNumbers(1, None)  # type: ignore[arg-type]
+        ec.EllipticCurvePrivateNumbers(1, typing.cast(typing.Any, None))
 
 
 def test_ec_public_numbers_repr():
@@ -1023,7 +1024,7 @@ class TestECSerialization:
         )
         with pytest.raises(TypeError):
             key.private_bytes(
-                "notencoding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption(),
             )
@@ -1039,7 +1040,7 @@ class TestECSerialization:
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "invalidformat"),
                 serialization.NoEncryption(),
             )
 
@@ -1055,7 +1056,7 @@ class TestECSerialization:
             key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.TraditionalOpenSSL,
-                "notanencalg",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notanencalg"),
             )
 
     def test_private_bytes_unsupported_encryption_type(self, backend):
@@ -1329,7 +1330,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
         )
         with pytest.raises(TypeError):
             key.public_bytes(
-                "notencoding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.PublicFormat.SubjectPublicKeyInfo,
             )
 
@@ -1377,7 +1378,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
         with pytest.raises(TypeError):
             key.public_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "invalidformat"),
             )
 
     def test_public_bytes_pkcs1_unsupported(self, backend):
@@ -1460,7 +1461,7 @@ class TestEllipticCurvePEMPublicKeySerialization:
     def test_from_encoded_point_not_a_curve(self):
         with pytest.raises(TypeError):
             ec.EllipticCurvePublicKey.from_encoded_point(
-                "notacurve",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notacurve"),
                 b"\x04data",
             )
 
@@ -1612,7 +1613,7 @@ class TestECDH:
         with raises_unsupported_algorithm(
             exceptions._Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM
         ):
-            key.exchange(None, key.public_key())  # type: ignore[arg-type]
+            key.exchange(typing.cast(typing.Any, None), key.public_key())
 
     def test_exchange_non_matching_curve(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())

--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -7,6 +7,7 @@ import binascii
 import copy
 import os
 import textwrap
+import typing
 
 import pytest
 
@@ -121,13 +122,13 @@ class TestEd25519Signing:
     def test_invalid_type_public_bytes(self, backend):
         with pytest.raises(TypeError):
             Ed25519PublicKey.from_public_bytes(
-                object()  # type: ignore[arg-type]
+                typing.cast(typing.Any, object())
             )
 
     def test_invalid_type_private_bytes(self, backend):
         with pytest.raises(TypeError):
             Ed25519PrivateKey.from_private_bytes(
-                object()  # type: ignore[arg-type]
+                typing.cast(typing.Any, object())
             )
 
     def test_invalid_length_from_public_bytes(self, backend):
@@ -148,7 +149,7 @@ class TestEd25519Signing:
             key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.Raw,
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
             )
         with pytest.raises(ValueError):
             key.private_bytes(

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -7,6 +7,7 @@ import binascii
 import copy
 import os
 import textwrap
+import typing
 
 import pytest
 
@@ -177,14 +178,12 @@ class TestEd448Signing:
 
     def test_invalid_type_public_bytes(self, backend):
         with pytest.raises(TypeError):
-            Ed448PublicKey.from_public_bytes(
-                object()  # type: ignore[arg-type]
-            )
+            Ed448PublicKey.from_public_bytes(typing.cast(typing.Any, object()))
 
     def test_invalid_type_private_bytes(self, backend):
         with pytest.raises(TypeError):
             Ed448PrivateKey.from_private_bytes(
-                object()  # type: ignore[arg-type]
+                typing.cast(typing.Any, object())
             )
 
     def test_invalid_length_from_public_bytes(self, backend):
@@ -205,7 +204,7 @@ class TestEd448Signing:
             key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.Raw,
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
             )
         with pytest.raises(ValueError):
             key.private_bytes(

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -4,6 +4,7 @@
 
 
 import binascii
+import typing
 
 import pytest
 
@@ -19,11 +20,11 @@ class TestHashContext:
     def test_hash_reject_unicode(self, backend):
         m = hashes.Hash(hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):
-            m.update("\u00fc")  # type: ignore[arg-type]
+            m.update(typing.cast(typing.Any, "\u00fc"))
 
     def test_hash_algorithm_instance(self, backend):
         with pytest.raises(TypeError):
-            hashes.Hash(hashes.SHA1, backend=backend)  # type: ignore[arg-type]
+            hashes.Hash(typing.cast(typing.Any, hashes.SHA1), backend=backend)
 
     def test_raises_after_finalize(self, backend):
         h = hashes.Hash(hashes.SHA1(), backend=backend)
@@ -180,11 +181,13 @@ class TestHashHash:
 
     def test_hash_algorithm_instance(self):
         with pytest.raises(TypeError):
-            hashes.Hash.hash(hashes.SHA1, b"data")  # type: ignore[arg-type]
+            hashes.Hash.hash(typing.cast(typing.Any, hashes.SHA1), b"data")
 
     def test_hash_reject_unicode(self):
         with pytest.raises(TypeError):
-            hashes.Hash.hash(hashes.SHA256(), "\u00fc")  # type: ignore[arg-type]
+            hashes.Hash.hash(
+                hashes.SHA256(), typing.cast(typing.Any, "\u00fc")
+            )
 
     def test_hash_unsupported_algorithm(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -6,6 +6,7 @@
 import binascii
 import os
 import sys
+import typing
 
 import pytest
 
@@ -72,7 +73,7 @@ class TestHKDF:
             HKDF(
                 hashes.SHA256(),
                 16,
-                salt="foo",  # type: ignore[arg-type]
+                salt=typing.cast(typing.Any, "foo"),
                 info=None,
                 backend=backend,
             )
@@ -82,7 +83,7 @@ class TestHKDF:
                 hashes.SHA256(),
                 16,
                 salt=None,
-                info="foo",  # type: ignore[arg-type]
+                info=typing.cast(typing.Any, "foo"),
                 backend=backend,
             )
 
@@ -91,21 +92,21 @@ class TestHKDF:
                 hashes.SHA256(), 16, salt=None, info=None, backend=backend
             )
 
-            hkdf.derive("foo")  # type: ignore[arg-type]
+            hkdf.derive(typing.cast(typing.Any, "foo"))
 
         with pytest.raises(TypeError):
             hkdf = HKDF(
                 hashes.SHA256(), 16, salt=None, info=None, backend=backend
             )
 
-            hkdf.verify("foo", b"bar")  # type: ignore[arg-type]
+            hkdf.verify(typing.cast(typing.Any, "foo"), b"bar")
 
         with pytest.raises(TypeError):
             hkdf = HKDF(
                 hashes.SHA256(), 16, salt=None, info=None, backend=backend
             )
 
-            hkdf.verify(b"foo", "bar")  # type: ignore[arg-type]
+            hkdf.verify(b"foo", typing.cast(typing.Any, "bar"))
 
     def test_derive_short_output(self, backend):
         hkdf = HKDF(hashes.SHA256(), 4, salt=None, info=None, backend=backend)
@@ -247,7 +248,7 @@ class TestHKDFExpand:
         hkdf = HKDFExpand(hashes.SHA256(), 42, info, backend)
 
         with pytest.raises(TypeError):
-            hkdf.derive("first")  # type: ignore[arg-type]
+            hkdf.derive(typing.cast(typing.Any, "first"))
 
     def test_overflow_protection_enormous_digest_size(self):
         enormous_digest_size = sys.maxsize >> 3

--- a/tests/hazmat/primitives/test_hmac.py
+++ b/tests/hazmat/primitives/test_hmac.py
@@ -4,6 +4,7 @@
 
 
 import binascii
+import typing
 
 import pytest
 
@@ -33,13 +34,13 @@ class TestHMAC:
     def test_hmac_reject_unicode(self, backend):
         h = hmac.HMAC(b"mykey", hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):
-            h.update("\u00fc")  # type: ignore[arg-type]
+            h.update(typing.cast(typing.Any, "\u00fc"))
 
     def test_hmac_algorithm_instance(self, backend):
         with pytest.raises(TypeError):
             hmac.HMAC(
                 b"key",
-                hashes.SHA1,  # type: ignore[arg-type]
+                typing.cast(typing.Any, hashes.SHA1),
                 backend=backend,
             )
 
@@ -77,7 +78,7 @@ class TestHMAC:
     def test_verify_reject_unicode(self, backend):
         h = hmac.HMAC(b"", hashes.SHA1(), backend=backend)
         with pytest.raises(TypeError):
-            h.verify("")  # type: ignore[arg-type]
+            h.verify(typing.cast(typing.Any, ""))
 
     def test_unsupported_hash(self, backend):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):

--- a/tests/hazmat/primitives/test_hpke.py
+++ b/tests/hazmat/primitives/test_hpke.py
@@ -8,6 +8,7 @@ import hashlib
 import itertools
 import json
 import os
+import typing
 
 import pytest
 
@@ -91,15 +92,27 @@ SUPPORTED_SUITES = list(
 class TestHPKE:
     def test_invalid_kem_type(self):
         with pytest.raises(TypeError):
-            Suite("not a kem", KDF.HKDF_SHA256, AEAD.AES_128_GCM)  # type: ignore[arg-type]
+            Suite(
+                typing.cast(typing.Any, "not a kem"),
+                KDF.HKDF_SHA256,
+                AEAD.AES_128_GCM,
+            )
 
     def test_invalid_kdf_type(self):
         with pytest.raises(TypeError):
-            Suite(KEM.X25519, "not a kdf", AEAD.AES_128_GCM)  # type: ignore[arg-type]
+            Suite(
+                KEM.X25519,
+                typing.cast(typing.Any, "not a kdf"),
+                AEAD.AES_128_GCM,
+            )
 
     def test_invalid_aead_type(self):
         with pytest.raises(TypeError):
-            Suite(KEM.X25519, KDF.HKDF_SHA256, "not an aead")  # type: ignore[arg-type]
+            Suite(
+                KEM.X25519,
+                KDF.HKDF_SHA256,
+                typing.cast(typing.Any, "not an aead"),
+            )
 
     @pytest.mark.parametrize(
         "kem,expected",
@@ -656,17 +669,25 @@ class TestHPKE:
 
         # Wrong type for mlkem_key in private constructor.
         with pytest.raises(TypeError):
-            MLKEM768X25519PrivateKey(x25519_sk, x25519_sk)  # type: ignore[arg-type]
+            MLKEM768X25519PrivateKey(
+                typing.cast(typing.Any, x25519_sk), x25519_sk
+            )
         # Wrong type for x25519_key in private constructor.
         with pytest.raises(TypeError):
-            MLKEM768X25519PrivateKey(mlkem_sk, mlkem_sk)  # type: ignore[arg-type]
+            MLKEM768X25519PrivateKey(
+                mlkem_sk, typing.cast(typing.Any, mlkem_sk)
+            )
 
         # Wrong type for mlkem_key in public constructor.
         with pytest.raises(TypeError):
-            MLKEM768X25519PublicKey(x25519_pk, x25519_pk)  # type: ignore[arg-type]
+            MLKEM768X25519PublicKey(
+                typing.cast(typing.Any, x25519_pk), x25519_pk
+            )
         # Wrong type for x25519_key in public constructor.
         with pytest.raises(TypeError):
-            MLKEM768X25519PublicKey(mlkem_pk, mlkem_pk)  # type: ignore[arg-type]
+            MLKEM768X25519PublicKey(
+                mlkem_pk, typing.cast(typing.Any, mlkem_pk)
+            )
 
     @pytest.mark.supported(
         only_if=lambda backend: (
@@ -765,20 +786,22 @@ class TestHPKE:
 
         # Wrong type for mlkem_key in private constructor.
         with pytest.raises(TypeError):
-            MLKEM1024P384PrivateKey(p384_sk, p384_sk)  # type: ignore[arg-type]
+            MLKEM1024P384PrivateKey(typing.cast(typing.Any, p384_sk), p384_sk)
         # Wrong type for p384_key in private constructor.
         with pytest.raises(TypeError):
-            MLKEM1024P384PrivateKey(mlkem_sk, mlkem_sk)  # type: ignore[arg-type]
+            MLKEM1024P384PrivateKey(
+                mlkem_sk, typing.cast(typing.Any, mlkem_sk)
+            )
         # Wrong EC curve for p384_key in private constructor.
         with pytest.raises(TypeError):
             MLKEM1024P384PrivateKey(mlkem_sk, p256_sk)
 
         # Wrong type for mlkem_key in public constructor.
         with pytest.raises(TypeError):
-            MLKEM1024P384PublicKey(p384_pk, p384_pk)  # type: ignore[arg-type]
+            MLKEM1024P384PublicKey(typing.cast(typing.Any, p384_pk), p384_pk)
         # Wrong type for p384_key in public constructor.
         with pytest.raises(TypeError):
-            MLKEM1024P384PublicKey(mlkem_pk, mlkem_pk)  # type: ignore[arg-type]
+            MLKEM1024P384PublicKey(mlkem_pk, typing.cast(typing.Any, mlkem_pk))
         # Wrong EC curve for p384_key in public constructor.
         with pytest.raises(TypeError):
             MLKEM1024P384PublicKey(mlkem_pk, p256_pk)

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -5,6 +5,7 @@
 
 import re
 import sys
+import typing
 
 import pytest
 
@@ -218,7 +219,7 @@ class TestKBKDFHMAC:
                 hashes.SHA1(),
                 Mode.CounterMode,
                 32,
-                b"r",  # type: ignore[arg-type]
+                typing.cast(typing.Any, b"r"),
                 4,
                 CounterLocation.BeforeFixed,
                 b"label",
@@ -249,7 +250,7 @@ class TestKBKDFHMAC:
                 Mode.CounterMode,
                 32,
                 4,
-                b"l",  # type: ignore[arg-type]
+                typing.cast(typing.Any, b"l"),
                 CounterLocation.BeforeFixed,
                 b"label",
                 b"context",
@@ -276,7 +277,7 @@ class TestKBKDFHMAC:
         with pytest.raises(TypeError):
             KBKDFHMAC(
                 hashes.SHA256(),
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
                 32,
                 4,
                 4,
@@ -295,7 +296,7 @@ class TestKBKDFHMAC:
                 32,
                 4,
                 4,
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
                 b"label",
                 b"context",
                 None,
@@ -486,7 +487,7 @@ class TestKBKDFHMAC:
                 4,
                 4,
                 CounterLocation.BeforeFixed,
-                "label",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "label"),
                 b"context",
                 None,
                 backend=backend,
@@ -502,7 +503,7 @@ class TestKBKDFHMAC:
                 4,
                 CounterLocation.BeforeFixed,
                 b"label",
-                "context",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "context"),
                 None,
                 backend=backend,
             )
@@ -521,7 +522,7 @@ class TestKBKDFHMAC:
                 None,
                 backend=backend,
             )
-            kdf.derive("material")  # type: ignore[arg-type]
+            kdf.derive(typing.cast(typing.Any, "material"))
 
     def test_buffer_protocol(self, backend):
         kdf = KBKDFHMAC(
@@ -668,7 +669,7 @@ class TestKBKDFCMAC:
                 algorithms.AES,
                 Mode.CounterMode,
                 32,
-                b"r",  # type: ignore[arg-type]
+                typing.cast(typing.Any, b"r"),
                 4,
                 CounterLocation.BeforeFixed,
                 b"label",
@@ -699,7 +700,7 @@ class TestKBKDFCMAC:
                 Mode.CounterMode,
                 32,
                 4,
-                b"l",  # type: ignore[arg-type]
+                typing.cast(typing.Any, b"l"),
                 CounterLocation.BeforeFixed,
                 b"label",
                 b"context",
@@ -726,7 +727,7 @@ class TestKBKDFCMAC:
         with pytest.raises(TypeError):
             KBKDFCMAC(
                 algorithms.AES,
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
                 32,
                 4,
                 4,
@@ -745,7 +746,7 @@ class TestKBKDFCMAC:
                 32,
                 4,
                 4,
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
                 b"label",
                 b"context",
                 None,
@@ -935,7 +936,7 @@ class TestKBKDFCMAC:
                 4,
                 4,
                 CounterLocation.BeforeFixed,
-                "label",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "label"),
                 b"context",
                 None,
                 backend=backend,
@@ -951,7 +952,7 @@ class TestKBKDFCMAC:
                 4,
                 CounterLocation.BeforeFixed,
                 b"label",
-                "context",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "context"),
                 None,
                 backend=backend,
             )
@@ -986,7 +987,7 @@ class TestKBKDFCMAC:
             backend=backend,
         )
         with pytest.raises(TypeError):
-            kdf.derive("material")  # type: ignore[arg-type]
+            kdf.derive(typing.cast(typing.Any, "material"))
 
     def test_wrong_key_material_length(self, backend):
         kdf = KBKDFCMAC(

--- a/tests/hazmat/primitives/test_mldsa.py
+++ b/tests/hazmat/primitives/test_mldsa.py
@@ -8,6 +8,7 @@ import copy
 import dataclasses
 import hashlib
 import os
+import typing
 
 import pytest
 
@@ -413,10 +414,10 @@ class TestMLDSA:
     def test_mu_hasher_invalid_key_type(self, backend):
         with pytest.raises(TypeError):
             mldsa.MLDSAMuHasher(
-                ed25519.Ed25519PrivateKey.generate()  # type: ignore[arg-type]
+                typing.cast(typing.Any, ed25519.Ed25519PrivateKey.generate())
             )
         with pytest.raises(TypeError):
-            mldsa.MLDSAMuHasher(b"not a key")  # type: ignore[arg-type]
+            mldsa.MLDSAMuHasher(typing.cast(typing.Any, b"not a key"))
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.hash_supported(

--- a/tests/hazmat/primitives/test_padding.py
+++ b/tests/hazmat/primitives/test_padding.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import typing
+
 import pytest
 
 from cryptography.exceptions import AlreadyFinalized
@@ -35,10 +37,10 @@ class TestPKCS7:
     def test_non_bytes(self):
         padder = padding.PKCS7(128).padder()
         with pytest.raises(TypeError):
-            padder.update("abc")  # type: ignore[arg-type]
+            padder.update(typing.cast(typing.Any, "abc"))
         unpadder = padding.PKCS7(128).unpadder()
         with pytest.raises(TypeError):
-            unpadder.update("abc")  # type: ignore[arg-type]
+            unpadder.update(typing.cast(typing.Any, "abc"))
 
     def test_zany_py2_bytes_subclass(self):
         class mybytes(bytes):  # noqa: N801
@@ -165,10 +167,10 @@ class TestANSIX923:
     def test_non_bytes(self):
         padder = padding.ANSIX923(128).padder()
         with pytest.raises(TypeError):
-            padder.update("abc")  # type: ignore[arg-type]
+            padder.update(typing.cast(typing.Any, "abc"))
         unpadder = padding.ANSIX923(128).unpadder()
         with pytest.raises(TypeError):
-            unpadder.update("abc")  # type: ignore[arg-type]
+            unpadder.update(typing.cast(typing.Any, "abc"))
 
     def test_zany_py2_bytes_subclass(self):
         class mybytes(bytes):  # noqa: N801

--- a/tests/hazmat/primitives/test_pbkdf2hmac.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import typing
+
 import pytest
 
 from cryptography.exceptions import AlreadyFinalized, InvalidKey, _Reasons
@@ -47,7 +49,7 @@ class TestPBKDF2HMAC:
             PBKDF2HMAC(
                 hashes.SHA1(),
                 20,
-                "salt",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "salt"),
                 10,
                 backend,
             )
@@ -55,7 +57,7 @@ class TestPBKDF2HMAC:
     def test_unicode_error_with_key_material(self, backend):
         kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
         with pytest.raises(TypeError):
-            kdf.derive("unicode here")  # type: ignore[arg-type]
+            kdf.derive(typing.cast(typing.Any, "unicode here"))
 
     def test_buffer_protocol(self, backend):
         kdf = PBKDF2HMAC(hashes.SHA1(), 10, b"salt", 10, backend)

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -144,7 +144,7 @@ class TestPKCS12Loading:
         with pytest.raises(TypeError):
             load_key_and_certificates(
                 b"irrelevant",
-                object(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 backend,
             )
 
@@ -997,14 +997,14 @@ def test_pkcs12_ordering():
 class TestPKCS12Objects:
     def test_certificate_constructor(self, backend):
         with pytest.raises(TypeError):
-            PKCS12Certificate(None, None)  # type:ignore[arg-type]
+            PKCS12Certificate(typing.cast(typing.Any, None), None)
         with pytest.raises(TypeError):
-            PKCS12Certificate("hello", None)  # type:ignore[arg-type]
+            PKCS12Certificate(typing.cast(typing.Any, "hello"), None)
         cert = _load_cert(backend, os.path.join("x509", "cryptography.io.pem"))
         with pytest.raises(TypeError):
-            PKCS12Certificate(cert, "hello")  # type:ignore[arg-type]
+            PKCS12Certificate(cert, typing.cast(typing.Any, "hello"))
         with pytest.raises(TypeError):
-            PKCS12Certificate(cert, 42)  # type:ignore[arg-type]
+            PKCS12Certificate(cert, typing.cast(typing.Any, 42))
 
     def test_certificate_equality(self, backend):
         cert2 = _load_cert(
@@ -1060,14 +1060,14 @@ class TestPKCS12Objects:
     def test_key_and_certificates_constructor(self, backend):
         with pytest.raises(TypeError):
             PKCS12KeyAndCertificates(
-                "hello",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "hello"),
                 None,
                 [],
             )
         with pytest.raises(TypeError):
             PKCS12KeyAndCertificates(
                 None,
-                "hello",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "hello"),
                 [],
             )
         with pytest.raises(TypeError):

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -1025,7 +1025,7 @@ class TestPKCS12Objects:
         assert c2a != c2b
         assert c2a != c3a
 
-        assert c2n != "test"  # type: ignore[comparison-overlap]
+        assert c2n != typing.cast(typing.Any, "test")
 
     def test_certificate_hash(self, backend):
         cert2 = _load_cert(
@@ -1074,7 +1074,7 @@ class TestPKCS12Objects:
             PKCS12KeyAndCertificates(
                 None,
                 None,
-                ["hello"],  # type:ignore[list-item]
+                [typing.cast(typing.Any, "hello")],
             )
 
     def test_key_and_certificates_equality(self, backend):

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -57,11 +57,11 @@ class TestPKCS7Loading:
 
     def test_not_bytes_der(self, backend):
         with pytest.raises(TypeError):
-            pkcs7.load_der_pkcs7_certificates(38)  # type: ignore[arg-type]
+            pkcs7.load_der_pkcs7_certificates(typing.cast(typing.Any, 38))
 
     def test_not_bytes_pem(self, backend):
         with pytest.raises(TypeError):
-            pkcs7.load_pem_pkcs7_certificates(38)  # type: ignore[arg-type]
+            pkcs7.load_pem_pkcs7_certificates(typing.cast(typing.Any, 38))
 
     def test_load_pkcs7_pem(self, backend):
         certs = load_vectors_from_file(
@@ -175,7 +175,7 @@ class TestPKCS7SignatureBuilder:
     def test_invalid_data(self, backend):
         builder = pkcs7.PKCS7SignatureBuilder()
         with pytest.raises(TypeError):
-            builder.set_data("not bytes")  # type: ignore[arg-type]
+            builder.set_data(typing.cast(typing.Any, "not bytes"))
 
     def test_set_data_twice(self, backend):
         builder = pkcs7.PKCS7SignatureBuilder().set_data(b"test")
@@ -201,14 +201,14 @@ class TestPKCS7SignatureBuilder:
             pkcs7.PKCS7SignatureBuilder().add_signer(
                 cert,
                 key,
-                hashes.SHA512_256(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, hashes.SHA512_256()),
             )
 
     def test_not_a_cert(self, backend):
         _, key = _load_cert_key()
         with pytest.raises(TypeError):
             pkcs7.PKCS7SignatureBuilder().add_signer(
-                b"notacert",  # type: ignore[arg-type]
+                typing.cast(typing.Any, b"notacert"),
                 key,
                 hashes.SHA256(),
             )
@@ -219,7 +219,7 @@ class TestPKCS7SignatureBuilder:
         with pytest.raises(TypeError):
             pkcs7.PKCS7SignatureBuilder().add_signer(
                 cert,
-                key,  # type: ignore[arg-type]
+                typing.cast(typing.Any, key),
                 hashes.SHA256(),
             )
 
@@ -756,7 +756,7 @@ class TestPKCS7SignatureBuilder:
                 rsa_cert,
                 rsa_key,
                 hashes.SHA512(),
-                rsa_padding=object(),  # type: ignore[arg-type]
+                rsa_padding=typing.cast(typing.Any, object()),
             )
 
     def test_multiple_signers(self, backend):
@@ -835,7 +835,7 @@ class TestPKCS7SignatureBuilder:
     def test_add_additional_cert_not_a_cert(self, backend):
         with pytest.raises(TypeError):
             pkcs7.PKCS7SignatureBuilder().add_certificate(
-                b"notacert"  # type: ignore[arg-type]
+                typing.cast(typing.Any, b"notacert")
             )
 
     def test_add_additional_cert(self, backend):
@@ -912,7 +912,7 @@ class TestPKCS7EnvelopeBuilder:
     def test_invalid_data(self, backend):
         builder = pkcs7.PKCS7EnvelopeBuilder()
         with pytest.raises(TypeError):
-            builder.set_data("not bytes")  # type: ignore[arg-type]
+            builder.set_data(typing.cast(typing.Any, "not bytes"))
 
     def test_set_data_twice(self, backend):
         builder = pkcs7.PKCS7EnvelopeBuilder().set_data(b"test")
@@ -938,7 +938,7 @@ class TestPKCS7EnvelopeBuilder:
     def test_not_a_cert(self, backend):
         with pytest.raises(TypeError):
             pkcs7.PKCS7EnvelopeBuilder().add_recipient(
-                b"notacert",  # type: ignore[arg-type]
+                typing.cast(typing.Any, b"notacert"),
             )
 
     def test_set_content_encryption_algorithm_twice(self, backend):
@@ -953,7 +953,7 @@ class TestPKCS7EnvelopeBuilder:
 
         with pytest.raises(TypeError):
             pkcs7.PKCS7EnvelopeBuilder().set_content_encryption_algorithm(
-                InvalidAlgorithm,  # type: ignore[arg-type]
+                typing.cast(typing.Any, InvalidAlgorithm),
             )
 
     def test_encrypt_invalid_options(self, backend):
@@ -1166,11 +1166,15 @@ class TestPKCS7Decrypt:
 
     def test_not_a_cert(self, backend, private_key):
         with pytest.raises(TypeError):
-            pkcs7.pkcs7_decrypt_der(b"", b"wrong_type", private_key, [])  # type: ignore[arg-type]
+            pkcs7.pkcs7_decrypt_der(
+                b"", typing.cast(typing.Any, b"wrong_type"), private_key, []
+            )
 
     def test_not_a_pkey(self, backend, certificate):
         with pytest.raises(TypeError):
-            pkcs7.pkcs7_decrypt_der(b"", certificate, b"wrong_type", [])  # type: ignore[arg-type]
+            pkcs7.pkcs7_decrypt_der(
+                b"", certificate, typing.cast(typing.Any, b"wrong_type"), []
+            )
 
     @pytest.mark.parametrize(
         "invalid_options",
@@ -1497,7 +1501,7 @@ class TestPKCS7SerializeCerts:
         )
         with pytest.raises(TypeError):
             pkcs7.serialize_certificates(
-                object(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 serialization.Encoding.PEM,
             )
 
@@ -1507,7 +1511,7 @@ class TestPKCS7SerializeCerts:
         with pytest.raises(TypeError):
             pkcs7.serialize_certificates(
                 certs,
-                "not an encoding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "not an encoding"),
             )
 
 

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -233,7 +233,7 @@ class TestPKCS7SignatureBuilder:
         with pytest.raises(ValueError):
             builder.sign(
                 serialization.Encoding.SMIME,
-                [b"invalid"],  # type: ignore[list-item]
+                [typing.cast(typing.Any, b"invalid")],
             )
 
     def test_sign_invalid_encoding(self, backend):
@@ -964,7 +964,7 @@ class TestPKCS7EnvelopeBuilder:
         with pytest.raises(ValueError):
             builder.encrypt(
                 serialization.Encoding.SMIME,
-                [b"invalid"],  # type: ignore[list-item]
+                [typing.cast(typing.Any, b"invalid")],
             )
 
     def test_encrypt_invalid_encoding(self, backend):

--- a/tests/hazmat/primitives/test_poly1305.py
+++ b/tests/hazmat/primitives/test_poly1305.py
@@ -5,6 +5,7 @@
 
 import binascii
 import os
+import typing
 
 import pytest
 
@@ -70,10 +71,10 @@ class TestPoly1305:
     def test_reject_unicode(self, backend):
         poly = Poly1305(b"0" * 32)
         with pytest.raises(TypeError):
-            poly.update("")  # type:ignore[arg-type]
+            poly.update(typing.cast(typing.Any, ""))
 
         with pytest.raises(TypeError):
-            Poly1305.generate_tag(b"0" * 32, "")  # type:ignore[arg-type]
+            Poly1305.generate_tag(b"0" * 32, typing.cast(typing.Any, ""))
 
     def test_verify(self, backend):
         poly = Poly1305(b"0" * 32)
@@ -106,17 +107,17 @@ class TestPoly1305:
     def test_verify_reject_unicode(self, backend):
         poly = Poly1305(b"0" * 32)
         with pytest.raises(TypeError):
-            poly.verify("")  # type:ignore[arg-type]
+            poly.verify(typing.cast(typing.Any, ""))
 
         with pytest.raises(TypeError):
-            Poly1305.verify_tag(b"0" * 32, b"msg", "")  # type:ignore[arg-type]
+            Poly1305.verify_tag(b"0" * 32, b"msg", typing.cast(typing.Any, ""))
 
     def test_invalid_key_type(self, backend):
         with pytest.raises(TypeError):
-            Poly1305(object())  # type:ignore[arg-type]
+            Poly1305(typing.cast(typing.Any, object()))
 
         with pytest.raises(TypeError):
-            Poly1305.generate_tag(object(), b"msg")  # type:ignore[arg-type]
+            Poly1305.generate_tag(typing.cast(typing.Any, object()), b"msg")
 
     def test_invalid_key_length(self, backend):
         with pytest.raises(ValueError):

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -7,6 +7,7 @@ import binascii
 import copy
 import itertools
 import os
+import typing
 
 import pytest
 
@@ -732,7 +733,7 @@ class TestRSASignature:
         with pytest.raises(TypeError):
             private_key.sign(
                 b"msg",
-                "notpadding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notpadding"),
                 hashes.SHA256(),
             )
 
@@ -933,7 +934,7 @@ class TestRSASignature:
             public_key.recover_data_from_signature(
                 signature,
                 padding.PKCS1v15(),
-                prehashed_alg,  # type: ignore[arg-type]
+                typing.cast(typing.Any, prehashed_alg),
             )
 
     def test_corrupted_private_key(self, backend):
@@ -1300,7 +1301,7 @@ class TestRSAVerification:
             public_key.verify(
                 b"sig",
                 b"msg",
-                "notpadding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notpadding"),
                 hashes.SHA256(),
             )
 
@@ -1705,7 +1706,7 @@ class TestPSS:
     def test_calculate_max_pss_salt_length(self):
         with pytest.raises(TypeError):
             padding.calculate_max_pss_salt_length(
-                object(),  # type:ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 hashes.SHA256(),
             )
 
@@ -1713,7 +1714,7 @@ class TestPSS:
         with pytest.raises(TypeError):
             padding.PSS(
                 mgf=padding.MGF1(hashes.SHA256()),
-                salt_length=b"not_a_length",  # type:ignore[arg-type]
+                salt_length=typing.cast(typing.Any, b"not_a_length"),
             )
 
     def test_invalid_salt_length_negative_integer(self):
@@ -1746,7 +1747,7 @@ class TestPSS:
 class TestMGF1:
     def test_invalid_hash_algorithm(self):
         with pytest.raises(TypeError):
-            padding.MGF1(b"not_a_hash")  # type:ignore[arg-type]
+            padding.MGF1(typing.cast(typing.Any, b"not_a_hash"))
 
     def test_valid_mgf1_parameters(self):
         algorithm = hashes.SHA256()
@@ -1760,7 +1761,7 @@ class TestOAEP:
         with pytest.raises(TypeError):
             padding.OAEP(
                 mgf=mgf,
-                algorithm=b"",  # type:ignore[arg-type]
+                algorithm=typing.cast(typing.Any, b""),
                 label=None,
             )
 
@@ -2233,7 +2234,7 @@ class TestRSAEncryption:
         with pytest.raises(TypeError):
             public_key.encrypt(
                 b"somedata",
-                padding=object(),  # type: ignore[arg-type]
+                padding=typing.cast(typing.Any, object()),
             )
 
     def test_unsupported_oaep_mgf(
@@ -2294,10 +2295,10 @@ class TestRSANumbers:
 
     def test_public_numbers_invalid_types(self):
         with pytest.raises(TypeError):
-            rsa.RSAPublicNumbers(e=None, n=15)  # type: ignore[arg-type]
+            rsa.RSAPublicNumbers(e=typing.cast(typing.Any, None), n=15)
 
         with pytest.raises(TypeError):
-            rsa.RSAPublicNumbers(e=1, n=None)  # type: ignore[arg-type]
+            rsa.RSAPublicNumbers(e=1, n=typing.cast(typing.Any, None))
 
     @pytest.mark.parametrize(
         ("p", "q", "d", "dmp1", "dmq1", "iqmp", "public_numbers"),
@@ -2709,7 +2710,7 @@ class TestRSAPrivateKeySerialization:
         key = rsa_key_2048
         with pytest.raises(TypeError):
             key.private_bytes(
-                "notencoding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.PrivateFormat.PKCS8,
                 serialization.NoEncryption(),
             )
@@ -2721,7 +2722,7 @@ class TestRSAPrivateKeySerialization:
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "invalidformat"),
                 serialization.NoEncryption(),
             )
 
@@ -2733,7 +2734,7 @@ class TestRSAPrivateKeySerialization:
             key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.TraditionalOpenSSL,
-                "notanencalg",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notanencalg"),
             )
 
     def test_private_bytes_unsupported_encryption_type(
@@ -2835,7 +2836,7 @@ class TestRSAPEMPublicKeySerialization:
         key = rsa_key_2048.public_key()
         with pytest.raises(TypeError):
             key.public_bytes(
-                "notencoding",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notencoding"),
                 serialization.PublicFormat.PKCS1,
             )
 
@@ -2846,7 +2847,7 @@ class TestRSAPEMPublicKeySerialization:
         with pytest.raises(TypeError):
             key.public_bytes(
                 serialization.Encoding.PEM,
-                "invalidformat",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "invalidformat"),
             )
 
     @pytest.mark.parametrize(

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -5,6 +5,7 @@
 
 import binascii
 import os
+import typing
 
 import pytest
 
@@ -88,7 +89,7 @@ class TestScrypt:
 
         with pytest.raises(TypeError):
             Scrypt(
-                salt,  # type: ignore[arg-type]
+                typing.cast(typing.Any, salt),
                 length,
                 work_factor,
                 block_size,
@@ -135,7 +136,7 @@ class TestScrypt:
         )
 
         with pytest.raises(TypeError):
-            scrypt.derive(password)  # type: ignore[arg-type]
+            scrypt.derive(typing.cast(typing.Any, password))
 
     def test_buffer_protocol(self, backend):
         password = bytearray(b"password")

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -8,6 +8,7 @@ import itertools
 import os
 import sys
 import textwrap
+import typing
 
 import pytest
 
@@ -184,7 +185,7 @@ class TestDERSerialization:
                 key_file,
                 lambda derfile: load_der_private_key(
                     derfile.read(),
-                    password,  # type:ignore[arg-type]
+                    typing.cast(typing.Any, password),
                     backend,
                 ),
                 mode="rb",
@@ -959,7 +960,7 @@ class TestPEMSerialization:
                 key_file,
                 lambda pemfile: load_pem_private_key(
                     pemfile.read().encode(),
-                    password,  # type:ignore[arg-type]
+                    typing.cast(typing.Any, password),
                     backend,
                 ),
             )
@@ -1420,7 +1421,7 @@ class TestPEMSerialization:
 class TestKeySerializationEncryptionTypes:
     def test_non_bytes_password(self):
         with pytest.raises(ValueError):
-            BestAvailableEncryption(object())  # type:ignore[arg-type]
+            BestAvailableEncryption(typing.cast(typing.Any, object()))
 
     def test_encryption_with_zero_length_password(self):
         with pytest.raises(ValueError):
@@ -1874,12 +1875,12 @@ class TestEncryptionBuilder:
         with pytest.raises(ValueError):
             b.kdf_rounds(-1)
         with pytest.raises(TypeError):
-            b.kdf_rounds("string")  # type: ignore[arg-type]
+            b.kdf_rounds(typing.cast(typing.Any, "string"))
 
     def test_invalid_password(self):
         b = PrivateFormat.OpenSSH.encryption_builder()
         with pytest.raises(ValueError):
-            b.build(12)  # type: ignore[arg-type]
+            b.build(typing.cast(typing.Any, 12))
         with pytest.raises(ValueError):
             b.build(b"")
 

--- a/tests/hazmat/primitives/test_ssh.py
+++ b/tests/hazmat/primitives/test_ssh.py
@@ -6,6 +6,7 @@
 import base64
 import datetime
 import os
+import typing
 
 import pytest
 
@@ -631,7 +632,7 @@ class TestOpenSSHSerialization:
         # bad object type
         with pytest.raises(ValueError):
             ssh._serialize_ssh_private_key(
-                object(),  # type:ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 b"",
                 NoEncryption(),
             )
@@ -1267,7 +1268,7 @@ class TestSSHCertificate:
     def test_not_bytes(self):
         with pytest.raises(TypeError):
             load_ssh_public_identity(
-                "these aren't bytes"  # type:ignore[arg-type]
+                typing.cast(typing.Any, "these aren't bytes")
             )
 
     def test_load_ssh_public_key(self):
@@ -1450,7 +1451,7 @@ class TestSSHCertificateBuilder:
         public_key = ec.generate_private_key(ec.SECP256R1()).public_key()
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
-            builder.public_key("not a key")  # type: ignore[arg-type]
+            builder.public_key(typing.cast(typing.Any, "not a key"))
         builder = builder.public_key(public_key)
         with pytest.raises(ValueError):
             builder.public_key(public_key)
@@ -1458,7 +1459,7 @@ class TestSSHCertificateBuilder:
     def test_serial_errors(self):
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
-            builder.serial("not a serial")  # type: ignore[arg-type]
+            builder.serial(typing.cast(typing.Any, "not a serial"))
         with pytest.raises(ValueError):
             builder.serial(-1)
         with pytest.raises(ValueError):
@@ -1470,7 +1471,7 @@ class TestSSHCertificateBuilder:
     def test_type_errors(self):
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
-            builder.type("not a type")  # type: ignore[arg-type]
+            builder.type(typing.cast(typing.Any, "not a type"))
         builder = builder.type(SSHCertificateType.USER)
         with pytest.raises(ValueError):
             builder.type(SSHCertificateType.USER)
@@ -1478,7 +1479,7 @@ class TestSSHCertificateBuilder:
     def test_key_id_errors(self):
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
-            builder.key_id("not bytes")  # type: ignore[arg-type]
+            builder.key_id(typing.cast(typing.Any, "not bytes"))
         builder = builder.key_id(b"test")
         with pytest.raises(ValueError):
             builder.key_id(b"test")
@@ -1486,7 +1487,7 @@ class TestSSHCertificateBuilder:
     def test_valid_principals_errors(self):
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
-            builder.valid_principals("not a list")  # type: ignore[arg-type]
+            builder.valid_principals(typing.cast(typing.Any, "not a list"))
         with pytest.raises(TypeError):
             builder.valid_principals(
                 [b"test", "not bytes"]  # type: ignore[list-item]
@@ -1514,7 +1515,7 @@ class TestSSHCertificateBuilder:
     def test_valid_before_errors(self):
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
-            builder.valid_before("not an int")  # type: ignore[arg-type]
+            builder.valid_before(typing.cast(typing.Any, "not an int"))
         with pytest.raises(ValueError):
             builder.valid_before(-1)
         with pytest.raises(ValueError):
@@ -1526,7 +1527,7 @@ class TestSSHCertificateBuilder:
     def test_valid_after_errors(self):
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
-            builder.valid_after("not an int")  # type: ignore[arg-type]
+            builder.valid_after(typing.cast(typing.Any, "not an int"))
         with pytest.raises(ValueError):
             builder.valid_after(-1)
         with pytest.raises(ValueError):
@@ -1539,13 +1540,13 @@ class TestSSHCertificateBuilder:
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
             builder.add_critical_option(
-                "not bytes",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "not bytes"),
                 b"test",
             )
         with pytest.raises(TypeError):
             builder.add_critical_option(
                 b"test",
-                object(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, object()),
             )
         builder = builder.add_critical_option(b"test", b"test")
         with pytest.raises(ValueError):
@@ -1555,11 +1556,11 @@ class TestSSHCertificateBuilder:
         builder = SSHCertificateBuilder()
         with pytest.raises(TypeError):
             builder.add_extension(
-                "not bytes",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "not bytes"),
                 b"test",
             )
         with pytest.raises(TypeError):
-            builder.add_extension(b"test", object())  # type: ignore[arg-type]
+            builder.add_extension(b"test", typing.cast(typing.Any, object()))
         builder = builder.add_extension(b"test", b"test")
         with pytest.raises(ValueError):
             builder.add_extension(b"test", b"test")
@@ -1971,8 +1972,12 @@ class TestSSHKeyFingerprint:
         )
         public_key = load_ssh_public_key(ssh_key)
         with pytest.raises(TypeError):
-            ssh_key_fingerprint(public_key, hashes.SM3())  # type: ignore[arg-type]
+            ssh_key_fingerprint(
+                public_key, typing.cast(typing.Any, hashes.SM3())
+            )
 
     def test_ssh_key_fingerprint_unsupported_key(self):
         with pytest.raises(ValueError):
-            ssh_key_fingerprint(object(), hashes.SHA256())  # type: ignore[arg-type]
+            ssh_key_fingerprint(
+                typing.cast(typing.Any, object()), hashes.SHA256()
+            )

--- a/tests/hazmat/primitives/test_ssh.py
+++ b/tests/hazmat/primitives/test_ssh.py
@@ -1490,7 +1490,7 @@ class TestSSHCertificateBuilder:
             builder.valid_principals(typing.cast(typing.Any, "not a list"))
         with pytest.raises(TypeError):
             builder.valid_principals(
-                [b"test", "not bytes"]  # type: ignore[list-item]
+                [b"test", typing.cast(typing.Any, "not bytes")]
             )
         with pytest.raises(TypeError):
             builder.valid_principals([])

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -7,6 +7,7 @@ import binascii
 import copy
 import os
 import textwrap
+import typing
 
 import pytest
 
@@ -100,7 +101,7 @@ class TestX25519Exchange:
         key = X25519PrivateKey.generate().public_key()
         with pytest.raises(TypeError):
             key.public_bytes(
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
                 serialization.PublicFormat.Raw,
             )
         with pytest.raises(ValueError):
@@ -110,7 +111,7 @@ class TestX25519Exchange:
         with pytest.raises(TypeError):
             key.public_bytes(
                 serialization.Encoding.DER,
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
             )
         with pytest.raises(TypeError):
             key.public_bytes(
@@ -180,7 +181,7 @@ class TestX25519Exchange:
     def test_invalid_type_exchange(self, backend):
         key = X25519PrivateKey.generate()
         with pytest.raises(TypeError):
-            key.exchange(object())  # type: ignore[arg-type]
+            key.exchange(typing.cast(typing.Any, object()))
 
     def test_invalid_length_from_public_bytes(self, backend):
         with pytest.raises(ValueError):
@@ -202,7 +203,7 @@ class TestX25519Exchange:
             key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.Raw,
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
             )
         with pytest.raises(ValueError):
             key.private_bytes(
@@ -226,20 +227,24 @@ class TestX25519Exchange:
             )
 
         with pytest.raises(TypeError):
-            key.private_bytes(None, None, None)  # type: ignore[arg-type]
+            key.private_bytes(
+                typing.cast(typing.Any, None),
+                typing.cast(typing.Any, None),
+                typing.cast(typing.Any, None),
+            )
 
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.Raw,
-                None,  # type: ignore[arg-type]
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
+                typing.cast(typing.Any, None),
             )
 
         with pytest.raises(TypeError):
             key.private_bytes(
                 serialization.Encoding.PEM,
                 serialization.PrivateFormat.PKCS8,
-                object(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, object()),
             )
 
         with pytest.raises(ValueError):

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -7,6 +7,7 @@ import binascii
 import copy
 import os
 import textwrap
+import typing
 
 import pytest
 
@@ -185,7 +186,7 @@ class TestX448Exchange:
     def test_invalid_type_exchange(self, backend):
         key = X448PrivateKey.generate()
         with pytest.raises(TypeError):
-            key.exchange(object())  # type: ignore[arg-type]
+            key.exchange(typing.cast(typing.Any, object()))
 
     def test_invalid_length_from_public_bytes(self, backend):
         with pytest.raises(ValueError):
@@ -207,7 +208,7 @@ class TestX448Exchange:
             key.private_bytes(
                 serialization.Encoding.Raw,
                 serialization.PrivateFormat.Raw,
-                None,  # type: ignore[arg-type]
+                typing.cast(typing.Any, None),
             )
         with pytest.raises(ValueError):
             key.private_bytes(

--- a/tests/hazmat/primitives/test_x963kdf.py
+++ b/tests/hazmat/primitives/test_x963kdf.py
@@ -5,6 +5,7 @@
 
 import binascii
 import sys
+import typing
 
 import pytest
 
@@ -86,7 +87,7 @@ class TestX963KDF:
             X963KDF(
                 hashes.SHA256(),
                 16,
-                sharedinfo="foo",  # type: ignore[arg-type]
+                sharedinfo=typing.cast(typing.Any, "foo"),
                 backend=backend,
             )
 
@@ -95,21 +96,21 @@ class TestX963KDF:
                 hashes.SHA256(), 16, sharedinfo=None, backend=backend
             )
 
-            xkdf.derive("foo")  # type: ignore[arg-type]
+            xkdf.derive(typing.cast(typing.Any, "foo"))
 
         with pytest.raises(TypeError):
             xkdf = X963KDF(
                 hashes.SHA256(), 16, sharedinfo=None, backend=backend
             )
 
-            xkdf.verify("foo", b"bar")  # type: ignore[arg-type]
+            xkdf.verify(typing.cast(typing.Any, "foo"), b"bar")
 
         with pytest.raises(TypeError):
             xkdf = X963KDF(
                 hashes.SHA256(), 16, sharedinfo=None, backend=backend
             )
 
-            xkdf.verify(b"foo", "bar")  # type: ignore[arg-type]
+            xkdf.verify(b"foo", typing.cast(typing.Any, "bar"))
 
     def test_derive_into(self, backend):
         key = binascii.unhexlify(

--- a/tests/hazmat/primitives/test_xofhash.py
+++ b/tests/hazmat/primitives/test_xofhash.py
@@ -7,6 +7,7 @@ import binascii
 import os
 import random
 import sys
+import typing
 
 import pytest
 
@@ -42,15 +43,15 @@ class TestXOFHash:
     def test_hash_reject_unicode(self, backend):
         m = hashes.XOFHash(hashes.SHAKE128(sys.maxsize))
         with pytest.raises(TypeError):
-            m.update("\u00fc")  # type: ignore[arg-type]
+            m.update(typing.cast(typing.Any, "\u00fc"))
 
     def test_incorrect_hash_algorithm_type(self, backend):
         with pytest.raises(TypeError):
             # Instance required
-            hashes.XOFHash(hashes.SHAKE128)  # type: ignore[arg-type]
+            hashes.XOFHash(typing.cast(typing.Any, hashes.SHAKE128))
 
         with pytest.raises(TypeError):
-            hashes.XOFHash(hashes.SHA256())  # type: ignore[arg-type]
+            hashes.XOFHash(typing.cast(typing.Any, hashes.SHA256()))
 
     def test_raises_update_after_squeeze(self, backend):
         h = hashes.XOFHash(hashes.SHAKE128(digest_size=256))

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -4,6 +4,7 @@
 
 
 import os
+import typing
 
 import pytest
 
@@ -42,7 +43,7 @@ class TestHOTP:
         secret = os.urandom(16)
 
         with pytest.raises(TypeError):
-            HOTP(secret, 6, MD5(), backend)  # type: ignore[arg-type]
+            HOTP(secret, 6, typing.cast(typing.Any, MD5()), backend)
 
     @pytest.mark.parametrize("params", vectors)
     def test_truncate(self, backend, params):
@@ -86,7 +87,7 @@ class TestHOTP:
         secret = b"12345678901234567890"
 
         with pytest.raises(TypeError):
-            HOTP(secret, b"foo", SHA1(), backend)  # type: ignore[arg-type]
+            HOTP(secret, typing.cast(typing.Any, b"foo"), SHA1(), backend)
 
     def test_get_provisioning_uri(self, backend):
         secret = b"12345678901234567890"
@@ -113,7 +114,7 @@ class TestHOTP:
         hotp = HOTP(key, 6, SHA1(), backend)
 
         with pytest.raises(TypeError):
-            hotp.generate(2.5)  # type: ignore[arg-type]
+            hotp.generate(typing.cast(typing.Any, 2.5))
 
         with pytest.raises(ValueError):
             hotp.generate(2**64)

--- a/tests/hazmat/primitives/twofactor/test_totp.py
+++ b/tests/hazmat/primitives/twofactor/test_totp.py
@@ -3,6 +3,8 @@
 # for complete details.
 
 
+import typing
+
 import pytest
 
 from cryptography.hazmat.primitives import hashes
@@ -148,4 +150,4 @@ class TestTOTP:
         totp = TOTP(key, 8, hashes.SHA1(), 30, backend)
 
         with pytest.raises(TypeError):
-            totp.generate("test")  # type: ignore[arg-type]
+            totp.generate(typing.cast(typing.Any, "test"))

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -8,6 +8,7 @@ import datetime
 import json
 import os
 import time
+import typing
 
 import pretend
 import pytest
@@ -116,9 +117,9 @@ class TestFernet:
     def test_invalid_types(self, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
         with pytest.raises(TypeError):
-            f.encrypt("")  # type: ignore[arg-type]
+            f.encrypt(typing.cast(typing.Any, ""))
         with pytest.raises(TypeError):
-            f.decrypt(12345)  # type: ignore[arg-type]
+            f.decrypt(typing.cast(typing.Any, 12345))
 
     def test_timestamp_ignored_no_ttl(self, monkeypatch, backend):
         f = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)
@@ -134,7 +135,7 @@ class TestFernet:
         with pytest.raises(ValueError):
             f.decrypt_at_time(
                 token,
-                ttl=None,  # type: ignore[arg-type]
+                ttl=typing.cast(typing.Any, None),
                 current_time=int(time.time()),
             )
 
@@ -199,7 +200,7 @@ class TestMultiFernet:
         with pytest.raises(ValueError):
             f.decrypt_at_time(
                 token,
-                ttl=None,  # type: ignore[arg-type]
+                ttl=typing.cast(typing.Any, None),
                 current_time=100,
             )
 
@@ -209,7 +210,7 @@ class TestMultiFernet:
 
     def test_non_iterable_argument(self, backend):
         with pytest.raises(TypeError):
-            MultiFernet(None)  # type: ignore[arg-type]
+            MultiFernet(typing.cast(typing.Any, None))
 
     def test_rotate_bytes(self, backend):
         f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -512,7 +512,7 @@ class TestOCSPResponseBuilder:
         with pytest.raises(ValueError):
             builder.certificates([])
         with pytest.raises(TypeError):
-            builder.certificates(["notacert"])  # type: ignore[list-item]
+            builder.certificates([typing.cast(typing.Any, "notacert")])
         with pytest.raises(TypeError):
             builder.certificates(typing.cast(typing.Any, "invalid"))
 
@@ -1186,7 +1186,7 @@ class TestSignedCertificateTimestampsExtension:
     def test_init(self):
         with pytest.raises(TypeError):
             x509.SignedCertificateTimestamps(
-                [object()]  # type: ignore[list-item]
+                [typing.cast(typing.Any, object())]
             )
 
     def test_repr(self):

--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -6,6 +6,7 @@
 import base64
 import datetime
 import os
+import typing
 from typing import Optional
 
 import pytest
@@ -237,7 +238,7 @@ class TestOCSPRequestBuilder:
                 b"0" * 20,
                 b"0" * 20,
                 1,
-                "notahash",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notahash"),
             )
         with pytest.raises(ValueError):
             builder.add_certificate_by_hash(
@@ -251,7 +252,7 @@ class TestOCSPRequestBuilder:
             builder.add_certificate_by_hash(
                 b"0" * 20,
                 b"0" * 20,
-                "notanint",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanint"),
                 hashes.SHA1(),
             )
 
@@ -276,7 +277,7 @@ class TestOCSPRequestBuilder:
         builder = ocsp.OCSPRequestBuilder()
         with pytest.raises(TypeError):
             builder.add_extension(
-                "notanext",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanext"),
                 False,
             )
 
@@ -295,7 +296,7 @@ class TestOCSPRequestBuilder:
         builder = ocsp.OCSPRequestBuilder()
         with pytest.raises(TypeError):
             builder.add_certificate(
-                b"notacert",  # type:ignore[arg-type]
+                typing.cast(typing.Any, b"notacert"),
                 issuer,
                 hashes.SHA1(),
             )
@@ -303,7 +304,7 @@ class TestOCSPRequestBuilder:
         with pytest.raises(TypeError):
             builder.add_certificate(
                 cert,
-                b"notacert",  # type:ignore[arg-type]
+                typing.cast(typing.Any, b"notacert"),
                 hashes.SHA1(),
             )
 
@@ -396,7 +397,7 @@ class TestOCSPResponseBuilder:
         builder = ocsp.OCSPResponseBuilder()
         with pytest.raises(TypeError):
             builder.add_response(
-                "bad",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "bad"),
                 issuer,
                 hashes.SHA256(),
                 ocsp.OCSPCertStatus.GOOD,
@@ -408,7 +409,7 @@ class TestOCSPResponseBuilder:
         with pytest.raises(TypeError):
             builder.add_response(
                 cert,
-                "bad",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "bad"),
                 hashes.SHA256(),
                 ocsp.OCSPCertStatus.GOOD,
                 time,
@@ -420,7 +421,7 @@ class TestOCSPResponseBuilder:
             builder.add_response(
                 cert,
                 issuer,
-                "notahash",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notahash"),
                 ocsp.OCSPCertStatus.GOOD,
                 time,
                 time,
@@ -433,7 +434,7 @@ class TestOCSPResponseBuilder:
                 issuer,
                 hashes.SHA256(),
                 ocsp.OCSPCertStatus.GOOD,
-                "bad",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "bad"),
                 time,
                 None,
                 None,
@@ -445,7 +446,7 @@ class TestOCSPResponseBuilder:
                 hashes.SHA256(),
                 ocsp.OCSPCertStatus.GOOD,
                 time,
-                "bad",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "bad"),
                 None,
                 None,
             )
@@ -455,7 +456,7 @@ class TestOCSPResponseBuilder:
                 cert,
                 issuer,
                 hashes.SHA256(),
-                0,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 0),
                 time,
                 time,
                 None,
@@ -503,7 +504,7 @@ class TestOCSPResponseBuilder:
                 time,
                 time,
                 time,
-                0,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 0),
             )
 
     def test_invalid_certificates(self):
@@ -513,7 +514,7 @@ class TestOCSPResponseBuilder:
         with pytest.raises(TypeError):
             builder.certificates(["notacert"])  # type: ignore[list-item]
         with pytest.raises(TypeError):
-            builder.certificates("invalid")  # type: ignore[arg-type]
+            builder.certificates(typing.cast(typing.Any, "invalid"))
 
         _, issuer = _cert_and_issuer()
         builder = builder.certificates([issuer])
@@ -526,10 +527,10 @@ class TestOCSPResponseBuilder:
         with pytest.raises(TypeError):
             builder.responder_id(
                 ocsp.OCSPResponderEncoding.HASH,
-                "invalid",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "invalid"),
             )
         with pytest.raises(TypeError):
-            builder.responder_id("notanenum", cert)  # type: ignore[arg-type]
+            builder.responder_id(typing.cast(typing.Any, "notanenum"), cert)
 
         builder = builder.responder_id(ocsp.OCSPResponderEncoding.NAME, cert)
         with pytest.raises(ValueError):
@@ -539,7 +540,7 @@ class TestOCSPResponseBuilder:
         builder = ocsp.OCSPResponseBuilder()
         with pytest.raises(TypeError):
             builder.add_extension(
-                "notanextension",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notanextension"),
                 True,
             )
 
@@ -625,7 +626,7 @@ class TestOCSPResponseBuilder:
             None,
         )
         with pytest.raises(TypeError):
-            builder.sign(private_key, "notahash")  # type: ignore[arg-type]
+            builder.sign(private_key, typing.cast(typing.Any, "notahash"))
 
     def test_sign_good_cert(self):
         builder = ocsp.OCSPResponseBuilder()
@@ -962,7 +963,7 @@ class TestOCSPResponseBuilder:
     def test_invalid_build_not_a_status(self):
         with pytest.raises(TypeError):
             ocsp.OCSPResponseBuilder.build_unsuccessful(
-                "notastatus"  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notastatus")
             )
 
     def test_invalid_build_successful_status(self):
@@ -995,7 +996,7 @@ class TestOCSPResponseBuilder:
             None,
         )
         with pytest.raises(TypeError):
-            builder.sign(object(), hashes.SHA256())  # type:ignore[arg-type]
+            builder.sign(typing.cast(typing.Any, object()), hashes.SHA256())
 
     def test_add_response_by_hash(self):
         builder = ocsp.OCSPResponseBuilder()
@@ -1077,7 +1078,7 @@ class TestOCSPResponseBuilder:
                 b"0" * 20,
                 b"0" * 20,
                 1,
-                "notahash",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notahash"),
                 ocsp.OCSPCertStatus.GOOD,
                 time,
                 time,
@@ -1112,7 +1113,7 @@ class TestOCSPResponseBuilder:
             builder.add_response_by_hash(
                 b"0" * 20,
                 b"0" * 20,
-                "notanint",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notanint"),
                 hashes.SHA1(),
                 ocsp.OCSPCertStatus.GOOD,
                 time,

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -6390,7 +6390,7 @@ class TestNameAttribute:
         with pytest.raises(TypeError):
             x509.NameAttribute(
                 NameOID.ORGANIZATION_NAME,
-                None,  # type:ignore[type-var]
+                typing.cast(typing.Any, None),
             )
 
     def test_init_bad_length(self):
@@ -6492,7 +6492,7 @@ class TestRelativeDistinguishedName:
     def test_init_not_nameattribute(self):
         with pytest.raises(TypeError):
             x509.RelativeDistinguishedName(
-                ["not-a-NameAttribute"]  # type:ignore[list-item]
+                [typing.cast(typing.Any, "not-a-NameAttribute")]
             )
 
     def test_init_duplicate_attribute(self):
@@ -6766,7 +6766,7 @@ class TestName:
 
     def test_not_nameattribute(self):
         with pytest.raises(TypeError):
-            x509.Name(["not-a-NameAttribute"])  # type: ignore[list-item]
+            x509.Name([typing.cast(typing.Any, "not-a-NameAttribute")])
 
     def test_bytes(self, backend):
         name = x509.Name(

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -564,7 +564,7 @@ class TestCertificateRevocationList:
         )
 
         with pytest.raises(TypeError):
-            crl.public_bytes("NotAnEncoding")  # type: ignore[arg-type]
+            crl.public_bytes(typing.cast(typing.Any, "NotAnEncoding"))
 
     def test_verify_bad(self, backend):
         crl = _load_cert(
@@ -610,12 +610,10 @@ class TestCertificateRevocationList:
         )
 
         with pytest.raises(TypeError):
-            crl.is_signature_valid(
-                "not a public key"  # type: ignore[arg-type]
-            )
+            crl.is_signature_valid(typing.cast(typing.Any, "not a public key"))
 
         with pytest.raises(TypeError):
-            crl.is_signature_valid(object)  # type: ignore[arg-type]
+            crl.is_signature_valid(typing.cast(typing.Any, object))
 
     def test_crl_issuer_invalid_printable_string(self):
         data = _load_cert(
@@ -1707,7 +1705,7 @@ class TestRSACertificate:
         )
 
         with pytest.raises(TypeError):
-            cert.public_bytes("NotAnEncoding")  # type: ignore[arg-type]
+            cert.public_bytes(typing.cast(typing.Any, "NotAnEncoding"))
 
     @pytest.mark.parametrize(
         ("cert_path", "loader_func", "encoding"),
@@ -2319,7 +2317,7 @@ class TestRSACertificateRequest:
         )
 
         with pytest.raises(TypeError):
-            request.public_bytes("NotAnEncoding")  # type: ignore[arg-type]
+            request.public_bytes(typing.cast(typing.Any, "NotAnEncoding"))
 
     def test_signature_invalid(self, backend):
         request = _load_cert(
@@ -2970,7 +2968,7 @@ class TestCertificateBuilder:
             builder.sign(
                 rsa_key_2048,
                 hashes.SHA256(),
-                rsa_padding=b"notapadding",  # type: ignore[arg-type]
+                rsa_padding=typing.cast(typing.Any, b"notapadding"),
             )
         eckey = ec.generate_private_key(ec.SECP256R1())
         with pytest.raises(TypeError):
@@ -3104,10 +3102,10 @@ class TestCertificateBuilder:
         builder = x509.CertificateBuilder()
 
         with pytest.raises(TypeError):
-            builder.issuer_name("subject")  # type:ignore[arg-type]
+            builder.issuer_name(typing.cast(typing.Any, "subject"))
 
         with pytest.raises(TypeError):
-            builder.issuer_name(object)  # type:ignore[arg-type]
+            builder.issuer_name(typing.cast(typing.Any, object))
 
     def test_issuer_name_may_only_be_set_once(self):
         name = x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
@@ -3120,10 +3118,10 @@ class TestCertificateBuilder:
         builder = x509.CertificateBuilder()
 
         with pytest.raises(TypeError):
-            builder.subject_name("subject")  # type:ignore[arg-type]
+            builder.subject_name(typing.cast(typing.Any, "subject"))
 
         with pytest.raises(TypeError):
-            builder.subject_name(object)  # type:ignore[arg-type]
+            builder.subject_name(typing.cast(typing.Any, object))
 
     def test_subject_name_may_only_be_set_once(self):
         name = x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
@@ -3155,7 +3153,7 @@ class TestCertificateBuilder:
         builder = x509.CertificateBuilder()
 
         with pytest.raises(TypeError):
-            builder.public_key(private_key)  # type: ignore[arg-type]
+            builder.public_key(typing.cast(typing.Any, private_key))
 
     def test_public_key_may_only_be_set_once(
         self, rsa_key_2048: rsa.RSAPrivateKey, backend
@@ -3214,16 +3212,19 @@ class TestCertificateBuilder:
         with pytest.raises(TypeError):
             x509.CertificateBuilder().public_key(
                 rsa_key_2048.public_key(),
-                rsa_padding=padding.PSS(  # type: ignore[arg-type]
-                    mgf=padding.MGF1(hashes.SHA256()),
-                    salt_length=padding.PSS.DIGEST_LENGTH,
+                rsa_padding=typing.cast(
+                    typing.Any,
+                    padding.PSS(
+                        mgf=padding.MGF1(hashes.SHA256()),
+                        salt_length=padding.PSS.DIGEST_LENGTH,
+                    ),
                 ),
             )
 
         with pytest.raises(TypeError):
             x509.CertificateBuilder().public_key(
                 rsa_key_2048.public_key(),
-                rsa_padding=padding.PKCS1v15,  # type: ignore[arg-type]
+                rsa_padding=typing.cast(typing.Any, padding.PKCS1v15),
             )
 
     def test_public_key_rsa_padding_requires_rsa_key(self, backend):
@@ -3237,7 +3238,7 @@ class TestCertificateBuilder:
     def test_serial_number_must_be_an_integer_type(self):
         with pytest.raises(TypeError):
             x509.CertificateBuilder().serial_number(
-                10.0  # type:ignore[arg-type]
+                typing.cast(typing.Any, 10.0)
             )
 
     def test_serial_number_must_be_non_negative(self):
@@ -3351,12 +3352,12 @@ class TestCertificateBuilder:
     def test_invalid_not_valid_after(self):
         with pytest.raises(TypeError):
             x509.CertificateBuilder().not_valid_after(
-                104204304504  # type:ignore[arg-type]
+                typing.cast(typing.Any, 104204304504)
             )
 
         with pytest.raises(TypeError):
             x509.CertificateBuilder().not_valid_after(
-                datetime.time()  # type:ignore[arg-type]
+                typing.cast(typing.Any, datetime.time())
             )
 
         with pytest.raises(ValueError):
@@ -3400,12 +3401,12 @@ class TestCertificateBuilder:
     def test_invalid_not_valid_before(self):
         with pytest.raises(TypeError):
             x509.CertificateBuilder().not_valid_before(
-                104204304504  # type:ignore[arg-type]
+                typing.cast(typing.Any, 104204304504)
             )
 
         with pytest.raises(TypeError):
             x509.CertificateBuilder().not_valid_before(
-                datetime.time()  # type:ignore[arg-type]
+                typing.cast(typing.Any, datetime.time())
             )
 
         with pytest.raises(ValueError):
@@ -3438,7 +3439,7 @@ class TestCertificateBuilder:
 
         with pytest.raises(TypeError):
             builder.add_extension(
-                object(),  # type:ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 False,
             )
 
@@ -3596,7 +3597,7 @@ class TestCertificateBuilder:
         with pytest.raises(UnsupportedAlgorithm):
             builder.sign(
                 private_key,
-                hashes.MD5(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, hashes.MD5()),
                 backend,
             )
 
@@ -4841,7 +4842,7 @@ class TestCertificateSigningRequestBuilder:
         with pytest.raises(TypeError):
             builder.sign(
                 private_key,
-                "NotAHash",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "NotAHash"),
                 backend,
             )
 
@@ -5333,14 +5334,14 @@ class TestCertificateSigningRequestBuilder:
     def test_set_invalid_subject(self):
         builder = x509.CertificateSigningRequestBuilder()
         with pytest.raises(TypeError):
-            builder.subject_name("NotAName")  # type:ignore[arg-type]
+            builder.subject_name(typing.cast(typing.Any, "NotAName"))
 
     def test_add_invalid_extension_type(self):
         builder = x509.CertificateSigningRequestBuilder()
 
         with pytest.raises(TypeError):
             builder.add_extension(
-                object(),  # type:ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 False,
             )
 
@@ -5472,14 +5473,14 @@ class TestCertificateSigningRequestBuilder:
         request = x509.CertificateSigningRequestBuilder()
         with pytest.raises(TypeError):
             request.add_attribute(
-                b"not an oid",  # type:ignore[arg-type]
+                typing.cast(typing.Any, b"not an oid"),
                 b"val",
             )
 
         with pytest.raises(TypeError):
             request.add_attribute(
                 x509.oid.AttributeOID.CHALLENGE_PASSWORD,
-                383,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 383),
             )
 
     def test_duplicate_attribute(self, backend):
@@ -5518,7 +5519,7 @@ class TestCertificateSigningRequestBuilder:
             builder.add_attribute(
                 x509.ObjectIdentifier("1.2.3.4"),
                 b"",
-                _tag=object(),  # type:ignore[arg-type]
+                _tag=typing.cast(typing.Any, object()),
             )
 
     def test_set_subject_twice(self):
@@ -5763,7 +5764,7 @@ class TestCertificateSigningRequestBuilder:
             builder.sign(
                 rsa_key_2048,
                 hashes.SHA256(),
-                rsa_padding=b"notapadding",  # type: ignore[arg-type]
+                rsa_padding=typing.cast(typing.Any, b"notapadding"),
             )
         eckey = ec.generate_private_key(ec.SECP256R1())
         with pytest.raises(TypeError):
@@ -6361,7 +6362,7 @@ class TestNameAttribute:
     def test_init_bad_oid(self):
         with pytest.raises(TypeError):
             x509.NameAttribute(
-                None,  # type:ignore[arg-type]
+                typing.cast(typing.Any, None),
                 "value",
             )
 
@@ -6412,7 +6413,7 @@ class TestNameAttribute:
             x509.NameAttribute(
                 NameOID.COMMON_NAME,
                 "common",
-                "notanenum",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanenum"),
             )
 
     def test_eq(self):

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -4,6 +4,7 @@
 
 
 import datetime
+import typing
 
 import pytest
 
@@ -42,7 +43,7 @@ class TestCertificateRevocationListBuilder:
     def test_issuer_name_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
         with pytest.raises(TypeError):
-            builder.issuer_name("notanx509name")  # type:ignore[arg-type]
+            builder.issuer_name(typing.cast(typing.Any, "notanx509name"))
 
     def test_set_issuer_name_twice(self):
         builder = x509.CertificateRevocationListBuilder().issuer_name(
@@ -84,7 +85,7 @@ class TestCertificateRevocationListBuilder:
     def test_last_update_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
         with pytest.raises(TypeError):
-            builder.last_update("notadatetime")  # type:ignore[arg-type]
+            builder.last_update(typing.cast(typing.Any, "notadatetime"))
 
     def test_last_update_before_1950(self):
         builder = x509.CertificateRevocationListBuilder()
@@ -129,7 +130,7 @@ class TestCertificateRevocationListBuilder:
     def test_next_update_invalid(self):
         builder = x509.CertificateRevocationListBuilder()
         with pytest.raises(TypeError):
-            builder.next_update("notadatetime")  # type:ignore[arg-type]
+            builder.next_update(typing.cast(typing.Any, "notadatetime"))
 
     def test_next_update_before_1950(self):
         builder = x509.CertificateRevocationListBuilder()
@@ -169,13 +170,13 @@ class TestCertificateRevocationListBuilder:
         builder = x509.CertificateRevocationListBuilder()
 
         with pytest.raises(TypeError):
-            builder.add_extension(object(), False)  # type:ignore[arg-type]
+            builder.add_extension(typing.cast(typing.Any, object()), False)
 
     def test_add_invalid_revoked_certificate(self):
         builder = x509.CertificateRevocationListBuilder()
 
         with pytest.raises(TypeError):
-            builder.add_revoked_certificate(object())  # type:ignore[arg-type]
+            builder.add_revoked_certificate(typing.cast(typing.Any, object()))
 
     def test_no_issuer_name(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
         private_key = rsa_key_2048
@@ -238,7 +239,7 @@ class TestCertificateRevocationListBuilder:
             builder.sign(
                 rsa_key_2048,
                 hashes.SHA256(),
-                rsa_padding=b"notapadding",  # type: ignore[arg-type]
+                rsa_padding=typing.cast(typing.Any, b"notapadding"),
             )
         eckey = ec.generate_private_key(ec.SECP256R1())
         with pytest.raises(TypeError):
@@ -536,7 +537,7 @@ class TestCertificateRevocationListBuilder:
         with pytest.raises(TypeError):
             builder.sign(
                 private_key,
-                object(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 backend,
             )
 
@@ -562,7 +563,7 @@ class TestCertificateRevocationListBuilder:
         with pytest.raises(TypeError):
             builder.sign(
                 private_key,
-                object(),  # type:ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 backend,
             )
         with pytest.raises(ValueError):
@@ -594,7 +595,7 @@ class TestCertificateRevocationListBuilder:
         with pytest.raises(TypeError):
             builder.sign(
                 private_key,
-                object(),  # type:ignore[arg-type]
+                typing.cast(typing.Any, object()),
                 backend,
             )
         with pytest.raises(ValueError):
@@ -893,7 +894,7 @@ class TestCertificateRevocationListBuilder:
         with pytest.raises(UnsupportedAlgorithm):
             builder.sign(
                 private_key,
-                hashes.MD5(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, hashes.MD5()),
                 backend,
             )
 
@@ -920,7 +921,7 @@ class TestCertificateRevocationListBuilder:
         with pytest.raises(UnsupportedAlgorithm):
             builder.sign(
                 private_key,
-                hashes.MD5(),  # type: ignore[arg-type]
+                typing.cast(typing.Any, hashes.MD5()),
                 backend,
             )
 

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -145,7 +145,7 @@ class TestExtension:
 class TestTLSFeature:
     def test_not_enum_type(self):
         with pytest.raises(TypeError):
-            x509.TLSFeature([3])  # type:ignore[list-item]
+            x509.TLSFeature([typing.cast(typing.Any, 3)])
 
     def test_empty_list(self):
         with pytest.raises(TypeError):
@@ -470,7 +470,7 @@ class TestNoticeReference:
         with pytest.raises(TypeError):
             x509.NoticeReference(
                 "org",
-                [1, 2, "three"],  # type:ignore[list-item]
+                [1, 2, typing.cast(typing.Any, "three")],
             )
 
     def test_notice_numbers_none(self):
@@ -574,7 +574,7 @@ class TestPolicyInformation:
         with pytest.raises(TypeError):
             x509.PolicyInformation(
                 x509.ObjectIdentifier("1.2.3"),
-                [1, 2],  # type:ignore[list-item]
+                [typing.cast(typing.Any, 1), typing.cast(typing.Any, 2)],
             )
 
     def test_iter_input(self):
@@ -637,7 +637,7 @@ class TestCertificatePolicies:
         pq = ["string"]
         pi = x509.PolicyInformation(x509.ObjectIdentifier("1.2.3"), pq)
         with pytest.raises(TypeError):
-            x509.CertificatePolicies([1, pi])  # type:ignore[list-item]
+            x509.CertificatePolicies([typing.cast(typing.Any, 1), pi])
 
     def test_iter_len(self):
         pq = ["string"]
@@ -1245,7 +1245,7 @@ class TestAuthorityKeyIdentifier:
         with pytest.raises(TypeError):
             x509.AuthorityKeyIdentifier(
                 b"identifier",
-                ["notname"],  # type:ignore[list-item]
+                [typing.cast(typing.Any, "notname")],
                 3,
             )
 
@@ -1436,7 +1436,7 @@ class TestBasicConstraints:
 class TestExtendedKeyUsage:
     def test_not_all_oids(self):
         with pytest.raises(TypeError):
-            x509.ExtendedKeyUsage(["notoid"])  # type:ignore[list-item]
+            x509.ExtendedKeyUsage([typing.cast(typing.Any, "notoid")])
 
     def test_iter_len(self):
         eku = x509.ExtendedKeyUsage(
@@ -3130,7 +3130,7 @@ class TestAuthorityInformationAccess:
     def test_invalid_descriptions(self):
         with pytest.raises(TypeError):
             x509.AuthorityInformationAccess(
-                ["notanAccessDescription"]  # type:ignore[list-item]
+                [typing.cast(typing.Any, "notanAccessDescription")]
             )
 
     def test_iter_len(self):
@@ -3336,7 +3336,7 @@ class TestSubjectInformationAccess:
     def test_invalid_descriptions(self):
         with pytest.raises(TypeError):
             x509.SubjectInformationAccess(
-                ["notanAccessDescription"]  # type:ignore[list-item]
+                [typing.cast(typing.Any, "notanAccessDescription")]
             )
 
     def test_iter_len(self):
@@ -4156,7 +4156,7 @@ class TestDistributionPoint:
     def test_distribution_point_full_name_not_general_names(self):
         with pytest.raises(TypeError):
             x509.DistributionPoint(
-                ["notgn"],  # type:ignore[list-item]
+                [typing.cast(typing.Any, "notgn")],
                 None,
                 None,
                 None,
@@ -4192,7 +4192,7 @@ class TestDistributionPoint:
                 None,
                 None,
                 None,
-                ["notgn"],  # type:ignore[list-item]
+                [typing.cast(typing.Any, "notgn")],
             )
 
     def test_reason_not_reasonflags(self):
@@ -4200,7 +4200,7 @@ class TestDistributionPoint:
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier("http://crypt.og/crl")],
                 None,
-                frozenset(["notreasonflags"]),  # type:ignore[list-item]
+                frozenset([typing.cast(typing.Any, "notreasonflags")]),
                 None,
             )
 
@@ -4392,7 +4392,7 @@ class TestFreshestCRL:
     def test_invalid_distribution_points(self):
         with pytest.raises(TypeError):
             x509.FreshestCRL(
-                ["notadistributionpoint"]  # type:ignore[list-item]
+                [typing.cast(typing.Any, "notadistributionpoint")]
             )
 
     def test_iter_len(self):
@@ -4643,7 +4643,7 @@ class TestCRLDistributionPoints:
     def test_invalid_distribution_points(self):
         with pytest.raises(TypeError):
             x509.CRLDistributionPoints(
-                ["notadistributionpoint"],  # type:ignore[list-item]
+                [typing.cast(typing.Any, "notadistributionpoint")],
             )
 
     def test_iter_len(self):
@@ -6134,7 +6134,7 @@ class TestPrecertificateSignedCertificateTimestampsExtension:
     def test_init(self):
         with pytest.raises(TypeError):
             x509.PrecertificateSignedCertificateTimestamps(
-                [object()]  # type:ignore[list-item]
+                [typing.cast(typing.Any, object())]
             )
 
     def test_repr(self):
@@ -6480,7 +6480,7 @@ class TestOCSPAcceptableResponses:
         with pytest.raises(TypeError):
             x509.OCSPAcceptableResponses(typing.cast(typing.Any, 38))
         with pytest.raises(TypeError):
-            x509.OCSPAcceptableResponses([38])  # type:ignore[list-item]
+            x509.OCSPAcceptableResponses([typing.cast(typing.Any, 38)])
 
     def test_eq(self):
         acceptable_responses1 = x509.OCSPAcceptableResponses(
@@ -6758,7 +6758,7 @@ class TestProfessionInfo:
         with pytest.raises(TypeError):
             x509.ProfessionInfo(
                 None,
-                [42],  # type:ignore[list-item]
+                [typing.cast(typing.Any, 42)],
                 [],
                 None,
                 None,
@@ -7014,7 +7014,7 @@ class TestAdmission:
             x509.Admission(
                 None,
                 None,
-                [42],  # type:ignore[list-item]
+                [typing.cast(typing.Any, 42)],
             )
 
     def test_eq(self):
@@ -7332,12 +7332,12 @@ class TestAdmissions:
         with pytest.raises(TypeError):
             x509.Admissions(
                 None,
-                [42],  # type:ignore[list-item]
+                [typing.cast(typing.Any, 42)],
             )
         with pytest.raises(TypeError):
             x509.Admissions(
                 None,
-                [None],  # type:ignore[list-item]
+                [typing.cast(typing.Any, None)],
             )
 
     def test_eq(self):

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -63,14 +63,14 @@ class TestExtension:
     def test_not_an_oid(self):
         bc = x509.BasicConstraints(ca=False, path_length=None)
         with pytest.raises(TypeError):
-            x509.Extension("notanoid", True, bc)  # type:ignore[arg-type]
+            x509.Extension(typing.cast(typing.Any, "notanoid"), True, bc)
 
     def test_critical_not_a_bool(self):
         bc = x509.BasicConstraints(ca=False, path_length=None)
         with pytest.raises(TypeError):
             x509.Extension(
                 ExtensionOID.BASIC_CONSTRAINTS,
-                "notabool",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notabool"),
                 bc,
             )
 
@@ -221,7 +221,7 @@ class TestUnrecognizedExtension:
     def test_invalid_oid(self):
         with pytest.raises(TypeError):
             x509.UnrecognizedExtension(
-                "notanoid",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanoid"),
                 b"somedata",
             )
 
@@ -349,7 +349,7 @@ class TestCertificateIssuer:
 class TestCRLReason:
     def test_invalid_reason_flags(self):
         with pytest.raises(TypeError):
-            x509.CRLReason("notareason")  # type:ignore[arg-type]
+            x509.CRLReason(typing.cast(typing.Any, "notareason"))
 
     def test_eq(self):
         reason1 = x509.CRLReason(x509.ReasonFlags.unspecified)
@@ -382,7 +382,7 @@ class TestCRLReason:
 class TestDeltaCRLIndicator:
     def test_not_int(self):
         with pytest.raises(TypeError):
-            x509.DeltaCRLIndicator("notanint")  # type:ignore[arg-type]
+            x509.DeltaCRLIndicator(typing.cast(typing.Any, "notanint"))
 
     def test_eq(self):
         delta1 = x509.DeltaCRLIndicator(1)
@@ -414,7 +414,7 @@ class TestDeltaCRLIndicator:
 class TestInvalidityDate:
     def test_invalid_invalidity_date(self):
         with pytest.raises(TypeError):
-            x509.InvalidityDate("notadate")  # type:ignore[arg-type]
+            x509.InvalidityDate(typing.cast(typing.Any, "notadate"))
 
     def test_eq(self):
         invalid1 = x509.InvalidityDate(datetime.datetime(2015, 1, 1, 1, 1))
@@ -475,7 +475,7 @@ class TestNoticeReference:
 
     def test_notice_numbers_none(self):
         with pytest.raises(TypeError):
-            x509.NoticeReference("org", None)  # type:ignore[arg-type]
+            x509.NoticeReference("org", typing.cast(typing.Any, None))
 
     def test_iter_input(self):
         numbers = [1, 3, 4]
@@ -513,7 +513,7 @@ class TestNoticeReference:
 class TestUserNotice:
     def test_notice_reference_invalid(self):
         with pytest.raises(TypeError):
-            x509.UserNotice("invalid", None)  # type:ignore[arg-type]
+            x509.UserNotice(typing.cast(typing.Any, "invalid"), None)
 
     def test_notice_reference_none(self):
         un = x509.UserNotice(None, "text")
@@ -557,7 +557,7 @@ class TestUserNotice:
 class TestPolicyInformation:
     def test_invalid_policy_identifier(self):
         with pytest.raises(TypeError):
-            x509.PolicyInformation("notanoid", None)  # type:ignore[arg-type]
+            x509.PolicyInformation(typing.cast(typing.Any, "notanoid"), None)
 
     def test_none_policy_qualifiers(self):
         pi = x509.PolicyInformation(x509.ObjectIdentifier("1.2.3"), None)
@@ -1266,7 +1266,7 @@ class TestAuthorityKeyIdentifier:
             x509.AuthorityKeyIdentifier(
                 b"identifier",
                 [dirname],
-                "notanint",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanint"),
             )
 
     def test_authority_issuer_none_serial_not_none(self):
@@ -1379,7 +1379,7 @@ class TestBasicConstraints:
     def test_ca_not_boolean(self):
         with pytest.raises(TypeError):
             x509.BasicConstraints(
-                ca="notbool",  # type:ignore[arg-type]
+                ca=typing.cast(typing.Any, "notbool"),
                 path_length=None,
             )
 
@@ -1391,13 +1391,13 @@ class TestBasicConstraints:
         with pytest.raises(TypeError):
             x509.BasicConstraints(
                 ca=True,
-                path_length=1.1,  # type:ignore[arg-type]
+                path_length=typing.cast(typing.Any, 1.1),
             )
 
         with pytest.raises(TypeError):
             x509.BasicConstraints(
                 ca=True,
-                path_length="notint",  # type:ignore[arg-type]
+                path_length=typing.cast(typing.Any, "notint"),
             )
 
     def test_path_length_negative(self):
@@ -1872,7 +1872,10 @@ class TestKeyUsageExtension:
 class TestPrivateKeyUsagePeriodExtension:
     def test_not_validity(self):
         with pytest.raises(TypeError):
-            x509.PrivateKeyUsagePeriod("notValidBefore", "notValidAfter")  # type:ignore[arg-type]
+            x509.PrivateKeyUsagePeriod(
+                typing.cast(typing.Any, "notValidBefore"),
+                typing.cast(typing.Any, "notValidAfter"),
+            )
 
     def test_repr(self):
         period = x509.PrivateKeyUsagePeriod(
@@ -1934,7 +1937,7 @@ class TestPrivateKeyUsagePeriodExtension:
         with pytest.raises(TypeError):
             x509.PrivateKeyUsagePeriod(
                 not_before=datetime.datetime(2012, 1, 1),
-                not_after="invalid type",  # type:ignore[arg-type]
+                not_after=typing.cast(typing.Any, "invalid type"),
             )
 
     def test_not_before_after_not_after(self):
@@ -2096,10 +2099,10 @@ class TestDNSName:
         assert name.value == "*.xn--4ca7aey.example.com"
 
         with pytest.raises(TypeError):
-            x509.DNSName(1.3)  # type:ignore[arg-type]
+            x509.DNSName(typing.cast(typing.Any, 1.3))
 
         with pytest.raises(TypeError):
-            x509.DNSName(b"bytes not allowed")  # type:ignore[arg-type]
+            x509.DNSName(typing.cast(typing.Any, b"bytes not allowed"))
 
     def test_ne(self):
         n1 = x509.DNSName("test1")
@@ -2119,10 +2122,10 @@ class TestDNSName:
 class TestDirectoryName:
     def test_not_name(self):
         with pytest.raises(TypeError):
-            x509.DirectoryName(b"notaname")  # type:ignore[arg-type]
+            x509.DirectoryName(typing.cast(typing.Any, b"notaname"))
 
         with pytest.raises(TypeError):
-            x509.DirectoryName(1.3)  # type:ignore[arg-type]
+            x509.DirectoryName(typing.cast(typing.Any, 1.3))
 
     def test_repr(self):
         name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "value1")])
@@ -2181,10 +2184,10 @@ class TestRFC822Name:
 
     def test_not_text(self):
         with pytest.raises(TypeError):
-            x509.RFC822Name(1.3)  # type:ignore[arg-type]
+            x509.RFC822Name(typing.cast(typing.Any, 1.3))
 
         with pytest.raises(TypeError):
-            x509.RFC822Name(b"bytes")  # type:ignore[arg-type]
+            x509.RFC822Name(typing.cast(typing.Any, b"bytes"))
 
     def test_invalid_email(self):
         with pytest.raises(ValueError):
@@ -2221,7 +2224,7 @@ class TestUniformResourceIdentifier:
 
     def test_not_text(self):
         with pytest.raises(TypeError):
-            x509.UniformResourceIdentifier(1.3)  # type:ignore[arg-type]
+            x509.UniformResourceIdentifier(typing.cast(typing.Any, 1.3))
 
     def test_no_parsed_hostname(self):
         gn = x509.UniformResourceIdentifier("singlelabel")
@@ -2257,10 +2260,10 @@ class TestUniformResourceIdentifier:
 class TestRegisteredID:
     def test_not_oid(self):
         with pytest.raises(TypeError):
-            x509.RegisteredID(b"notanoid")  # type:ignore[arg-type]
+            x509.RegisteredID(typing.cast(typing.Any, b"notanoid"))
 
         with pytest.raises(TypeError):
-            x509.RegisteredID(1.3)  # type:ignore[arg-type]
+            x509.RegisteredID(typing.cast(typing.Any, 1.3))
 
     def test_repr(self):
         gn = x509.RegisteredID(NameOID.COMMON_NAME)
@@ -2291,10 +2294,10 @@ class TestRegisteredID:
 class TestIPAddress:
     def test_not_ipaddress(self):
         with pytest.raises(TypeError):
-            x509.IPAddress(b"notanipaddress")  # type:ignore[arg-type]
+            x509.IPAddress(typing.cast(typing.Any, b"notanipaddress"))
 
         with pytest.raises(TypeError):
-            x509.IPAddress(1.3)  # type:ignore[arg-type]
+            x509.IPAddress(typing.cast(typing.Any, 1.3))
 
     def test_repr(self):
         gn = x509.IPAddress(ipaddress.IPv4Address("127.0.0.1"))
@@ -2332,14 +2335,14 @@ class TestOtherName:
     def test_invalid_args(self):
         with pytest.raises(TypeError):
             x509.OtherName(
-                b"notanobjectidentifier",  # type:ignore[arg-type]
+                typing.cast(typing.Any, b"notanobjectidentifier"),
                 b"derdata",
             )
 
         with pytest.raises(TypeError):
             x509.OtherName(
                 x509.ObjectIdentifier("1.2.3.4"),
-                "notderdata",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notderdata"),
             )
 
     def test_repr(self):
@@ -2561,7 +2564,7 @@ class TestCRLNumber:
 
     def test_invalid_number(self):
         with pytest.raises(TypeError):
-            x509.CRLNumber("notanumber")  # type:ignore[arg-type]
+            x509.CRLNumber(typing.cast(typing.Any, "notanumber"))
 
     def test_hash(self):
         c1 = x509.CRLNumber(1)
@@ -2965,7 +2968,7 @@ class TestAccessDescription:
     def test_invalid_access_method(self):
         with pytest.raises(TypeError):
             x509.AccessDescription(
-                "notanoid",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanoid"),
                 x509.DNSName("test"),
             )
 
@@ -2973,7 +2976,7 @@ class TestAccessDescription:
         with pytest.raises(TypeError):
             x509.AccessDescription(
                 AuthorityInformationAccessOID.CA_ISSUERS,
-                "invalid",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "invalid"),
             )
 
     def test_valid_nonstandard_method(self):
@@ -3042,11 +3045,11 @@ class TestAccessDescription:
 class TestPolicyConstraints:
     def test_invalid_explicit_policy(self):
         with pytest.raises(TypeError):
-            x509.PolicyConstraints("invalid", None)  # type:ignore[arg-type]
+            x509.PolicyConstraints(typing.cast(typing.Any, "invalid"), None)
 
     def test_invalid_inhibit_policy(self):
         with pytest.raises(TypeError):
-            x509.PolicyConstraints(None, "invalid")  # type:ignore[arg-type]
+            x509.PolicyConstraints(None, typing.cast(typing.Any, "invalid"))
 
     def test_both_none(self):
         with pytest.raises(ValueError):
@@ -3864,11 +3867,11 @@ class TestNameConstraints:
 
     def test_invalid_permitted_subtrees(self):
         with pytest.raises(TypeError):
-            x509.NameConstraints("badpermitted", None)  # type:ignore[arg-type]
+            x509.NameConstraints(typing.cast(typing.Any, "badpermitted"), None)
 
     def test_invalid_excluded_subtrees(self):
         with pytest.raises(TypeError):
-            x509.NameConstraints(None, "badexcluded")  # type:ignore[arg-type]
+            x509.NameConstraints(None, typing.cast(typing.Any, "badexcluded"))
 
     def test_no_subtrees(self):
         with pytest.raises(ValueError):
@@ -4163,7 +4166,7 @@ class TestDistributionPoint:
         with pytest.raises(TypeError):
             x509.DistributionPoint(
                 None,
-                "notname",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notname"),
                 None,
                 None,
             )
@@ -4206,7 +4209,7 @@ class TestDistributionPoint:
             x509.DistributionPoint(
                 [x509.UniformResourceIdentifier("http://crypt.og/crl")],
                 None,
-                [x509.ReasonFlags.ca_compromise],  # type:ignore[arg-type]
+                typing.cast(typing.Any, [x509.ReasonFlags.ca_compromise]),
                 None,
             )
 
@@ -5345,7 +5348,7 @@ class TestOCSPNoCheckExtension:
 class TestInhibitAnyPolicy:
     def test_not_int(self):
         with pytest.raises(TypeError):
-            x509.InhibitAnyPolicy("notint")  # type:ignore[arg-type]
+            x509.InhibitAnyPolicy(typing.cast(typing.Any, "notint"))
 
     def test_negative_int(self):
         with pytest.raises(ValueError):
@@ -6443,7 +6446,7 @@ class TestInvalidExtension:
 class TestOCSPNonce:
     def test_non_bytes(self):
         with pytest.raises(TypeError):
-            x509.OCSPNonce(38)  # type:ignore[arg-type]
+            x509.OCSPNonce(typing.cast(typing.Any, 38))
 
     def test_eq(self):
         nonce1 = x509.OCSPNonce(b"0" * 5)
@@ -6475,7 +6478,7 @@ class TestOCSPNonce:
 class TestOCSPAcceptableResponses:
     def test_invalid_types(self):
         with pytest.raises(TypeError):
-            x509.OCSPAcceptableResponses(38)  # type:ignore[arg-type]
+            x509.OCSPAcceptableResponses(typing.cast(typing.Any, 38))
         with pytest.raises(TypeError):
             x509.OCSPAcceptableResponses([38])  # type:ignore[list-item]
 
@@ -6543,7 +6546,7 @@ class TestMSCertificateTemplate:
     def test_invalid_type(self):
         with pytest.raises(TypeError):
             x509.MSCertificateTemplate(
-                "notanoid",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanoid"),
                 None,
                 None,
             )
@@ -6551,14 +6554,14 @@ class TestMSCertificateTemplate:
         with pytest.raises(TypeError):
             x509.MSCertificateTemplate(
                 oid,
-                "notanint",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanint"),
                 None,
             )
         with pytest.raises(TypeError):
             x509.MSCertificateTemplate(
                 oid,
                 None,
-                "notanint",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "notanint"),
             )
 
     def test_eq(self):
@@ -6632,21 +6635,21 @@ class TestNamingAuthority:
     def test_invalid_init(self):
         with pytest.raises(TypeError):
             x509.NamingAuthority(
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
                 None,
                 None,
             )
         with pytest.raises(TypeError):
             x509.NamingAuthority(
                 x509.ObjectIdentifier("1.2.3"),
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
                 None,
             )
         with pytest.raises(TypeError):
             x509.NamingAuthority(
                 x509.ObjectIdentifier("1.2.3"),
                 "https://example.com",
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
             )
 
     def test_eq(self):
@@ -6739,14 +6742,14 @@ class TestProfessionInfo:
         with pytest.raises(TypeError):
             x509.ProfessionInfo(
                 None,
-                None,  # type:ignore[arg-type]
+                typing.cast(typing.Any, None),
                 None,
                 None,
                 None,
             )
         with pytest.raises(TypeError):
             x509.ProfessionInfo(
-                "spam",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "spam"),
                 [],
                 [],
                 None,
@@ -6764,7 +6767,7 @@ class TestProfessionInfo:
             x509.ProfessionInfo(
                 None,
                 [],
-                "spam",  # type:ignore[arg-type]
+                typing.cast(typing.Any, "spam"),
                 None,
                 None,
             )
@@ -6773,7 +6776,7 @@ class TestProfessionInfo:
                 None,
                 [],
                 [],
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
                 None,
             )
         with pytest.raises(TypeError):
@@ -6782,7 +6785,7 @@ class TestProfessionInfo:
                 [],
                 [],
                 None,
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
             )
 
     def test_eq(self):
@@ -6991,21 +6994,21 @@ class TestAdmission:
     def test_invalid_init(self):
         with pytest.raises(TypeError):
             x509.Admission(
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
                 None,
                 [],
             )
         with pytest.raises(TypeError):
             x509.Admission(
                 None,
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
                 [],
             )
         with pytest.raises(TypeError):
             x509.Admission(
                 None,
                 None,
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
             )
         with pytest.raises(TypeError):
             x509.Admission(
@@ -7318,13 +7321,13 @@ class TestAdmissions:
     def test_invalid_init(self):
         with pytest.raises(TypeError):
             x509.Admissions(
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
                 [],
             )
         with pytest.raises(TypeError):
             x509.Admissions(
                 None,
-                42,  # type:ignore[arg-type]
+                typing.cast(typing.Any, 42),
             )
         with pytest.raises(TypeError):
             x509.Admissions(

--- a/tests/x509/test_x509_revokedcertbuilder.py
+++ b/tests/x509/test_x509_revokedcertbuilder.py
@@ -4,6 +4,7 @@
 
 
 import datetime
+import typing
 
 import pytest
 
@@ -14,7 +15,7 @@ class TestRevokedCertificateBuilder:
     def test_serial_number_must_be_integer(self):
         with pytest.raises(TypeError):
             x509.RevokedCertificateBuilder().serial_number(
-                "notanx509name"  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notanx509name")
             )
 
     def test_serial_number_must_be_non_negative(self):
@@ -77,7 +78,7 @@ class TestRevokedCertificateBuilder:
     def test_revocation_date_invalid(self):
         with pytest.raises(TypeError):
             x509.RevokedCertificateBuilder().revocation_date(
-                "notadatetime"  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notadatetime")
             )
 
     def test_revocation_date_before_1950(self):
@@ -106,7 +107,7 @@ class TestRevokedCertificateBuilder:
     def test_add_invalid_extension(self):
         with pytest.raises(TypeError):
             x509.RevokedCertificateBuilder().add_extension(
-                "notanextension",  # type: ignore[arg-type]
+                typing.cast(typing.Any, "notanextension"),
                 False,
             )
 

--- a/tests/x509/verification/test_verification.py
+++ b/tests/x509/verification/test_verification.py
@@ -4,6 +4,7 @@
 
 import datetime
 import os
+import typing
 from functools import lru_cache
 from ipaddress import IPv4Address
 from typing import Optional
@@ -74,18 +75,20 @@ class TestPolicyBuilder:
         # Subject must be a supported GeneralName type
         with pytest.raises(TypeError):
             PolicyBuilder().store(dummy_store()).build_server_verifier(
-                "cryptography.io"  # type: ignore[arg-type]
+                typing.cast(typing.Any, "cryptography.io")
             )
         with pytest.raises(TypeError):
             PolicyBuilder().store(dummy_store()).build_server_verifier(
-                "0.0.0.0"  # type: ignore[arg-type]
+                typing.cast(typing.Any, "0.0.0.0")
             )
         with pytest.raises(TypeError):
             PolicyBuilder().store(dummy_store()).build_server_verifier(
-                IPv4Address("0.0.0.0")  # type: ignore[arg-type]
+                typing.cast(typing.Any, IPv4Address("0.0.0.0"))
             )
         with pytest.raises(TypeError):
-            PolicyBuilder().store(dummy_store()).build_server_verifier(None)  # type: ignore[arg-type]
+            PolicyBuilder().store(dummy_store()).build_server_verifier(
+                typing.cast(typing.Any, None)
+            )
 
     def test_builder_pattern(self):
         now = datetime.datetime.now().replace(microsecond=0)

--- a/tests/x509/verification/test_verification.py
+++ b/tests/x509/verification/test_verification.py
@@ -129,7 +129,7 @@ class TestStore:
 
     def test_store_rejects_non_certificates(self):
         with pytest.raises(TypeError):
-            Store(["not a cert"])  # type: ignore[list-item]
+            Store([typing.cast(typing.Any, "not a cert")])
 
 
 class TestClientVerifier:
@@ -315,7 +315,7 @@ class TestCustomExtensionPolicies:
                 pass
 
             ext_policy.require_present(
-                _Extension,  # type: ignore[type-var]
+                typing.cast(typing.Any, _Extension),
                 Criticality.AGNOSTIC,
                 None,
             )


### PR DESCRIPTION
Tests that deliberately pass an invalid type (e.g. asserting `TypeError` is raised) previously silenced mypy with `# type: ignore[...]` comments. This replaces those with `typing.cast(typing.Any, <value>)` wrapped around the specific invalid value.

Two commits:

1. All 362 `# type: ignore[arg-type]` comments across 43 test files (370 cast sites — a few calls had two invalid arguments sharing one comment).
2. The 31 remaining ignores of the same pattern: 28 `[list-item]` (invalid element inside a list/frozenset literal — only the actually-invalid elements are wrapped), 2 `[type-var]`, and 1 `[comparison-overlap]`.

The casts were placed mechanically from mypy's `--show-error-end` spans, so each cast covers exactly the expression mypy flagged. This is stricter than the ignore comments: an ignore suppressed all matching errors on its line, while a cast silences only the one intended argument — and `warn_redundant_casts` / `warn_unused_ignores` (both enabled) verify every cast is doing real work.

Not converted (still legitimately ignored): the 12 `[operator]` ordering tests (`key1 < key2` — the operands are correctly typed, the operation itself is what's unsupported), 10 `[call-arg]`/`[misc]` call-shape tests (unexpected/missing/positional-only arguments — no value has a wrong type), and 3 `[attr-defined]` private/platform attribute accesses.

`nox -e local` passes (ruff, clippy, mypy, and both test suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GJ4ETkPmpuZwWaiMJetF2

---
_Generated by [Claude Code](https://claude.ai/code/session_016GJ4ETkPmpuZwWaiMJetF2)_