### PR TITLE
Skip slow DH_check tests on AWS-LC and LibreSSL for large moduli

### DIFF
--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -11,6 +11,7 @@ import typing
 
 import pytest
 
+from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dh
 
@@ -176,6 +177,14 @@ class TestDH:
         p = int.from_bytes(binascii.unhexlify(vector["p"]), "big")
         if backend._fips_enabled and p < backend._fips_dh_min_modulus:
             pytest.skip("modulus too small for FIPS mode")
+        if (
+            rust_openssl.CRYPTOGRAPHY_IS_AWSLC
+            or rust_openssl.CRYPTOGRAPHY_IS_LIBRESSL
+        ) and p.bit_length() >= 3072:
+            pytest.skip(
+                "Key generation for large moduli is very slow on AWS-LC "
+                "and LibreSSL"
+            )
 
         params = dh.DHParameterNumbers(p, int(vector["g"]))
         param = params.parameters(backend)

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -177,13 +177,16 @@ class TestDH:
         p = int.from_bytes(binascii.unhexlify(vector["p"]), "big")
         if backend._fips_enabled and p < backend._fips_dh_min_modulus:
             pytest.skip("modulus too small for FIPS mode")
+        # DH_check is very slow for large moduli on AWS-LC and LibreSSL.
+        # For AWS-LC this is tracked in
+        # https://github.com/aws/aws-lc/issues/3335
         if (
             rust_openssl.CRYPTOGRAPHY_IS_AWSLC
             or rust_openssl.CRYPTOGRAPHY_IS_LIBRESSL
         ) and p.bit_length() >= 3072:
             pytest.skip(
-                "Key generation for large moduli is very slow on AWS-LC "
-                "and LibreSSL"
+                "DH_check is very slow for large moduli on AWS-LC and "
+                "LibreSSL"
             )
 
         params = dh.DHParameterNumbers(p, int(vector["g"]))

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -185,8 +185,7 @@ class TestDH:
             or rust_openssl.CRYPTOGRAPHY_IS_LIBRESSL
         ) and p.bit_length() >= 3072:
             pytest.skip(
-                "DH_check is very slow for large moduli on AWS-LC and "
-                "LibreSSL"
+                "DH_check is very slow for large moduli on AWS-LC and LibreSSL"
             )
 
         params = dh.DHParameterNumbers(p, int(vector["g"]))


### PR DESCRIPTION
## Summary
Add a test skip condition for DH parameter validation tests when using AWS-LC or LibreSSL with large moduli (≥3072 bits), as DH_check is known to be very slow on these backends for large key sizes.

## Changes
- Import `rust_openssl` bindings to detect AWS-LC and LibreSSL backends
- Add conditional skip in `test_dh_parameters_allows_rfc3526_groups` for large moduli on AWS-LC and LibreSSL
- Reference AWS-LC issue https://github.com/aws/aws-lc/issues/3335 tracking the performance problem

## Details
The DH_check operation is significantly slower on AWS-LC and LibreSSL when validating large Diffie-Hellman parameters (3072 bits and above). This change prevents test timeouts by skipping these specific test cases on affected backends while maintaining full test coverage on other OpenSSL implementations.

https://claude.ai/code/session_01PL9rchfs5nzFEamLrJnVTZ