### PR TITLE
Set pytest testpaths so flag-only invocations don't collect the rootdir

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -96,11 +96,6 @@ def tests(session: nox.Session) -> None:
     else:
         cov_args = []
 
-    if session.posargs:
-        tests = session.posargs
-    else:
-        tests = ["tests/"]
-
     session.run(
         "pytest",
         "-n",
@@ -108,7 +103,7 @@ def tests(session: nox.Session) -> None:
         "--dist=worksteal",
         *cov_args,
         "--durations=10",
-        *tests,
+        *session.posargs,
     )
 
     if session.name != "tests-nocoverage":
@@ -334,18 +329,13 @@ def local(session: nox.Session):
         "--uv",
     )
 
-    if session.posargs:
-        tests = session.posargs
-    else:
-        tests = ["tests/"]
-
     session.run(
         "pytest",
         "-n",
         "auto",
         "--dist=worksteal",
         "--durations=10",
-        *tests,
+        *session.posargs,
     )
 
     session.run("cargo", "test", "--all", external=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ exclude = [
 
 [tool.pytest.ini_options]
 addopts = "-r s --capture=no --strict-markers --benchmark-disable"
+testpaths = ["tests"]
 console_output_style = "progress-even-when-capture-no"
 markers = [
     "skip_fips: this test is not executed in FIPS mode",


### PR DESCRIPTION
Passing only flags to the test sessions (e.g. nox -e tests -- --wycheproof-root=...) replaced the default test path, so pytest collected from the repository root and every xdist worker walked all of target/ during collection - over 10 seconds of apparent hang at "ready: N/N workers" once the cargo build tree was large. With testpaths set, pathless pytest runs collect tests/ directly and the noxfile no longer needs its own default-path fallback.