### PR TITLE
Remove no-op backend arguments in test_x509.py

### DIFF
--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -184,7 +184,7 @@ def _check_crl_times(
 
 
 class TestCertificateRevocationList:
-    def test_load_pem_crl(self, backend):
+    def test_load_pem_crl(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
@@ -199,7 +199,7 @@ class TestCertificateRevocationList:
             == SignatureAlgorithmOID.RSA_WITH_SHA256
         )
 
-    def test_load_der_crl(self, backend):
+    def test_load_der_crl(self):
         crl = _load_cert(
             os.path.join("x509", "PKITS_data", "crls", "GoodCACRL.crl"),
             x509.load_der_x509_crl,
@@ -210,14 +210,14 @@ class TestCertificateRevocationList:
         assert fingerprint == b"dd3db63c50f4c4a13e090f14053227cb1011a5ad"
         assert isinstance(crl.signature_hash_algorithm, hashes.SHA256)
 
-    def test_load_large_crl(self, backend):
+    def test_load_large_crl(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_almost_10k.pem"),
             x509.load_pem_x509_crl,
         )
         assert len(crl) == 9999
 
-    def test_empty_crl_no_sequence(self, backend):
+    def test_empty_crl_no_sequence(self):
         # The SEQUENCE for revoked certificates is optional so let's
         # test that we handle it properly.
         crl = _load_cert(
@@ -231,29 +231,29 @@ class TestCertificateRevocationList:
         assert crl.get_revoked_certificate_by_serial_number(12) is None
         assert list(iter(crl)) == []
 
-    def test_invalid_pem(self, backend):
+    def test_invalid_pem(self):
         with pytest.raises(ValueError):
-            x509.load_pem_x509_crl(b"notacrl", backend)
+            x509.load_pem_x509_crl(b"notacrl")
 
         pem_bytes = _load_cert(
             os.path.join("x509", "custom", "valid_signature_cert.pem"),
             lambda data: data,
         )
         with pytest.raises(ValueError):
-            x509.load_pem_x509_crl(pem_bytes, backend)
+            x509.load_pem_x509_crl(pem_bytes)
 
-    def test_invalid_der(self, backend):
+    def test_invalid_der(self):
         with pytest.raises(ValueError):
-            x509.load_der_x509_crl(b"notacrl", backend)
+            x509.load_der_x509_crl(b"notacrl")
 
-    def test_invalid_time(self, backend):
+    def test_invalid_time(self):
         with pytest.raises(ValueError, match="TBSCertList::this_update"):
             _load_cert(
                 os.path.join("x509", "custom", "crl_invalid_time.der"),
                 x509.load_der_x509_crl,
             )
 
-    def test_unknown_signature_algorithm(self, backend):
+    def test_unknown_signature_algorithm(self):
         crl = _load_cert(
             os.path.join(
                 "x509", "custom", "crl_md2_unknown_crit_entry_ext.pem"
@@ -264,14 +264,14 @@ class TestCertificateRevocationList:
         with raises_unsupported_algorithm(None):
             crl.signature_hash_algorithm
 
-    def test_invalid_version(self, backend):
+    def test_invalid_version(self):
         with pytest.raises(x509.InvalidVersion):
             _load_cert(
                 os.path.join("x509", "custom", "crl_bad_version.pem"),
                 x509.load_pem_x509_crl,
             )
 
-    def test_issuer(self, backend):
+    def test_issuer(self):
         crl = _load_cert(
             os.path.join("x509", "PKITS_data", "crls", "GoodCACRL.crl"),
             x509.load_der_x509_crl,
@@ -289,7 +289,7 @@ class TestCertificateRevocationList:
             x509.NameAttribute(x509.OID_COMMON_NAME, "Good CA")
         ]
 
-    def test_equality(self, backend):
+    def test_equality(self):
         crl1 = _load_cert(
             os.path.join("x509", "PKITS_data", "crls", "GoodCACRL.crl"),
             x509.load_der_x509_crl,
@@ -309,7 +309,7 @@ class TestCertificateRevocationList:
         assert crl1 != crl3
         assert crl1 != object()
 
-    def test_comparison(self, backend):
+    def test_comparison(self):
         crl1 = _load_cert(
             os.path.join("x509", "PKITS_data", "crls", "GoodCACRL.crl"),
             x509.load_der_x509_crl,
@@ -317,7 +317,7 @@ class TestCertificateRevocationList:
         with pytest.raises(TypeError):
             crl1 < crl1  # type: ignore[operator]
 
-    def test_update_dates(self, backend):
+    def test_update_dates(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
@@ -334,7 +334,7 @@ class TestCertificateRevocationList:
         assert crl.next_update_utc.isoformat() == "2016-01-01T00:00:00+00:00"
         assert crl.last_update_utc.isoformat() == "2015-01-01T00:00:00+00:00"
 
-    def test_no_next_update(self, backend):
+    def test_no_next_update(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_no_next_update.pem"),
             x509.load_pem_x509_crl,
@@ -344,7 +344,7 @@ class TestCertificateRevocationList:
             assert crl.next_update is None
         assert crl.next_update_utc is None
 
-    def test_unrecognized_extension(self, backend):
+    def test_unrecognized_extension(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_unrecognized_extension.der"),
             x509.load_der_x509_crl,
@@ -356,7 +356,7 @@ class TestCertificateRevocationList:
         ext = crl.extensions.get_extension_for_oid(unrecognized.oid)
         assert ext.value == unrecognized
 
-    def test_revoked_cert_retrieval(self, backend):
+    def test_revoked_cert_retrieval(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
@@ -372,7 +372,7 @@ class TestCertificateRevocationList:
         next(it)
         assert len(typing.cast(typing.Sized, it)) == 11
 
-    def test_get_revoked_certificate_by_serial_number(self, backend):
+    def test_get_revoked_certificate_by_serial_number(self):
         crl = _load_cert(
             os.path.join(
                 "x509", "PKITS_data", "crls", "LongSerialNumberCACRL.crl"
@@ -385,7 +385,7 @@ class TestCertificateRevocationList:
         assert revoked.serial_number == serial_number
         assert crl.get_revoked_certificate_by_serial_number(500) is None
 
-    def test_revoked_cert_retrieval_retain_only_revoked(self, backend):
+    def test_revoked_cert_retrieval_retain_only_revoked(self):
         """
         This test attempts to trigger the crash condition described in
         https://github.com/pyca/cryptography/issues/2557
@@ -404,7 +404,7 @@ class TestCertificateRevocationList:
         )
         assert revoked.serial_number == 11
 
-    def test_extensions(self, backend):
+    def test_extensions(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_ian_aia_aki.pem"),
             x509.load_pem_x509_crl,
@@ -441,7 +441,7 @@ class TestCertificateRevocationList:
             [x509.UniformResourceIdentifier("https://cryptography.io")]
         )
 
-    def test_delta_crl_indicator(self, backend):
+    def test_delta_crl_indicator(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_delta_crl_indicator.pem"),
             x509.load_pem_x509_crl,
@@ -453,7 +453,7 @@ class TestCertificateRevocationList:
         assert dci.value == x509.DeltaCRLIndicator(12345678901234567890)
         assert dci.critical is True
 
-    def test_signature(self, backend):
+    def test_signature(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
@@ -471,7 +471,7 @@ class TestCertificateRevocationList:
             b"58a472b0"
         )
 
-    def test_tbs_certlist_bytes(self, backend):
+    def test_tbs_certlist_bytes(self):
         crl = _load_cert(
             os.path.join("x509", "PKITS_data", "crls", "GoodCACRL.crl"),
             x509.load_der_x509_crl,
@@ -492,7 +492,7 @@ class TestCertificateRevocationList:
             crl.signature_hash_algorithm,
         )
 
-    def test_public_bytes_pem(self, backend):
+    def test_public_bytes_pem(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_empty.pem"),
             x509.load_pem_x509_crl,
@@ -512,7 +512,7 @@ class TestCertificateRevocationList:
             next_update=datetime.datetime(2015, 12, 28, 0, 44, 47),
         )
 
-    def test_public_bytes_der(self, backend):
+    def test_public_bytes_der(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
@@ -547,17 +547,15 @@ class TestCertificateRevocationList:
             ),
         ],
     )
-    def test_public_bytes_match(
-        self, cert_path, loader_func, encoding, backend
-    ):
+    def test_public_bytes_match(self, cert_path, loader_func, encoding):
         crl_bytes = load_vectors_from_file(
             cert_path, lambda pemfile: pemfile.read(), mode="rb"
         )
-        crl = loader_func(crl_bytes, backend)
+        crl = loader_func(crl_bytes)
         serialized = crl.public_bytes(encoding)
         assert serialized == crl_bytes
 
-    def test_public_bytes_invalid_encoding(self, backend):
+    def test_public_bytes_invalid_encoding(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_empty.pem"),
             x509.load_pem_x509_crl,
@@ -566,7 +564,7 @@ class TestCertificateRevocationList:
         with pytest.raises(TypeError):
             crl.public_bytes(typing.cast(typing.Any, "NotAnEncoding"))
 
-    def test_verify_bad(self, backend):
+    def test_verify_bad(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "invalid_signature_crl.pem"),
             x509.load_pem_x509_crl,
@@ -580,7 +578,7 @@ class TestCertificateRevocationList:
         assert isinstance(public_key, rsa.RSAPublicKey)
         assert not crl.is_signature_valid(public_key)
 
-    def test_load_inner_outer_mismatch(self, backend):
+    def test_load_inner_outer_mismatch(self):
         data = load_vectors_from_file(
             os.path.join("x509", "custom", "crl_inner_outer_mismatch.der"),
             lambda f: f.read(),
@@ -589,7 +587,7 @@ class TestCertificateRevocationList:
         with pytest.raises(ValueError, match="Inner and outer"):
             x509.load_der_x509_crl(data)
 
-    def test_verify_good(self, backend):
+    def test_verify_good(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "valid_signature_crl.pem"),
             x509.load_pem_x509_crl,
@@ -603,7 +601,7 @@ class TestCertificateRevocationList:
         assert isinstance(public_key, rsa.RSAPublicKey)
         assert crl.is_signature_valid(public_key)
 
-    def test_verify_argument_must_be_a_public_key(self, backend):
+    def test_verify_argument_must_be_a_public_key(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "valid_signature_crl.pem"),
             x509.load_pem_x509_crl,
@@ -627,7 +625,7 @@ class TestCertificateRevocationList:
 
 
 class TestRevokedCertificate:
-    def test_revoked_basics(self, backend):
+    def test_revoked_basics(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
@@ -649,7 +647,7 @@ class TestRevokedCertificate:
                 == "2015-01-01T00:00:00+00:00"
             )
 
-    def test_revoked_extensions(self, backend):
+    def test_revoked_extensions(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
@@ -711,14 +709,14 @@ class TestRevokedCertificate:
 
         assert len(flags) == 0
 
-    def test_no_revoked_certs(self, backend):
+    def test_no_revoked_certs(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_empty.pem"),
             x509.load_pem_x509_crl,
         )
         assert len(crl) == 0
 
-    def test_duplicate_entry_ext(self, backend):
+    def test_duplicate_entry_ext(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_dup_entry_ext.pem"),
             x509.load_pem_x509_crl,
@@ -727,7 +725,7 @@ class TestRevokedCertificate:
         with pytest.raises(x509.DuplicateExtension):
             crl[0].extensions
 
-    def test_unsupported_crit_entry_ext(self, backend):
+    def test_unsupported_crit_entry_ext(self):
         crl = _load_cert(
             os.path.join(
                 "x509", "custom", "crl_md2_unknown_crit_entry_ext.pem"
@@ -741,7 +739,7 @@ class TestRevokedCertificate:
         assert isinstance(ext.value, x509.UnrecognizedExtension)
         assert ext.value.value == b"\n\x01\x00"
 
-    def test_unsupported_reason(self, backend):
+    def test_unsupported_reason(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_unsupported_reason.pem"),
             x509.load_pem_x509_crl,
@@ -750,7 +748,7 @@ class TestRevokedCertificate:
         with pytest.raises(ValueError):
             crl[0].extensions
 
-    def test_invalid_cert_issuer_ext(self, backend):
+    def test_invalid_cert_issuer_ext(self):
         crl = _load_cert(
             os.path.join(
                 "x509", "custom", "crl_inval_cert_issuer_entry_ext.pem"
@@ -761,7 +759,7 @@ class TestRevokedCertificate:
         with pytest.raises(ValueError):
             crl[0].extensions
 
-    def test_invalidity_date_fractional_seconds(self, backend):
+    def test_invalidity_date_fractional_seconds(self):
         # The InvalidityDate GeneralizedTime must be encoded as DER, so a
         # value carrying fractional seconds is rejected, in line with the
         # other X.509 time fields and this extension's own encoder.
@@ -775,7 +773,7 @@ class TestRevokedCertificate:
         with pytest.raises(ValueError):
             crl[0].extensions
 
-    def test_indexing(self, backend):
+    def test_indexing(self):
         crl = _load_cert(
             os.path.join("x509", "custom", "crl_all_reasons.pem"),
             x509.load_pem_x509_crl,
@@ -792,7 +790,7 @@ class TestRevokedCertificate:
         assert crl[2:4][1].serial_number == crl[3].serial_number
 
     def test_get_revoked_certificate_doesnt_reorder(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
@@ -816,10 +814,10 @@ class TestRevokedCertificate:
                 x509.RevokedCertificateBuilder()
                 .serial_number(i)
                 .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
-                .build(backend)
+                .build()
             )
             builder = builder.add_revoked_certificate(revoked_cert)
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         assert crl[0].serial_number == 2
         assert crl[2].serial_number == 3
         # make sure get_revoked_certificate_by_serial_number doesn't affect
@@ -830,7 +828,7 @@ class TestRevokedCertificate:
 
 
 class TestRSAECertificate:
-    def test_load_cert_pub_key(self, backend):
+    def test_load_cert_pub_key(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "ca", "rsae_ca.pem"),
             x509.load_pem_x509_certificate,
@@ -866,7 +864,7 @@ class TestRSAECertificate:
 
 
 class TestRSAPSSCertificate:
-    def test_load_cert_pub_key(self, backend):
+    def test_load_cert_pub_key(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "rsa_pss_cert.pem"),
             x509.load_pem_x509_certificate,
@@ -896,7 +894,7 @@ class TestRSAPSSCertificate:
             cert.signature_hash_algorithm,
         )
 
-    def test_load_pss_cert_no_null(self, backend):
+    def test_load_pss_cert_no_null(self):
         """
         This test verifies that PSS certs where the hash algorithm
         identifiers have no trailing null still load properly. LibreSSL
@@ -913,7 +911,7 @@ class TestRSAPSSCertificate:
         assert isinstance(pss._mgf._algorithm, hashes.SHA256)
         assert isinstance(cert.signature_hash_algorithm, hashes.SHA256)
 
-    def test_load_pss_sha1_mgf1_sha1(self, backend):
+    def test_load_pss_sha1_mgf1_sha1(self):
         cert = _load_cert(
             os.path.join("x509", "ee-pss-sha1-cert.pem"),
             x509.load_pem_x509_certificate,
@@ -928,7 +926,7 @@ class TestRSAPSSCertificate:
         assert pss._salt_length == 20
         assert isinstance(cert.signature_hash_algorithm, hashes.SHA1)
 
-    def test_invalid_mgf(self, backend):
+    def test_invalid_mgf(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "rsa_pss_cert_invalid_mgf.der"),
             x509.load_der_x509_certificate,
@@ -936,7 +934,7 @@ class TestRSAPSSCertificate:
         with pytest.raises(ValueError):
             cert.signature_algorithm_parameters
 
-    def test_unsupported_mgf_hash(self, backend):
+    def test_unsupported_mgf_hash(self):
         cert = _load_cert(
             os.path.join(
                 "x509", "custom", "rsa_pss_cert_unsupported_mgf_hash.der"
@@ -946,7 +944,7 @@ class TestRSAPSSCertificate:
         with pytest.raises(UnsupportedAlgorithm):
             cert.signature_algorithm_parameters
 
-    def test_no_sig_params(self, backend):
+    def test_no_sig_params(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "rsa_pss_cert_no_sig_params.der"),
             x509.load_der_x509_certificate,
@@ -958,7 +956,7 @@ class TestRSAPSSCertificate:
 
 
 class TestRSACertificate:
-    def test_load_pem_cert(self, backend):
+    def test_load_pem_cert(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
             x509.load_pem_x509_certificate,
@@ -980,7 +978,7 @@ class TestRSACertificate:
             == PublicKeyAlgorithmOID.RSAES_PKCS1_v1_5
         )
 
-    def test_check_pkcs1_signature_algorithm_parameters(self, backend):
+    def test_check_pkcs1_signature_algorithm_parameters(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "ca", "rsa_ca.pem"),
             x509.load_pem_x509_certificate,
@@ -999,14 +997,14 @@ class TestRSACertificate:
             cert.signature_hash_algorithm,
         )
 
-    def test_load_legacy_pem_header(self, backend):
+    def test_load_legacy_pem_header(self):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.old_header.pem"),
             x509.load_pem_x509_certificate,
         )
         assert isinstance(cert, x509.Certificate)
 
-    def test_load_with_other_sections(self, backend):
+    def test_load_with_other_sections(self):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.with_garbage.pem"),
             x509.load_pem_x509_certificate,
@@ -1019,7 +1017,7 @@ class TestRSACertificate:
         )
         assert isinstance(cert, x509.Certificate)
 
-    def test_load_multiple_sections(self, backend):
+    def test_load_multiple_sections(self):
         # We match OpenSSL's behavior of loading the first cert
         # if there are multiple. Arguably this would ideally be an
         # error, but "load the first" is a common expectation.
@@ -1033,7 +1031,7 @@ class TestRSACertificate:
         )
         assert cert == cert2
 
-    def test_negative_serial_number(self, backend):
+    def test_negative_serial_number(self):
         # We load certificates with negative serial numbers but on load
         # and on access of the attribute we raise a warning
         with pytest.warns(utils.DeprecatedIn36):
@@ -1045,7 +1043,7 @@ class TestRSACertificate:
         with pytest.warns(utils.DeprecatedIn36):
             assert cert.serial_number == -18008675309
 
-    def test_country_jurisdiction_country_too_long(self, backend):
+    def test_country_jurisdiction_country_too_long(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "bad_country.pem"),
             x509.load_pem_x509_certificate,
@@ -1068,7 +1066,7 @@ class TestRSACertificate:
                 == "also too long"
             )
 
-    def test_alternate_rsa_with_sha1_oid(self, backend):
+    def test_alternate_rsa_with_sha1_oid(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "alternate-rsa-sha1-oid.der"),
             x509.load_der_x509_certificate,
@@ -1084,7 +1082,7 @@ class TestRSACertificate:
             == PublicKeyAlgorithmOID.RSAES_PKCS1_v1_5
         )
 
-    def test_load_bmpstring_explicittext(self, backend):
+    def test_load_bmpstring_explicittext(self):
         cert = _load_cert(
             os.path.join("x509", "accvraiz1.pem"),
             x509.load_pem_x509_certificate,
@@ -1097,7 +1095,7 @@ class TestRSACertificate:
             "156E). CPS en http://www.accv.es"
         )
 
-    def test_load_der_cert(self, backend):
+    def test_load_der_cert(self):
         cert = _load_cert(
             os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
             x509.load_der_x509_certificate,
@@ -1108,7 +1106,7 @@ class TestRSACertificate:
         assert fingerprint == b"6f49779533d565e8b7c1062503eab41492c38e4d"
         assert isinstance(cert.signature_hash_algorithm, hashes.SHA256)
 
-    def test_signature(self, backend):
+    def test_signature(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
             x509.load_pem_x509_certificate,
@@ -1134,7 +1132,7 @@ class TestRSACertificate:
         ),
         skip_message="Does not support SHA-1 signature.",
     )
-    def test_tbs_certificate_bytes(self, backend):
+    def test_tbs_certificate_bytes(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
             x509.load_pem_x509_certificate,
@@ -1175,9 +1173,7 @@ class TestRSACertificate:
             cert.signature_hash_algorithm,
         )
 
-    def test_tbs_precertificate_bytes_duplicate_extensions_raises(
-        self, backend
-    ):
+    def test_tbs_precertificate_bytes_duplicate_extensions_raises(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "two_basic_constraints.pem"),
             x509.load_pem_x509_certificate,
@@ -1189,7 +1185,7 @@ class TestRSACertificate:
         ):
             cert.tbs_precertificate_bytes
 
-    def test_tbs_precertificate_bytes_no_extensions_raises(self, backend):
+    def test_tbs_precertificate_bytes_no_extensions_raises(self):
         cert = _load_cert(
             os.path.join("x509", "v1_cert.pem"),
             x509.load_pem_x509_certificate,
@@ -1201,7 +1197,7 @@ class TestRSACertificate:
         ):
             cert.tbs_precertificate_bytes
 
-    def test_tbs_precertificate_bytes_missing_extension_raises(self, backend):
+    def test_tbs_precertificate_bytes_missing_extension_raises(self):
         cert = _load_cert(
             os.path.join("x509", "cryptography.io.pem"),
             x509.load_pem_x509_certificate,
@@ -1215,7 +1211,7 @@ class TestRSACertificate:
         ):
             cert.tbs_precertificate_bytes
 
-    def test_tbs_precertificate_bytes_strips_scts(self, backend):
+    def test_tbs_precertificate_bytes_strips_scts(self):
         cert = _load_cert(
             os.path.join("x509", "cryptography-scts.pem"),
             x509.load_pem_x509_certificate,
@@ -1231,7 +1227,7 @@ class TestRSACertificate:
         )
         assert cert.tbs_precertificate_bytes != cert.tbs_certificate_bytes
 
-    def test_issuer(self, backend):
+    def test_issuer(self):
         cert = _load_cert(
             os.path.join(
                 "x509",
@@ -1254,7 +1250,7 @@ class TestRSACertificate:
             x509.NameAttribute(NameOID.COMMON_NAME, "Good CA")
         ]
 
-    def test_all_issuer_name_types(self, backend):
+    def test_all_issuer_name_types(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "all_supported_names.pem"),
             x509.load_pem_x509_certificate,
@@ -1295,7 +1291,7 @@ class TestRSACertificate:
             x509.NameAttribute(NameOID.EMAIL_ADDRESS, "test1@test.local"),
         ]
 
-    def test_subject(self, backend):
+    def test_subject(self):
         cert = _load_cert(
             os.path.join(
                 "x509",
@@ -1324,7 +1320,7 @@ class TestRSACertificate:
             )
         ]
 
-    def test_unicode_name(self, backend):
+    def test_unicode_name(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "utf8_common_name.pem"),
             x509.load_pem_x509_certificate,
@@ -1336,7 +1332,7 @@ class TestRSACertificate:
             x509.NameAttribute(NameOID.COMMON_NAME, "We heart UTF8!\u2122")
         ]
 
-    def test_invalid_unicode_name(self, backend):
+    def test_invalid_unicode_name(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "invalid_utf8_common_name.pem"),
             x509.load_pem_x509_certificate,
@@ -1346,7 +1342,7 @@ class TestRSACertificate:
         with pytest.raises(ValueError, match="issuer"):
             cert.issuer
 
-    def test_name_attribute_unsupported_type_tag(self, backend):
+    def test_name_attribute_unsupported_type_tag(self):
         # A name attribute value whose ASN.1 tag is not one of the recognised
         # string types must raise a ValueError, not a bare KeyError.
         cert = _load_cert(
@@ -1360,7 +1356,7 @@ class TestRSACertificate:
         with pytest.raises(ValueError, match="issuer"):
             cert.issuer
 
-    def test_non_ascii_dns_name(self, backend):
+    def test_non_ascii_dns_name(self):
         cert = _load_cert(
             os.path.join("x509", "utf8-dnsname.pem"),
             x509.load_pem_x509_certificate,
@@ -1381,7 +1377,7 @@ class TestRSACertificate:
             "*.xn--biztosts-fza2j.hu",
         ]
 
-    def test_all_subject_name_types(self, backend):
+    def test_all_subject_name_types(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "all_supported_names.pem"),
             x509.load_pem_x509_certificate,
@@ -1425,7 +1421,7 @@ class TestRSACertificate:
             x509.NameAttribute(NameOID.EMAIL_ADDRESS, "test3@test.local"),
         ]
 
-    def test_load_good_ca_cert(self, backend):
+    def test_load_good_ca_cert(self):
         cert = _load_cert(
             os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
             x509.load_der_x509_certificate,
@@ -1443,7 +1439,7 @@ class TestRSACertificate:
         fingerprint = binascii.hexlify(cert.fingerprint(hashes.SHA1()))
         assert fingerprint == b"6f49779533d565e8b7c1062503eab41492c38e4d"
 
-    def test_utc_pre_2000_not_before_cert(self, backend):
+    def test_utc_pre_2000_not_before_cert(self):
         cert = _load_cert(
             os.path.join(
                 "x509",
@@ -1460,7 +1456,7 @@ class TestRSACertificate:
             not_valid_after=None,
         )
 
-    def test_pre_2000_utc_not_after_cert(self, backend):
+    def test_pre_2000_utc_not_after_cert(self):
         cert = _load_cert(
             os.path.join(
                 "x509",
@@ -1477,7 +1473,7 @@ class TestRSACertificate:
             not_valid_after=datetime.datetime(1999, 1, 1, 12, 1),
         )
 
-    def test_post_2000_utc_cert(self, backend):
+    def test_post_2000_utc_cert(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
             x509.load_pem_x509_certificate,
@@ -1488,7 +1484,7 @@ class TestRSACertificate:
             not_valid_after=datetime.datetime(2014, 12, 26, 21, 41, 20),
         )
 
-    def test_generalized_time_not_before_cert(self, backend):
+    def test_generalized_time_not_before_cert(self):
         cert = _load_cert(
             os.path.join(
                 "x509",
@@ -1505,7 +1501,7 @@ class TestRSACertificate:
         )
         assert cert.version is x509.Version.v3
 
-    def test_generalized_time_not_after_cert(self, backend):
+    def test_generalized_time_not_after_cert(self):
         cert = _load_cert(
             os.path.join(
                 "x509",
@@ -1522,7 +1518,7 @@ class TestRSACertificate:
         )
         assert cert.version is x509.Version.v3
 
-    def test_invalid_version_cert(self, backend):
+    def test_invalid_version_cert(self):
         with pytest.raises(x509.InvalidVersion) as exc:
             _load_cert(
                 os.path.join("x509", "custom", "invalid_version.pem"),
@@ -1531,7 +1527,7 @@ class TestRSACertificate:
 
         assert exc.value.parsed_version == 7
 
-    def test_invalid_visiblestring_in_explicit_text(self, backend):
+    def test_invalid_visiblestring_in_explicit_text(self):
         cert = _load_cert(
             os.path.join(
                 "x509",
@@ -1550,7 +1546,7 @@ class TestRSACertificate:
             "Verwendung unterliegt Haftungsbeschränkungen, gemäss CPS"
         )
 
-    def test_eq(self, backend):
+    def test_eq(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
             x509.load_pem_x509_certificate,
@@ -1561,7 +1557,7 @@ class TestRSACertificate:
         )
         assert cert == cert2
 
-    def test_ne(self, backend):
+    def test_ne(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
             x509.load_pem_x509_certificate,
@@ -1578,7 +1574,7 @@ class TestRSACertificate:
         assert cert != cert2
         assert cert != object()
 
-    def test_ordering_unsupported(self, backend):
+    def test_ordering_unsupported(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
             x509.load_pem_x509_certificate,
@@ -1590,7 +1586,7 @@ class TestRSACertificate:
         with pytest.raises(TypeError, match="'>' not supported"):
             cert > cert2  # type: ignore[operator]
 
-    def test_hash(self, backend):
+    def test_hash(self):
         cert1 = _load_cert(
             os.path.join("x509", "custom", "post2000utctime.pem"),
             x509.load_pem_x509_certificate,
@@ -1612,16 +1608,16 @@ class TestRSACertificate:
         assert hash(cert1) == hash(cert2)
         assert hash(cert1) != hash(cert3)
 
-    def test_version_1_cert(self, backend):
+    def test_version_1_cert(self):
         cert = _load_cert(
             os.path.join("x509", "v1_cert.pem"),
             x509.load_pem_x509_certificate,
         )
         assert cert.version is x509.Version.v1
 
-    def test_invalid_pem(self, backend):
+    def test_invalid_pem(self):
         with pytest.raises(ValueError, match="Unable to load"):
-            x509.load_pem_x509_certificate(b"notacert", backend)
+            x509.load_pem_x509_certificate(b"notacert")
 
         crl = load_vectors_from_file(
             filename=os.path.join("x509", "custom", "crl_empty.pem"),
@@ -1629,13 +1625,13 @@ class TestRSACertificate:
             mode="rb",
         )
         with pytest.raises(ValueError, match="Valid PEM but no"):
-            x509.load_pem_x509_certificate(crl, backend)
+            x509.load_pem_x509_certificate(crl)
 
-    def test_invalid_der(self, backend):
+    def test_invalid_der(self):
         with pytest.raises(ValueError):
-            x509.load_der_x509_certificate(b"notacert", backend)
+            x509.load_der_x509_certificate(b"notacert")
 
-    def test_unsupported_signature_hash_algorithm_cert(self, backend):
+    def test_unsupported_signature_hash_algorithm_cert(self):
         cert = _load_cert(
             os.path.join("x509", "verisign_md2_root.pem"),
             x509.load_pem_x509_certificate,
@@ -1643,7 +1639,7 @@ class TestRSACertificate:
         with raises_unsupported_algorithm(None):
             cert.signature_hash_algorithm
 
-    def test_public_bytes_pem(self, backend):
+    def test_public_bytes_pem(self):
         # Load an existing certificate.
         cert = _load_cert(
             os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
@@ -1655,7 +1651,6 @@ class TestRSACertificate:
             cert.public_bytes(
                 encoding=serialization.Encoding.PEM,
             ),
-            backend,
         )
 
         # We should recover what we had to start with.
@@ -1671,7 +1666,7 @@ class TestRSACertificate:
         fingerprint = binascii.hexlify(cert.fingerprint(hashes.SHA1()))
         assert fingerprint == b"6f49779533d565e8b7c1062503eab41492c38e4d"
 
-    def test_public_bytes_der(self, backend):
+    def test_public_bytes_der(self):
         # Load an existing certificate.
         cert = _load_cert(
             os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
@@ -1698,7 +1693,7 @@ class TestRSACertificate:
         fingerprint = binascii.hexlify(cert.fingerprint(hashes.SHA1()))
         assert fingerprint == b"6f49779533d565e8b7c1062503eab41492c38e4d"
 
-    def test_public_bytes_invalid_encoding(self, backend):
+    def test_public_bytes_invalid_encoding(self):
         cert = _load_cert(
             os.path.join("x509", "PKITS_data", "certs", "GoodCACert.crt"),
             x509.load_der_x509_certificate,
@@ -1722,9 +1717,7 @@ class TestRSACertificate:
             ),
         ],
     )
-    def test_public_bytes_match(
-        self, cert_path, loader_func, encoding, backend
-    ):
+    def test_public_bytes_match(self, cert_path, loader_func, encoding):
         cert_bytes = load_vectors_from_file(
             cert_path, lambda pemfile: pemfile.read(), mode="rb"
         )
@@ -1743,7 +1736,7 @@ class TestRSACertificate:
             "www.rapidssl.com/resources/cps (c)14,OU=GT48742965)>, ...)>"
         )
 
-    def test_parse_tls_feature_extension(self, backend):
+    def test_parse_tls_feature_extension(self):
         cert = _load_cert(
             os.path.join("x509", "tls-feature-ocsp-staple.pem"),
             x509.load_pem_x509_certificate,
@@ -1873,7 +1866,7 @@ class TestRSACertificate:
         only_if=lambda backend: backend.x25519_supported(),
         skip_message="Requires OpenSSL with Ed25519 and X25519 support",
     )
-    def test_verify_directly_issued_by_unsupported_key_type(self, backend):
+    def test_verify_directly_issued_by_unsupported_key_type(self):
         private_key = ed25519.Ed25519PrivateKey.generate()
         x25519_public = x25519.X25519PrivateKey.generate().public_key()
         # Generate an ed25519 CA
@@ -1910,7 +1903,7 @@ class TestRSACertificate:
         with pytest.raises(TypeError):
             cert.verify_directly_issued_by(leaf)
 
-    def test_admissions_extension(self, backend):
+    def test_admissions_extension(self):
         cert = _load_cert(
             os.path.join(
                 "x509",
@@ -2057,7 +2050,7 @@ class TestRSACertificateRequest:
             ],
         ],
     )
-    def test_load_rsa_certificate_request(self, path, loader_func, backend):
+    def test_load_rsa_certificate_request(self, path, loader_func):
         request = _load_cert(path, loader_func)
         assert isinstance(request.signature_hash_algorithm, hashes.SHA1)
         assert (
@@ -2083,14 +2076,14 @@ class TestRSACertificateRequest:
         assert isinstance(extensions, x509.Extensions)
         assert list(extensions) == []
 
-    def test_load_legacy_pem_header(self, backend):
+    def test_load_legacy_pem_header(self):
         cert = _load_cert(
             os.path.join("x509", "requests", "ec_sha256_old_header.pem"),
             x509.load_pem_x509_csr,
         )
         assert isinstance(cert, x509.CertificateSigningRequest)
 
-    def test_invalid_pem(self, backend):
+    def test_invalid_pem(self):
         with pytest.raises(ValueError, match="Unable to load"):
             x509.load_pem_x509_csr(b"notacsr")
 
@@ -2105,11 +2098,11 @@ class TestRSACertificateRequest:
     @pytest.mark.parametrize(
         "loader_func", [x509.load_pem_x509_csr, x509.load_der_x509_csr]
     )
-    def test_invalid_certificate_request(self, loader_func, backend):
+    def test_invalid_certificate_request(self, loader_func):
         with pytest.raises(ValueError):
             loader_func(b"notacsr")
 
-    def test_unsupported_signature_hash_algorithm_request(self, backend):
+    def test_unsupported_signature_hash_algorithm_request(self):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_md4.pem"),
             x509.load_pem_x509_csr,
@@ -2117,14 +2110,14 @@ class TestRSACertificateRequest:
         with raises_unsupported_algorithm(None):
             request.signature_hash_algorithm
 
-    def test_invalid_version(self, backend):
+    def test_invalid_version(self):
         with pytest.raises(x509.InvalidVersion):
             _load_cert(
                 os.path.join("x509", "requests", "bad-version.pem"),
                 x509.load_pem_x509_csr,
             )
 
-    def test_duplicate_extension(self, backend):
+    def test_duplicate_extension(self):
         request = _load_cert(
             os.path.join("x509", "requests", "two_basic_constraints.pem"),
             x509.load_pem_x509_csr,
@@ -2134,7 +2127,7 @@ class TestRSACertificateRequest:
 
         assert exc.value.oid == ExtensionOID.BASIC_CONSTRAINTS
 
-    def test_unsupported_critical_extension(self, backend):
+    def test_unsupported_critical_extension(self):
         request = _load_cert(
             os.path.join(
                 "x509", "requests", "unsupported_extension_critical.pem"
@@ -2147,7 +2140,7 @@ class TestRSACertificateRequest:
         assert isinstance(ext.value, x509.UnrecognizedExtension)
         assert ext.value.value == b"value"
 
-    def test_unsupported_extension(self, backend):
+    def test_unsupported_extension(self):
         request = _load_cert(
             os.path.join("x509", "requests", "unsupported_extension.pem"),
             x509.load_pem_x509_csr,
@@ -2159,14 +2152,14 @@ class TestRSACertificateRequest:
             x509.ObjectIdentifier("1.2.3.4"), b"value"
         )
 
-    def test_no_extension_with_other_attributes(self, backend):
+    def test_no_extension_with_other_attributes(self):
         request = _load_cert(
             os.path.join("x509", "requests", "challenge-unstructured.pem"),
             x509.load_pem_x509_csr,
         )
         assert len(request.extensions) == 0
 
-    def test_request_basic_constraints(self, backend):
+    def test_request_basic_constraints(self):
         request = _load_cert(
             os.path.join("x509", "requests", "basic_constraints.pem"),
             x509.load_pem_x509_csr,
@@ -2181,7 +2174,7 @@ class TestRSACertificateRequest:
             ),
         ]
 
-    def test_subject_alt_name(self, backend):
+    def test_subject_alt_name(self):
         request = _load_cert(
             os.path.join("x509", "requests", "san_rsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -2194,7 +2187,7 @@ class TestRSACertificateRequest:
             x509.DNSName("sub.cryptography.io"),
         ]
 
-    def test_freeipa_bad_critical(self, backend):
+    def test_freeipa_bad_critical(self):
         csr = _load_cert(
             os.path.join("x509", "requests", "freeipa-bad-critical.pem"),
             x509.load_pem_x509_csr,
@@ -2202,7 +2195,7 @@ class TestRSACertificateRequest:
         with pytest.raises(ValueError):
             csr.extensions
 
-    def test_public_bytes_pem(self, backend):
+    def test_public_bytes_pem(self):
         # Load an existing CSR.
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
@@ -2230,7 +2223,7 @@ class TestRSACertificateRequest:
             x509.NameAttribute(NameOID.COMMON_NAME, "cryptography.io"),
         ]
 
-    def test_public_bytes_der(self, backend):
+    def test_public_bytes_der(self):
         # Load an existing CSR.
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
@@ -2258,7 +2251,7 @@ class TestRSACertificateRequest:
             x509.NameAttribute(NameOID.COMMON_NAME, "cryptography.io"),
         ]
 
-    def test_signature(self, backend):
+    def test_signature(self):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -2280,7 +2273,7 @@ class TestRSACertificateRequest:
         ),
         skip_message="Does not support SHA-1 signature.",
     )
-    def test_tbs_certrequest_bytes(self, backend):
+    def test_tbs_certrequest_bytes(self):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -2310,7 +2303,7 @@ class TestRSACertificateRequest:
             request.signature_hash_algorithm,
         )
 
-    def test_public_bytes_invalid_encoding(self, backend):
+    def test_public_bytes_invalid_encoding(self):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -2319,14 +2312,14 @@ class TestRSACertificateRequest:
         with pytest.raises(TypeError):
             request.public_bytes(typing.cast(typing.Any, "NotAnEncoding"))
 
-    def test_signature_invalid(self, backend):
+    def test_signature_invalid(self):
         request = _load_cert(
             os.path.join("x509", "requests", "invalid_signature.pem"),
             x509.load_pem_x509_csr,
         )
         assert not request.is_signature_valid
 
-    def test_signature_valid(self, backend):
+    def test_signature_valid(self):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha256.pem"),
             x509.load_pem_x509_csr,
@@ -2348,9 +2341,7 @@ class TestRSACertificateRequest:
             ),
         ],
     )
-    def test_public_bytes_match(
-        self, request_path, loader_func, encoding, backend
-    ):
+    def test_public_bytes_match(self, request_path, loader_func, encoding):
         request_bytes = load_vectors_from_file(
             request_path, lambda pemfile: pemfile.read(), mode="rb"
         )
@@ -2358,7 +2349,7 @@ class TestRSACertificateRequest:
         serialized = request.public_bytes(encoding)
         assert serialized == request_bytes
 
-    def test_eq(self, backend):
+    def test_eq(self):
         request1 = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -2370,7 +2361,7 @@ class TestRSACertificateRequest:
 
         assert request1 == request2
 
-    def test_ne(self, backend):
+    def test_ne(self):
         request1 = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -2383,7 +2374,7 @@ class TestRSACertificateRequest:
         assert request1 != request2
         assert request1 != object()
 
-    def test_ordering_unsupported(self, backend):
+    def test_ordering_unsupported(self):
         csr = _load_cert(
             os.path.join("x509", "requests", "rsa_sha256.pem"),
             x509.load_pem_x509_csr,
@@ -2395,7 +2386,7 @@ class TestRSACertificateRequest:
         with pytest.raises(TypeError, match="'>' not supported"):
             csr > csr2  # type: ignore[operator]
 
-    def test_hash(self, backend):
+    def test_hash(self):
         request1 = _load_cert(
             os.path.join("x509", "requests", "rsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -2516,7 +2507,7 @@ class TestRSACertificateRequest:
         ]
 
     def test_build_cert_private_type_encoding(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = rsa_key_2048
@@ -2546,7 +2537,7 @@ class TestRSACertificateRequest:
             .not_valid_before(not_valid_before)
             .not_valid_after(not_valid_after)
         )
-        cert = builder.sign(issuer_private_key, hashes.SHA256(), backend)
+        cert = builder.sign(issuer_private_key, hashes.SHA256())
 
         for dn in (cert.subject, cert.issuer):
             assert (
@@ -2567,7 +2558,7 @@ class TestRSACertificateRequest:
             )
 
     def test_build_cert_printable_string_country_name(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = rsa_key_2048
@@ -2609,7 +2600,7 @@ class TestRSACertificateRequest:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, hashes.SHA256(), backend)
+        cert = builder.sign(issuer_private_key, hashes.SHA256())
 
         parsed = test_support.test_parse_certificate(
             cert.public_bytes(serialization.Encoding.DER)
@@ -2624,7 +2615,7 @@ class TestRSACertificateRequest:
 
 class TestCertificateBuilder:
     def test_checks_for_unsupported_extensions(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
         builder = (
@@ -2643,11 +2634,9 @@ class TestCertificateBuilder:
         )
 
         with pytest.raises(NotImplementedError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_encode_nonstandard_aia(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_encode_nonstandard_aia(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
 
         aia = x509.AuthorityInformationAccess(
@@ -2674,11 +2663,9 @@ class TestCertificateBuilder:
             .add_extension(aia, False)
         )
 
-        builder.sign(private_key, hashes.SHA256(), backend)
+        builder.sign(private_key, hashes.SHA256())
 
-    def test_encode_nonstandard_sia(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_encode_nonstandard_sia(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
 
         sia = x509.SubjectInformationAccess(
@@ -2705,15 +2692,13 @@ class TestCertificateBuilder:
             .add_extension(sia, False)
         )
 
-        cert = builder.sign(private_key, hashes.SHA256(), backend)
+        cert = builder.sign(private_key, hashes.SHA256())
         ext = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_INFORMATION_ACCESS
         )
         assert ext.value == sia
 
-    def test_subject_dn_asn1_types(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_subject_dn_asn1_types(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
 
         name = x509.Name(
@@ -2756,7 +2741,7 @@ class TestCertificateBuilder:
             .serial_number(777)
             .not_valid_before(datetime.datetime(1999, 1, 1))
             .not_valid_after(datetime.datetime(2020, 1, 1))
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         for dn in (cert.subject, cert.issuer):
@@ -2775,7 +2760,6 @@ class TestCertificateBuilder:
         rsa_key_2048: rsa.RSAPrivateKey,
         not_valid_before,
         not_valid_after,
-        backend,
     ):
         private_key = rsa_key_2048
         builder = (
@@ -2791,7 +2775,7 @@ class TestCertificateBuilder:
             .not_valid_before(not_valid_before)
             .not_valid_after(not_valid_after)
         )
-        cert = builder.sign(private_key, hashes.SHA256(), backend)
+        cert = builder.sign(private_key, hashes.SHA256())
         _check_cert_times(
             cert,
             not_valid_before=not_valid_before,
@@ -2806,7 +2790,7 @@ class TestCertificateBuilder:
         assert parsed.not_after_tag == 0x18
 
     def test_rdns_preserve_iteration_order(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         """
         This test checks that RDN ordering is consistent when loading
@@ -2837,7 +2821,7 @@ class TestCertificateBuilder:
             .public_key(rsa_key_2048.public_key())
             .not_valid_before(datetime.datetime(2020, 1, 1))
             .not_valid_after(datetime.datetime(2038, 1, 1))
-            .sign(rsa_key_2048, hashes.SHA256(), backend)
+            .sign(rsa_key_2048, hashes.SHA256())
         )
         loaded_cert = x509.load_pem_x509_certificate(
             cert.public_bytes(encoding=serialization.Encoding.PEM)
@@ -2926,9 +2910,7 @@ class TestCertificateBuilder:
         assert isinstance(cert.signature_algorithm_parameters, padding.PSS)
         assert cert.signature_algorithm_parameters._salt_length == computed_len
 
-    def test_sign_pss_auto_unsupported(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_pss_auto_unsupported(self, rsa_key_2048: rsa.RSAPrivateKey):
         builder = (
             x509.CertificateBuilder()
             .subject_name(
@@ -2948,9 +2930,7 @@ class TestCertificateBuilder:
         with pytest.raises(TypeError):
             builder.sign(rsa_key_2048, hashes.SHA256(), rsa_padding=pss)
 
-    def test_sign_invalid_padding(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_invalid_padding(self, rsa_key_2048: rsa.RSAPrivateKey):
         builder = (
             x509.CertificateBuilder()
             .subject_name(
@@ -2976,9 +2956,7 @@ class TestCertificateBuilder:
                 eckey, hashes.SHA256(), rsa_padding=padding.PKCS1v15()
             )
 
-    def test_sign_pss_hash_none(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_pss_hash_none(self, rsa_key_2048: rsa.RSAPrivateKey):
         builder = (
             x509.CertificateBuilder()
             .subject_name(
@@ -2996,7 +2974,7 @@ class TestCertificateBuilder:
         with pytest.raises(TypeError):
             builder.sign(rsa_key_2048, None, rsa_padding=pss)
 
-    def test_no_subject_name(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_no_subject_name(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
         builder = (
             x509.CertificateBuilder()
@@ -3009,9 +2987,9 @@ class TestCertificateBuilder:
             .not_valid_after(datetime.datetime(2030, 12, 31, 8, 30))
         )
         with pytest.raises(ValueError):
-            builder.sign(subject_private_key, hashes.SHA256(), backend)
+            builder.sign(subject_private_key, hashes.SHA256())
 
-    def test_no_issuer_name(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_no_issuer_name(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
         builder = (
             x509.CertificateBuilder()
@@ -3024,9 +3002,9 @@ class TestCertificateBuilder:
             .not_valid_after(datetime.datetime(2030, 12, 31, 8, 30))
         )
         with pytest.raises(ValueError):
-            builder.sign(subject_private_key, hashes.SHA256(), backend)
+            builder.sign(subject_private_key, hashes.SHA256())
 
-    def test_no_public_key(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_no_public_key(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
         builder = (
             x509.CertificateBuilder()
@@ -3041,11 +3019,9 @@ class TestCertificateBuilder:
             .not_valid_after(datetime.datetime(2030, 12, 31, 8, 30))
         )
         with pytest.raises(ValueError):
-            builder.sign(subject_private_key, hashes.SHA256(), backend)
+            builder.sign(subject_private_key, hashes.SHA256())
 
-    def test_no_not_valid_before(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_no_not_valid_before(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
         builder = (
             x509.CertificateBuilder()
@@ -3060,11 +3036,9 @@ class TestCertificateBuilder:
             .not_valid_after(datetime.datetime(2030, 12, 31, 8, 30))
         )
         with pytest.raises(ValueError):
-            builder.sign(subject_private_key, hashes.SHA256(), backend)
+            builder.sign(subject_private_key, hashes.SHA256())
 
-    def test_no_not_valid_after(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_no_not_valid_after(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
         builder = (
             x509.CertificateBuilder()
@@ -3079,9 +3053,9 @@ class TestCertificateBuilder:
             .not_valid_before(datetime.datetime(2002, 1, 1, 12, 1))
         )
         with pytest.raises(ValueError):
-            builder.sign(subject_private_key, hashes.SHA256(), backend)
+            builder.sign(subject_private_key, hashes.SHA256())
 
-    def test_no_serial_number(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_no_serial_number(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
         builder = (
             x509.CertificateBuilder()
@@ -3096,7 +3070,7 @@ class TestCertificateBuilder:
             .not_valid_after(datetime.datetime(2030, 12, 31, 8, 30))
         )
         with pytest.raises(ValueError):
-            builder.sign(subject_private_key, hashes.SHA256(), backend)
+            builder.sign(subject_private_key, hashes.SHA256())
 
     def test_issuer_name_must_be_a_name_type(self):
         builder = x509.CertificateBuilder()
@@ -3147,7 +3121,7 @@ class TestCertificateBuilder:
             builder.not_valid_after(datetime.datetime(2001, 1, 1, 12, 1))
 
     def test_public_key_must_be_public_key(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
         builder = x509.CertificateBuilder()
@@ -3156,7 +3130,7 @@ class TestCertificateBuilder:
             builder.public_key(typing.cast(typing.Any, private_key))
 
     def test_public_key_may_only_be_set_once(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
         public_key = private_key.public_key()
@@ -3165,9 +3139,7 @@ class TestCertificateBuilder:
         with pytest.raises(ValueError):
             builder.public_key(public_key)
 
-    def test_public_key_rsa_pss_spki(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_public_key_rsa_pss_spki(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         cert = (
             x509.CertificateBuilder()
@@ -3207,7 +3179,7 @@ class TestCertificateBuilder:
         cert.verify_directly_issued_by(cert)
 
     def test_public_key_rsa_padding_must_be_pss_class(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         with pytest.raises(TypeError):
             x509.CertificateBuilder().public_key(
@@ -3227,7 +3199,7 @@ class TestCertificateBuilder:
                 rsa_padding=typing.cast(typing.Any, padding.PKCS1v15),
             )
 
-    def test_public_key_rsa_padding_requires_rsa_key(self, backend):
+    def test_public_key_rsa_padding_requires_rsa_key(self):
         private_key = ec.generate_private_key(ec.SECP256R1())
         with pytest.raises(TypeError):
             x509.CertificateBuilder().public_key(
@@ -3249,9 +3221,7 @@ class TestCertificateBuilder:
         with pytest.raises(ValueError):
             x509.CertificateBuilder().serial_number(0)
 
-    def test_minimal_serial_number(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_minimal_serial_number(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
         builder = (
             x509.CertificateBuilder()
@@ -3266,12 +3236,10 @@ class TestCertificateBuilder:
             .not_valid_before(datetime.datetime(2002, 1, 1, 12, 1))
             .not_valid_after(datetime.datetime(2030, 12, 31, 8, 30))
         )
-        cert = builder.sign(subject_private_key, hashes.SHA256(), backend)
+        cert = builder.sign(subject_private_key, hashes.SHA256())
         assert cert.serial_number == 1
 
-    def test_biggest_serial_number(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_biggest_serial_number(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
         builder = (
             x509.CertificateBuilder()
@@ -3286,7 +3254,7 @@ class TestCertificateBuilder:
             .not_valid_before(datetime.datetime(2002, 1, 1, 12, 1))
             .not_valid_after(datetime.datetime(2030, 12, 31, 8, 30))
         )
-        cert = builder.sign(subject_private_key, hashes.SHA256(), backend)
+        cert = builder.sign(subject_private_key, hashes.SHA256())
         assert cert.serial_number == (1 << 159) - 1
 
     def test_serial_number_must_be_less_than_160_bits_long(self):
@@ -3299,9 +3267,7 @@ class TestCertificateBuilder:
         with pytest.raises(ValueError):
             builder.serial_number(20)
 
-    def test_aware_not_valid_after(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_aware_not_valid_after(self, rsa_key_2048: rsa.RSAPrivateKey):
         tz = datetime.timezone(datetime.timedelta(hours=-8))
         time = datetime.datetime(2012, 1, 16, 22, 43, tzinfo=tz)
         utc_time = datetime.datetime(2012, 1, 17, 6, 43)
@@ -3319,12 +3285,12 @@ class TestCertificateBuilder:
             .not_valid_before(utc_time - datetime.timedelta(days=365))
         )
 
-        cert = cert_builder.sign(private_key, hashes.SHA256(), backend)
+        cert = cert_builder.sign(private_key, hashes.SHA256())
         _check_cert_times(
             cert, not_valid_before=None, not_valid_after=utc_time
         )
 
-    def test_earliest_time(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_earliest_time(self, rsa_key_2048: rsa.RSAPrivateKey):
         time = datetime.datetime(1950, 1, 1)
         private_key = rsa_key_2048
         cert_builder = (
@@ -3340,7 +3306,7 @@ class TestCertificateBuilder:
             .not_valid_before(time)
             .not_valid_after(time)
         )
-        cert = cert_builder.sign(private_key, hashes.SHA256(), backend)
+        cert = cert_builder.sign(private_key, hashes.SHA256())
         _check_cert_times(cert, not_valid_before=time, not_valid_after=time)
         parsed = test_support.test_parse_certificate(
             cert.public_bytes(serialization.Encoding.DER)
@@ -3373,9 +3339,7 @@ class TestCertificateBuilder:
         with pytest.raises(ValueError):
             builder.not_valid_after(datetime.datetime.now())
 
-    def test_aware_not_valid_before(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_aware_not_valid_before(self, rsa_key_2048: rsa.RSAPrivateKey):
         tz = datetime.timezone(datetime.timedelta(hours=-8))
         time = datetime.datetime(2012, 1, 16, 22, 43, tzinfo=tz)
         utc_time = datetime.datetime(2012, 1, 17, 6, 43)
@@ -3393,7 +3357,7 @@ class TestCertificateBuilder:
             .not_valid_after(utc_time + datetime.timedelta(days=366))
         )
 
-        cert = cert_builder.sign(private_key, hashes.SHA256(), backend)
+        cert = cert_builder.sign(private_key, hashes.SHA256())
         _check_cert_times(
             cert, not_valid_before=utc_time, not_valid_after=None
         )
@@ -3445,7 +3409,7 @@ class TestCertificateBuilder:
 
     @pytest.mark.parametrize("algorithm", [object(), None])
     def test_sign_with_unsupported_hash(
-        self, rsa_key_2048: rsa.RSAPrivateKey, algorithm, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey, algorithm
     ):
         private_key = rsa_key_2048
         builder = x509.CertificateBuilder()
@@ -3463,9 +3427,9 @@ class TestCertificateBuilder:
         )
 
         with pytest.raises(TypeError):
-            builder.sign(private_key, algorithm, backend)
+            builder.sign(private_key, algorithm)
 
-    def test_sign_with_unsupported_hash_ed25519(self, backend):
+    def test_sign_with_unsupported_hash_ed25519(self):
         private_key = ed25519.Ed25519PrivateKey.generate()
         builder = (
             x509.CertificateBuilder()
@@ -3482,13 +3446,13 @@ class TestCertificateBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.ed448_supported(),
         skip_message="Requires OpenSSL with Ed448 support",
     )
-    def test_sign_with_unsupported_hash_ed448(self, backend):
+    def test_sign_with_unsupported_hash_ed448(self):
         private_key = ed448.Ed448PrivateKey.generate()
         builder = (
             x509.CertificateBuilder()
@@ -3505,7 +3469,7 @@ class TestCertificateBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.mldsa_supported(),
@@ -3519,7 +3483,7 @@ class TestCertificateBuilder:
             mldsa.MLDSA87PrivateKey,
         ],
     )
-    def test_sign_with_unsupported_hash_mldsa(self, priv_key_cls, backend):
+    def test_sign_with_unsupported_hash_mldsa(self, priv_key_cls):
         private_key = priv_key_cls.generate()
         builder = (
             x509.CertificateBuilder()
@@ -3536,7 +3500,7 @@ class TestCertificateBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.hash_supported(hashes.MD5()),
@@ -3556,8 +3520,8 @@ class TestCertificateBuilder:
             hashes.SHA3_512(),
         ],
     )
-    def test_sign_dsa_with_unsupported_hash(self, hash_algorithm, backend):
-        private_key = DSA_KEY_2048.private_key(backend)
+    def test_sign_dsa_with_unsupported_hash(self, hash_algorithm):
+        private_key = DSA_KEY_2048.private_key()
         builder = x509.CertificateBuilder()
         builder = (
             builder.subject_name(
@@ -3572,7 +3536,7 @@ class TestCertificateBuilder:
             .not_valid_after(datetime.datetime(2032, 1, 1, 12, 1))
         )
         with pytest.raises(UnsupportedAlgorithm):
-            builder.sign(private_key, hash_algorithm, backend)
+            builder.sign(private_key, hash_algorithm)
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.hash_supported(hashes.MD5()),
@@ -3614,11 +3578,9 @@ class TestCertificateBuilder:
             (hashes.SHA512, x509.SignatureAlgorithmOID.DSA_WITH_SHA512),
         ],
     )
-    def test_build_cert_with_dsa_private_key(
-        self, hashalg, hashalg_oid, backend
-    ):
-        issuer_private_key = DSA_KEY_2048.private_key(backend)
-        subject_private_key = DSA_KEY_2048.private_key(backend)
+    def test_build_cert_with_dsa_private_key(self, hashalg, hashalg_oid):
+        issuer_private_key = DSA_KEY_2048.private_key()
+        subject_private_key = DSA_KEY_2048.private_key()
 
         not_valid_before = datetime.datetime(2002, 1, 1, 12, 1)
         not_valid_after = datetime.datetime(2030, 12, 31, 8, 30)
@@ -3645,7 +3607,7 @@ class TestCertificateBuilder:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, hashalg(), backend)
+        cert = builder.sign(issuer_private_key, hashalg())
 
         assert cert.version is x509.Version.v3
         assert cert.signature_algorithm_oid == hashalg_oid
@@ -3798,7 +3760,7 @@ class TestCertificateBuilder:
             ec.ECDSA(hashes.SHA256()),
         )
 
-    def test_sign_deterministic_wrong_key_type(self, rsa_key_2048, backend):
+    def test_sign_deterministic_wrong_key_type(self, rsa_key_2048):
         not_valid_before = datetime.datetime(2002, 1, 1, 12, 1)
         not_valid_after = datetime.datetime(2030, 12, 31, 8, 30)
         builder = (
@@ -3812,14 +3774,11 @@ class TestCertificateBuilder:
         )
         with pytest.raises(TypeError):
             builder.sign(
-                rsa_key_2048,
-                hashes.SHA256(),
-                backend,
-                ecdsa_deterministic=True,
+                rsa_key_2048, hashes.SHA256(), ecdsa_deterministic=True
             )
 
     def test_build_cert_with_bmpstring_universalstring_name(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
         issuer = x509.Name(
@@ -3851,11 +3810,11 @@ class TestCertificateBuilder:
             .not_valid_before(datetime.datetime(2002, 1, 1, 12, 1))
             .not_valid_after(datetime.datetime(2032, 1, 1, 12, 1))
         )
-        cert = builder.sign(private_key, hashes.SHA256(), backend)
+        cert = builder.sign(private_key, hashes.SHA256())
         assert cert.issuer == issuer
         assert cert.subject == subject
 
-    def test_build_cert_with_ed25519(self, backend):
+    def test_build_cert_with_ed25519(self):
         issuer_private_key = ed25519.Ed25519PrivateKey.generate()
         subject_private_key = ed25519.Ed25519PrivateKey.generate()
 
@@ -3884,7 +3843,7 @@ class TestCertificateBuilder:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, None, backend)
+        cert = builder.sign(issuer_private_key, None)
         issuer_private_key.public_key().verify(
             cert.signature, cert.tbs_certificate_bytes
         )
@@ -3915,7 +3874,7 @@ class TestCertificateBuilder:
         ]
 
     def test_build_cert_with_public_ed25519_rsa_sig(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = ed25519.Ed25519PrivateKey.generate()
@@ -3937,7 +3896,7 @@ class TestCertificateBuilder:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, hashes.SHA256(), backend)
+        cert = builder.sign(issuer_private_key, hashes.SHA256())
         assert cert.signature_hash_algorithm is not None
         issuer_private_key.public_key().verify(
             cert.signature,
@@ -3956,7 +3915,7 @@ class TestCertificateBuilder:
         only_if=lambda backend: backend.ed448_supported(),
         skip_message="Requires OpenSSL with Ed448 support",
     )
-    def test_build_cert_with_ed448(self, backend):
+    def test_build_cert_with_ed448(self):
         issuer_private_key = ed448.Ed448PrivateKey.generate()
         subject_private_key = ed448.Ed448PrivateKey.generate()
 
@@ -3985,7 +3944,7 @@ class TestCertificateBuilder:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, None, backend)
+        cert = builder.sign(issuer_private_key, None)
         issuer_private_key.public_key().verify(
             cert.signature, cert.tbs_certificate_bytes
         )
@@ -4020,7 +3979,7 @@ class TestCertificateBuilder:
         skip_message="Requires OpenSSL with Ed448 support",
     )
     def test_build_cert_with_public_ed448_rsa_sig(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = ed448.Ed448PrivateKey.generate()
@@ -4042,7 +4001,7 @@ class TestCertificateBuilder:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, hashes.SHA256(), backend)
+        cert = builder.sign(issuer_private_key, hashes.SHA256())
         assert cert.signature_hash_algorithm is not None
         issuer_private_key.public_key().verify(
             cert.signature,
@@ -4085,7 +4044,7 @@ class TestCertificateBuilder:
         ],
     )
     def test_build_cert_with_mldsa(
-        self, priv_key_cls, pub_key_cls, sig_oid, pub_oid, backend
+        self, priv_key_cls, pub_key_cls, sig_oid, pub_oid
     ):
         issuer_private_key = priv_key_cls.generate()
         subject_private_key = priv_key_cls.generate()
@@ -4111,7 +4070,7 @@ class TestCertificateBuilder:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, None, backend)
+        cert = builder.sign(issuer_private_key, None)
         issuer_private_key.public_key().verify(
             cert.signature, cert.tbs_certificate_bytes
         )
@@ -4127,7 +4086,7 @@ class TestCertificateBuilder:
         skip_message="Requires a backend with ML-DSA support",
     )
     def test_build_cert_with_public_mldsa_rsa_sig(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = mldsa.MLDSA65PrivateKey.generate()
@@ -4149,7 +4108,7 @@ class TestCertificateBuilder:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, hashes.SHA256(), backend)
+        cert = builder.sign(issuer_private_key, hashes.SHA256())
         assert cert.signature_hash_algorithm is not None
         issuer_private_key.public_key().verify(
             cert.signature,
@@ -4190,7 +4149,6 @@ class TestCertificateBuilder:
         priv_key_cls,
         pub_key_cls,
         pub_key_oid,
-        backend,
     ):
         issuer_private_key = rsa_key_2048
         subject_private_key = priv_key_cls.generate()
@@ -4212,7 +4170,7 @@ class TestCertificateBuilder:
             .not_valid_after(not_valid_after)
         )
 
-        cert = builder.sign(issuer_private_key, hashes.SHA256(), backend)
+        cert = builder.sign(issuer_private_key, hashes.SHA256())
         assert cert.signature_hash_algorithm is not None
         issuer_private_key.public_key().verify(
             cert.signature,
@@ -4228,7 +4186,7 @@ class TestCertificateBuilder:
         assert cert.public_key_algorithm_oid == pub_key_oid
 
     def test_build_cert_with_rsa_key_too_small(
-        self, rsa_key_512: rsa.RSAPrivateKey, backend
+        self, rsa_key_512: rsa.RSAPrivateKey
     ):
         issuer_private_key = rsa_key_512
         subject_private_key = rsa_key_512
@@ -4251,7 +4209,7 @@ class TestCertificateBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(issuer_private_key, hashes.SHA512(), backend)
+            builder.sign(issuer_private_key, hashes.SHA512())
 
     @pytest.mark.parametrize(
         "add_ext",
@@ -4718,9 +4676,7 @@ class TestCertificateBuilder:
             x509.SubjectKeyIdentifier,
         ],
     )
-    def test_extensions(
-        self, rsa_key_2048: rsa.RSAPrivateKey, add_ext, backend
-    ):
+    def test_extensions(self, rsa_key_2048: rsa.RSAPrivateKey, add_ext):
         issuer_private_key = rsa_key_2048
         subject_private_key = rsa_key_2048
 
@@ -4746,7 +4702,7 @@ class TestCertificateBuilder:
             .public_key(subject_private_key.public_key())
             .serial_number(123)
             .add_extension(add_ext, critical=False)
-            .sign(issuer_private_key, hashes.SHA256(), backend)
+            .sign(issuer_private_key, hashes.SHA256())
         )
 
         ext = cert.extensions.get_extension_for_class(type(add_ext))
@@ -4767,7 +4723,7 @@ class TestCertificateBuilder:
         assert ext.value == add_ext
 
     def test_build_ca_request_with_path_length_none(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
 
@@ -4781,11 +4737,11 @@ class TestCertificateBuilder:
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=None), critical=True
             )
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         loaded_request = x509.load_pem_x509_csr(
-            request.public_bytes(encoding=serialization.Encoding.PEM), backend
+            request.public_bytes(encoding=serialization.Encoding.PEM)
         )
         subject = loaded_request.subject
         assert isinstance(subject, x509.Name)
@@ -4805,7 +4761,7 @@ class TestCertificateBuilder:
         ],
     )
     def test_unrecognized_extension(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend, unrecognized
+        self, rsa_key_2048: rsa.RSAPrivateKey, unrecognized
     ):
         private_key = rsa_key_2048
 
@@ -4822,7 +4778,7 @@ class TestCertificateBuilder:
             .public_key(private_key.public_key())
             .serial_number(123)
             .add_extension(unrecognized, critical=False)
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         ext = cert.extensions.get_extension_for_oid(unrecognized.oid)
@@ -4832,7 +4788,7 @@ class TestCertificateBuilder:
 
 class TestCertificateSigningRequestBuilder:
     def test_sign_invalid_hash_algorithm(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
 
@@ -4840,44 +4796,38 @@ class TestCertificateSigningRequestBuilder:
             x509.Name([])
         )
         with pytest.raises(TypeError):
-            builder.sign(
-                private_key,
-                typing.cast(typing.Any, "NotAHash"),
-                backend,
-            )
+            builder.sign(private_key, typing.cast(typing.Any, "NotAHash"))
 
-    def test_request_with_unsupported_hash_ed25519(self, backend):
+    def test_request_with_unsupported_hash_ed25519(self):
         private_key = ed25519.Ed25519PrivateKey.generate()
         builder = x509.CertificateSigningRequestBuilder().subject_name(
             x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.ed448_supported(),
         skip_message="Requires OpenSSL with Ed448 support",
     )
-    def test_request_with_unsupported_hash_ed448(self, backend):
+    def test_request_with_unsupported_hash_ed448(self):
         private_key = ed448.Ed448PrivateKey.generate()
         builder = x509.CertificateSigningRequestBuilder().subject_name(
             x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_no_subject_name(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_no_subject_name(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
 
         builder = x509.CertificateSigningRequestBuilder()
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_build_ca_request_with_rsa(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_build_ca_request_with_rsa(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
 
         request = (
@@ -4890,7 +4840,7 @@ class TestCertificateSigningRequestBuilder:
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=2), critical=True
             )
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         assert isinstance(request.signature_hash_algorithm, hashes.SHA256)
@@ -4909,7 +4859,7 @@ class TestCertificateSigningRequestBuilder:
         assert basic_constraints.value.path_length == 2
 
     def test_build_ca_request_with_unicode(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
 
@@ -4927,11 +4877,11 @@ class TestCertificateSigningRequestBuilder:
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=2), critical=True
             )
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         loaded_request = x509.load_pem_x509_csr(
-            request.public_bytes(encoding=serialization.Encoding.PEM), backend
+            request.public_bytes(encoding=serialization.Encoding.PEM)
         )
         subject = loaded_request.subject
         assert isinstance(subject, x509.Name)
@@ -4939,9 +4889,7 @@ class TestCertificateSigningRequestBuilder:
             x509.NameAttribute(NameOID.ORGANIZATION_NAME, "PyCA\U0001f37a"),
         ]
 
-    def test_subject_dn_asn1_types(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_subject_dn_asn1_types(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
 
         request = (
@@ -4991,7 +4939,7 @@ class TestCertificateSigningRequestBuilder:
                     ]
                 )
             )
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
         for oid, asn1_type in TestNameAttribute.EXPECTED_TYPES:
             assert (
@@ -5000,7 +4948,7 @@ class TestCertificateSigningRequestBuilder:
             )
 
     def test_build_ca_request_with_multivalue_rdns(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
         subject = x509.Name(
@@ -5021,17 +4969,17 @@ class TestCertificateSigningRequestBuilder:
         request = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(subject)
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         loaded_request = x509.load_pem_x509_csr(
-            request.public_bytes(encoding=serialization.Encoding.PEM), backend
+            request.public_bytes(encoding=serialization.Encoding.PEM)
         )
         assert isinstance(loaded_request.subject, x509.Name)
         assert loaded_request.subject == subject
 
     def test_build_nonca_request_with_rsa(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
 
@@ -5044,7 +4992,7 @@ class TestCertificateSigningRequestBuilder:
                 x509.BasicConstraints(ca=False, path_length=None),
                 critical=True,
             )
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         assert isinstance(request.signature_hash_algorithm, hashes.SHA256)
@@ -5141,19 +5089,16 @@ class TestCertificateSigningRequestBuilder:
             ec.ECDSA(hashes.SHA256()),
         )
 
-    def test_csr_deterministic_wrong_key_type(self, rsa_key_2048, backend):
+    def test_csr_deterministic_wrong_key_type(self, rsa_key_2048):
         builder = x509.CertificateSigningRequestBuilder().subject_name(
             x509.Name([])
         )
         with pytest.raises(TypeError):
             builder.sign(
-                rsa_key_2048,
-                hashes.SHA256(),
-                backend,
-                ecdsa_deterministic=True,
+                rsa_key_2048, hashes.SHA256(), ecdsa_deterministic=True
             )
 
-    def test_build_ca_request_with_ed25519(self, backend):
+    def test_build_ca_request_with_ed25519(self):
         private_key = ed25519.Ed25519PrivateKey.generate()
 
         request = (
@@ -5170,7 +5115,7 @@ class TestCertificateSigningRequestBuilder:
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=2), critical=True
             )
-            .sign(private_key, None, backend)
+            .sign(private_key, None)
         )
 
         assert request.signature_hash_algorithm is None
@@ -5191,7 +5136,7 @@ class TestCertificateSigningRequestBuilder:
         only_if=lambda backend: backend.ed448_supported(),
         skip_message="Requires OpenSSL with Ed448 support",
     )
-    def test_build_ca_request_with_ed448(self, backend):
+    def test_build_ca_request_with_ed448(self):
         private_key = ed448.Ed448PrivateKey.generate()
 
         request = (
@@ -5208,7 +5153,7 @@ class TestCertificateSigningRequestBuilder:
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=2), critical=True
             )
-            .sign(private_key, None, backend)
+            .sign(private_key, None)
         )
 
         assert request.signature_hash_algorithm is None
@@ -5250,7 +5195,7 @@ class TestCertificateSigningRequestBuilder:
         ],
     )
     def test_build_ca_request_with_mldsa(
-        self, priv_key_cls, pub_key_cls, sig_oid, backend
+        self, priv_key_cls, pub_key_cls, sig_oid
     ):
         private_key = priv_key_cls.generate()
 
@@ -5268,7 +5213,7 @@ class TestCertificateSigningRequestBuilder:
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=2), critical=True
             )
-            .sign(private_key, None, backend)
+            .sign(private_key, None)
         )
 
         assert request.is_signature_valid
@@ -5291,8 +5236,8 @@ class TestCertificateSigningRequestBuilder:
         only_if=lambda backend: backend.dsa_supported(),
         skip_message="Does not support DSA.",
     )
-    def test_build_ca_request_with_dsa(self, backend):
-        private_key = DSA_KEY_2048.private_key(backend)
+    def test_build_ca_request_with_dsa(self):
+        private_key = DSA_KEY_2048.private_key()
 
         request = (
             x509.CertificateSigningRequestBuilder()
@@ -5302,7 +5247,7 @@ class TestCertificateSigningRequestBuilder:
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=2), critical=True
             )
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         assert isinstance(request.signature_hash_algorithm, hashes.SHA256)
@@ -5345,9 +5290,7 @@ class TestCertificateSigningRequestBuilder:
                 False,
             )
 
-    def test_add_unsupported_extension(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_add_unsupported_extension(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         builder = x509.CertificateSigningRequestBuilder()
         builder = (
@@ -5361,11 +5304,9 @@ class TestCertificateSigningRequestBuilder:
             .add_extension(DummyExtension(), False)
         )
         with pytest.raises(NotImplementedError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_add_two_extensions(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_add_two_extensions(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         builder = x509.CertificateSigningRequestBuilder()
         request = (
@@ -5379,7 +5320,7 @@ class TestCertificateSigningRequestBuilder:
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=2), critical=True
             )
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         assert isinstance(request.signature_hash_algorithm, hashes.SHA256)
@@ -5469,7 +5410,7 @@ class TestCertificateSigningRequestBuilder:
         with pytest.raises(ValueError):
             builder.sign(private_key, hashes.SHA256(), backend)
 
-    def test_add_attribute_bad_types(self, backend):
+    def test_add_attribute_bad_types(self):
         request = x509.CertificateSigningRequestBuilder()
         with pytest.raises(TypeError):
             request.add_attribute(
@@ -5483,7 +5424,7 @@ class TestCertificateSigningRequestBuilder:
                 typing.cast(typing.Any, 383),
             )
 
-    def test_duplicate_attribute(self, backend):
+    def test_duplicate_attribute(self):
         request = x509.CertificateSigningRequestBuilder().add_attribute(
             x509.oid.AttributeOID.CHALLENGE_PASSWORD, b"val"
         )
@@ -5492,8 +5433,8 @@ class TestCertificateSigningRequestBuilder:
                 x509.oid.AttributeOID.CHALLENGE_PASSWORD, b"val2"
             )
 
-    def test_add_attribute_tag(self, backend):
-        private_key = ec.generate_private_key(ec.SECP256R1(), backend)
+    def test_add_attribute_tag(self):
+        private_key = ec.generate_private_key(ec.SECP256R1())
         builder = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(x509.Name([]))
@@ -5503,7 +5444,7 @@ class TestCertificateSigningRequestBuilder:
                 _tag=_ASN1Type.GeneralizedTime,
             )
         )
-        request = builder.sign(private_key, hashes.SHA256(), backend)
+        request = builder.sign(private_key, hashes.SHA256())
         attr = request.attributes.get_attribute_for_oid(
             x509.ObjectIdentifier("1.2.3.4")
         )
@@ -5511,7 +5452,7 @@ class TestCertificateSigningRequestBuilder:
         assert attr.value == b"\x00\x00"
         assert attr._type == _ASN1Type.GeneralizedTime.value
 
-    def test_add_attribute_tag_non_int(self, backend):
+    def test_add_attribute_tag_non_int(self):
         builder = x509.CertificateSigningRequestBuilder().subject_name(
             x509.Name([])
         )
@@ -5601,9 +5542,7 @@ class TestCertificateSigningRequestBuilder:
             ),
         ],
     )
-    def test_extensions(
-        self, rsa_key_2048: rsa.RSAPrivateKey, add_ext, backend
-    ):
+    def test_extensions(self, rsa_key_2048: rsa.RSAPrivateKey, add_ext):
         private_key = rsa_key_2048
 
         csr = (
@@ -5615,7 +5554,7 @@ class TestCertificateSigningRequestBuilder:
                 add_ext,
                 critical=False,
             )
-            .sign(private_key, hashes.SHA256(), backend)
+            .sign(private_key, hashes.SHA256())
         )
 
         assert len(csr.extensions) == 1
@@ -5623,9 +5562,7 @@ class TestCertificateSigningRequestBuilder:
         assert not ext.critical
         assert ext.value == add_ext
 
-    def test_invalid_asn1_othername(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_invalid_asn1_othername(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
 
         builder = (
@@ -5647,10 +5584,10 @@ class TestCertificateSigningRequestBuilder:
             )
         )
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
     def test_subject_alt_name_unsupported_general_name(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
 
@@ -5666,9 +5603,9 @@ class TestCertificateSigningRequestBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_rsa_key_too_small(self, rsa_key_512: rsa.RSAPrivateKey, backend):
+    def test_rsa_key_too_small(self, rsa_key_512: rsa.RSAPrivateKey):
         private_key = rsa_key_512
         builder = x509.CertificateSigningRequestBuilder()
         builder = builder.subject_name(
@@ -5676,7 +5613,7 @@ class TestCertificateSigningRequestBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA512(), backend)
+            builder.sign(private_key, hashes.SHA512())
 
     @pytest.mark.parametrize(
         ("alg", "mgf_alg"),
@@ -5742,9 +5679,7 @@ class TestCertificateSigningRequestBuilder:
         assert isinstance(csr.signature_algorithm_parameters, padding.PSS)
         assert csr.signature_algorithm_parameters._salt_length == computed_len
 
-    def test_sign_pss_auto_unsupported(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_pss_auto_unsupported(self, rsa_key_2048: rsa.RSAPrivateKey):
         builder = x509.CertificateSigningRequestBuilder().subject_name(
             x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
         )
@@ -5754,9 +5689,7 @@ class TestCertificateSigningRequestBuilder:
         with pytest.raises(TypeError):
             builder.sign(rsa_key_2048, hashes.SHA256(), rsa_padding=pss)
 
-    def test_sign_invalid_padding(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_invalid_padding(self, rsa_key_2048: rsa.RSAPrivateKey):
         builder = x509.CertificateSigningRequestBuilder().subject_name(
             x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
         )
@@ -5772,9 +5705,7 @@ class TestCertificateSigningRequestBuilder:
                 eckey, hashes.SHA256(), rsa_padding=padding.PKCS1v15()
             )
 
-    def test_sign_pss_hash_none(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_pss_hash_none(self, rsa_key_2048: rsa.RSAPrivateKey):
         builder = x509.CertificateSigningRequestBuilder().subject_name(
             x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
         )
@@ -5794,7 +5725,7 @@ class TestDSACertificate:
         ),
         skip_message="Does not support SHA-1 signature.",
     )
-    def test_load_dsa_cert(self, backend):
+    def test_load_dsa_cert(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "dsa_selfsigned_ca.pem"),
             x509.load_pem_x509_certificate,
@@ -5844,7 +5775,7 @@ class TestDSACertificate:
             "822ff5d234e073b901cf5941f58e1f538e71d40d", 16
         )
 
-    def test_load_dsa_cert_null_alg_params(self, backend):
+    def test_load_dsa_cert_null_alg_params(self):
         """
         This test verifies that we reject certificates with encoded null
         parameters in the DSA signature AlgorithmIdentifier. This is invalid;
@@ -5857,7 +5788,7 @@ class TestDSACertificate:
                 x509.load_pem_x509_certificate,
             )
 
-    def test_signature(self, backend):
+    def test_signature(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "dsa_selfsigned_ca.pem"),
             x509.load_pem_x509_certificate,
@@ -5870,7 +5801,7 @@ class TestDSACertificate:
         assert r == 215618264820276283222494627481362273536404860490
         assert s == 532023851299196869156027211159466197586787351758
 
-    def test_tbs_certificate_bytes(self, backend):
+    def test_tbs_certificate_bytes(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "dsa_selfsigned_ca.pem"),
             x509.load_pem_x509_certificate,
@@ -5928,7 +5859,7 @@ class TestDSACertificate:
             cert.signature_hash_algorithm,
         )
 
-    def test_verify_directly_issued_by_dsa(self, backend):
+    def test_verify_directly_issued_by_dsa(self):
         issuer_private_key = DSA_KEY_3072.private_key()
         subject_private_key = DSA_KEY_2048.private_key()
         ca, cert = _generate_ca_and_leaf(
@@ -5936,7 +5867,7 @@ class TestDSACertificate:
         )
         cert.verify_directly_issued_by(ca)
 
-    def test_verify_directly_issued_by_dsa_bad_sig(self, backend):
+    def test_verify_directly_issued_by_dsa_bad_sig(self):
         issuer_private_key = DSA_KEY_3072.private_key()
         subject_private_key = DSA_KEY_2048.private_key()
         ca, cert = _generate_ca_and_leaf(
@@ -5969,7 +5900,7 @@ class TestDSACertificateRequest:
             ],
         ],
     )
-    def test_load_dsa_request(self, path, loader_func, backend):
+    def test_load_dsa_request(self, path, loader_func):
         request = _load_cert(path, loader_func)
         assert isinstance(request.signature_hash_algorithm, hashes.SHA1)
         public_key = request.public_key()
@@ -5984,7 +5915,7 @@ class TestDSACertificateRequest:
             x509.NameAttribute(NameOID.LOCALITY_NAME, "Austin"),
         ]
 
-    def test_signature(self, backend):
+    def test_signature(self):
         request = _load_cert(
             os.path.join("x509", "requests", "dsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -5994,7 +5925,7 @@ class TestDSACertificateRequest:
             b"ce95de17273f0a924df23ce9d8188"
         )
 
-    def test_tbs_certrequest_bytes(self, backend):
+    def test_tbs_certrequest_bytes(self):
         request = _load_cert(
             os.path.join("x509", "requests", "dsa_sha1.pem"),
             x509.load_pem_x509_csr,
@@ -6074,7 +6005,7 @@ class TestECDSACertificate:
             cert.signature_algorithm_parameters,
         )
 
-    def test_load_ecdsa_cert_null_alg_params(self, backend):
+    def test_load_ecdsa_cert_null_alg_params(self):
         """
         This test verifies that we reject certificates with encoded null
         parameters in the ECDSA signature AlgorithmIdentifier. This is invalid;
@@ -6109,7 +6040,7 @@ class TestECDSACertificate:
             "<Name(2.5.4.45=#0070b3d51f305f0001,OU=02,CN=ScottishPower)>"
         )
 
-    def test_load_name_attribute_long_form_asn1_tag(self, backend):
+    def test_load_name_attribute_long_form_asn1_tag(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "long-form-name-attribute.pem"),
             x509.load_pem_x509_certificate,
@@ -6119,7 +6050,7 @@ class TestECDSACertificate:
         with pytest.raises(ValueError, match="Long-form"):
             cert.issuer
 
-    def test_ms_certificate_template(self, backend):
+    def test_ms_certificate_template(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "ms-certificate-template.pem"),
             x509.load_pem_x509_certificate,
@@ -6135,7 +6066,7 @@ class TestECDSACertificate:
             minor_version=None,
         )
 
-    def test_signature(self, backend):
+    def test_signature(self):
         cert = _load_cert(
             os.path.join("x509", "ecdsa_root.pem"),
             x509.load_pem_x509_certificate,
@@ -6290,7 +6221,7 @@ class TestECDSACertificateRequest:
 
 
 class TestOtherCertificate:
-    def test_unsupported_subject_public_key_info(self, backend):
+    def test_unsupported_subject_public_key_info(self):
         cert = _load_cert(
             os.path.join(
                 "x509", "custom", "unsupported_subject_public_key_info.pem"
@@ -6301,14 +6232,14 @@ class TestOtherCertificate:
         with pytest.raises(UnsupportedAlgorithm):
             cert.public_key()
 
-    def test_bad_time_in_validity(self, backend):
+    def test_bad_time_in_validity(self):
         with pytest.raises(ValueError, match="Validity::not_after"):
             _load_cert(
                 os.path.join("x509", "badasn1time.pem"),
                 x509.load_pem_x509_certificate,
             )
 
-    def test_invalid_empty_eku(self, backend):
+    def test_invalid_empty_eku(self):
         cert = _load_cert(
             os.path.join("x509", "custom", "empty-eku.pem"),
             x509.load_pem_x509_certificate,
@@ -6768,14 +6699,14 @@ class TestName:
         with pytest.raises(TypeError):
             x509.Name([typing.cast(typing.Any, "not-a-NameAttribute")])
 
-    def test_bytes(self, backend):
+    def test_bytes(self):
         name = x509.Name(
             [
                 x509.NameAttribute(NameOID.COMMON_NAME, "cryptography.io"),
                 x509.NameAttribute(NameOID.ORGANIZATION_NAME, "PyCA"),
             ]
         )
-        assert name.public_bytes(backend) == binascii.unhexlify(
+        assert name.public_bytes() == binascii.unhexlify(
             b"30293118301606035504030c0f63727970746f6772617068792e696f310d300"
             b"b060355040a0c0450794341"
         )
@@ -6829,7 +6760,7 @@ class TestName:
             b"009060355042d03020102"
         )
 
-    def test_bmpstring_bytes(self, backend):
+    def test_bmpstring_bytes(self):
         # For this test we need an odd length string. BMPString is UCS-2
         # encoded so it will always be even length and OpenSSL will error if
         # you pass an odd length string without encoding it properly first.
@@ -6843,12 +6774,12 @@ class TestName:
                 x509.NameAttribute(NameOID.ORGANIZATION_NAME, "PyCA"),
             ]
         )
-        assert name.public_bytes(backend) == binascii.unhexlify(
+        assert name.public_bytes() == binascii.unhexlify(
             b"30383127302506035504031e1e00630072007900700074006f00670072006100"
             b"7000680079002e0069006f310d300b060355040a0c0450794341"
         )
 
-    def test_universalstring_bytes(self, backend):
+    def test_universalstring_bytes(self):
         # UniversalString is UCS-4
         name = x509.Name(
             [
@@ -6860,7 +6791,7 @@ class TestName:
                 x509.NameAttribute(NameOID.ORGANIZATION_NAME, "PyCA"),
             ]
         )
-        assert name.public_bytes(backend) == binascii.unhexlify(
+        assert name.public_bytes() == binascii.unhexlify(
             b"30563145304306035504031c3c00000063000000720000007900000070000000"
             b"740000006f000000670000007200000061000000700000006800000079000000"
             b"2e000000690000006f310d300b060355040a0c0450794341"
@@ -6868,7 +6799,7 @@ class TestName:
 
 
 class TestEd25519Certificate:
-    def test_load_pem_cert(self, backend):
+    def test_load_pem_cert(self):
         cert = _load_cert(
             os.path.join("x509", "ed25519", "root-ed25519.pem"),
             x509.load_pem_x509_certificate,
@@ -6884,14 +6815,14 @@ class TestEd25519Certificate:
         assert cert.signature_algorithm_oid == SignatureAlgorithmOID.ED25519
         assert cert.signature_algorithm_parameters is None
 
-    def test_deepcopy(self, backend):
+    def test_deepcopy(self):
         cert = _load_cert(
             os.path.join("x509", "ed25519", "root-ed25519.pem"),
             x509.load_pem_x509_certificate,
         )
         assert copy.deepcopy(cert) is cert
 
-    def test_verify_directly_issued_by_ed25519(self, backend):
+    def test_verify_directly_issued_by_ed25519(self):
         issuer_private_key = ed25519.Ed25519PrivateKey.generate()
         subject_private_key = ed25519.Ed25519PrivateKey.generate()
         ca, cert = _generate_ca_and_leaf(
@@ -6899,7 +6830,7 @@ class TestEd25519Certificate:
         )
         cert.verify_directly_issued_by(ca)
 
-    def test_verify_directly_issued_by_ed25519_bad_sig(self, backend):
+    def test_verify_directly_issued_by_ed25519_bad_sig(self):
         issuer_private_key = ed25519.Ed25519PrivateKey.generate()
         subject_private_key = ed25519.Ed25519PrivateKey.generate()
         ca, cert = _generate_ca_and_leaf(
@@ -6915,7 +6846,7 @@ class TestEd25519Certificate:
     skip_message="Requires OpenSSL with Ed448 support",
 )
 class TestEd448Certificate:
-    def test_load_pem_cert(self, backend):
+    def test_load_pem_cert(self):
         cert = _load_cert(
             os.path.join("x509", "ed448", "root-ed448.pem"),
             x509.load_pem_x509_certificate,
@@ -6931,7 +6862,7 @@ class TestEd448Certificate:
         assert cert.signature_algorithm_oid == SignatureAlgorithmOID.ED448
         assert cert.signature_algorithm_parameters is None
 
-    def test_verify_directly_issued_by_ed448(self, backend):
+    def test_verify_directly_issued_by_ed448(self):
         issuer_private_key = ed448.Ed448PrivateKey.generate()
         subject_private_key = ed448.Ed448PrivateKey.generate()
         ca, cert = _generate_ca_and_leaf(
@@ -6939,7 +6870,7 @@ class TestEd448Certificate:
         )
         cert.verify_directly_issued_by(ca)
 
-    def test_verify_directly_issued_by_ed448_bad_sig(self, backend):
+    def test_verify_directly_issued_by_ed448_bad_sig(self):
         issuer_private_key = ed448.Ed448PrivateKey.generate()
         subject_private_key = ed448.Ed448PrivateKey.generate()
         ca, cert = _generate_ca_and_leaf(
@@ -6976,7 +6907,7 @@ class TestEd448Certificate:
 )
 class TestMLDSACertificate:
     def test_sign_and_verify_directly_issued_by_mldsa(
-        self, priv_key_cls, pub_key_cls, sig_oid, backend
+        self, priv_key_cls, pub_key_cls, sig_oid
     ):
         issuer_private_key = priv_key_cls.generate()
         subject_private_key = priv_key_cls.generate()
@@ -6989,7 +6920,7 @@ class TestMLDSACertificate:
         cert.verify_directly_issued_by(ca)
 
     def test_verify_directly_issued_by_mldsa_bad_sig(
-        self, priv_key_cls, pub_key_cls, sig_oid, backend
+        self, priv_key_cls, pub_key_cls, sig_oid
     ):
         issuer_private_key = priv_key_cls.generate()
         subject_private_key = priv_key_cls.generate()
@@ -7008,18 +6939,18 @@ class TestMLDSACertificate:
 class TestSignatureRejection:
     """Test if signing rejects DH keys properly."""
 
-    def load_key(self, backend):
+    def load_key(self):
         vector = load_vectors_from_file(
             os.path.join("asymmetric", "DH", "rfc3526.txt"),
             load_nist_vectors,
         )[1]
         p = int.from_bytes(binascii.unhexlify(vector["p"]), "big")
         params = dh.DHParameterNumbers(p, int(vector["g"]))
-        param = params.parameters(backend)
+        param = params.parameters()
         return param.generate_private_key()
 
-    def test_crt_signing_check(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
-        issuer_private_key = self.load_key(backend)
+    def test_crt_signing_check(self, rsa_key_2048: rsa.RSAPrivateKey):
+        issuer_private_key = self.load_key()
         public_key = rsa_key_2048.public_key()
         not_valid_before = datetime.datetime(2020, 1, 1, 1, 1)
         not_valid_after = datetime.datetime(2050, 12, 31, 8, 30)
@@ -7038,19 +6969,19 @@ class TestSignatureRejection:
         )
 
         with pytest.raises(TypeError):
-            builder.sign(issuer_private_key, hashes.SHA256(), backend)
+            builder.sign(issuer_private_key, hashes.SHA256())
 
-    def test_csr_signing_check(self, backend):
-        private_key = self.load_key(backend)
+    def test_csr_signing_check(self):
+        private_key = self.load_key()
         builder = x509.CertificateSigningRequestBuilder().subject_name(
             x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
         )
 
         with pytest.raises(TypeError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_crl_signing_check(self, backend):
-        private_key = self.load_key(backend)
+    def test_crl_signing_check(self):
+        private_key = self.load_key()
         last_time = (
             datetime.datetime.now().replace(tzinfo=None).replace(microsecond=0)
         )
@@ -7065,7 +6996,7 @@ class TestSignatureRejection:
         )
 
         with pytest.raises(TypeError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
 
 def test_random_serial_number(monkeypatch):
@@ -7222,7 +7153,7 @@ class TestAttributes:
 
 
 class TestRequestAttributes:
-    def test_get_attribute_for_oid_challenge(self, backend):
+    def test_get_attribute_for_oid_challenge(self):
         request = _load_cert(
             os.path.join("x509", "requests", "challenge.pem"),
             x509.load_pem_x509_csr,
@@ -7235,7 +7166,7 @@ class TestRequestAttributes:
             b"challenge me!",
         )
 
-    def test_get_attribute_for_oid_multiple(self, backend):
+    def test_get_attribute_for_oid_multiple(self):
         request = _load_cert(
             os.path.join("x509", "requests", "challenge-unstructured.pem"),
             x509.load_pem_x509_csr,
@@ -7255,7 +7186,7 @@ class TestRequestAttributes:
             b"an unstructured field",
         )
 
-    def test_unsupported_asn1_type_in_attribute(self, backend):
+    def test_unsupported_asn1_type_in_attribute(self):
         request = _load_cert(
             os.path.join("x509", "requests", "challenge-invalid.der"),
             x509.load_der_x509_csr,
@@ -7268,7 +7199,7 @@ class TestRequestAttributes:
         )
         assert attr._type == 2
 
-    def test_long_form_asn1_tag_in_attribute(self, backend):
+    def test_long_form_asn1_tag_in_attribute(self):
         request = _load_cert(
             os.path.join("x509", "requests", "long-form-attribute.pem"),
             x509.load_pem_x509_csr,
@@ -7276,7 +7207,7 @@ class TestRequestAttributes:
         with pytest.raises(ValueError, match="Long-form"):
             request.attributes
 
-    def test_challenge_multivalued(self, backend):
+    def test_challenge_multivalued(self):
         """
         We only support single-valued SETs in our X509 request attributes
         """
@@ -7287,7 +7218,7 @@ class TestRequestAttributes:
         with pytest.raises(ValueError, match="Only single-valued"):
             request.attributes
 
-    def test_no_challenge_password(self, backend):
+    def test_no_challenge_password(self):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha256.pem"),
             x509.load_pem_x509_csr,
@@ -7298,7 +7229,7 @@ class TestRequestAttributes:
             )
         assert exc.value.oid == x509.oid.AttributeOID.CHALLENGE_PASSWORD
 
-    def test_no_attributes(self, backend):
+    def test_no_attributes(self):
         request = _load_cert(
             os.path.join("x509", "requests", "rsa_sha256.pem"),
             x509.load_pem_x509_csr,


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (FIPS checks, `*_supported()` probes, or helpers that do) are left untouched.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_