### PR TITLE
Remove always-true pytest.mark.supported marks from cipher tests

### DIFF
--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -92,12 +92,6 @@ class TestAESModeXTS:
             base.Cipher(algorithms.AES256(b"0" * 32), modes.XTS(b"\x00" * 16))
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.CBC(b"\x00" * 16)
-    ),
-    skip_message="Does not support AES CBC",
-)
 class TestAESModeCBC:
     test_cbc = generate_encrypt_test(
         load_nist_vectors,
@@ -124,12 +118,6 @@ class TestAESModeCBC:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.ECB()
-    ),
-    skip_message="Does not support AES ECB",
-)
 class TestAESModeECB:
     test_ecb = generate_encrypt_test(
         load_nist_vectors,
@@ -156,12 +144,6 @@ class TestAESModeECB:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), OFB(b"\x00" * 16)
-    ),
-    skip_message="Does not support AES OFB",
-)
 class TestAESModeOFB:
     test_ofb = generate_encrypt_test(
         load_nist_vectors,
@@ -252,12 +234,6 @@ class TestAESModeCFB8:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.CTR(b"\x00" * 16)
-    ),
-    skip_message="Does not support AES CTR",
-)
 class TestAESModeCTR:
     test_ctr = generate_encrypt_test(
         load_nist_vectors,

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -16,12 +16,6 @@ from ...utils import load_nist_vectors, raises_unsupported_algorithm
 from .utils import generate_aead_test
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.GCM(b"\x00" * 12)
-    ),
-    skip_message="Does not support AES GCM",
-)
 class TestAESModeGCM:
     test_gcm = generate_aead_test(
         load_nist_vectors,

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -129,12 +129,6 @@ class TestCipherContext:
             decryptor.finalize()
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.GCM(b"\x00" * 12)
-    ),
-    skip_message="Does not support AES GCM",
-)
 class TestAEADCipherContext:
     test_aead_exceptions = generate_aead_exception_test(
         algorithms.AES,

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -106,12 +106,6 @@ class TestCamellia:
             Camellia(typing.cast(typing.Any, "0" * 32))
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        AES(b"\x00" * 16), modes.ECB()
-    ),
-    skip_message="Does not support AES ECB",
-)
 class TestCipherUpdateInto:
     @pytest.mark.parametrize(
         "params",
@@ -131,12 +125,6 @@ class TestCipherUpdateInto:
         assert res == len(pt)
         assert bytes(buf)[:res] == ct
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            AES(b"\x00" * 16), modes.GCM(b"0" * 12)
-        ),
-        skip_message="Does not support AES GCM",
-    )
     def test_update_into_gcm(self, backend):
         key = binascii.unhexlify(b"e98b72a9881a84ca6b76e0f43e68647a")
         iv = binascii.unhexlify(b"8b23299fde174053f3d652ba")
@@ -156,12 +144,6 @@ class TestCipherUpdateInto:
         assert res == len(pt)
         assert bytes(buf)[:res] == pt
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            AES(b"\x00" * 16), modes.GCM(b"0" * 12)
-        ),
-        skip_message="Does not support AES GCM",
-    )
     def test_finalize_with_tag_already_finalized(self, backend):
         key = binascii.unhexlify(b"e98b72a9881a84ca6b76e0f43e68647a")
         iv = binascii.unhexlify(b"8b23299fde174053f3d652ba")
@@ -178,12 +160,6 @@ class TestCipherUpdateInto:
         with pytest.raises(AlreadyFinalized):
             decryptor.finalize_with_tag(encryptor.tag)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            AES(b"\x00" * 16), modes.GCM(b"0" * 12)
-        ),
-        skip_message="Does not support AES GCM",
-    )
     def test_finalize_with_tag_duplicate_tag(self, backend):
         decryptor = ciphers.Cipher(
             AES(b"\x00" * 16),
@@ -229,12 +205,6 @@ class TestCipherUpdateInto:
         with pytest.raises((TypeError, BufferError)):
             encryptor.update_into(b"testing", buf)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            AES(b"\x00" * 16), modes.GCM(b"\x00" * 12)
-        ),
-        skip_message="Does not support AES GCM",
-    )
     def test_update_into_buffer_too_small_gcm(self, backend):
         key = b"\x00" * 16
         c = ciphers.Cipher(AES(key), modes.GCM(b"\x00" * 12), backend)

--- a/tests/hazmat/primitives/test_cmac.py
+++ b/tests/hazmat/primitives/test_cmac.py
@@ -48,12 +48,6 @@ fake_key = b"\x00" * 16
 
 
 class TestCMAC:
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cmac_algorithm_supported(
-            AES(fake_key)
-        ),
-        skip_message="Does not support CMAC.",
-    )
     @pytest.mark.parametrize("params", vectors_aes)
     def test_aes_generate(self, backend, params):
         key = params["key"]
@@ -64,12 +58,6 @@ class TestCMAC:
         cmac.update(binascii.unhexlify(message))
         assert binascii.hexlify(cmac.finalize()) == output
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cmac_algorithm_supported(
-            AES(fake_key)
-        ),
-        skip_message="Does not support CMAC.",
-    )
     @pytest.mark.parametrize("params", vectors_aes)
     def test_aes_verify(self, backend, params):
         key = params["key"]
@@ -122,12 +110,6 @@ class TestCMAC:
         cmac.update(binascii.unhexlify(message))
         cmac.verify(binascii.unhexlify(output))
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cmac_algorithm_supported(
-            AES(fake_key)
-        ),
-        skip_message="Does not support CMAC.",
-    )
     def test_invalid_verify(self, backend):
         key = b"2b7e151628aed2a6abf7158809cf4f3c"
         cmac = CMAC(AES(key), backend)
@@ -148,12 +130,6 @@ class TestCMAC:
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
             CMAC(DummyBlockCipherAlgorithm(b"bad"), backend)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cmac_algorithm_supported(
-            AES(fake_key)
-        ),
-        skip_message="Does not support CMAC.",
-    )
     def test_raises_after_finalize(self, backend):
         key = b"2b7e151628aed2a6abf7158809cf4f3c"
         cmac = CMAC(AES(key), backend)
@@ -171,12 +147,6 @@ class TestCMAC:
         with pytest.raises(AlreadyFinalized):
             cmac.verify(b"")
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cmac_algorithm_supported(
-            AES(fake_key)
-        ),
-        skip_message="Does not support CMAC.",
-    )
     def test_verify_reject_unicode(self, backend):
         key = b"2b7e151628aed2a6abf7158809cf4f3c"
         cmac = CMAC(AES(key), backend)
@@ -187,12 +157,6 @@ class TestCMAC:
         with pytest.raises(TypeError):
             cmac.verify(typing.cast(typing.Any, ""))
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cmac_algorithm_supported(
-            AES(fake_key)
-        ),
-        skip_message="Does not support CMAC.",
-    )
     def test_copy_with_backend(self, backend):
         key = b"2b7e151628aed2a6abf7158809cf4f3c"
         cmac = CMAC(AES(key), backend)
@@ -200,12 +164,6 @@ class TestCMAC:
         copy_cmac = cmac.copy()
         assert cmac.finalize() == copy_cmac.finalize()
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cmac_algorithm_supported(
-            AES(fake_key)
-        ),
-        skip_message="Does not support CMAC.",
-    )
     def test_buffer_protocol(self, backend):
         key = bytearray(b"2b7e151628aed2a6abf7158809cf4f3c")
         cmac = CMAC(AES(key), backend)


### PR DESCRIPTION
Removes `pytest.mark.supported` marks whose `only_if` predicate returns true on every OpenSSL build tested in CI (OpenSSL 3.0+, LibreSSL, BoringSSL, AWS-LC, including the FIPS and no-legacy configurations), so they can never skip anything:

- `cipher_supported` with AES in CBC/ECB/OFB/CTR/GCM — these combinations are registered unconditionally in the cipher registry, and AES passes the FIPS filter
- `cmac_algorithm_supported(AES)` — resolves to AES-CBC support

Marks that can actually skip are left in place: AES CFB/CFB8 and XTS (missing on BoringSSL/AWS-LC), TripleDES CMAC (false under FIPS), and all the conditional algorithms (Camellia, SM4, ChaCha20, legacy ciphers).

Part 2 of 4; the parts are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cbo58H9P62exuadDC9VoA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cbo58H9P62exuadDC9VoA9)_