### PR TITLE
Enable debug logging for uv in CI and nox installs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,12 +18,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Value for RUST_LOG on steps that run `uv pip install -v` directly:
-  # suppress uv's per-file cache/index log lines while keeping the rest
-  # of the -v output. Must be scoped to those steps (not set globally as
-  # RUST_LOG) because uv honors RUST_LOG even without -v. Keep in sync
-  # with UV_RUST_LOG in noxfile.py, which covers all nox-run installs.
-  UV_VERBOSE_RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
+  # Enable uv's debug output everywhere, minus its per-file cache/index
+  # log lines. All directives must stay scoped to uv targets (no bare
+  # level like `debug`) so other Rust binaries that read RUST_LOG are
+  # unaffected. Keep in sync with UV_RUST_LOG in noxfile.py, which
+  # covers nox-run installs outside CI.
+  RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
 
 jobs:
   benchmark:
@@ -58,17 +58,11 @@ jobs:
         run: |
           uv venv .venv-base
           . .venv-base/bin/activate
-          uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base/pyproject.toml:test
-        env:
-          RUST_LOG: ${{ env.UV_VERBOSE_RUST_LOG }}
-      - name: Create virtualenv (PR)
+          uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base/pyproject.toml:test      - name: Create virtualenv (PR)
         run: |
           uv venv .venv-pr
           . .venv-pr/bin/activate
           uv pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr/pyproject.toml:test
-        env:
-          RUST_LOG: ${{ env.UV_VERBOSE_RUST_LOG }}
-
       - name: Run benchmarks (base)
         run: .venv-base/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-base.json --x509-limbo-root=x509-limbo/
       - name: Run benchmarks (PR)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,11 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Enable uv's debug output everywhere, minus its per-file cache/index
-  # log lines. All directives must stay scoped to uv targets (no bare
-  # level like `debug`) so other Rust binaries that read RUST_LOG are
-  # unaffected. Keep in sync with UV_RUST_LOG in noxfile.py, which
-  # covers nox-run installs outside CI.
+  # See RUST_LOG in ci.yml
   RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
 
 jobs:
@@ -58,11 +54,13 @@ jobs:
         run: |
           uv venv .venv-base
           . .venv-base/bin/activate
-          uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base/pyproject.toml:test      - name: Create virtualenv (PR)
+          uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base/pyproject.toml:test
+      - name: Create virtualenv (PR)
         run: |
           uv venv .venv-pr
           . .venv-pr/bin/activate
           uv pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr/pyproject.toml:test
+
       - name: Run benchmarks (base)
         run: .venv-base/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-base.json --x509-limbo-root=x509-limbo/
       - name: Run benchmarks (PR)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,11 +51,17 @@ jobs:
           uv venv .venv-base
           . .venv-base/bin/activate
           uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base/pyproject.toml:test
+        env:
+          # Suppress uv's per-file cache/index log lines while keeping
+          # the rest of the -v output.
+          RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
       - name: Create virtualenv (PR)
         run: |
           uv venv .venv-pr
           . .venv-pr/bin/activate
           uv pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr/pyproject.toml:test
+        env:
+          RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
 
       - name: Run benchmarks (base)
         run: .venv-base/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-base.json --x509-limbo-root=x509-limbo/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,6 +17,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  # Value for RUST_LOG on steps that run `uv pip install -v` directly:
+  # suppress uv's per-file cache/index log lines while keeping the rest
+  # of the -v output. Must be scoped to those steps (not set globally as
+  # RUST_LOG) because uv honors RUST_LOG even without -v. Keep in sync
+  # with UV_RUST_LOG in noxfile.py, which covers all nox-run installs.
+  UV_VERBOSE_RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
@@ -52,16 +60,14 @@ jobs:
           . .venv-base/bin/activate
           uv pip install -v -c ./cryptography-base/ci-constraints-requirements.txt ./cryptography-base ./cryptography-base/vectors/ --group ./cryptography-base/pyproject.toml:test
         env:
-          # Suppress uv's per-file cache/index log lines while keeping
-          # the rest of the -v output.
-          RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
+          RUST_LOG: ${{ env.UV_VERBOSE_RUST_LOG }}
       - name: Create virtualenv (PR)
         run: |
           uv venv .venv-pr
           . .venv-pr/bin/activate
           uv pip install -v -c ./cryptography-pr/ci-constraints-requirements.txt ./cryptography-pr ./cryptography-pr/vectors/ --group ./cryptography-pr/pyproject.toml:test
         env:
-          RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
+          RUST_LOG: ${{ env.UV_VERBOSE_RUST_LOG }}
 
       - name: Run benchmarks (base)
         run: .venv-base/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-base.json --x509-limbo-root=x509-limbo/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   # See RUST_LOG in ci.yml
-  RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
+  RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error,uv_resolver::resolver=warn
 
 jobs:
   benchmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,10 @@ jobs:
       - run: uv venv
       - run: source .venv/bin/activate && ./.github/downstream.d/${{ matrix.DOWNSTREAM }}.sh install
       - run: uv pip install -v .
+        env:
+          # Suppress uv's per-file cache/index log lines while keeping
+          # the rest of the -v output.
+          RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
       # cryptography main has a version of "(X+1).0.0.dev1" where X is the
       # most recently released major version. A package used by a downstream
       # may depend on cryptography <=X. If you use entrypoints stuff, this can

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: 0
+  # Value for RUST_LOG on steps that run `uv pip install -v` directly:
+  # suppress uv's per-file cache/index log lines while keeping the rest
+  # of the -v output. Must be scoped to those steps (not set globally as
+  # RUST_LOG) because uv honors RUST_LOG even without -v. Keep in sync
+  # with UV_RUST_LOG in noxfile.py, which covers all nox-run installs.
+  UV_VERBOSE_RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
 
 jobs:
   linux:
@@ -468,9 +474,7 @@ jobs:
       - run: source .venv/bin/activate && ./.github/downstream.d/${{ matrix.DOWNSTREAM }}.sh install
       - run: uv pip install -v .
         env:
-          # Suppress uv's per-file cache/index log lines while keeping
-          # the rest of the -v output.
-          RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
+          RUST_LOG: ${{ env.UV_VERBOSE_RUST_LOG }}
       # cryptography main has a version of "(X+1).0.0.dev1" where X is the
       # most recently released major version. A package used by a downstream
       # may depend on cryptography <=X. If you use entrypoints stuff, this can

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: 0
-  # Value for RUST_LOG on steps that run `uv pip install -v` directly:
-  # suppress uv's per-file cache/index log lines while keeping the rest
-  # of the -v output. Must be scoped to those steps (not set globally as
-  # RUST_LOG) because uv honors RUST_LOG even without -v. Keep in sync
-  # with UV_RUST_LOG in noxfile.py, which covers all nox-run installs.
-  UV_VERBOSE_RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
+  # Enable uv's debug output everywhere, minus its per-file cache/index
+  # log lines. All directives must stay scoped to uv targets (no bare
+  # level like `debug`) so other Rust binaries that read RUST_LOG are
+  # unaffected. Keep in sync with UV_RUST_LOG in noxfile.py, which
+  # covers nox-run installs outside CI.
+  RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
 
 jobs:
   linux:
@@ -473,8 +473,6 @@ jobs:
       - run: uv venv
       - run: source .venv/bin/activate && ./.github/downstream.d/${{ matrix.DOWNSTREAM }}.sh install
       - run: uv pip install -v .
-        env:
-          RUST_LOG: ${{ env.UV_VERBOSE_RUST_LOG }}
       # cryptography main has a version of "(X+1).0.0.dev1" where X is the
       # most recently released major version. A package used by a downstream
       # may depend on cryptography <=X. If you use entrypoints stuff, this can

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   # level like `debug`) so other Rust binaries that read RUST_LOG are
   # unaffected. Keep in sync with UV_RUST_LOG in noxfile.py, which
   # covers nox-run installs outside CI.
-  RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error
+  RUST_LOG: uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error,uv_resolver::resolver=warn
 
 jobs:
   linux:

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,18 +24,30 @@ nox.options.reuse_existing_virtualenvs = True
 nox.options.default_venv_backend = "uv"
 
 
+# ``uv pip install -v`` emits per-file lines ("No cache entry for",
+# "Skipping file for") that drown out the build output we actually want.
+# RUST_LOG overrides uv's default ``-v`` filter, so silence just those
+# modules while keeping the rest of the debug output.
+UV_RUST_LOG = (
+    "uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error"
+)
+
+
 def install(
     session: nox.Session,
     *args: str,
     verbose: bool = True,
 ) -> None:
+    env = {}
     if verbose:
         args += ("-v",)
+        env["RUST_LOG"] = UV_RUST_LOG
     session.install(
         "-c",
         "ci-constraints-requirements.txt",
         *args,
         silent=False,
+        env=env,
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,10 +24,7 @@ nox.options.reuse_existing_virtualenvs = True
 nox.options.default_venv_backend = "uv"
 
 
-# ``uv pip install -v`` emits per-file lines ("No cache entry for",
-# "Skipping file for") that drown out the build output we actually want.
-# RUST_LOG overrides uv's default ``-v`` filter, so silence just those
-# modules while keeping the rest of the debug output.
+# See RUST_LOG in .github/workflows/ci.yml
 UV_RUST_LOG = (
     "uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error"
 )

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,8 @@ nox.options.default_venv_backend = "uv"
 
 # See RUST_LOG in .github/workflows/ci.yml
 UV_RUST_LOG = (
-    "uv=debug,uv_client::cached_client=warn,uv_client::registry_client=error"
+    "uv=debug,uv_client::cached_client=warn,"
+    "uv_client::registry_client=error,uv_resolver::resolver=warn"
 )
 
 


### PR DESCRIPTION
This change enables debug-level logging for the `uv` package manager across CI workflows and local nox-based installations, while filtering out verbose per-file cache and index log lines.

## Summary

Adds consistent `RUST_LOG` configuration to capture `uv`'s debug output in both CI environments and local development workflows. This improves visibility into package installation behavior for debugging purposes.

## Key changes

- **noxfile.py**: Define `UV_RUST_LOG` constant with filtered debug logging configuration and pass it as an environment variable to `session.install()` when verbose mode is enabled
- **.github/workflows/ci.yml**: Set `RUST_LOG` environment variable globally for all CI jobs with the same filtering rules
- **.github/workflows/benchmark.yml**: Set `RUST_LOG` environment variable for benchmark workflow jobs

## Implementation details

- The `RUST_LOG` configuration uses scoped directives (e.g., `uv=debug`, `uv_client::cached_client=warn`) to ensure only `uv`-related Rust binaries are affected, preventing noise from other Rust tools
- The same configuration is defined in both `noxfile.py` and CI workflows with a cross-reference comment to keep them in sync
- In nox, the environment variable is only set when verbose mode is enabled, allowing users to opt into debug logging via the existing verbose flag

https://claude.ai/code/session_01K7t5jPQeRAu7nWTFbVdVqR