### PR TITLE
Remove always-true pytest.mark.supported marks from hash, HMAC, and KDF tests

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -161,9 +161,6 @@ class Backend:
 
         return rust_openssl.ciphers.cipher_supported(cipher, mode)
 
-    def pbkdf2_hmac_supported(self, algorithm: hashes.HashAlgorithm) -> bool:
-        return self.hmac_supported(algorithm)
-
     def _consume_errors(self) -> list[rust_openssl.OpenSSLError]:
         return rust_openssl.capture_error_stack()
 

--- a/tests/hazmat/primitives/test_hash_vectors.py
+++ b/tests/hazmat/primitives/test_hash_vectors.py
@@ -27,10 +27,6 @@ class TestSHA1:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hash_supported(hashes.SHA224()),
-    skip_message="Does not support SHA224",
-)
 class TestSHA224:
     test_sha224 = generate_hash_test(
         load_hash_vectors,
@@ -40,10 +36,6 @@ class TestSHA224:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hash_supported(hashes.SHA256()),
-    skip_message="Does not support SHA256",
-)
 class TestSHA256:
     test_sha256 = generate_hash_test(
         load_hash_vectors,
@@ -53,10 +45,6 @@ class TestSHA256:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hash_supported(hashes.SHA384()),
-    skip_message="Does not support SHA384",
-)
 class TestSHA384:
     test_sha384 = generate_hash_test(
         load_hash_vectors,
@@ -66,10 +54,6 @@ class TestSHA384:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hash_supported(hashes.SHA512()),
-    skip_message="Does not support SHA512",
-)
 class TestSHA512:
     test_sha512 = generate_hash_test(
         load_hash_vectors,

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -55,10 +55,6 @@ class TestSHA1:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hash_supported(hashes.SHA224()),
-    skip_message="Does not support SHA224",
-)
 class TestSHA224:
     test_sha224 = generate_base_hash_test(
         hashes.SHA224(),
@@ -66,10 +62,6 @@ class TestSHA224:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hash_supported(hashes.SHA256()),
-    skip_message="Does not support SHA256",
-)
 class TestSHA256:
     test_sha256 = generate_base_hash_test(
         hashes.SHA256(),
@@ -77,10 +69,6 @@ class TestSHA256:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hash_supported(hashes.SHA384()),
-    skip_message="Does not support SHA384",
-)
 class TestSHA384:
     test_sha384 = generate_base_hash_test(
         hashes.SHA384(),
@@ -88,10 +76,6 @@ class TestSHA384:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hash_supported(hashes.SHA512()),
-    skip_message="Does not support SHA512",
-)
 class TestSHA512:
     test_sha512 = generate_base_hash_test(
         hashes.SHA512(),

--- a/tests/hazmat/primitives/test_hkdf_vectors.py
+++ b/tests/hazmat/primitives/test_hkdf_vectors.py
@@ -5,18 +5,12 @@
 
 import os
 
-import pytest
-
 from cryptography.hazmat.primitives import hashes
 
 from ...utils import load_nist_vectors
 from .utils import generate_hkdf_test
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
-    skip_message="Does not support SHA1.",
-)
 class TestHKDFSHA1:
     test_hkdfsha1 = generate_hkdf_test(
         load_nist_vectors,
@@ -26,10 +20,6 @@ class TestHKDFSHA1:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hmac_supported(hashes.SHA256()),
-    skip_message="Does not support SHA256.",
-)
 class TestHKDFSHA256:
     test_hkdfsha256 = generate_hkdf_test(
         load_nist_vectors,

--- a/tests/hazmat/primitives/test_hmac_vectors.py
+++ b/tests/hazmat/primitives/test_hmac_vectors.py
@@ -26,10 +26,6 @@ class TestHMACMD5:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
-    skip_message="Does not support SHA1",
-)
 class TestHMACSHA1:
     test_hmac_sha1 = generate_hmac_test(
         load_hash_vectors,
@@ -39,10 +35,6 @@ class TestHMACSHA1:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hmac_supported(hashes.SHA224()),
-    skip_message="Does not support SHA224",
-)
 class TestHMACSHA224:
     test_hmac_sha224 = generate_hmac_test(
         load_hash_vectors,
@@ -52,10 +44,6 @@ class TestHMACSHA224:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hmac_supported(hashes.SHA256()),
-    skip_message="Does not support SHA256",
-)
 class TestHMACSHA256:
     test_hmac_sha256 = generate_hmac_test(
         load_hash_vectors,
@@ -65,10 +53,6 @@ class TestHMACSHA256:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hmac_supported(hashes.SHA384()),
-    skip_message="Does not support SHA384",
-)
 class TestHMACSHA384:
     test_hmac_sha384 = generate_hmac_test(
         load_hash_vectors,
@@ -78,10 +62,6 @@ class TestHMACSHA384:
     )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hmac_supported(hashes.SHA512()),
-    skip_message="Does not support SHA512",
-)
 class TestHMACSHA512:
     test_hmac_sha512 = generate_hmac_test(
         load_hash_vectors,

--- a/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
@@ -13,10 +13,6 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from ...utils import load_nist_vectors, load_vectors_from_file
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.pbkdf2_hmac_supported(hashes.SHA1()),
-    skip_message="Does not support SHA1 for PBKDF2HMAC",
-)
 def test_pbkdf2_hmacsha1_vectors(subtests, backend):
     params = load_vectors_from_file(
         os.path.join("KDF", "rfc-6070-PBKDF2-SHA1.txt"),

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -8,7 +8,6 @@ import typing
 
 import pytest
 
-from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.hashes import MD5, SHA1
 from cryptography.hazmat.primitives.twofactor import InvalidToken
 from cryptography.hazmat.primitives.twofactor.hotp import HOTP
@@ -18,10 +17,6 @@ from ....utils import load_nist_vectors, load_vectors_from_file
 vectors = load_vectors_from_file("twofactor/rfc-4226.txt", load_nist_vectors)
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
-    skip_message="Does not support HMAC-SHA1.",
-)
 class TestHOTP:
     def test_invalid_key_length(self, backend):
         secret = os.urandom(10)

--- a/tests/hazmat/primitives/twofactor/test_totp.py
+++ b/tests/hazmat/primitives/twofactor/test_totp.py
@@ -17,10 +17,6 @@ vectors = load_vectors_from_file("twofactor/rfc-6238.txt", load_nist_vectors)
 
 
 class TestTOTP:
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
-        skip_message="Does not support HMAC-SHA1.",
-    )
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA1"]
     )
@@ -32,10 +28,6 @@ class TestTOTP:
         totp = TOTP(secret, 8, hashes.SHA1(), 30, backend)
         assert totp.generate(time) == totp_value
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.hmac_supported(hashes.SHA256()),
-        skip_message="Does not support HMAC-SHA256.",
-    )
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA256"]
     )
@@ -47,10 +39,6 @@ class TestTOTP:
         totp = TOTP(secret, 8, hashes.SHA256(), 30, backend)
         assert totp.generate(time) == totp_value
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.hmac_supported(hashes.SHA512()),
-        skip_message="Does not support HMAC-SHA512.",
-    )
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA512"]
     )
@@ -62,10 +50,6 @@ class TestTOTP:
         totp = TOTP(secret, 8, hashes.SHA512(), 30, backend)
         assert totp.generate(time) == totp_value
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.hmac_supported(hashes.SHA1()),
-        skip_message="Does not support HMAC-SHA1.",
-    )
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA1"]
     )
@@ -77,10 +61,6 @@ class TestTOTP:
         totp = TOTP(secret, 8, hashes.SHA1(), 30, backend)
         totp.verify(totp_value, time)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.hmac_supported(hashes.SHA256()),
-        skip_message="Does not support HMAC-SHA256.",
-    )
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA256"]
     )
@@ -92,10 +72,6 @@ class TestTOTP:
         totp = TOTP(secret, 8, hashes.SHA256(), 30, backend)
         totp.verify(totp_value, time)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.hmac_supported(hashes.SHA512()),
-        skip_message="Does not support HMAC-SHA512.",
-    )
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA512"]
     )

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -15,7 +15,6 @@ import pytest
 
 import cryptography_vectors
 from cryptography.fernet import Fernet, InvalidToken, MultiFernet
-from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 
 def json_parametrize(keys, filename):
@@ -31,12 +30,6 @@ def json_parametrize(keys, filename):
         )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 32), modes.CBC(b"\x00" * 16)
-    ),
-    skip_message="Does not support AES CBC",
-)
 class TestFernet:
     @json_parametrize(
         ("secret", "now", "iv", "src", "token"),
@@ -159,12 +152,6 @@ class TestFernet:
             f.extract_timestamp(b"nonsensetoken")
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 32), modes.CBC(b"\x00" * 16)
-    ),
-    skip_message="Does not support AES CBC",
-)
 class TestMultiFernet:
     def test_encrypt(self, backend):
         f1 = Fernet(base64.urlsafe_b64encode(b"\x00" * 32), backend=backend)


### PR DESCRIPTION
Removes `pytest.mark.supported` marks whose `only_if` predicate returns true on every OpenSSL build tested in CI (OpenSSL 3.0+, LibreSSL, BoringSSL, AWS-LC, including the FIPS and no-legacy configurations), so they can never skip anything:

- `hash_supported` with SHA-224/256/384/512 — universal, and all in the FIPS allowlist
- `hmac_supported` with SHA-1/224/256/384/512 — SHA-1 is explicitly allowed for HMAC under FIPS, and all five are in AWS-LC's HMAC allowlist
- `pbkdf2_hmac_supported(SHA1())` — resolves to HMAC-SHA1 support
- `cipher_supported(AES, CBC)` on the Fernet tests

Marks that can actually skip are left in place: MD5/SM3/BLAKE2 hashes and HMAC-MD5 (false under FIPS or missing on some backends), SHA-3/SHAKE and SHA-512/224/256 (missing on BoringSSL), etc.

The removed mark was the only caller of `Backend.pbkdf2_hmac_supported`, which left that method uncovered and failed the 100% coverage check, so this also deletes the now-unused method.

Part 3 of 4; the parts are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cbo58H9P62exuadDC9VoA9