### PR TITLE
Release the GIL during PBKDF2, Scrypt, and Argon2 key derivation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,14 +39,6 @@ Changelog
   classes and the classes in
   :mod:`~cryptography.hazmat.primitives.asymmetric.padding` can now be
   compared with ``==``.
-* The GIL is now released during key derivation with
-  :class:`~cryptography.hazmat.primitives.kdf.pbkdf2.PBKDF2HMAC`,
-  :class:`~cryptography.hazmat.primitives.kdf.scrypt.Scrypt`,
-  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2d`,
-  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2i`, and
-  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id`, allowing
-  other threads to run while these deliberately expensive computations
-  execute.
 
 .. _v49-0-0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,14 @@ Changelog
   classes and the classes in
   :mod:`~cryptography.hazmat.primitives.asymmetric.padding` can now be
   compared with ``==``.
+* The GIL is now released during key derivation with
+  :class:`~cryptography.hazmat.primitives.kdf.pbkdf2.PBKDF2HMAC`,
+  :class:`~cryptography.hazmat.primitives.kdf.scrypt.Scrypt`,
+  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2d`,
+  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2i`, and
+  :class:`~cryptography.hazmat.primitives.kdf.argon2.Argon2id`, allowing
+  other threads to run while these deliberately expensive computations
+  execute.
 
 .. _v49-0-0:
 

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -171,7 +171,9 @@ impl Scrypt {
         }
 
         let salt = self.salt.as_bytes(py);
-        let (n, r, p) = (self.n, self.r, self.p);
+        let n = self.n;
+        let r = self.r;
+        let p = self.p;
         py.detach(|| {
             openssl::pkcs5::scrypt(
                 key_material,
@@ -368,7 +370,9 @@ impl BaseArgon2 {
         let salt = self.salt.as_bytes(py);
         let ad = self.ad.as_ref().map(|ad| ad.as_bytes(py));
         let secret = self.secret.as_ref().map(|secret| secret.as_bytes(py));
-        let (iterations, lanes, memory_cost) = (self.iterations, self.lanes, self.memory_cost);
+        let iterations = self.iterations;
+        let lanes = self.lanes;
+        let memory_cost = self.memory_cost;
         py.detach(|| {
             (derive_fn)(
                 None,

--- a/src/rust/src/backend/kdf.rs
+++ b/src/rust/src/backend/kdf.rs
@@ -51,13 +51,10 @@ impl Pbkdf2Hmac {
             ));
         }
 
-        openssl::pkcs5::pbkdf2_hmac(
-            key_material,
-            self.salt.as_bytes(py),
-            self.iterations,
-            self.md,
-            output,
-        )?;
+        let salt = self.salt.as_bytes(py);
+        let iterations = self.iterations;
+        let md = self.md;
+        py.detach(|| openssl::pkcs5::pbkdf2_hmac(key_material, salt, iterations, md, output))?;
 
         Ok(self.length)
     }
@@ -173,15 +170,19 @@ impl Scrypt {
             ));
         }
 
-        openssl::pkcs5::scrypt(
-            key_material,
-            self.salt.as_bytes(py),
-            self.n,
-            self.r,
-            self.p,
-            (usize::MAX / 2).try_into().unwrap(),
-            output,
-        )
+        let salt = self.salt.as_bytes(py);
+        let (n, r, p) = (self.n, self.r, self.p);
+        py.detach(|| {
+            openssl::pkcs5::scrypt(
+                key_material,
+                salt,
+                n,
+                r,
+                p,
+                (usize::MAX / 2).try_into().unwrap(),
+                output,
+            )
+        })
         .map_err(|_| {
             // memory required formula explained here:
             // https://blog.filippo.io/the-scrypt-parameters/
@@ -364,17 +365,23 @@ impl BaseArgon2 {
             Argon2Variant::Argon2id => openssl::kdf::argon2id,
         };
 
-        (derive_fn)(
-            None,
-            key_material,
-            self.salt.as_bytes(py),
-            self.ad.as_ref().map(|ad| ad.as_bytes(py)),
-            self.secret.as_ref().map(|secret| secret.as_bytes(py)),
-            self.iterations,
-            self.lanes,
-            self.memory_cost,
-            output,
-        )
+        let salt = self.salt.as_bytes(py);
+        let ad = self.ad.as_ref().map(|ad| ad.as_bytes(py));
+        let secret = self.secret.as_ref().map(|secret| secret.as_bytes(py));
+        let (iterations, lanes, memory_cost) = (self.iterations, self.lanes, self.memory_cost);
+        py.detach(|| {
+            (derive_fn)(
+                None,
+                key_material,
+                salt,
+                ad,
+                secret,
+                iterations,
+                lanes,
+                memory_cost,
+                output,
+            )
+        })
         .map_err(|_| {
             // In theory other init issues (e.g. PROV_R_INVALID_THREAD_POOL_SIZE
             // on builds without thread-pool support) can also occur here, but


### PR DESCRIPTION
These KDFs are deliberately expensive, so holding the GIL for the duration of a derivation blocks all other Python threads for a potentially long time.

The salt/ad/secret byte slices are extracted from their `Py<PyBytes>` holders while the GIL is held (safe to use across the release since `bytes` is immutable), the numeric parameters are copied to locals, and then the underlying OpenSSL derivation runs inside `py.detach()` — the same pattern already used in `ec.rs` and `rsa.rs`.

All three Argon2 variants funnel through `BaseArgon2::derive_into_buffer`, so `derive`, `derive_into`, `verify`, and the PHC-encoded paths are all covered.

The fast KDFs (HKDF, X963KDF, ConcatKDF, KBKDF) are intentionally left untouched: releasing the GIL there would require restructuring their per-block loops for marginal benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wq9126jiMgXBRNbQ2QXVeg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wq9126jiMgXBRNbQ2QXVeg)_