### PR TITLE
Remove always-true pytest.mark.supported marks from keywrap and PKCS7 tests

### DIFF
--- a/tests/hazmat/primitives/test_keywrap.py
+++ b/tests/hazmat/primitives/test_keywrap.py
@@ -9,20 +9,12 @@ import os
 import pytest
 
 from cryptography.hazmat.primitives import keywrap
-from cryptography.hazmat.primitives.ciphers import algorithms, modes
 
 from ...utils import load_nist_vectors
 from .utils import _load_all_params
 
 
 class TestAESKeyWrap:
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            algorithms.AES(b"\x00" * 16), modes.ECB()
-        ),
-        skip_message="Does not support AES key wrap (RFC 3394) because AES-ECB"
-        " is unsupported",
-    )
     def test_wrap(self, backend, subtests):
         params = _load_all_params(
             os.path.join("keywrap", "kwtestvectors"),
@@ -38,13 +30,6 @@ class TestAESKeyWrap:
                 )
                 assert param["c"] == binascii.hexlify(wrapped_key)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            algorithms.AES(b"\x00" * 16), modes.ECB()
-        ),
-        skip_message="Does not support AES key wrap (RFC 3394) because AES-ECB"
-        " is unsupported",
-    )
     def test_unwrap(self, backend, subtests):
         params = _load_all_params(
             os.path.join("keywrap", "kwtestvectors"),
@@ -66,36 +51,15 @@ class TestAESKeyWrap:
                     )
                     assert param["p"] == binascii.hexlify(unwrapped_key)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            algorithms.AES(b"\x00" * 16), modes.ECB()
-        ),
-        skip_message="Does not support AES key wrap (RFC 3394) because AES-ECB"
-        " is unsupported",
-    )
     def test_wrap_invalid_key_length(self, backend):
         # The wrapping key must be of length [16, 24, 32]
         with pytest.raises(ValueError):
             keywrap.aes_key_wrap(b"badkey", b"sixteen_byte_key", backend)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            algorithms.AES(b"\x00" * 16), modes.ECB()
-        ),
-        skip_message="Does not support AES key wrap (RFC 3394) because AES-ECB"
-        " is unsupported",
-    )
     def test_unwrap_invalid_key_length(self, backend):
         with pytest.raises(ValueError):
             keywrap.aes_key_unwrap(b"badkey", b"\x00" * 24, backend)
 
-    @pytest.mark.supported(
-        only_if=lambda backend: backend.cipher_supported(
-            algorithms.AES(b"\x00" * 16), modes.ECB()
-        ),
-        skip_message="Does not support AES key wrap (RFC 3394) because AES-ECB"
-        " is unsupported",
-    )
     def test_wrap_invalid_key_to_wrap_length(self, backend):
         # Keys to wrap must be at least 16 bytes long
         with pytest.raises(ValueError):
@@ -115,13 +79,6 @@ class TestAESKeyWrap:
             keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 27, backend)
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.cipher_supported(
-        algorithms.AES(b"\x00" * 16), modes.ECB()
-    ),
-    skip_message="Does not support AES key wrap (RFC 5649) because AES-ECB"
-    " is unsupported",
-)
 class TestAESKeyWrapWithPadding:
     def test_wrap(self, backend, subtests):
         params = _load_all_params(

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -36,10 +36,6 @@ from ...utils import load_vectors_from_file, raises_unsupported_algorithm
 __all__ = ["rsa_key_2048"]
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.pkcs7_supported(),
-    skip_message="Requires OpenSSL with PKCS7 support",
-)
 class TestPKCS7Loading:
     def test_load_invalid_der_pkcs7(self, backend):
         with pytest.raises(ValueError):
@@ -1439,10 +1435,6 @@ class TestPKCS7Decrypt:
             )
 
 
-@pytest.mark.supported(
-    only_if=lambda backend: backend.pkcs7_supported(),
-    skip_message="Requires OpenSSL with PKCS7 support",
-)
 class TestPKCS7SerializeCerts:
     @pytest.mark.parametrize(
         ("encoding", "loader"),


### PR DESCRIPTION
Removes `pytest.mark.supported` marks whose `only_if` predicate returns true on every OpenSSL build tested in CI (OpenSSL 3.0+, LibreSSL, BoringSSL, AWS-LC, including the FIPS and no-legacy configurations), so they can never skip anything:

- `cipher_supported(AES, ECB)` on the keywrap tests — registered unconditionally, and AES passes the FIPS filter
- `pkcs7_supported()` — hardcoded to return `True`

Marks that can actually skip (e.g. the no-PKCS1v15-decryption PKCS7 tests) are left in place.

Part 4 of 4; the parts are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cbo58H9P62exuadDC9VoA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cbo58H9P62exuadDC9VoA9)_