### PR TITLE
Skip PBKDF2 Wycheproof tests with large iteration counts

### DIFF
--- a/tests/wycheproof/test_pbkdf2.py
+++ b/tests/wycheproof/test_pbkdf2.py
@@ -19,7 +19,7 @@ _HASH_ALGORITHMS = {
 
 
 @wycheproof_tests(
-    "pbkdf2_hmacsha1_test.json",
+    ("pbkdf2_hmacsha1_test.json", 8),
     "pbkdf2_hmacsha224_test.json",
     "pbkdf2_hmacsha256_test.json",
     "pbkdf2_hmacsha384_test.json",

--- a/tests/wycheproof/test_pbkdf2.py
+++ b/tests/wycheproof/test_pbkdf2.py
@@ -4,6 +4,8 @@
 
 import binascii
 
+import pytest
+
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
@@ -19,7 +21,7 @@ _HASH_ALGORITHMS = {
 
 
 @wycheproof_tests(
-    ("pbkdf2_hmacsha1_test.json", 8),
+    "pbkdf2_hmacsha1_test.json",
     "pbkdf2_hmacsha224_test.json",
     "pbkdf2_hmacsha256_test.json",
     "pbkdf2_hmacsha384_test.json",
@@ -28,6 +30,9 @@ _HASH_ALGORITHMS = {
 )
 def test_pbkdf2(backend, wycheproof):
     assert wycheproof.valid
+
+    if wycheproof.has_flag("LargeIterationCount"):
+        pytest.skip("Skipped due to large iteration count")
 
     algorithm = _HASH_ALGORITHMS[wycheproof.testfiledata["algorithm"]]
 

--- a/tests/wycheproof/utils.py
+++ b/tests/wycheproof/utils.py
@@ -2,19 +2,40 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+import typing
+
 import pytest
 
 from ..utils import load_wycheproof_tests
 
 
 def wycheproof_tests(*paths, subdir="testvectors_v1"):
+    # Each entry in paths is either a filename, or a (filename, num_shards)
+    # tuple. Sharded files are split into num_shards separate test items so
+    # that expensive vector files don't serialize on a single xdist worker.
+    params: list[typing.Any] = []
+    for entry in paths:
+        if isinstance(entry, tuple):
+            path, num_shards = entry
+            params.extend(
+                pytest.param(path, shard, num_shards, id=f"{path}-{shard}")
+                for shard in range(num_shards)
+            )
+        else:
+            params.append(pytest.param(entry, 0, 1, id=entry))
+
     def wrapper(func):
-        @pytest.mark.parametrize("path", paths)
-        def run_wycheproof(backend, subtests, pytestconfig, path):
+        @pytest.mark.parametrize(("path", "shard", "num_shards"), params)
+        def run_wycheproof(
+            backend, subtests, pytestconfig, path, shard, num_shards
+        ):
             wycheproof_root = pytestconfig.getoption(
                 "--wycheproof-root", skip=True
             )
-            for test in load_wycheproof_tests(wycheproof_root, path, subdir):
+            tests = load_wycheproof_tests(wycheproof_root, path, subdir)
+            for i, test in enumerate(tests):
+                if i % num_shards != shard:
+                    continue
                 with subtests.test():
                     func(backend, test)
 

--- a/tests/wycheproof/utils.py
+++ b/tests/wycheproof/utils.py
@@ -2,40 +2,19 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
-import typing
-
 import pytest
 
 from ..utils import load_wycheproof_tests
 
 
 def wycheproof_tests(*paths, subdir="testvectors_v1"):
-    # Each entry in paths is either a filename, or a (filename, num_shards)
-    # tuple. Sharded files are split into num_shards separate test items so
-    # that expensive vector files don't serialize on a single xdist worker.
-    params: list[typing.Any] = []
-    for entry in paths:
-        if isinstance(entry, tuple):
-            path, num_shards = entry
-            params.extend(
-                pytest.param(path, shard, num_shards, id=f"{path}-{shard}")
-                for shard in range(num_shards)
-            )
-        else:
-            params.append(pytest.param(entry, 0, 1, id=entry))
-
     def wrapper(func):
-        @pytest.mark.parametrize(("path", "shard", "num_shards"), params)
-        def run_wycheproof(
-            backend, subtests, pytestconfig, path, shard, num_shards
-        ):
+        @pytest.mark.parametrize("path", paths)
+        def run_wycheproof(backend, subtests, pytestconfig, path):
             wycheproof_root = pytestconfig.getoption(
                 "--wycheproof-root", skip=True
             )
-            tests = load_wycheproof_tests(wycheproof_root, path, subdir)
-            for i, test in enumerate(tests):
-                if i % num_shards != shard:
-                    continue
+            for test in load_wycheproof_tests(wycheproof_root, path, subdir):
                 with subtests.test():
                     func(backend, test)
 


### PR DESCRIPTION
Skip PBKDF2 Wycheproof test vectors that have the "LargeIterationCount" flag to avoid excessively long test execution times.

## Changes

- Added `pytest` import to the test module
- Added a check in `test_pbkdf2()` to skip test cases flagged with "LargeIterationCount"

## Details

Some Wycheproof test vectors for PBKDF2 use very large iteration counts, which can cause tests to run for an impractical amount of time. This change allows those specific test cases to be skipped while still running all other test vectors, improving test suite performance without sacrificing coverage of the standard test cases.

https://claude.ai/code/session_01TKpxEGP1wJkgKNx1utX6QK