### PR TITLE
Cache maturin's pyo3 config file to stop recompiling pyo3 every CI run

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -20,3 +20,26 @@ runs:
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       with:
         key: ${{ steps.normalized-key.outputs.key }}-5
+    # maturin writes the pyo3 config file to target/maturin/, and pyo3-ffi's
+    # build script registers cargo:rerun-if-changed on it. rust-cache's
+    # cleanup deletes target/maturin/ before saving, so the file was
+    # recreated with a fresh mtime on every run, which recompiled pyo3-ffi
+    # and pyo3 despite a warm cache. Cache it separately. This step must
+    # come after rust-cache: post steps run in reverse order, so this one
+    # saves before rust-cache's cleanup deletes the directory.
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: target/maturin
+        key: "maturin-pyo3-config-${{ runner.os }}-${{ runner.arch }}-${{ steps.normalized-key.outputs.key }}-${{ hashFiles('Cargo.lock') }}-0"
+    # Cargo's rerun-if-changed check compares the config file's mtime
+    # against the .fingerprint timestamps from rust-cache. The two caches
+    # can be saved on different runs, so pin the config to a fixed old
+    # mtime to keep it older than any cached fingerprint. If the config is
+    # stale (e.g. new Python version), maturin rewrites it and the build
+    # correctly reruns.
+    - name: Pin maturin config mtimes
+      run: |
+        if [ -d target/maturin ]; then
+          find target/maturin -type f -exec touch -t 200101010000 {} +
+        fi
+      shell: bash

--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -30,7 +30,7 @@ runs:
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: target/maturin
-        key: "maturin-pyo3-config-${{ runner.os }}-${{ runner.arch }}-${{ steps.normalized-key.outputs.key }}-${{ hashFiles('Cargo.lock') }}-0"
+        key: "maturin-pyo3-config-${{ steps.normalized-key.outputs.key }}-0"
     # Cargo's rerun-if-changed check compares the config file's mtime
     # against the .fingerprint timestamps from rust-cache. The two caches
     # can be saved on different runs, so pin the config to a fixed old


### PR DESCRIPTION
Every CI run recompiles `pyo3-ffi` and `pyo3` despite a full rust-cache hit, on every platform. The cause:

1. maturin writes its pyo3 interpreter config to `target/maturin/pyo3-config-*.txt`, and pyo3-ffi's build script registers `cargo:rerun-if-changed` on that file.
2. rust-cache's save-time cleanup treats `target/maturin` as a profile directory and deletes everything in it except `build`/`.fingerprint`/`deps`, so the config file never makes it into the cache.
3. The next run recreates the file with a fresh mtime, cargo sees it as changed, and pyo3-ffi + pyo3 (at the head of the build's critical path) recompile.

Reproduced locally: deleting only `target/maturin` from a warm target dir triggers exactly the `Compiling pyo3-ffi` / `Compiling pyo3` seen in CI logs; preserving it through a tar round-trip leaves only the workspace crates rebuilding.

This adds a small `actions/cache` step for `target/maturin` in the shared cache action, ordered after rust-cache so its save-post runs before rust-cache's cleanup deletes the directory. Since the two caches can be saved on different runs, the restored file is pinned to a fixed old mtime (same trick as `pin_artifact_mtimes.py` for the OpenSSL artifacts) so it is always older than the cached fingerprints. If the config is genuinely stale (e.g. a new Python version), maturin rewrites it and the rebuild happens as it should.

Expected effect: ~10–15s off each Windows job (where the build is slowest) and ~5–8s off the other ~30 jobs per run, starting from the second run after the new cache is seeded. `Compiling pyo3` should disappear from warm-cache build logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FABWEgTpKgsJLeWhhGEg5j

---
_Generated by [Claude Code](https://claude.ai/code/session_01FABWEgTpKgsJLeWhhGEg5j)_