### PR TITLE
Deprecate Diffie-Hellman over finite fields (FFDH)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,20 +8,11 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
-* Deprecated Diffie-Hellman key exchange over finite fields (FFDH). The
-  classes and functions in ``cryptography.hazmat.primitives.asymmetric.dh``
-  now emit a ``CryptographyDeprecationWarning`` when used, as does loading a
-  DH key or DH parameters with
-  :func:`~cryptography.hazmat.primitives.serialization.load_pem_private_key`,
-  :func:`~cryptography.hazmat.primitives.serialization.load_der_private_key`,
-  :func:`~cryptography.hazmat.primitives.serialization.load_pem_public_key`,
-  :func:`~cryptography.hazmat.primitives.serialization.load_der_public_key`,
-  :func:`~cryptography.hazmat.primitives.serialization.load_pem_parameters`,
-  or
-  :func:`~cryptography.hazmat.primitives.serialization.load_der_parameters`.
-  Users should migrate to :doc:`/hazmat/primitives/asymmetric/x25519` or
-  elliptic curve Diffie-Hellman
-  (:class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDH`).
+* Deprecated Diffie-Hellman key exchange over finite fields (FFDH).
+  Everything FFDH is deprecated, including the types in
+  ``cryptography.hazmat.primitives.asymmetric.dh`` and loading FFDH keys or
+  parameters with the key loading APIs. Users should migrate to a more
+  modern key exchange algorithm, such as ML-KEM.
 * Added ``xof()`` class methods to
   :class:`~cryptography.hazmat.primitives.hashes.SHAKE128` and
   :class:`~cryptography.hazmat.primitives.hashes.SHAKE256` for constructing

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changelog
   Everything FFDH is deprecated, including the types in
   ``cryptography.hazmat.primitives.asymmetric.dh`` and loading FFDH keys or
   parameters with the key loading APIs. Users should migrate to a more
-  modern key exchange algorithm, such as ML-KEM.
+  modern key exchange algorithm.
 * Added ``xof()`` class methods to
   :class:`~cryptography.hazmat.primitives.hashes.SHAKE128` and
   :class:`~cryptography.hazmat.primitives.hashes.SHAKE256` for constructing

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,20 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Deprecated Diffie-Hellman key exchange over finite fields (FFDH). The
+  classes and functions in ``cryptography.hazmat.primitives.asymmetric.dh``
+  now emit a ``CryptographyDeprecationWarning`` when used, as does loading a
+  DH key or DH parameters with
+  :func:`~cryptography.hazmat.primitives.serialization.load_pem_private_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_der_private_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_pem_public_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_der_public_key`,
+  :func:`~cryptography.hazmat.primitives.serialization.load_pem_parameters`,
+  or
+  :func:`~cryptography.hazmat.primitives.serialization.load_der_parameters`.
+  Users should migrate to :doc:`/hazmat/primitives/asymmetric/x25519` or
+  elliptic curve Diffie-Hellman
+  (:class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDH`).
 * Added ``xof()`` class methods to
   :class:`~cryptography.hazmat.primitives.hashes.SHAKE128` and
   :class:`~cryptography.hazmat.primitives.hashes.SHAKE256` for constructing

--- a/docs/hazmat/primitives/asymmetric/dh.rst
+++ b/docs/hazmat/primitives/asymmetric/dh.rst
@@ -7,11 +7,9 @@ Diffie-Hellman key exchange
 
 .. deprecated:: 50.0.0
     Diffie-Hellman over finite fields (FFDH) is deprecated and support will
-    be removed in a future release. Using any of the classes or functions in
-    this module, as well as loading a DH key or DH parameters, emits a
-    ``CryptographyDeprecationWarning``. Use
-    :doc:`/hazmat/primitives/asymmetric/x25519` or
-    :class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDH` instead.
+    be removed in a future release. Users should migrate to a more modern
+    key exchange algorithm, such as
+    :doc:`ML-KEM </hazmat/primitives/asymmetric/mlkem>`.
 
 .. note::
     For security and performance reasons we suggest using

--- a/docs/hazmat/primitives/asymmetric/dh.rst
+++ b/docs/hazmat/primitives/asymmetric/dh.rst
@@ -5,6 +5,14 @@ Diffie-Hellman key exchange
 
 .. currentmodule:: cryptography.hazmat.primitives.asymmetric.dh
 
+.. deprecated:: 50.0.0
+    Diffie-Hellman over finite fields (FFDH) is deprecated and support will
+    be removed in a future release. Using any of the classes or functions in
+    this module, as well as loading a DH key or DH parameters, emits a
+    ``CryptographyDeprecationWarning``. Use
+    :doc:`/hazmat/primitives/asymmetric/x25519` or
+    :class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDH` instead.
+
 .. note::
     For security and performance reasons we suggest using
     :class:`~cryptography.hazmat.primitives.asymmetric.ec.ECDH` instead of DH

--- a/docs/hazmat/primitives/asymmetric/dh.rst
+++ b/docs/hazmat/primitives/asymmetric/dh.rst
@@ -8,8 +8,7 @@ Diffie-Hellman key exchange
 .. deprecated:: 50.0.0
     Diffie-Hellman over finite fields (FFDH) is deprecated and support will
     be removed in a future release. Users should migrate to a more modern
-    key exchange algorithm, such as
-    :doc:`ML-KEM </hazmat/primitives/asymmetric/mlkem>`.
+    key exchange algorithm.
 
 .. note::
     For security and performance reasons we suggest using

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -216,6 +216,11 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
 .. function:: load_pem_parameters(data)
     .. versionadded:: 2.0
 
+    .. deprecated:: 50.0.0
+        Diffie-Hellman over finite fields (FFDH) is deprecated and support
+        will be removed in a future release. Loading DH parameters emits a
+        ``CryptographyDeprecationWarning``.
+
     Deserialize parameters from PEM encoded data to one of the supported
     asymmetric parameters types.
 
@@ -343,6 +348,11 @@ the rest.
 .. function:: load_der_parameters(data)
 
     .. versionadded:: 2.0
+
+    .. deprecated:: 50.0.0
+        Diffie-Hellman over finite fields (FFDH) is deprecated and support
+        will be removed in a future release. Loading DH parameters emits a
+        ``CryptographyDeprecationWarning``.
 
     Deserialize parameters from DER encoded data to one of the supported
     asymmetric parameters types.

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -218,8 +218,7 @@ all begin with ``-----BEGIN {format}-----`` and end with ``-----END
 
     .. deprecated:: 50.0.0
         Diffie-Hellman over finite fields (FFDH) is deprecated and support
-        will be removed in a future release. Loading DH parameters emits a
-        ``CryptographyDeprecationWarning``.
+        will be removed in a future release.
 
     Deserialize parameters from PEM encoded data to one of the supported
     asymmetric parameters types.
@@ -351,8 +350,7 @@ the rest.
 
     .. deprecated:: 50.0.0
         Diffie-Hellman over finite fields (FFDH) is deprecated and support
-        will be removed in a future release. Loading DH parameters emits a
-        ``CryptographyDeprecationWarning``.
+        will be removed in a future release.
 
     Deserialize parameters from DER encoded data to one of the supported
     asymmetric parameters types.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -71,6 +71,7 @@ facto
 fallback
 Fernet
 fernet
+FFDH
 FIPS
 Gaynor
 GiB

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives import _serialization
 _FFDH_DEPRECATION_MSG = (
     "Diffie-Hellman over finite fields (FFDH) is deprecated and support "
     "will be removed in a future release. Use a more modern key exchange "
-    "algorithm, such as ML-KEM, instead."
+    "algorithm."
 )
 
 generate_parameters = rust_openssl.dh.generate_parameters

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -6,8 +6,14 @@ from __future__ import annotations
 
 import abc
 
+from cryptography import utils
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.primitives import _serialization
+
+_FFDH_DEPRECATION_MSG = (
+    "Diffie-Hellman over finite fields (FFDH) is deprecated and support "
+    "will be removed in a future release. Use X25519 or ECDH instead."
+)
 
 generate_parameters = rust_openssl.dh.generate_parameters
 
@@ -157,3 +163,90 @@ class DHPrivateKey(metaclass=abc.ABCMeta):
 
 DHPrivateKeyWithSerialization = DHPrivateKey
 DHPrivateKey.register(rust_openssl.dh.DHPrivateKey)
+
+# Aliases that do not emit the deprecation warning on attribute access, for
+# internal use (e.g. the unions in
+# cryptography.hazmat.primitives.asymmetric.types, which are evaluated at
+# import time).
+_DHPublicKey = DHPublicKey
+_DHPrivateKey = DHPrivateKey
+
+utils.deprecated(
+    generate_parameters,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="generate_parameters",
+)
+
+utils.deprecated(
+    DHPrivateNumbers,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHPrivateNumbers",
+)
+
+utils.deprecated(
+    DHPublicNumbers,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHPublicNumbers",
+)
+
+utils.deprecated(
+    DHParameterNumbers,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHParameterNumbers",
+)
+
+utils.deprecated(
+    DHParameters,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHParameters",
+)
+
+utils.deprecated(
+    DHParameters,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHParametersWithSerialization",
+)
+
+utils.deprecated(
+    DHPublicKey,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHPublicKey",
+)
+
+utils.deprecated(
+    DHPublicKey,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHPublicKeyWithSerialization",
+)
+
+utils.deprecated(
+    DHPrivateKey,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHPrivateKey",
+)
+
+utils.deprecated(
+    DHPrivateKey,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="DHPrivateKeyWithSerialization",
+)

--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -12,7 +12,8 @@ from cryptography.hazmat.primitives import _serialization
 
 _FFDH_DEPRECATION_MSG = (
     "Diffie-Hellman over finite fields (FFDH) is deprecated and support "
-    "will be removed in a future release. Use X25519 or ECDH instead."
+    "will be removed in a future release. Use a more modern key exchange "
+    "algorithm, such as ML-KEM, instead."
 )
 
 generate_parameters = rust_openssl.dh.generate_parameters

--- a/src/cryptography/hazmat/primitives/asymmetric/types.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/types.py
@@ -19,9 +19,10 @@ from cryptography.hazmat.primitives.asymmetric import (
     x25519,
 )
 
-# Every asymmetric key type
+# Every asymmetric key type. These use the private DH aliases so that
+# importing this module doesn't trigger the FFDH deprecation warning.
 PublicKeyTypes = typing.Union[
-    dh.DHPublicKey,
+    dh._DHPublicKey,
     dsa.DSAPublicKey,
     rsa.RSAPublicKey,
     ec.EllipticCurvePublicKey,
@@ -37,7 +38,7 @@ PublicKeyTypes = typing.Union[
 ]
 # Every asymmetric key type
 PrivateKeyTypes = typing.Union[
-    dh.DHPrivateKey,
+    dh._DHPrivateKey,
     ed25519.Ed25519PrivateKey,
     ed448.Ed448PrivateKey,
     mldsa.MLDSA44PrivateKey,

--- a/src/cryptography/hazmat/primitives/serialization/__init__.py
+++ b/src/cryptography/hazmat/primitives/serialization/__init__.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from cryptography import utils
 from cryptography.hazmat.primitives._serialization import (
     BestAvailableEncryption,
     Encoding,
@@ -14,6 +15,7 @@ from cryptography.hazmat.primitives._serialization import (
     PublicFormat,
     _KeySerializationEncryption,
 )
+from cryptography.hazmat.primitives.asymmetric.dh import _FFDH_DEPRECATION_MSG
 from cryptography.hazmat.primitives.serialization.base import (
     load_der_parameters,
     load_der_private_key,
@@ -63,3 +65,21 @@ __all__ = [
     "load_ssh_public_key",
     "ssh_key_fingerprint",
 ]
+
+# These can only load FFDH parameters, so the functions themselves are
+# deprecated alongside the rest of FFDH.
+utils.deprecated(
+    load_pem_parameters,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="load_pem_parameters",
+)
+
+utils.deprecated(
+    load_der_parameters,
+    __name__,
+    _FFDH_DEPRECATION_MSG,
+    utils.DeprecatedIn50,
+    name="load_der_parameters",
+)

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -27,6 +27,7 @@ DeprecatedIn41 = CryptographyDeprecationWarning
 DeprecatedIn42 = CryptographyDeprecationWarning
 DeprecatedIn43 = CryptographyDeprecationWarning
 DeprecatedIn47 = CryptographyDeprecationWarning
+DeprecatedIn50 = CryptographyDeprecationWarning
 
 
 # If you're wondering why we don't use `Buffer`, it's because `Buffer` would

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -12,7 +12,7 @@ use crate::{types, x509};
 
 fn warn_ffdh_deprecated(py: pyo3::Python<'_>) -> pyo3::PyResult<()> {
     let warning_cls = types::DEPRECATED_IN_50.get(py)?;
-    let message = c"Diffie-Hellman over finite fields (FFDH) is deprecated and support will be removed in a future release. Use X25519 or ECDH instead.";
+    let message = c"Diffie-Hellman over finite fields (FFDH) is deprecated and support will be removed in a future release. Use a more modern key exchange algorithm, such as ML-KEM, instead.";
     pyo3::PyErr::warn(py, &warning_cls, message, 1)
 }
 
@@ -85,11 +85,7 @@ pub(crate) fn public_key_from_pkey(
 // `x942` is true the optional trailing INTEGER is the X9.42 subprime `q`;
 // otherwise the structure is PKCS#3 and the optional trailing INTEGER is
 // `privateValueLength`, which we ignore.
-fn load_dh_parameters(
-    py: pyo3::Python<'_>,
-    data: &[u8],
-    x942: bool,
-) -> CryptographyResult<DHParameters> {
+fn load_dh_parameters(data: &[u8], x942: bool) -> CryptographyResult<DHParameters> {
     let (p, q, g) = if x942 {
         let asn1_params = asn1::parse_single::<common::DHParams<'_>>(data)?;
         let p = openssl::bn::BigNum::from_slice(asn1_params.p.as_bytes())?;
@@ -108,27 +104,24 @@ fn load_dh_parameters(
 
     let dh = openssl::dh::Dh::from_pqg(p, q, g)?;
     check_dh_parameters(&dh)?;
-    warn_ffdh_deprecated(py)?;
     Ok(DHParameters { dh })
 }
 
 #[pyo3::pyfunction]
 #[pyo3(signature = (data, backend=None))]
 fn from_der_parameters(
-    py: pyo3::Python<'_>,
     data: &[u8],
     backend: Option<pyo3::Bound<'_, pyo3::PyAny>>,
 ) -> CryptographyResult<DHParameters> {
     let _ = backend;
     // DER carries no tag distinguishing PKCS#3 from X9.42, so we permissively
     // accept an optional trailing `q` for backwards compatibility.
-    load_dh_parameters(py, data, true)
+    load_dh_parameters(data, true)
 }
 
 #[pyo3::pyfunction]
 #[pyo3(signature = (data, backend=None))]
 fn from_pem_parameters(
-    py: pyo3::Python<'_>,
     data: &[u8],
     backend: Option<pyo3::Bound<'_, pyo3::PyAny>>,
 ) -> CryptographyResult<DHParameters> {
@@ -139,7 +132,7 @@ fn from_pem_parameters(
         "Valid PEM but no BEGIN DH PARAMETERS/END DH PARAMETERS delimiters. Are you sure this is a DH parameters?",
     )?;
 
-    load_dh_parameters(py, parsed.contents(), parsed.tag() == "X9.42 DH PARAMETERS")
+    load_dh_parameters(parsed.contents(), parsed.tag() == "X9.42 DH PARAMETERS")
 }
 
 fn dh_parameters_from_numbers(

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -12,7 +12,7 @@ use crate::{types, x509};
 
 fn warn_ffdh_deprecated(py: pyo3::Python<'_>) -> pyo3::PyResult<()> {
     let warning_cls = types::DEPRECATED_IN_50.get(py)?;
-    let message = c"Diffie-Hellman over finite fields (FFDH) is deprecated and support will be removed in a future release. Use a more modern key exchange algorithm, such as ML-KEM, instead.";
+    let message = c"Diffie-Hellman over finite fields (FFDH) is deprecated and support will be removed in a future release. Use a more modern key exchange algorithm.";
     pyo3::PyErr::warn(py, &warning_cls, message, 1)
 }
 

--- a/src/rust/src/backend/dh.rs
+++ b/src/rust/src/backend/dh.rs
@@ -8,7 +8,13 @@ use pyo3::types::PyAnyMethods;
 use crate::asn1::encode_der_data;
 use crate::backend::utils;
 use crate::error::{CryptographyError, CryptographyResult};
-use crate::x509;
+use crate::{types, x509};
+
+fn warn_ffdh_deprecated(py: pyo3::Python<'_>) -> pyo3::PyResult<()> {
+    let warning_cls = types::DEPRECATED_IN_50.get(py)?;
+    let message = c"Diffie-Hellman over finite fields (FFDH) is deprecated and support will be removed in a future release. Use X25519 or ECDH instead.";
+    pyo3::PyErr::warn(py, &warning_cls, message, 1)
+}
 
 #[pyo3::pyclass(frozen, module = "cryptography.hazmat.bindings._rust.openssl.dh")]
 pub(crate) struct DHPrivateKey {
@@ -54,18 +60,22 @@ fn generate_parameters(
 }
 
 pub(crate) fn private_key_from_pkey(
+    py: pyo3::Python<'_>,
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
 ) -> CryptographyResult<DHPrivateKey> {
     check_dh_parameters(&pkey.dh()?)?;
+    warn_ffdh_deprecated(py)?;
     Ok(DHPrivateKey {
         pkey: pkey.to_owned(),
     })
 }
 
 pub(crate) fn public_key_from_pkey(
+    py: pyo3::Python<'_>,
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Public>,
 ) -> CryptographyResult<DHPublicKey> {
     check_dh_parameters(&pkey.dh()?)?;
+    warn_ffdh_deprecated(py)?;
     Ok(DHPublicKey {
         pkey: pkey.to_owned(),
     })
@@ -75,7 +85,11 @@ pub(crate) fn public_key_from_pkey(
 // `x942` is true the optional trailing INTEGER is the X9.42 subprime `q`;
 // otherwise the structure is PKCS#3 and the optional trailing INTEGER is
 // `privateValueLength`, which we ignore.
-fn load_dh_parameters(data: &[u8], x942: bool) -> CryptographyResult<DHParameters> {
+fn load_dh_parameters(
+    py: pyo3::Python<'_>,
+    data: &[u8],
+    x942: bool,
+) -> CryptographyResult<DHParameters> {
     let (p, q, g) = if x942 {
         let asn1_params = asn1::parse_single::<common::DHParams<'_>>(data)?;
         let p = openssl::bn::BigNum::from_slice(asn1_params.p.as_bytes())?;
@@ -94,24 +108,27 @@ fn load_dh_parameters(data: &[u8], x942: bool) -> CryptographyResult<DHParameter
 
     let dh = openssl::dh::Dh::from_pqg(p, q, g)?;
     check_dh_parameters(&dh)?;
+    warn_ffdh_deprecated(py)?;
     Ok(DHParameters { dh })
 }
 
 #[pyo3::pyfunction]
 #[pyo3(signature = (data, backend=None))]
 fn from_der_parameters(
+    py: pyo3::Python<'_>,
     data: &[u8],
     backend: Option<pyo3::Bound<'_, pyo3::PyAny>>,
 ) -> CryptographyResult<DHParameters> {
     let _ = backend;
     // DER carries no tag distinguishing PKCS#3 from X9.42, so we permissively
     // accept an optional trailing `q` for backwards compatibility.
-    load_dh_parameters(data, true)
+    load_dh_parameters(py, data, true)
 }
 
 #[pyo3::pyfunction]
 #[pyo3(signature = (data, backend=None))]
 fn from_pem_parameters(
+    py: pyo3::Python<'_>,
     data: &[u8],
     backend: Option<pyo3::Bound<'_, pyo3::PyAny>>,
 ) -> CryptographyResult<DHParameters> {
@@ -122,7 +139,7 @@ fn from_pem_parameters(
         "Valid PEM but no BEGIN DH PARAMETERS/END DH PARAMETERS delimiters. Are you sure this is a DH parameters?",
     )?;
 
-    load_dh_parameters(parsed.contents(), parsed.tag() == "X9.42 DH PARAMETERS")
+    load_dh_parameters(py, parsed.contents(), parsed.tag() == "X9.42 DH PARAMETERS")
 }
 
 fn dh_parameters_from_numbers(

--- a/src/rust/src/backend/keys.rs
+++ b/src/rust/src/backend/keys.rs
@@ -168,7 +168,7 @@ fn private_key_from_pkey<'p>(
         openssl::pkey::Id::DSA => Ok(crate::backend::dsa::private_key_from_pkey(pkey)
             .into_pyobject(py)?
             .into_any()),
-        openssl::pkey::Id::DH => Ok(crate::backend::dh::private_key_from_pkey(pkey)?
+        openssl::pkey::Id::DH => Ok(crate::backend::dh::private_key_from_pkey(py, pkey)?
             .into_pyobject(py)?
             .into_any()),
 
@@ -177,7 +177,7 @@ fn private_key_from_pkey<'p>(
             CRYPTOGRAPHY_IS_BORINGSSL,
             CRYPTOGRAPHY_IS_AWSLC
         )))]
-        openssl::pkey::Id::DHX => Ok(crate::backend::dh::private_key_from_pkey(pkey)?
+        openssl::pkey::Id::DHX => Ok(crate::backend::dh::private_key_from_pkey(py, pkey)?
             .into_pyobject(py)?
             .into_any()),
         #[cfg(any(
@@ -366,7 +366,7 @@ fn public_key_from_pkey<'p>(
         openssl::pkey::Id::DSA => Ok(crate::backend::dsa::public_key_from_pkey(pkey)
             .into_pyobject(py)?
             .into_any()),
-        openssl::pkey::Id::DH => Ok(crate::backend::dh::public_key_from_pkey(pkey)?
+        openssl::pkey::Id::DH => Ok(crate::backend::dh::public_key_from_pkey(py, pkey)?
             .into_pyobject(py)?
             .into_any()),
 
@@ -375,7 +375,7 @@ fn public_key_from_pkey<'p>(
             CRYPTOGRAPHY_IS_BORINGSSL,
             CRYPTOGRAPHY_IS_AWSLC
         )))]
-        openssl::pkey::Id::DHX => Ok(crate::backend::dh::public_key_from_pkey(pkey)?
+        openssl::pkey::Id::DHX => Ok(crate::backend::dh::public_key_from_pkey(py, pkey)?
             .into_pyobject(py)?
             .into_any()),
         #[cfg(any(

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -46,6 +46,8 @@ pub static DEPRECATED_IN_42: LazyPyImport =
     LazyPyImport::new("cryptography.utils", &["DeprecatedIn42"]);
 pub static DEPRECATED_IN_43: LazyPyImport =
     LazyPyImport::new("cryptography.utils", &["DeprecatedIn43"]);
+pub static DEPRECATED_IN_50: LazyPyImport =
+    LazyPyImport::new("cryptography.utils", &["DeprecatedIn50"]);
 
 pub static KEY_SERIALIZATION_ENCRYPTION_BUILDER: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives._serialization",

--- a/tests/hazmat/primitives/fixtures_dh.py
+++ b/tests/hazmat/primitives/fixtures_dh.py
@@ -3,23 +3,30 @@
 # for complete details.
 
 
+import warnings
+
+from cryptography import utils
 from cryptography.hazmat.primitives.asymmetric import dh
 
-FFDH3072_P = dh.DHParameterNumbers(
-    p=int(
-        "ffffffffffffffffadf85458a2bb4a9aafdc5620273d3cf1d8b9c583ce2d3695a9e"
-        "13641146433fbcc939dce249b3ef97d2fe363630c75d8f681b202aec4617ad3df1e"
-        "d5d5fd65612433f51f5f066ed0856365553ded1af3b557135e7f57c935984f0c70e"
-        "0e68b77e2a689daf3efe8721df158a136ade73530acca4f483a797abc0ab182b324"
-        "fb61d108a94bb2c8e3fbb96adab760d7f4681d4f42a3de394df4ae56ede76372bb1"
-        "90b07a7c8ee0a6d709e02fce1cdf7e2ecc03404cd28342f619172fe9ce98583ff8e"
-        "4f1232eef28183c3fe3b1b4c6fad733bb5fcbc2ec22005c58ef1837d1683b2c6f34"
-        "a26c1b2effa886b4238611fcfdcde355b3b6519035bbc34f4def99c023861b46fc9"
-        "d6e6c9077ad91d2691f7f7ee598cb0fac186d91caefe130985139270b4130c93bc4"
-        "37944f4fd4452e2d74dd364f2e21e71f54bff5cae82ab9c9df69ee86d2bc522363a"
-        "0dabc521979b0deada1dbf9a42d5c4484e0abcd06bfa53ddef3c1b20ee3fd59d7c2"
-        "5e41d2b66c62e37ffffffffffffffff",
-        16,
-    ),
-    g=2,
-)
+# This module is imported at test collection time; suppress the FFDH
+# deprecation warning so it doesn't appear in the warning summary.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", utils.DeprecatedIn50)
+    FFDH3072_P = dh.DHParameterNumbers(
+        p=int(
+            "ffffffffffffffffadf85458a2bb4a9aafdc5620273d3cf1d8b9c583ce2d3695a9e"
+            "13641146433fbcc939dce249b3ef97d2fe363630c75d8f681b202aec4617ad3df1e"
+            "d5d5fd65612433f51f5f066ed0856365553ded1af3b557135e7f57c935984f0c70e"
+            "0e68b77e2a689daf3efe8721df158a136ade73530acca4f483a797abc0ab182b324"
+            "fb61d108a94bb2c8e3fbb96adab760d7f4681d4f42a3de394df4ae56ede76372bb1"
+            "90b07a7c8ee0a6d709e02fce1cdf7e2ecc03404cd28342f619172fe9ce98583ff8e"
+            "4f1232eef28183c3fe3b1b4c6fad733bb5fcbc2ec22005c58ef1837d1683b2c6f34"
+            "a26c1b2effa886b4238611fcfdcde355b3b6519035bbc34f4def99c023861b46fc9"
+            "d6e6c9077ad91d2691f7f7ee598cb0fac186d91caefe130985139270b4130c93bc4"
+            "37944f4fd4452e2d74dd364f2e21e71f54bff5cae82ab9c9df69ee86d2bc522363a"
+            "0dabc521979b0deada1dbf9a42d5c4484e0abcd06bfa53ddef3c1b20ee3fd59d7c2"
+            "5e41d2b66c62e37ffffffffffffffff",
+            16,
+        ),
+        g=2,
+    )

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -11,6 +11,7 @@ import typing
 
 import pytest
 
+from cryptography import utils
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dh
@@ -18,6 +19,15 @@ from cryptography.hazmat.primitives.asymmetric import dh
 from ...doubles import DummyKeySerializationEncryption
 from ...utils import load_nist_vectors, load_vectors_from_file
 from .fixtures_dh import FFDH3072_P
+
+# Accessing any attribute of the dh module and loading any DH key or
+# parameters emits the FFDH deprecation warning. Ignore it module-wide
+# rather than wrapping every call site; TestDHDeprecationWarnings asserts
+# that the warnings are actually emitted.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Diffie-Hellman over finite fields"
+    ":cryptography.utils.CryptographyDeprecationWarning"
+)
 
 # RFC 3526
 P_1536 = int(
@@ -38,6 +48,60 @@ def _skip_dhx_unsupported(backend, is_dhx):
         return
     if not backend.dh_x942_serialization_supported():
         pytest.skip("DH x9.42 serialization is not supported")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "generate_parameters",
+        "DHParameterNumbers",
+        "DHPrivateNumbers",
+        "DHPublicNumbers",
+        "DHParameters",
+        "DHParametersWithSerialization",
+        "DHPublicKey",
+        "DHPublicKeyWithSerialization",
+        "DHPrivateKey",
+        "DHPrivateKeyWithSerialization",
+    ],
+)
+def test_dh_attribute_deprecation_warning(name):
+    with pytest.warns(utils.DeprecatedIn50):
+        getattr(dh, name)
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.dh_supported(),
+    skip_message="DH not supported",
+)
+class TestDHDeprecationWarnings:
+    @pytest.mark.skip_fips(reason="non-FIPS parameters")
+    def test_load_private_key_warns(self, backend):
+        data = load_vectors_from_file(
+            os.path.join("asymmetric", "DH", "dhkey.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
+        with pytest.warns(utils.DeprecatedIn50):
+            serialization.load_pem_private_key(data, None, backend)
+
+    def test_load_public_key_warns(self, backend):
+        data = load_vectors_from_file(
+            os.path.join("asymmetric", "DH", "dhpub.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
+        with pytest.warns(utils.DeprecatedIn50):
+            serialization.load_pem_public_key(data, backend)
+
+    def test_load_parameters_warns(self, backend):
+        data = load_vectors_from_file(
+            os.path.join("asymmetric", "DH", "dhp.pem"),
+            lambda pemfile: pemfile.read(),
+            mode="rb",
+        )
+        with pytest.warns(utils.DeprecatedIn50):
+            serialization.load_pem_parameters(data, backend)
 
 
 def test_dh_parameternumbers():

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -8,7 +8,6 @@ import copy
 import itertools
 import os
 import typing
-import warnings
 
 import pytest
 
@@ -28,14 +27,6 @@ pytestmark = pytest.mark.filterwarnings(
     "ignore:Diffie-Hellman over finite fields"
     ":cryptography.utils.CryptographyDeprecationWarning"
 )
-
-# load_{pem,der}_parameters are deprecated module attributes; bind them once
-# here so the parametrize decorators below don't emit the deprecation
-# warning at collection time, where the filterwarnings mark doesn't apply.
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", utils.DeprecatedIn50)
-    load_pem_parameters = serialization.load_pem_parameters
-    load_der_parameters = serialization.load_der_parameters
 
 # RFC 3526
 P_1536 = int(
@@ -924,58 +915,65 @@ class TestDHPublicKeySerialization:
 )
 class TestDHParameterSerialization:
     @pytest.mark.parametrize(
-        ("encoding", "loader_func"),
-        [
-            [serialization.Encoding.PEM, load_pem_parameters],
-            [serialization.Encoding.DER, load_der_parameters],
-        ],
+        "encoding",
+        [serialization.Encoding.PEM, serialization.Encoding.DER],
     )
-    def test_parameter_bytes(self, encoding, loader_func):
+    def test_parameter_bytes(self, encoding):
         parameters = FFDH3072_P.parameters()
         serialized = parameters.parameter_bytes(
             encoding, serialization.ParameterFormat.PKCS3
         )
-        loaded_key = loader_func(serialized)
+        if encoding is serialization.Encoding.PEM:
+            with pytest.warns(utils.DeprecatedIn50):
+                loaded_key = serialization.load_pem_parameters(serialized)
+        else:
+            with pytest.warns(utils.DeprecatedIn50):
+                loaded_key = serialization.load_der_parameters(serialized)
         loaded_param_num = loaded_key.parameter_numbers()
         assert loaded_param_num == parameters.parameter_numbers()
 
     @pytest.mark.parametrize(
-        ("param_path", "loader_func", "encoding", "is_dhx"),
+        ("param_path", "encoding", "is_dhx"),
         [
             (
                 os.path.join("asymmetric", "DH", "dhp.pem"),
-                load_pem_parameters,
                 serialization.Encoding.PEM,
                 False,
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp.der"),
-                load_der_parameters,
                 serialization.Encoding.DER,
                 False,
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp_rfc5114_2.pem"),
-                load_pem_parameters,
                 serialization.Encoding.PEM,
                 True,
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp_rfc5114_2.der"),
-                load_der_parameters,
                 serialization.Encoding.DER,
                 True,
             ),
         ],
     )
     def test_parameter_bytes_match(
-        self, param_path, loader_func, encoding, backend, is_dhx
+        self, param_path, encoding, backend, is_dhx
     ):
         _skip_dhx_unsupported(backend, is_dhx)
         param_bytes = load_vectors_from_file(
             param_path, lambda pemfile: pemfile.read(), mode="rb"
         )
-        parameters = loader_func(param_bytes, backend)
+        if encoding is serialization.Encoding.PEM:
+            with pytest.warns(utils.DeprecatedIn50):
+                parameters = serialization.load_pem_parameters(
+                    param_bytes, backend
+                )
+        else:
+            with pytest.warns(utils.DeprecatedIn50):
+                parameters = serialization.load_der_parameters(
+                    param_bytes, backend
+                )
         serialized = parameters.parameter_bytes(
             encoding,
             serialization.ParameterFormat.PKCS3,
@@ -983,36 +981,41 @@ class TestDHParameterSerialization:
         assert serialized == param_bytes
 
     @pytest.mark.parametrize(
-        ("param_path", "loader_func", "vec_path"),
+        ("param_path", "encoding", "vec_path"),
         [
             (
                 os.path.join("asymmetric", "DH", "dhp.pem"),
-                load_pem_parameters,
+                serialization.Encoding.PEM,
                 os.path.join("asymmetric", "DH", "dhkey.txt"),
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp.der"),
-                load_der_parameters,
+                serialization.Encoding.DER,
                 os.path.join("asymmetric", "DH", "dhkey.txt"),
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp_rfc5114_2.pem"),
-                load_pem_parameters,
+                serialization.Encoding.PEM,
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt"),
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp_rfc5114_2.der"),
-                load_der_parameters,
+                serialization.Encoding.DER,
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt"),
             ),
         ],
     )
-    def test_public_bytes_values(self, param_path, loader_func, vec_path):
+    def test_public_bytes_values(self, param_path, encoding, vec_path):
         key_bytes = load_vectors_from_file(
             param_path, lambda pemfile: pemfile.read(), mode="rb"
         )
         vec = load_vectors_from_file(vec_path, load_nist_vectors)[0]
-        parameters = loader_func(key_bytes)
+        if encoding is serialization.Encoding.PEM:
+            with pytest.warns(utils.DeprecatedIn50):
+                parameters = serialization.load_pem_parameters(key_bytes)
+        else:
+            with pytest.warns(utils.DeprecatedIn50):
+                parameters = serialization.load_der_parameters(key_bytes)
         parameter_numbers = parameters.parameter_numbers()
         assert parameter_numbers.g == int(vec["g"], 16)
         assert parameter_numbers.p == int(vec["p"], 16)
@@ -1030,7 +1033,8 @@ class TestDHParameterSerialization:
             lambda pemfile: pemfile.read(),
             mode="rb",
         )
-        parameters = serialization.load_pem_parameters(param_bytes)
+        with pytest.warns(utils.DeprecatedIn50):
+            parameters = serialization.load_pem_parameters(param_bytes)
         parameter_numbers = parameters.parameter_numbers()
         assert parameter_numbers.g == 2
         assert parameter_numbers.q is None

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -8,6 +8,7 @@ import copy
 import itertools
 import os
 import typing
+import warnings
 
 import pytest
 
@@ -22,12 +23,19 @@ from .fixtures_dh import FFDH3072_P
 
 # Accessing any attribute of the dh module and loading any DH key or
 # parameters emits the FFDH deprecation warning. Ignore it module-wide
-# rather than wrapping every call site; TestDHDeprecationWarnings asserts
-# that the warnings are actually emitted.
+# rather than wrapping every call site.
 pytestmark = pytest.mark.filterwarnings(
     "ignore:Diffie-Hellman over finite fields"
     ":cryptography.utils.CryptographyDeprecationWarning"
 )
+
+# load_{pem,der}_parameters are deprecated module attributes; bind them once
+# here so the parametrize decorators below don't emit the deprecation
+# warning at collection time, where the filterwarnings mark doesn't apply.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", utils.DeprecatedIn50)
+    load_pem_parameters = serialization.load_pem_parameters
+    load_der_parameters = serialization.load_der_parameters
 
 # RFC 3526
 P_1536 = int(
@@ -48,60 +56,6 @@ def _skip_dhx_unsupported(backend, is_dhx):
         return
     if not backend.dh_x942_serialization_supported():
         pytest.skip("DH x9.42 serialization is not supported")
-
-
-@pytest.mark.parametrize(
-    "name",
-    [
-        "generate_parameters",
-        "DHParameterNumbers",
-        "DHPrivateNumbers",
-        "DHPublicNumbers",
-        "DHParameters",
-        "DHParametersWithSerialization",
-        "DHPublicKey",
-        "DHPublicKeyWithSerialization",
-        "DHPrivateKey",
-        "DHPrivateKeyWithSerialization",
-    ],
-)
-def test_dh_attribute_deprecation_warning(name):
-    with pytest.warns(utils.DeprecatedIn50):
-        getattr(dh, name)
-
-
-@pytest.mark.supported(
-    only_if=lambda backend: backend.dh_supported(),
-    skip_message="DH not supported",
-)
-class TestDHDeprecationWarnings:
-    @pytest.mark.skip_fips(reason="non-FIPS parameters")
-    def test_load_private_key_warns(self, backend):
-        data = load_vectors_from_file(
-            os.path.join("asymmetric", "DH", "dhkey.pem"),
-            lambda pemfile: pemfile.read(),
-            mode="rb",
-        )
-        with pytest.warns(utils.DeprecatedIn50):
-            serialization.load_pem_private_key(data, None, backend)
-
-    def test_load_public_key_warns(self, backend):
-        data = load_vectors_from_file(
-            os.path.join("asymmetric", "DH", "dhpub.pem"),
-            lambda pemfile: pemfile.read(),
-            mode="rb",
-        )
-        with pytest.warns(utils.DeprecatedIn50):
-            serialization.load_pem_public_key(data, backend)
-
-    def test_load_parameters_warns(self, backend):
-        data = load_vectors_from_file(
-            os.path.join("asymmetric", "DH", "dhp.pem"),
-            lambda pemfile: pemfile.read(),
-            mode="rb",
-        )
-        with pytest.warns(utils.DeprecatedIn50):
-            serialization.load_pem_parameters(data, backend)
 
 
 def test_dh_parameternumbers():
@@ -972,8 +926,8 @@ class TestDHParameterSerialization:
     @pytest.mark.parametrize(
         ("encoding", "loader_func"),
         [
-            [serialization.Encoding.PEM, serialization.load_pem_parameters],
-            [serialization.Encoding.DER, serialization.load_der_parameters],
+            [serialization.Encoding.PEM, load_pem_parameters],
+            [serialization.Encoding.DER, load_der_parameters],
         ],
     )
     def test_parameter_bytes(self, encoding, loader_func):
@@ -990,25 +944,25 @@ class TestDHParameterSerialization:
         [
             (
                 os.path.join("asymmetric", "DH", "dhp.pem"),
-                serialization.load_pem_parameters,
+                load_pem_parameters,
                 serialization.Encoding.PEM,
                 False,
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp.der"),
-                serialization.load_der_parameters,
+                load_der_parameters,
                 serialization.Encoding.DER,
                 False,
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp_rfc5114_2.pem"),
-                serialization.load_pem_parameters,
+                load_pem_parameters,
                 serialization.Encoding.PEM,
                 True,
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp_rfc5114_2.der"),
-                serialization.load_der_parameters,
+                load_der_parameters,
                 serialization.Encoding.DER,
                 True,
             ),
@@ -1033,22 +987,22 @@ class TestDHParameterSerialization:
         [
             (
                 os.path.join("asymmetric", "DH", "dhp.pem"),
-                serialization.load_pem_parameters,
+                load_pem_parameters,
                 os.path.join("asymmetric", "DH", "dhkey.txt"),
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp.der"),
-                serialization.load_der_parameters,
+                load_der_parameters,
                 os.path.join("asymmetric", "DH", "dhkey.txt"),
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp_rfc5114_2.pem"),
-                serialization.load_pem_parameters,
+                load_pem_parameters,
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt"),
             ),
             (
                 os.path.join("asymmetric", "DH", "dhp_rfc5114_2.der"),
-                serialization.load_der_parameters,
+                load_der_parameters,
                 os.path.join("asymmetric", "DH", "dhkey_rfc5114_2.txt"),
             ),
         ],

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -12,6 +12,7 @@ import typing
 
 import pytest
 
+from cryptography import utils
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.decrepit.ciphers.algorithms import _DES, ARC4, RC2
@@ -1779,7 +1780,9 @@ class TestDHSerialization:
             lambda pemfile: pemfile.read(),
             mode="rb",
         )
-        public_key = load_pem_private_key(data, None).public_key()
+        with pytest.warns(utils.DeprecatedIn50):
+            private_key = load_pem_private_key(data, None)
+        public_key = private_key.public_key()
         for enc in (
             Encoding.PEM,
             Encoding.DER,
@@ -1811,7 +1814,8 @@ class TestDHSerialization:
             lambda pemfile: pemfile.read(),
             mode="rb",
         )
-        private_key = load_pem_private_key(data, None)
+        with pytest.warns(utils.DeprecatedIn50):
+            private_key = load_pem_private_key(data, None)
         for enc in (
             Encoding.PEM,
             Encoding.DER,

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -16,6 +16,7 @@ from cryptography import utils
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.decrepit.ciphers.algorithms import _DES, ARC4, RC2
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import (
     dsa,
     ec,
@@ -33,10 +34,8 @@ from cryptography.hazmat.primitives.serialization import (
     NoEncryption,
     PrivateFormat,
     PublicFormat,
-    load_der_parameters,
     load_der_private_key,
     load_der_public_key,
-    load_pem_parameters,
     load_pem_private_key,
     load_pem_public_key,
 )
@@ -423,8 +422,8 @@ class TestDERSerialization:
     def test_wrong_parameters_format(self):
         param_data = b"---- NOT A KEY ----\n"
 
-        with pytest.raises(ValueError):
-            load_der_parameters(param_data)
+        with pytest.raises(ValueError), pytest.warns(utils.DeprecatedIn50):
+            serialization.load_der_parameters(param_data)
 
     def test_load_pkcs8_private_key_invalid_version(self):
         data = load_vectors_from_file(
@@ -1011,8 +1010,8 @@ class TestPEMSerialization:
     def test_wrong_parameters_format(self):
         param_data = b"---- NOT A KEY ----\n"
 
-        with pytest.raises(ValueError):
-            load_pem_parameters(param_data)
+        with pytest.raises(ValueError), pytest.warns(utils.DeprecatedIn50):
+            serialization.load_pem_parameters(param_data)
 
     def test_corrupt_traditional_format(self):
         # privkey.pem with a bunch of data missing.

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -7116,7 +7116,8 @@ class TestSignatureRejection:
             load_nist_vectors,
         )[1]
         p = int.from_bytes(binascii.unhexlify(vector["p"]), "big")
-        params = dh.DHParameterNumbers(p, int(vector["g"]))
+        with pytest.warns(utils.DeprecatedIn50):
+            params = dh.DHParameterNumbers(p, int(vector["g"]))
         param = params.parameters()
         return param.generate_private_key()
 


### PR DESCRIPTION
Deprecates everything FFDH, per the request:

- Every public name in `cryptography.hazmat.primitives.asymmetric.dh` (the key/parameters classes, the numbers classes, the `WithSerialization` aliases, and `generate_parameters`) is deprecated via `utils.deprecated` with a new `DeprecatedIn50`, so any attribute access warns.
- Loading a DH key via `load_{pem,der}_{private,public}_key` (including PKCS#12 and certificate/CSR `public_key()` for DH SPKIs) emits the same warning from the Rust side, after the key passes validation, so failed loads raise their normal errors without a spurious warning. Non-DH key loads are unaffected.
- `load_pem_parameters`/`load_der_parameters` can only load FFDH parameters, so the functions themselves are deprecated.
- `types.py` uses private non-warning aliases for the DH entries in `PublicKeyTypes`/`PrivateKeyTypes` so that `import cryptography.x509` stays warning-free.
- `test_dh.py` ignores the warning module-wide via `pytestmark`, with `pytest.warns` at the parameter-loader callsites; the handful of DH touchpoints in `test_serialization.py`/`test_x509.py` use `pytest.warns`. The suite runs warning-free.
- CHANGELOG entry and `.. deprecated:: 50.0.0` notes in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iUUcywCCXL51sy4WUGqbM

---
_Generated by [Claude Code](https://claude.ai/code/session_017iUUcywCCXL51sy4WUGqbM)_