### PR TITLE
Remove no-op backend arguments in CRL builder, revoked cert builder, and OCSP tests

### DIFF
--- a/tests/x509/test_ocsp.py
+++ b/tests/x509/test_ocsp.py
@@ -972,7 +972,7 @@ class TestOCSPResponseBuilder:
                 ocsp.OCSPResponseStatus.SUCCESSFUL
             )
 
-    def test_sign_unknown_private_key(self, backend):
+    def test_sign_unknown_private_key(self):
         builder = ocsp.OCSPResponseBuilder()
         cert, issuer = _cert_and_issuer()
         root_cert, _ = _generate_root()
@@ -1128,7 +1128,7 @@ class TestOCSPResponseBuilder:
         ),
         skip_message="Does not support BLAKE2b",
     )
-    def test_sign_unrecognized_hash_algorithm(self, backend):
+    def test_sign_unrecognized_hash_algorithm(self):
         builder = ocsp.OCSPResponseBuilder()
         cert, issuer = _cert_and_issuer()
         root_cert, private_key = _generate_root()
@@ -1194,7 +1194,7 @@ class TestSignedCertificateTimestampsExtension:
             "<SignedCertificateTimestamps([])>"
         )
 
-    def test_eq(self, backend):
+    def test_eq(self):
         sct1 = (
             _load_data(
                 os.path.join("x509", "ocsp", "resp-sct-extension.der"),
@@ -1217,7 +1217,7 @@ class TestSignedCertificateTimestampsExtension:
         )
         assert sct1 == sct2
 
-    def test_ne(self, backend):
+    def test_ne(self):
         sct1 = (
             _load_data(
                 os.path.join("x509", "ocsp", "resp-sct-extension.der"),
@@ -1232,7 +1232,7 @@ class TestSignedCertificateTimestampsExtension:
         assert sct1 != sct2
         assert sct1 != object()
 
-    def test_hash(self, backend):
+    def test_hash(self):
         sct1 = (
             _load_data(
                 os.path.join("x509", "ocsp", "resp-sct-extension.der"),
@@ -1257,7 +1257,7 @@ class TestSignedCertificateTimestampsExtension:
         assert hash(sct1) == hash(sct2)
         assert hash(sct1) != hash(sct3)
 
-    def test_entry_type(self, backend):
+    def test_entry_type(self):
         [sct, _, _, _] = (
             _load_data(
                 os.path.join("x509", "ocsp", "resp-sct-extension.der"),
@@ -1583,7 +1583,7 @@ class TestOCSPResponse:
         with pytest.raises(ValueError):
             resp.public_bytes(serialization.Encoding.PEM)
 
-    def test_single_extensions_sct(self, backend):
+    def test_single_extensions_sct(self):
         resp = _load_data(
             os.path.join("x509", "ocsp", "resp-sct-extension.der"),
             ocsp.load_der_ocsp_response,
@@ -1600,7 +1600,7 @@ class TestOCSPResponse:
             b"7ku9t3XOYLrhQmkfq+GeZqMPfl+wctiDAMR7iXqo/cs=",
         ]
 
-    def test_single_extensions(self, backend):
+    def test_single_extensions(self):
         resp = _load_data(
             os.path.join("x509", "ocsp", "resp-single-extension-reason.der"),
             ocsp.load_der_ocsp_response,
@@ -1639,7 +1639,7 @@ class TestOCSPResponse:
 
 
 class TestOCSPEdDSA:
-    def test_invalid_algorithm(self, backend):
+    def test_invalid_algorithm(self):
         builder = ocsp.OCSPResponseBuilder()
         cert, issuer = _cert_and_issuer()
         private_key = ed25519.Ed25519PrivateKey.generate()
@@ -1667,7 +1667,7 @@ class TestOCSPEdDSA:
         with pytest.raises(ValueError):
             builder.sign(private_key, hashes.SHA256())
 
-    def test_sign_ed25519(self, backend):
+    def test_sign_ed25519(self):
         builder = ocsp.OCSPResponseBuilder()
         cert, issuer = _cert_and_issuer()
         private_key = ed25519.Ed25519PrivateKey.generate()
@@ -1713,7 +1713,7 @@ class TestOCSPEdDSA:
         only_if=lambda backend: backend.ed448_supported(),
         skip_message="Requires OpenSSL with Ed448 support / OCSP",
     )
-    def test_sign_ed448(self, backend):
+    def test_sign_ed448(self):
         builder = ocsp.OCSPResponseBuilder()
         cert, issuer = _cert_and_issuer()
         private_key = ed448.Ed448PrivateKey.generate()

--- a/tests/x509/test_x509_crlbuilder.py
+++ b/tests/x509/test_x509_crlbuilder.py
@@ -54,7 +54,7 @@ class TestCertificateRevocationListBuilder:
                 x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
             )
 
-    def test_aware_last_update(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_aware_last_update(self, rsa_key_2048: rsa.RSAPrivateKey):
         tz = datetime.timezone(datetime.timedelta(hours=-8))
         last_time = datetime.datetime(2012, 1, 16, 22, 43, tzinfo=tz)
         utc_last = datetime.datetime(2012, 1, 17, 6, 43)
@@ -75,7 +75,7 @@ class TestCertificateRevocationListBuilder:
             .next_update(next_time)
         )
 
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         with pytest.warns(utils.DeprecatedIn42):
             assert crl.last_update == utc_last
         assert crl.last_update_utc == utc_last.replace(
@@ -99,7 +99,7 @@ class TestCertificateRevocationListBuilder:
         with pytest.raises(ValueError):
             builder.last_update(datetime.datetime(2002, 1, 1, 12, 1))
 
-    def test_aware_next_update(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_aware_next_update(self, rsa_key_2048: rsa.RSAPrivateKey):
         tz = datetime.timezone(datetime.timedelta(hours=-8))
         next_time = datetime.datetime(2022, 1, 16, 22, 43, tzinfo=tz)
         utc_next = datetime.datetime(2022, 1, 17, 6, 43)
@@ -120,7 +120,7 @@ class TestCertificateRevocationListBuilder:
             .next_update(next_time)
         )
 
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         with pytest.warns(utils.DeprecatedIn42):
             assert crl.next_update == utc_next
         assert crl.next_update_utc == utc_next.replace(
@@ -178,7 +178,7 @@ class TestCertificateRevocationListBuilder:
         with pytest.raises(TypeError):
             builder.add_revoked_certificate(typing.cast(typing.Any, object()))
 
-    def test_no_issuer_name(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_no_issuer_name(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         builder = (
             x509.CertificateRevocationListBuilder()
@@ -187,9 +187,9 @@ class TestCertificateRevocationListBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_no_last_update(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_no_last_update(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         builder = (
             x509.CertificateRevocationListBuilder()
@@ -200,9 +200,9 @@ class TestCertificateRevocationListBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_no_next_update(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_no_next_update(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         builder = (
             x509.CertificateRevocationListBuilder()
@@ -213,11 +213,9 @@ class TestCertificateRevocationListBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
-    def test_sign_invalid_padding(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_invalid_padding(self, rsa_key_2048: rsa.RSAPrivateKey):
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
         builder = (
@@ -247,7 +245,7 @@ class TestCertificateRevocationListBuilder:
                 eckey, hashes.SHA256(), rsa_padding=padding.PKCS1v15()
             )
 
-    def test_sign_empty_list(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_sign_empty_list(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -266,7 +264,7 @@ class TestCertificateRevocationListBuilder:
             .next_update(next_update)
         )
 
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         assert len(crl) == 0
         with pytest.warns(utils.DeprecatedIn42):
             assert crl.last_update == last_update
@@ -278,7 +276,7 @@ class TestCertificateRevocationListBuilder:
             tzinfo=datetime.timezone.utc
         )
 
-    def test_sign_pss(self, rsa_key_2048: rsa.RSAPrivateKey, backend):
+    def test_sign_pss(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -337,9 +335,7 @@ class TestCertificateRevocationListBuilder:
             ),
         ],
     )
-    def test_sign_extensions(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend, extension
-    ):
+    def test_sign_extensions(self, rsa_key_2048: rsa.RSAPrivateKey, extension):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -359,7 +355,7 @@ class TestCertificateRevocationListBuilder:
             .add_extension(extension, False)
         )
 
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         assert len(crl) == 0
         assert len(crl.extensions) == 1
         ext = crl.extensions.get_extension_for_class(type(extension))
@@ -367,7 +363,7 @@ class TestCertificateRevocationListBuilder:
         assert ext.value == extension
 
     def test_sign_multiple_extensions_critical(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
@@ -393,7 +389,7 @@ class TestCertificateRevocationListBuilder:
             .add_extension(ian, True)
         )
 
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         assert len(crl) == 0
         assert len(crl.extensions) == 2
         ext1 = crl.extensions.get_extension_for_class(x509.CRLNumber)
@@ -405,9 +401,7 @@ class TestCertificateRevocationListBuilder:
         assert ext2.critical is True
         assert ext2.value == ian
 
-    def test_freshestcrl_extension(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_freshestcrl_extension(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -437,7 +431,7 @@ class TestCertificateRevocationListBuilder:
             .add_extension(freshest, False)
         )
 
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         assert len(crl) == 0
         assert len(crl.extensions) == 1
         ext1 = crl.extensions.get_extension_for_class(x509.FreshestCRL)
@@ -449,9 +443,7 @@ class TestCertificateRevocationListBuilder:
         assert isinstance(uri, x509.UniformResourceIdentifier)
         assert uri.value == "http://d.om/delta"
 
-    def test_add_unsupported_extension(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_add_unsupported_extension(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -471,10 +463,10 @@ class TestCertificateRevocationListBuilder:
             .add_extension(DummyExtension(), False)
         )
         with pytest.raises(NotImplementedError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
     def test_add_unsupported_entry_extension(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         builder = (
             x509.RevokedCertificateBuilder()
@@ -489,9 +481,7 @@ class TestCertificateRevocationListBuilder:
         with pytest.raises(NotImplementedError):
             builder.build()
 
-    def test_sign_rsa_key_too_small(
-        self, rsa_key_512: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_rsa_key_too_small(self, rsa_key_512: rsa.RSAPrivateKey):
         private_key = rsa_key_512
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -511,11 +501,9 @@ class TestCertificateRevocationListBuilder:
         )
 
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA512(), backend)
+            builder.sign(private_key, hashes.SHA512())
 
-    def test_sign_with_invalid_hash(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
-    ):
+    def test_sign_with_invalid_hash(self, rsa_key_2048: rsa.RSAPrivateKey):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -535,13 +523,9 @@ class TestCertificateRevocationListBuilder:
         )
 
         with pytest.raises(TypeError):
-            builder.sign(
-                private_key,
-                typing.cast(typing.Any, object()),
-                backend,
-            )
+            builder.sign(private_key, typing.cast(typing.Any, object()))
 
-    def test_sign_with_invalid_hash_ed25519(self, backend):
+    def test_sign_with_invalid_hash_ed25519(self):
         private_key = ed25519.Ed25519PrivateKey.generate()
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -561,19 +545,15 @@ class TestCertificateRevocationListBuilder:
         )
 
         with pytest.raises(TypeError):
-            builder.sign(
-                private_key,
-                typing.cast(typing.Any, object()),
-                backend,
-            )
+            builder.sign(private_key, typing.cast(typing.Any, object()))
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.ed448_supported(),
         skip_message="Requires OpenSSL with Ed448 support",
     )
-    def test_sign_with_invalid_hash_ed448(self, backend):
+    def test_sign_with_invalid_hash_ed448(self):
         private_key = ed448.Ed448PrivateKey.generate()
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -593,20 +573,16 @@ class TestCertificateRevocationListBuilder:
         )
 
         with pytest.raises(TypeError):
-            builder.sign(
-                private_key,
-                typing.cast(typing.Any, object()),
-                backend,
-            )
+            builder.sign(private_key, typing.cast(typing.Any, object()))
         with pytest.raises(ValueError):
-            builder.sign(private_key, hashes.SHA256(), backend)
+            builder.sign(private_key, hashes.SHA256())
 
     @pytest.mark.supported(
         only_if=lambda backend: backend.dsa_supported(),
         skip_message="Requires OpenSSL with DSA support",
     )
-    def test_sign_dsa_key(self, backend):
-        private_key = DSA_KEY_2048.private_key(backend)
+    def test_sign_dsa_key(self):
+        private_key = DSA_KEY_2048.private_key()
         invalidity_date = x509.InvalidityDate(
             datetime.datetime(2002, 1, 1, 0, 0)
         )
@@ -618,7 +594,7 @@ class TestCertificateRevocationListBuilder:
             .serial_number(2)
             .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
             .add_extension(invalidity_date, False)
-            .build(backend)
+            .build()
         )
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -639,7 +615,7 @@ class TestCertificateRevocationListBuilder:
             .add_extension(ian, False)
         )
 
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         assert (
             crl.extensions.get_extension_for_class(
                 x509.IssuerAlternativeName
@@ -706,7 +682,7 @@ class TestCertificateRevocationListBuilder:
         assert ext.critical is False
         assert ext.value == invalidity_date
 
-    def test_sign_ed25519_key(self, backend):
+    def test_sign_ed25519_key(self):
         private_key = ed25519.Ed25519PrivateKey.generate()
         invalidity_date = x509.InvalidityDate(
             datetime.datetime(2002, 1, 1, 0, 0)
@@ -719,7 +695,7 @@ class TestCertificateRevocationListBuilder:
             .serial_number(2)
             .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
             .add_extension(invalidity_date, False)
-            .build(backend)
+            .build()
         )
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -740,7 +716,7 @@ class TestCertificateRevocationListBuilder:
             .add_extension(ian, False)
         )
 
-        crl = builder.sign(private_key, None, backend)
+        crl = builder.sign(private_key, None)
         assert crl.signature_hash_algorithm is None
         assert crl.signature_algorithm_oid == SignatureAlgorithmOID.ED25519
         assert (
@@ -762,7 +738,7 @@ class TestCertificateRevocationListBuilder:
         only_if=lambda backend: backend.ed448_supported(),
         skip_message="Requires OpenSSL with Ed448 support",
     )
-    def test_sign_ed448_key(self, backend):
+    def test_sign_ed448_key(self):
         private_key = ed448.Ed448PrivateKey.generate()
         invalidity_date = x509.InvalidityDate(
             datetime.datetime(2002, 1, 1, 0, 0)
@@ -775,7 +751,7 @@ class TestCertificateRevocationListBuilder:
             .serial_number(2)
             .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
             .add_extension(invalidity_date, False)
-            .build(backend)
+            .build()
         )
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -796,7 +772,7 @@ class TestCertificateRevocationListBuilder:
             .add_extension(ian, False)
         )
 
-        crl = builder.sign(private_key, None, backend)
+        crl = builder.sign(private_key, None)
         assert crl.signature_hash_algorithm is None
         assert crl.signature_algorithm_oid == SignatureAlgorithmOID.ED448
         assert (
@@ -826,7 +802,7 @@ class TestCertificateRevocationListBuilder:
             (mldsa.MLDSA87PrivateKey, SignatureAlgorithmOID.ML_DSA_87),
         ],
     )
-    def test_sign_mldsa_key(self, priv_key_cls, sig_oid, backend):
+    def test_sign_mldsa_key(self, priv_key_cls, sig_oid):
         private_key = priv_key_cls.generate()
         invalidity_date = x509.InvalidityDate(
             datetime.datetime(2002, 1, 1, 0, 0)
@@ -839,7 +815,7 @@ class TestCertificateRevocationListBuilder:
             .serial_number(2)
             .revocation_date(datetime.datetime(2012, 1, 1, 1, 1))
             .add_extension(invalidity_date, False)
-            .build(backend)
+            .build()
         )
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
@@ -860,7 +836,7 @@ class TestCertificateRevocationListBuilder:
             .add_extension(ian, False)
         )
 
-        crl = builder.sign(private_key, None, backend)
+        crl = builder.sign(private_key, None)
         assert crl.signature_hash_algorithm is None
         assert crl.signature_algorithm_oid == sig_oid
         assert crl.is_signature_valid(private_key.public_key())
@@ -872,8 +848,8 @@ class TestCertificateRevocationListBuilder:
         )
         assert crl[0].serial_number == revoked_cert0.serial_number
 
-    def test_dsa_key_sign_md5(self, backend):
-        private_key = DSA_KEY_2048.private_key(backend)
+    def test_dsa_key_sign_md5(self):
+        private_key = DSA_KEY_2048.private_key()
         last_time = datetime.datetime(2012, 1, 16, 22, 43)
         next_time = datetime.datetime(2022, 1, 17, 6, 43)
         builder = (
@@ -892,11 +868,7 @@ class TestCertificateRevocationListBuilder:
         )
 
         with pytest.raises(UnsupportedAlgorithm):
-            builder.sign(
-                private_key,
-                typing.cast(typing.Any, hashes.MD5()),
-                backend,
-            )
+            builder.sign(private_key, typing.cast(typing.Any, hashes.MD5()))
 
     def test_ec_key_sign_md5(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
@@ -926,7 +898,7 @@ class TestCertificateRevocationListBuilder:
             )
 
     def test_sign_with_revoked_certificates(
-        self, rsa_key_2048: rsa.RSAPrivateKey, backend
+        self, rsa_key_2048: rsa.RSAPrivateKey
     ):
         private_key = rsa_key_2048
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
@@ -938,7 +910,7 @@ class TestCertificateRevocationListBuilder:
             x509.RevokedCertificateBuilder()
             .serial_number(38)
             .revocation_date(datetime.datetime(2011, 1, 1, 1, 1))
-            .build(backend)
+            .build()
         )
         revoked_cert1 = (
             x509.RevokedCertificateBuilder()
@@ -948,7 +920,7 @@ class TestCertificateRevocationListBuilder:
             .add_extension(
                 x509.CRLReason(x509.ReasonFlags.ca_compromise), False
             )
-            .build(backend)
+            .build()
         )
         ci = x509.CertificateIssuer([x509.DNSName("cryptography.io")])
         revoked_cert2 = (
@@ -956,7 +928,7 @@ class TestCertificateRevocationListBuilder:
             .serial_number(40)
             .revocation_date(datetime.datetime(2011, 1, 1, 1, 1))
             .add_extension(ci, False)
-            .build(backend)
+            .build()
         )
         builder = (
             x509.CertificateRevocationListBuilder()
@@ -976,7 +948,7 @@ class TestCertificateRevocationListBuilder:
             .add_revoked_certificate(revoked_cert2)
         )
 
-        crl = builder.sign(private_key, hashes.SHA256(), backend)
+        crl = builder.sign(private_key, hashes.SHA256())
         assert len(crl) == 3
         with pytest.warns(utils.DeprecatedIn42):
             assert crl.last_update == last_update
@@ -1054,9 +1026,7 @@ class TestCertificateRevocationListBuilder:
             crl1.signature, crl1.tbs_certlist_bytes, ec.ECDSA(hashes.SHA256())
         )
 
-    def test_deterministic_signature_wrong_key_type(
-        self, rsa_key_2048, backend
-    ):
+    def test_deterministic_signature_wrong_key_type(self, rsa_key_2048):
         last_update = datetime.datetime(2002, 1, 1, 12, 1)
         next_update = datetime.datetime(2030, 1, 1, 12, 1)
         builder = (
@@ -1067,8 +1037,5 @@ class TestCertificateRevocationListBuilder:
         )
         with pytest.raises(TypeError):
             builder.sign(
-                rsa_key_2048,
-                hashes.SHA256(),
-                backend,
-                ecdsa_deterministic=True,
+                rsa_key_2048, hashes.SHA256(), ecdsa_deterministic=True
             )

--- a/tests/x509/test_x509_revokedcertbuilder.py
+++ b/tests/x509/test_x509_revokedcertbuilder.py
@@ -26,7 +26,7 @@ class TestRevokedCertificateBuilder:
         with pytest.raises(ValueError):
             x509.RevokedCertificateBuilder().serial_number(0)
 
-    def test_minimal_serial_number(self, backend):
+    def test_minimal_serial_number(self):
         revocation_date = datetime.datetime(2002, 1, 1, 12, 1)
         builder = (
             x509.RevokedCertificateBuilder()
@@ -34,10 +34,10 @@ class TestRevokedCertificateBuilder:
             .revocation_date(revocation_date)
         )
 
-        revoked_certificate = builder.build(backend)
+        revoked_certificate = builder.build()
         assert revoked_certificate.serial_number == 1
 
-    def test_biggest_serial_number(self, backend):
+    def test_biggest_serial_number(self):
         revocation_date = datetime.datetime(2002, 1, 1, 12, 1)
         builder = (
             x509.RevokedCertificateBuilder()
@@ -45,7 +45,7 @@ class TestRevokedCertificateBuilder:
             .revocation_date(revocation_date)
         )
 
-        revoked_certificate = builder.build(backend)
+        revoked_certificate = builder.build()
         assert revoked_certificate.serial_number == (1 << 159) - 1
 
     def test_serial_number_must_be_less_than_160_bits_long(self):
@@ -57,7 +57,7 @@ class TestRevokedCertificateBuilder:
         with pytest.raises(ValueError):
             builder.serial_number(4)
 
-    def test_aware_revocation_date(self, backend):
+    def test_aware_revocation_date(self):
         tz = datetime.timezone(datetime.timedelta(hours=-8))
         time = datetime.datetime(2012, 1, 16, 22, 43, tzinfo=tz)
         utc_time = datetime.datetime(2012, 1, 17, 6, 43)
@@ -68,7 +68,7 @@ class TestRevokedCertificateBuilder:
             .revocation_date(time)
         )
 
-        revoked_certificate = builder.build(backend)
+        revoked_certificate = builder.build()
         with pytest.warns(utils.DeprecatedIn42):
             assert revoked_certificate.revocation_date == utc_time
         assert revoked_certificate.revocation_date_utc == utc_time.replace(
@@ -111,21 +111,21 @@ class TestRevokedCertificateBuilder:
                 False,
             )
 
-    def test_no_serial_number(self, backend):
+    def test_no_serial_number(self):
         builder = x509.RevokedCertificateBuilder().revocation_date(
             datetime.datetime(2002, 1, 1, 12, 1)
         )
 
         with pytest.raises(ValueError):
-            builder.build(backend)
+            builder.build()
 
-    def test_no_revocation_date(self, backend):
+    def test_no_revocation_date(self):
         builder = x509.RevokedCertificateBuilder().serial_number(3)
 
         with pytest.raises(ValueError):
-            builder.build(backend)
+            builder.build()
 
-    def test_create_revoked(self, backend):
+    def test_create_revoked(self):
         serial_number = 333
         revocation_date = datetime.datetime(2002, 1, 1, 12, 1)
         builder = (
@@ -134,7 +134,7 @@ class TestRevokedCertificateBuilder:
             .revocation_date(revocation_date)
         )
 
-        revoked_certificate = builder.build(backend)
+        revoked_certificate = builder.build()
         assert revoked_certificate.serial_number == serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert revoked_certificate.revocation_date == revocation_date
@@ -152,7 +152,7 @@ class TestRevokedCertificateBuilder:
             x509.CertificateIssuer([x509.DNSName("cryptography.io")]),
         ],
     )
-    def test_add_extensions(self, backend, extension):
+    def test_add_extensions(self, extension):
         serial_number = 333
         revocation_date = datetime.datetime(2002, 1, 1, 12, 1)
         builder = (
@@ -162,7 +162,7 @@ class TestRevokedCertificateBuilder:
             .add_extension(extension, False)
         )
 
-        revoked_certificate = builder.build(backend)
+        revoked_certificate = builder.build()
         assert revoked_certificate.serial_number == serial_number
         with pytest.warns(utils.DeprecatedIn42):
             assert revoked_certificate.revocation_date == revocation_date
@@ -177,7 +177,7 @@ class TestRevokedCertificateBuilder:
         assert ext.critical is False
         assert ext.value == extension
 
-    def test_add_multiple_extensions(self, backend):
+    def test_add_multiple_extensions(self):
         serial_number = 333
         revocation_date = datetime.datetime(2002, 1, 1, 12, 1)
         invalidity_date = x509.InvalidityDate(
@@ -196,7 +196,7 @@ class TestRevokedCertificateBuilder:
             .add_extension(certificate_issuer, True)
         )
 
-        revoked_certificate = builder.build(backend)
+        revoked_certificate = builder.build()
         assert len(revoked_certificate.extensions) == 3
         for ext_data in [invalidity_date, certificate_issuer, crl_reason]:
             ext = revoked_certificate.extensions.get_extension_for_class(


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (FIPS checks, `*_supported()` probes, or helpers that do) are left untouched.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_