### PR TITLE
Update Read the Docs config: ubuntu 26.04, Python 3.14, uv installs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,10 +16,9 @@ build:
   tools:
     python: "3.14"
     rust: "latest"
-
-python:
-  install:
-    - method: uv
-      command: sync
-      groups:
-        - docs
+  jobs:
+    install:
+      - pip install uv
+      # uv needs to be told the target environment explicitly: RTD's venv
+      # isn't activated (no VIRTUAL_ENV) when these commands run.
+      - uv pip install --python "$READTHEDOCS_VIRTUALENV_PATH/bin/python" . --group docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,4 @@
-# https://docs.readthedocs.io/en/stable/config-file/v2.html#supported-settings
+# https://docs.readthedocs.com/platform/stable/config-file/v2.html
 
 version: 2
 
@@ -12,11 +12,14 @@ formats:
   - pdf
 
 build:
-  os: "ubuntu-24.04"
+  os: "ubuntu-26.04"
   tools:
-    python: "3.13"
+    python: "3.14"
     rust: "latest"
-  jobs:
-    install:
-      - pip install -U pip
-      - pip install . --group docs
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs


### PR DESCRIPTION
Updates `.readthedocs.yml`:

* `build.os`: `ubuntu-24.04` → `ubuntu-26.04`
* `build.tools.python`: `3.13` → `3.14`
* Installation now uses uv: `uv pip install . --group docs` (bootstrapped via `pip install uv`), replacing `pip install -U pip` + `pip install . --group docs`

Notes:

* `uv pip install` mirrors the previous pip invocation exactly — package plus the `docs` dependency group only — rather than `uv sync`'s project semantics (lockfile, default `dev` group).
* uv is passed `--python "$READTHEDOCS_VIRTUALENV_PATH/bin/python"` explicitly because `uv pip install` doesn't fall back to the interpreter on `PATH`; it requires `VIRTUAL_ENV`, a local `.venv`, or an explicit target, and RTD doesn't document setting `VIRTUAL_ENV` in build jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGoiroFb55hJBf1YkJaL1x

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGoiroFb55hJBf1YkJaL1x)_