### PR TITLE
Release the GIL during Ed25519, Ed448, DSA, and ML-DSA sign/verify

### DIFF
--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -76,13 +76,19 @@ impl DsaPrivateKey {
 
         let mut signer = openssl::pkey_ctx::PkeyCtx::new(&self.pkey)?;
         signer.sign_init()?;
-        let mut sig = vec![];
-        signer.sign_to_vec(data.as_bytes(), &mut sig).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err((
-                "DSA signing failed. This generally indicates an invalid key.",
-                error::list_from_openssl_error(py, &e).unbind(),
-            ))
-        })?;
+        let data_bytes = data.as_bytes();
+        let sig = py
+            .detach(|| {
+                let mut sig = vec![];
+                signer.sign_to_vec(data_bytes, &mut sig)?;
+                Ok::<_, openssl::error::ErrorStack>(sig)
+            })
+            .map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err((
+                    "DSA signing failed. This generally indicates an invalid key.",
+                    error::list_from_openssl_error(py, &e).unbind(),
+                ))
+            })?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -178,9 +184,9 @@ impl DsaPublicKey {
 
         let mut verifier = openssl::pkey_ctx::PkeyCtx::new(&self.pkey)?;
         verifier.verify_init()?;
-        let valid = verifier
-            .verify(data.as_bytes(), signature.as_bytes())
-            .unwrap_or(false);
+        let data_bytes = data.as_bytes();
+        let sig_bytes = signature.as_bytes();
+        let valid = py.detach(|| verifier.verify(data_bytes, sig_bytes).unwrap_or(false));
         if !valid {
             return Err(CryptographyError::from(
                 exceptions::InvalidSignature::new_err(()),

--- a/src/rust/src/backend/ed25519.rs
+++ b/src/rust/src/backend/ed25519.rs
@@ -70,9 +70,10 @@ impl Ed25519PrivateKey {
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let mut signer = openssl::sign::Signer::new_without_digest(&self.pkey)?;
         let len = signer.len()?;
+        let data_bytes = data.as_bytes();
         Ok(pyo3::types::PyBytes::new_with(py, len, |b| {
-            let n = signer
-                .sign_oneshot(b, data.as_bytes())
+            let n = py
+                .detach(|| signer.sign_oneshot(b, data_bytes))
                 .map_err(CryptographyError::from)?;
             assert_eq!(n, b.len());
             Ok(())
@@ -130,9 +131,17 @@ impl Ed25519PrivateKey {
 
 #[pyo3::pymethods]
 impl Ed25519PublicKey {
-    fn verify(&self, signature: CffiBuf<'_>, data: CffiBuf<'_>) -> CryptographyResult<()> {
-        let valid = openssl::sign::Verifier::new_without_digest(&self.pkey)?
-            .verify_oneshot(signature.as_bytes(), data.as_bytes())
+    fn verify(
+        &self,
+        py: pyo3::Python<'_>,
+        signature: CffiBuf<'_>,
+        data: CffiBuf<'_>,
+    ) -> CryptographyResult<()> {
+        let mut verifier = openssl::sign::Verifier::new_without_digest(&self.pkey)?;
+        let sig_bytes = signature.as_bytes();
+        let data_bytes = data.as_bytes();
+        let valid = py
+            .detach(|| verifier.verify_oneshot(sig_bytes, data_bytes))
             .unwrap_or(false);
 
         if !valid {

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -68,9 +68,10 @@ impl Ed448PrivateKey {
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let mut signer = openssl::sign::Signer::new_without_digest(&self.pkey)?;
         let len = signer.len()?;
+        let data_bytes = data.as_bytes();
         Ok(pyo3::types::PyBytes::new_with(py, len, |b| {
-            let n = signer
-                .sign_oneshot(b, data.as_bytes())
+            let n = py
+                .detach(|| signer.sign_oneshot(b, data_bytes))
                 .map_err(CryptographyError::from)?;
             assert_eq!(n, b.len());
             Ok(())
@@ -128,9 +129,16 @@ impl Ed448PrivateKey {
 
 #[pyo3::pymethods]
 impl Ed448PublicKey {
-    fn verify(&self, signature: CffiBuf<'_>, data: CffiBuf<'_>) -> CryptographyResult<()> {
-        let valid = openssl::sign::Verifier::new_without_digest(&self.pkey)?
-            .verify_oneshot(signature.as_bytes(), data.as_bytes())?;
+    fn verify(
+        &self,
+        py: pyo3::Python<'_>,
+        signature: CffiBuf<'_>,
+        data: CffiBuf<'_>,
+    ) -> CryptographyResult<()> {
+        let mut verifier = openssl::sign::Verifier::new_without_digest(&self.pkey)?;
+        let sig_bytes = signature.as_bytes();
+        let data_bytes = data.as_bytes();
+        let valid = py.detach(|| verifier.verify_oneshot(sig_bytes, data_bytes))?;
 
         if !valid {
             return Err(CryptographyError::from(

--- a/src/rust/src/backend/mldsa.rs
+++ b/src/rust/src/backend/mldsa.rs
@@ -91,7 +91,9 @@ impl MlDsa44PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("Context must be at most 255 bytes"),
             ));
         }
-        let sig = cryptography_openssl::mldsa::sign(&self.pkey, data.as_bytes(), ctx_bytes)?;
+        let data_bytes = data.as_bytes();
+        let sig =
+            py.detach(|| cryptography_openssl::mldsa::sign(&self.pkey, data_bytes, ctx_bytes))?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -105,7 +107,8 @@ impl MlDsa44PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let sig = cryptography_openssl::mldsa::sign_mu(&self.pkey, mu.as_bytes())?;
+        let mu_bytes = mu.as_bytes();
+        let sig = py.detach(|| cryptography_openssl::mldsa::sign_mu(&self.pkey, mu_bytes))?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -166,15 +169,22 @@ impl MlDsa44PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa44PublicKey {
-    fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
+    fn verify_mu(
+        &self,
+        py: pyo3::Python<'_>,
+        signature: CffiBuf<'_>,
+        mu: CffiBuf<'_>,
+    ) -> CryptographyResult<()> {
         if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let valid =
-            cryptography_openssl::mldsa::verify_mu(&self.pkey, signature.as_bytes(), mu.as_bytes())
-                .unwrap_or(false);
+        let sig_bytes = signature.as_bytes();
+        let mu_bytes = mu.as_bytes();
+        let valid = py
+            .detach(|| cryptography_openssl::mldsa::verify_mu(&self.pkey, sig_bytes, mu_bytes))
+            .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(
@@ -188,6 +198,7 @@ impl MlDsa44PublicKey {
     #[pyo3(signature = (signature, data, context=None))]
     fn verify(
         &self,
+        py: pyo3::Python<'_>,
         signature: CffiBuf<'_>,
         data: CffiBuf<'_>,
         context: Option<CffiBuf<'_>>,
@@ -198,13 +209,13 @@ impl MlDsa44PublicKey {
                 pyo3::exceptions::PyValueError::new_err("Context must be at most 255 bytes"),
             ));
         }
-        let valid = cryptography_openssl::mldsa::verify(
-            &self.pkey,
-            signature.as_bytes(),
-            data.as_bytes(),
-            ctx_bytes,
-        )
-        .unwrap_or(false);
+        let sig_bytes = signature.as_bytes();
+        let data_bytes = data.as_bytes();
+        let valid = py
+            .detach(|| {
+                cryptography_openssl::mldsa::verify(&self.pkey, sig_bytes, data_bytes, ctx_bytes)
+            })
+            .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(
@@ -327,7 +338,9 @@ impl MlDsa65PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("Context must be at most 255 bytes"),
             ));
         }
-        let sig = cryptography_openssl::mldsa::sign(&self.pkey, data.as_bytes(), ctx_bytes)?;
+        let data_bytes = data.as_bytes();
+        let sig =
+            py.detach(|| cryptography_openssl::mldsa::sign(&self.pkey, data_bytes, ctx_bytes))?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -341,7 +354,8 @@ impl MlDsa65PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let sig = cryptography_openssl::mldsa::sign_mu(&self.pkey, mu.as_bytes())?;
+        let mu_bytes = mu.as_bytes();
+        let sig = py.detach(|| cryptography_openssl::mldsa::sign_mu(&self.pkey, mu_bytes))?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -405,15 +419,22 @@ impl MlDsa65PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa65PublicKey {
-    fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
+    fn verify_mu(
+        &self,
+        py: pyo3::Python<'_>,
+        signature: CffiBuf<'_>,
+        mu: CffiBuf<'_>,
+    ) -> CryptographyResult<()> {
         if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let valid =
-            cryptography_openssl::mldsa::verify_mu(&self.pkey, signature.as_bytes(), mu.as_bytes())
-                .unwrap_or(false);
+        let sig_bytes = signature.as_bytes();
+        let mu_bytes = mu.as_bytes();
+        let valid = py
+            .detach(|| cryptography_openssl::mldsa::verify_mu(&self.pkey, sig_bytes, mu_bytes))
+            .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(
@@ -427,6 +448,7 @@ impl MlDsa65PublicKey {
     #[pyo3(signature = (signature, data, context=None))]
     fn verify(
         &self,
+        py: pyo3::Python<'_>,
         signature: CffiBuf<'_>,
         data: CffiBuf<'_>,
         context: Option<CffiBuf<'_>>,
@@ -437,13 +459,13 @@ impl MlDsa65PublicKey {
                 pyo3::exceptions::PyValueError::new_err("Context must be at most 255 bytes"),
             ));
         }
-        let valid = cryptography_openssl::mldsa::verify(
-            &self.pkey,
-            signature.as_bytes(),
-            data.as_bytes(),
-            ctx_bytes,
-        )
-        .unwrap_or(false);
+        let sig_bytes = signature.as_bytes();
+        let data_bytes = data.as_bytes();
+        let valid = py
+            .detach(|| {
+                cryptography_openssl::mldsa::verify(&self.pkey, sig_bytes, data_bytes, ctx_bytes)
+            })
+            .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(
@@ -566,7 +588,9 @@ impl MlDsa87PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("Context must be at most 255 bytes"),
             ));
         }
-        let sig = cryptography_openssl::mldsa::sign(&self.pkey, data.as_bytes(), ctx_bytes)?;
+        let data_bytes = data.as_bytes();
+        let sig =
+            py.detach(|| cryptography_openssl::mldsa::sign(&self.pkey, data_bytes, ctx_bytes))?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -580,7 +604,8 @@ impl MlDsa87PrivateKey {
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let sig = cryptography_openssl::mldsa::sign_mu(&self.pkey, mu.as_bytes())?;
+        let mu_bytes = mu.as_bytes();
+        let sig = py.detach(|| cryptography_openssl::mldsa::sign_mu(&self.pkey, mu_bytes))?;
         Ok(pyo3::types::PyBytes::new(py, &sig))
     }
 
@@ -641,15 +666,22 @@ impl MlDsa87PrivateKey {
 
 #[pyo3::pymethods]
 impl MlDsa87PublicKey {
-    fn verify_mu(&self, signature: CffiBuf<'_>, mu: CffiBuf<'_>) -> CryptographyResult<()> {
+    fn verify_mu(
+        &self,
+        py: pyo3::Python<'_>,
+        signature: CffiBuf<'_>,
+        mu: CffiBuf<'_>,
+    ) -> CryptographyResult<()> {
         if mu.as_bytes().len() != cryptography_openssl::mldsa::MLDSA_MU_BYTES {
             return Err(CryptographyError::from(
                 pyo3::exceptions::PyValueError::new_err("mu must be 64 bytes"),
             ));
         }
-        let valid =
-            cryptography_openssl::mldsa::verify_mu(&self.pkey, signature.as_bytes(), mu.as_bytes())
-                .unwrap_or(false);
+        let sig_bytes = signature.as_bytes();
+        let mu_bytes = mu.as_bytes();
+        let valid = py
+            .detach(|| cryptography_openssl::mldsa::verify_mu(&self.pkey, sig_bytes, mu_bytes))
+            .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(
@@ -663,6 +695,7 @@ impl MlDsa87PublicKey {
     #[pyo3(signature = (signature, data, context=None))]
     fn verify(
         &self,
+        py: pyo3::Python<'_>,
         signature: CffiBuf<'_>,
         data: CffiBuf<'_>,
         context: Option<CffiBuf<'_>>,
@@ -673,13 +706,13 @@ impl MlDsa87PublicKey {
                 pyo3::exceptions::PyValueError::new_err("Context must be at most 255 bytes"),
             ));
         }
-        let valid = cryptography_openssl::mldsa::verify(
-            &self.pkey,
-            signature.as_bytes(),
-            data.as_bytes(),
-            ctx_bytes,
-        )
-        .unwrap_or(false);
+        let sig_bytes = signature.as_bytes();
+        let data_bytes = data.as_bytes();
+        let valid = py
+            .detach(|| {
+                cryptography_openssl::mldsa::verify(&self.pkey, sig_bytes, data_bytes, ctx_bytes)
+            })
+            .unwrap_or(false);
 
         if !valid {
             return Err(CryptographyError::from(


### PR DESCRIPTION
RSA and EC already release the GIL around their underlying OpenSSL signing operations, but the remaining asymmetric algorithms did not, blocking all other Python threads for the duration of the operation.

This releases the GIL (via `py.detach()`, following the existing RSA/EC pattern) around:

- **Ed25519 / Ed448**: `sign` and `verify`
- **DSA**: `sign` and `verify`
- **ML-DSA 44/65/87**: `sign`, `sign_mu`, `verify`, and `verify_mu`

In each method the input buffers are extracted while holding the GIL, then only the pure-OpenSSL operation runs detached. Error-handling semantics are unchanged (e.g. Ed448's `verify` still propagates OpenSSL errors while Ed25519's maps them to `InvalidSignature`, matching the pre-existing difference).

No changelog entry, consistent with the review feedback on #15163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ujqF9RgSKwRgtmiSDWN68

---
_Generated by [Claude Code](https://claude.ai/code/session_018ujqF9RgSKwRgtmiSDWN68)_