### PR TITLE
Mark the X.509 verification APIs as stable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* The :mod:`X.509 verification <cryptography.x509.verification>` APIs are now
+  considered stable and are subject to our API stability policy.
 * Parsing a Signed Certificate Timestamp list now rejects encodings that
   carry trailing bytes after the list or after an individual SCT, instead of
   silently ignoring them.

--- a/docs/x509/verification.rst
+++ b/docs/x509/verification.rst
@@ -8,10 +8,6 @@ X.509 Verification
 Support for X.509 certificate verification, also known as path validation
 or chain building.
 
-.. note::
-    While usable, these APIs should be considered unstable and not yet
-    subject to our backwards compatibility policy.
-
 Example usage, with `certifi <https://pypi.org/project/certifi/>`_ providing
 the root of trust:
 


### PR DESCRIPTION
Removes the note in `docs/x509/verification.rst` stating that the `cryptography.x509.verification` APIs are unstable, making them subject to our API stability policy, and adds a changelog entry. This fulfills the promise from the 42.0.0 changelog entry, which said these APIs would remain unstable "until documented as such in a future release."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRHfSpV8USdUbDaPeharcZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRHfSpV8USdUbDaPeharcZ)_