### PR TITLE
Add ML-KEM validation tests

### DIFF
--- a/tests/hazmat/primitives/test_mlkem.py
+++ b/tests/hazmat/primitives/test_mlkem.py
@@ -200,9 +200,37 @@ class TestMLKEM:
             variant.private_key_class.from_seed_bytes(b"a" * 10)
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
+    @pytest.mark.parametrize("delta", [-1, 1])
+    def test_invalid_length_from_public_bytes(self, variant, delta, backend):
+        with pytest.raises(ValueError):
+            variant.public_key_class.from_public_bytes(
+                b"a" * (variant.pub_key_size + delta)
+            )
+
+    @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
     def test_invalid_type_seed(self, variant, backend):
         with pytest.raises(TypeError):
             variant.private_key_class.from_seed_bytes(object())
+
+    @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
+    def test_invalid_type_public_bytes(self, variant, backend):
+        with pytest.raises(TypeError):
+            variant.public_key_class.from_public_bytes(object())
+
+    @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
+    @pytest.mark.parametrize("delta", [-1, 1])
+    def test_invalid_decapsulate_ciphertext_length(
+        self, variant, delta, backend
+    ):
+        key = variant.private_key_class.generate()
+        with pytest.raises(ValueError):
+            key.decapsulate(b"a" * (variant.ciphertext_size + delta))
+
+    @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
+    def test_invalid_type_decapsulate_ciphertext(self, variant, backend):
+        key = variant.private_key_class.generate()
+        with pytest.raises(TypeError):
+            key.decapsulate(object())
 
     def test_kat_vectors_768(self, backend, subtests):
         vectors = load_vectors_from_file(


### PR DESCRIPTION
## summary
- add coverage for ML-KEM `from_public_bytes()` rejecting invalid raw public key lengths and non-buffer inputs
- add coverage for ML-KEM `decapsulate()` rejecting invalid ciphertext lengths and non-buffer inputs

This just locks in the existing validation behavior around raw key and ciphertext inputs

## tests
- `PYTEST_XDIST_AUTO_NUM_WORKERS=2 python3 -m nox -e local -- tests/hazmat/primitives/test_mlkem.py`
