### PR TITLE
Reduce bcrypt KDF work in SSH serialization tests

### DIFF
--- a/tests/hazmat/primitives/test_ssh.py
+++ b/tests/hazmat/primitives/test_ssh.py
@@ -192,12 +192,19 @@ class TestOpenSSHSerialization:
         password = None
         if "-psw" in key_file:
             password = b"password"
-        for data in [
-            priv_data,
-            bytearray(priv_data),
-            memoryview(priv_data),
-            memoryview(bytearray(priv_data)),
-        ]:
+        if password is None:
+            datas = [
+                priv_data,
+                bytearray(priv_data),
+                memoryview(priv_data),
+                memoryview(bytearray(priv_data)),
+            ]
+        else:
+            # Each load of an encrypted key runs the (intentionally slow)
+            # bcrypt KDF; bytes-like handling of encrypted keys is covered
+            # by test_bcrypt_encryption.
+            datas = [priv_data]
+        for data in datas:
             if key_file.startswith("dsa"):
                 with pytest.warns(utils.DeprecatedIn40):
                     private_key = load_ssh_private_key(data, password, backend)
@@ -323,10 +330,15 @@ class TestOpenSSHSerialization:
             b"1234" * 4,
             b"x" * 72,
         ):
-            # BestAvailableEncryption does not handle bytes-like?
-            best = BestAvailableEncryption(psw)
+            # Minimal KDF rounds: this test is about password and
+            # bytes-like handling, not KDF strength.
+            encryption = (
+                PrivateFormat.OpenSSH.encryption_builder()
+                .kdf_rounds(1)
+                .build(psw)
+            )
             encdata = private_key.private_bytes(
-                Encoding.PEM, PrivateFormat.OpenSSH, best
+                Encoding.PEM, PrivateFormat.OpenSSH, encryption
             )
             decoded_key = load_ssh_private_key(encdata, psw, backend)
             pub2 = decoded_key.public_key().public_bytes(
@@ -669,7 +681,8 @@ class TestOpenSSHSerialization:
         [
             1,
             10,
-            30,
+            # Greater than the default of 16
+            18,
         ],
     )
     def test_serialize_ssh_private_key_with_password(


### PR DESCRIPTION
test_ssh.py spent nearly all of its runtime in bcrypt_pbkdf (~7ms/round): with bcrypt uninstalled the file runs in 1.2s, with it installed 4.7s. These tests exercise password and bytes-like handling, not KDF strength, so:

- `test_bcrypt_encryption` (2.85s, the file's single-test long pole) serializes with `kdf_rounds(1)` instead of `BestAvailableEncryption`'s default 16 rounds — now <0.1s. `BestAvailableEncryption` remains covered by other tests in the file.
- `test_load_ssh_private_key` only runs the 4-way buffer-type loop for unencrypted keys; each extra load of an encrypted key repeated a 16-round KDF, and the encrypted × bytes-like matrix is already covered by `test_bcrypt_encryption`.
- The `kdf_rounds` parametrization uses 18 rather than 30 for its greater-than-default (16) case.

Same 145 passed / 1 skipped; file wall time drops from ~4.7s to ~2.1s, and the slowest single test from 2.85s to 0.61s so it spreads across xdist workers better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)