### PR TITLE
Remove no-op backend arguments in test_pkcs7.py

### DIFF
--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -37,11 +37,11 @@ __all__ = ["rsa_key_2048"]
 
 
 class TestPKCS7Loading:
-    def test_load_invalid_der_pkcs7(self, backend):
+    def test_load_invalid_der_pkcs7(self):
         with pytest.raises(ValueError):
             pkcs7.load_der_pkcs7_certificates(b"nonsense")
 
-    def test_load_invalid_pem_pkcs7(self, backend):
+    def test_load_invalid_pem_pkcs7(self):
         with pytest.raises(ValueError):
             pkcs7.load_pem_pkcs7_certificates(b"nonsense")
 
@@ -51,15 +51,15 @@ class TestPKCS7Loading:
 -----END CERTIFICATE-----
             """)
 
-    def test_not_bytes_der(self, backend):
+    def test_not_bytes_der(self):
         with pytest.raises(TypeError):
             pkcs7.load_der_pkcs7_certificates(typing.cast(typing.Any, 38))
 
-    def test_not_bytes_pem(self, backend):
+    def test_not_bytes_pem(self):
         with pytest.raises(TypeError):
             pkcs7.load_pem_pkcs7_certificates(typing.cast(typing.Any, 38))
 
-    def test_load_pkcs7_pem(self, backend):
+    def test_load_pkcs7_pem(self):
         certs = load_vectors_from_file(
             os.path.join("pkcs7", "isrg.pem"),
             lambda pemfile: pkcs7.load_pem_pkcs7_certificates(pemfile.read()),
@@ -77,7 +77,7 @@ class TestPKCS7Loading:
             os.path.join("pkcs7", "amazon-roots.p7b"),
         ],
     )
-    def test_load_pkcs7_der(self, filepath, backend):
+    def test_load_pkcs7_der(self, filepath):
         loading_fails = False
         if filepath.endswith("p7b"):
             if (
@@ -119,7 +119,7 @@ class TestPKCS7Loading:
             )
         ]
 
-    def test_load_pkcs7_der_unknown_content_type(self, backend):
+    def test_load_pkcs7_der_unknown_content_type(self):
         # An Authenticode signature, whose inner ContentInfo has a
         # SpcIndirectDataContent content type, which we don't know. It
         # should parse successfully as DER, without falling back to BER
@@ -137,7 +137,7 @@ class TestPKCS7Loading:
             x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "kernel-signer")
         ]
 
-    def test_load_pkcs7_unsupported_type(self, backend):
+    def test_load_pkcs7_unsupported_type(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_SERIALIZATION):
             load_vectors_from_file(
                 os.path.join("pkcs7", "enveloped.pem"),
@@ -186,22 +186,22 @@ def _load_cert_key():
     skip_message="Requires OpenSSL with PKCS7 verification test support",
 )
 class TestPKCS7SignatureBuilder:
-    def test_invalid_data(self, backend):
+    def test_invalid_data(self):
         builder = pkcs7.PKCS7SignatureBuilder()
         with pytest.raises(TypeError):
             builder.set_data(typing.cast(typing.Any, "not bytes"))
 
-    def test_set_data_twice(self, backend):
+    def test_set_data_twice(self):
         builder = pkcs7.PKCS7SignatureBuilder().set_data(b"test")
         with pytest.raises(ValueError):
             builder.set_data(b"test")
 
-    def test_sign_no_signer(self, backend):
+    def test_sign_no_signer(self):
         builder = pkcs7.PKCS7SignatureBuilder().set_data(b"test")
         with pytest.raises(ValueError):
             builder.sign(serialization.Encoding.SMIME, [])
 
-    def test_sign_no_data(self, backend):
+    def test_sign_no_data(self):
         cert, key = _load_cert_key()
         builder = pkcs7.PKCS7SignatureBuilder().add_signer(
             cert, key, hashes.SHA256()
@@ -209,7 +209,7 @@ class TestPKCS7SignatureBuilder:
         with pytest.raises(ValueError):
             builder.sign(serialization.Encoding.SMIME, [])
 
-    def test_unsupported_hash_alg(self, backend):
+    def test_unsupported_hash_alg(self):
         cert, key = _load_cert_key()
         with pytest.raises(TypeError):
             pkcs7.PKCS7SignatureBuilder().add_signer(
@@ -218,7 +218,7 @@ class TestPKCS7SignatureBuilder:
                 typing.cast(typing.Any, hashes.SHA512_256()),
             )
 
-    def test_not_a_cert(self, backend):
+    def test_not_a_cert(self):
         _, key = _load_cert_key()
         with pytest.raises(TypeError):
             pkcs7.PKCS7SignatureBuilder().add_signer(
@@ -227,7 +227,7 @@ class TestPKCS7SignatureBuilder:
                 hashes.SHA256(),
             )
 
-    def test_unsupported_key_type(self, backend):
+    def test_unsupported_key_type(self):
         cert, _ = _load_cert_key()
         key = ed25519.Ed25519PrivateKey.generate()
         with pytest.raises(TypeError):
@@ -237,7 +237,7 @@ class TestPKCS7SignatureBuilder:
                 hashes.SHA256(),
             )
 
-    def test_sign_invalid_options(self, backend):
+    def test_sign_invalid_options(self):
         cert, key = _load_cert_key()
         builder = (
             pkcs7.PKCS7SignatureBuilder()
@@ -250,7 +250,7 @@ class TestPKCS7SignatureBuilder:
                 [typing.cast(typing.Any, b"invalid")],
             )
 
-    def test_sign_invalid_encoding(self, backend):
+    def test_sign_invalid_encoding(self):
         cert, key = _load_cert_key()
         builder = (
             pkcs7.PKCS7SignatureBuilder()
@@ -260,7 +260,7 @@ class TestPKCS7SignatureBuilder:
         with pytest.raises(ValueError):
             builder.sign(serialization.Encoding.Raw, [])
 
-    def test_sign_invalid_options_text_no_detached(self, backend):
+    def test_sign_invalid_options_text_no_detached(self):
         cert, key = _load_cert_key()
         builder = (
             pkcs7.PKCS7SignatureBuilder()
@@ -271,7 +271,7 @@ class TestPKCS7SignatureBuilder:
         with pytest.raises(ValueError):
             builder.sign(serialization.Encoding.SMIME, options)
 
-    def test_sign_invalid_options_text_der_encoding(self, backend):
+    def test_sign_invalid_options_text_der_encoding(self):
         cert, key = _load_cert_key()
         builder = (
             pkcs7.PKCS7SignatureBuilder()
@@ -285,7 +285,7 @@ class TestPKCS7SignatureBuilder:
         with pytest.raises(ValueError):
             builder.sign(serialization.Encoding.DER, options)
 
-    def test_sign_invalid_options_no_attrs_and_no_caps(self, backend):
+    def test_sign_invalid_options_no_attrs_and_no_caps(self):
         cert, key = _load_cert_key()
         builder = (
             pkcs7.PKCS7SignatureBuilder()
@@ -299,7 +299,7 @@ class TestPKCS7SignatureBuilder:
         with pytest.raises(ValueError):
             builder.sign(serialization.Encoding.SMIME, options)
 
-    def test_smime_sign_detached(self, backend):
+    def test_smime_sign_detached(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         options = [pkcs7.PKCS7Options.DetachedSignature]
@@ -345,7 +345,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_sign_byteslike(self, backend):
+    def test_sign_byteslike(self):
         data = bytearray(b"hello world")
         cert, key = _load_cert_key()
         options = [pkcs7.PKCS7Options.DetachedSignature]
@@ -381,7 +381,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_sign_pem(self, backend):
+    def test_sign_pem(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         options: list[pkcs7.PKCS7Options] = []
@@ -408,9 +408,7 @@ class TestPKCS7SignatureBuilder:
             (hashes.SHA512(), b"\x06\t`\x86H\x01e\x03\x04\x02\x03"),
         ],
     )
-    def test_sign_alternate_digests_der(
-        self, hash_alg, expected_value, backend
-    ):
+    def test_sign_alternate_digests_der(self, hash_alg, expected_value):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -433,9 +431,7 @@ class TestPKCS7SignatureBuilder:
             (hashes.SHA512(), b"sha-512"),
         ],
     )
-    def test_sign_alternate_digests_detached(
-        self, hash_alg, expected_value, backend
-    ):
+    def test_sign_alternate_digests_detached(self, hash_alg, expected_value):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -449,7 +445,7 @@ class TestPKCS7SignatureBuilder:
         # byte string like "sha-384".
         assert expected_value in sig
 
-    def test_sign_attached(self, backend):
+    def test_sign_attached(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         options: list[pkcs7.PKCS7Options] = []
@@ -471,7 +467,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_sign_binary(self, backend):
+    def test_sign_binary(self):
         data = b"hello\nworld"
         cert, key = _load_cert_key()
         builder = (
@@ -504,7 +500,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_sign_smime_canonicalization(self, backend):
+    def test_sign_smime_canonicalization(self):
         data = b"hello\nworld"
         cert, key = _load_cert_key()
         builder = (
@@ -527,7 +523,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_sign_text(self, backend):
+    def test_sign_text(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -563,7 +559,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_smime_capabilities(self, backend):
+    def test_smime_capabilities(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -606,7 +602,7 @@ class TestPKCS7SignatureBuilder:
             [],
         )
 
-    def test_sign_no_capabilities(self, backend):
+    def test_sign_no_capabilities(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -634,7 +630,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_sign_no_attributes(self, backend):
+    def test_sign_no_attributes(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -660,7 +656,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_sign_no_certs(self, backend):
+    def test_sign_no_certs(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         builder = (
@@ -688,7 +684,7 @@ class TestPKCS7SignatureBuilder:
             ),
         ],
     )
-    def test_rsa_pkcs_padding_options(self, pad, backend):
+    def test_rsa_pkcs_padding_options(self, pad):
         data = b"hello world"
         rsa_key = load_vectors_from_file(
             os.path.join("x509", "custom", "ca", "rsa_key.pem"),
@@ -742,14 +738,14 @@ class TestPKCS7SignatureBuilder:
                 options,
             )
 
-    def test_not_rsa_key_with_padding(self, backend):
+    def test_not_rsa_key_with_padding(self):
         cert, key = _load_cert_key()
         with pytest.raises(TypeError):
             pkcs7.PKCS7SignatureBuilder().add_signer(
                 cert, key, hashes.SHA512(), rsa_padding=padding.PKCS1v15()
             )
 
-    def test_rsa_invalid_padding(self, backend):
+    def test_rsa_invalid_padding(self):
         rsa_key = load_vectors_from_file(
             os.path.join("x509", "custom", "ca", "rsa_key.pem"),
             lambda pemfile: serialization.load_pem_private_key(
@@ -773,7 +769,7 @@ class TestPKCS7SignatureBuilder:
                 rsa_padding=typing.cast(typing.Any, object()),
             )
 
-    def test_multiple_signers(self, backend):
+    def test_multiple_signers(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         rsa_key = load_vectors_from_file(
@@ -809,7 +805,7 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_multiple_signers_different_hash_algs(self, backend):
+    def test_multiple_signers_different_hash_algs(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         rsa_key = load_vectors_from_file(
@@ -846,13 +842,13 @@ class TestPKCS7SignatureBuilder:
             options,
         )
 
-    def test_add_additional_cert_not_a_cert(self, backend):
+    def test_add_additional_cert_not_a_cert(self):
         with pytest.raises(TypeError):
             pkcs7.PKCS7SignatureBuilder().add_certificate(
                 typing.cast(typing.Any, b"notacert")
             )
 
-    def test_add_additional_cert(self, backend):
+    def test_add_additional_cert(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         rsa_cert = load_vectors_from_file(
@@ -874,7 +870,7 @@ class TestPKCS7SignatureBuilder:
             sig.count(rsa_cert.public_bytes(serialization.Encoding.DER)) == 1
         )
 
-    def test_add_multiple_additional_certs(self, backend):
+    def test_add_multiple_additional_certs(self):
         data = b"hello world"
         cert, key = _load_cert_key()
         rsa_cert = load_vectors_from_file(
@@ -923,45 +919,45 @@ def _load_rsa_cert_key():
     "support",
 )
 class TestPKCS7EnvelopeBuilder:
-    def test_invalid_data(self, backend):
+    def test_invalid_data(self):
         builder = pkcs7.PKCS7EnvelopeBuilder()
         with pytest.raises(TypeError):
             builder.set_data(typing.cast(typing.Any, "not bytes"))
 
-    def test_set_data_twice(self, backend):
+    def test_set_data_twice(self):
         builder = pkcs7.PKCS7EnvelopeBuilder().set_data(b"test")
         with pytest.raises(ValueError):
             builder.set_data(b"test")
 
-    def test_encrypt_no_recipient(self, backend):
+    def test_encrypt_no_recipient(self):
         builder = pkcs7.PKCS7EnvelopeBuilder().set_data(b"test")
         with pytest.raises(ValueError):
             builder.encrypt(serialization.Encoding.SMIME, [])
 
-    def test_encrypt_no_data(self, backend):
+    def test_encrypt_no_data(self):
         cert, _ = _load_rsa_cert_key()
         builder = pkcs7.PKCS7EnvelopeBuilder().add_recipient(cert)
         with pytest.raises(ValueError):
             builder.encrypt(serialization.Encoding.SMIME, [])
 
-    def test_unsupported_encryption(self, backend):
+    def test_unsupported_encryption(self):
         cert_non_rsa, _ = _load_cert_key()
         with pytest.raises(TypeError):
             pkcs7.PKCS7EnvelopeBuilder().add_recipient(cert_non_rsa)
 
-    def test_not_a_cert(self, backend):
+    def test_not_a_cert(self):
         with pytest.raises(TypeError):
             pkcs7.PKCS7EnvelopeBuilder().add_recipient(
                 typing.cast(typing.Any, b"notacert"),
             )
 
-    def test_set_content_encryption_algorithm_twice(self, backend):
+    def test_set_content_encryption_algorithm_twice(self):
         builder = pkcs7.PKCS7EnvelopeBuilder()
         builder = builder.set_content_encryption_algorithm(algorithms.AES128)
         with pytest.raises(ValueError):
             builder.set_content_encryption_algorithm(algorithms.AES128)
 
-    def test_invalid_content_encryption_algorithm(self, backend):
+    def test_invalid_content_encryption_algorithm(self):
         class InvalidAlgorithm:
             pass
 
@@ -970,7 +966,7 @@ class TestPKCS7EnvelopeBuilder:
                 typing.cast(typing.Any, InvalidAlgorithm),
             )
 
-    def test_encrypt_invalid_options(self, backend):
+    def test_encrypt_invalid_options(self):
         cert, _ = _load_rsa_cert_key()
         builder = (
             pkcs7.PKCS7EnvelopeBuilder().set_data(b"test").add_recipient(cert)
@@ -981,7 +977,7 @@ class TestPKCS7EnvelopeBuilder:
                 [typing.cast(typing.Any, b"invalid")],
             )
 
-    def test_encrypt_invalid_encoding(self, backend):
+    def test_encrypt_invalid_encoding(self):
         cert, _ = _load_rsa_cert_key()
         builder = (
             pkcs7.PKCS7EnvelopeBuilder().set_data(b"test").add_recipient(cert)
@@ -999,9 +995,7 @@ class TestPKCS7EnvelopeBuilder:
             [pkcs7.PKCS7Options.Binary, pkcs7.PKCS7Options.Text],
         ],
     )
-    def test_encrypt_invalid_encryption_options(
-        self, backend, invalid_options
-    ):
+    def test_encrypt_invalid_encryption_options(self, invalid_options):
         cert, _ = _load_rsa_cert_key()
         builder = (
             pkcs7.PKCS7EnvelopeBuilder().set_data(b"test").add_recipient(cert)
@@ -1016,7 +1010,7 @@ class TestPKCS7EnvelopeBuilder:
             [pkcs7.PKCS7Options.Binary],
         ],
     )
-    def test_smime_encrypt_smime_encoding(self, backend, options):
+    def test_smime_encrypt_smime_encoding(self, options):
         data = b"hello world\n"
         cert, private_key = _load_rsa_cert_key()
         builder = (
@@ -1069,7 +1063,7 @@ class TestPKCS7EnvelopeBuilder:
             [pkcs7.PKCS7Options.Binary],
         ],
     )
-    def test_smime_encrypt_der_encoding(self, backend, options):
+    def test_smime_encrypt_der_encoding(self, options):
         data = b"hello world\n"
         cert, private_key = _load_rsa_cert_key()
         builder = (
@@ -1110,7 +1104,7 @@ class TestPKCS7EnvelopeBuilder:
             [pkcs7.PKCS7Options.Binary],
         ],
     )
-    def test_smime_encrypt_pem_encoding(self, backend, options):
+    def test_smime_encrypt_pem_encoding(self, options):
         data = b"hello world\n"
         cert, private_key = _load_rsa_cert_key()
         builder = (
@@ -1132,7 +1126,7 @@ class TestPKCS7EnvelopeBuilder:
         )
         assert decrypted_bytes == expected_data
 
-    def test_smime_encrypt_multiple_recipients(self, backend):
+    def test_smime_encrypt_multiple_recipients(self):
         data = b"hello world\n"
         cert, _ = _load_rsa_cert_key()
         builder = (
@@ -1160,31 +1154,31 @@ class TestPKCS7EnvelopeBuilder:
 )
 class TestPKCS7Decrypt:
     @pytest.fixture(name="data")
-    def fixture_data(self, backend) -> bytes:
+    def fixture_data(self) -> bytes:
         return b"Hello world!\n"
 
     @pytest.fixture(name="certificate")
-    def fixture_certificate(self, backend) -> x509.Certificate:
+    def fixture_certificate(self) -> x509.Certificate:
         certificate, _ = _load_rsa_cert_key()
         return certificate
 
     @pytest.fixture(name="private_key")
-    def fixture_private_key(self, backend) -> rsa.RSAPrivateKey:
+    def fixture_private_key(self) -> rsa.RSAPrivateKey:
         _, private_key = _load_rsa_cert_key()
         return private_key
 
-    def test_unsupported_certificate_encryption(self, backend, private_key):
+    def test_unsupported_certificate_encryption(self, private_key):
         cert_non_rsa, _ = _load_cert_key()
         with pytest.raises(TypeError):
             pkcs7.pkcs7_decrypt_der(b"", cert_non_rsa, private_key, [])
 
-    def test_not_a_cert(self, backend, private_key):
+    def test_not_a_cert(self, private_key):
         with pytest.raises(TypeError):
             pkcs7.pkcs7_decrypt_der(
                 b"", typing.cast(typing.Any, b"wrong_type"), private_key, []
             )
 
-    def test_not_a_pkey(self, backend, certificate):
+    def test_not_a_pkey(self, certificate):
         with pytest.raises(TypeError):
             pkcs7.pkcs7_decrypt_der(
                 b"", certificate, typing.cast(typing.Any, b"wrong_type"), []
@@ -1199,7 +1193,7 @@ class TestPKCS7Decrypt:
         ],
     )
     def test_pkcs7_decrypt_invalid_options(
-        self, backend, invalid_options, data, certificate, private_key
+        self, invalid_options, data, certificate, private_key
     ):
         with pytest.raises(ValueError):
             pkcs7.pkcs7_decrypt_der(
@@ -1207,9 +1201,7 @@ class TestPKCS7Decrypt:
             )
 
     @pytest.mark.parametrize("options", [[], [pkcs7.PKCS7Options.Text]])
-    def test_pkcs7_decrypt_der(
-        self, backend, data, certificate, private_key, options
-    ):
+    def test_pkcs7_decrypt_der(self, data, certificate, private_key, options):
         # Encryption
         builder = (
             pkcs7.PKCS7EnvelopeBuilder()
@@ -1226,7 +1218,7 @@ class TestPKCS7Decrypt:
         assert decrypted == data.replace(b"\n", b"\r\n")
 
     def test_pkcs7_decrypt_aes_256_cbc_encrypted_content(
-        self, backend, data, certificate, private_key
+        self, data, certificate, private_key
     ):
         # Encryption
         builder = (
@@ -1255,7 +1247,7 @@ class TestPKCS7Decrypt:
         ],
     )
     def test_pkcs7_decrypt_der_text_handmade_header(
-        self, backend, certificate, private_key, header
+        self, certificate, private_key, header
     ):
         # Encryption of data with a custom header
         base_data = "Hello world!\r\n"
@@ -1276,9 +1268,7 @@ class TestPKCS7Decrypt:
         assert decrypted == base_data.encode()
 
     @pytest.mark.parametrize("options", [[], [pkcs7.PKCS7Options.Text]])
-    def test_pkcs7_decrypt_pem(
-        self, backend, data, certificate, private_key, options
-    ):
+    def test_pkcs7_decrypt_pem(self, data, certificate, private_key, options):
         # Encryption
         builder = (
             pkcs7.PKCS7EnvelopeBuilder()
@@ -1295,7 +1285,7 @@ class TestPKCS7Decrypt:
         assert decrypted == data.replace(b"\n", b"\r\n")
 
     def test_pkcs7_decrypt_pem_with_wrong_tag(
-        self, backend, data, certificate, private_key
+        self, data, certificate, private_key
     ):
         with pytest.raises(ValueError):
             pkcs7.pkcs7_decrypt_pem(
@@ -1307,7 +1297,7 @@ class TestPKCS7Decrypt:
 
     @pytest.mark.parametrize("options", [[], [pkcs7.PKCS7Options.Text]])
     def test_pkcs7_decrypt_smime(
-        self, backend, data, certificate, private_key, options
+        self, data, certificate, private_key, options
     ):
         # Encryption
         builder = (
@@ -1324,7 +1314,7 @@ class TestPKCS7Decrypt:
         assert decrypted == data.replace(b"\n", b"\r\n")
 
     def test_pkcs7_decrypt_no_encrypted_content(
-        self, backend, data, certificate, private_key
+        self, data, certificate, private_key
     ):
         enveloped = load_vectors_from_file(
             os.path.join("pkcs7", "enveloped-no-content.der"),
@@ -1337,7 +1327,7 @@ class TestPKCS7Decrypt:
             pkcs7.pkcs7_decrypt_der(enveloped, certificate, private_key, [])
 
     def test_pkcs7_decrypt_text_no_header(
-        self, backend, data, certificate, private_key
+        self, data, certificate, private_key
     ):
         # Encryption of data without a header (no "Text" option)
         builder = (
@@ -1354,7 +1344,7 @@ class TestPKCS7Decrypt:
             )
 
     def test_pkcs7_decrypt_text_html_content_type(
-        self, backend, certificate, private_key
+        self, certificate, private_key
     ):
         # Encryption of data with a text/html content type header
         data = b"Content-Type: text/html\r\n\r\nHello world!<br>"
@@ -1374,7 +1364,7 @@ class TestPKCS7Decrypt:
             )
 
     def test_smime_decrypt_no_recipient_match(
-        self, backend, data, certificate, rsa_key_2048: rsa.RSAPrivateKey
+        self, data, certificate, rsa_key_2048: rsa.RSAPrivateKey
     ):
         # Encrypt some data with one RSA chain
         builder = (
@@ -1399,7 +1389,7 @@ class TestPKCS7Decrypt:
             )
 
     def test_smime_decrypt_unsupported_key_encryption_algorithm(
-        self, backend, data, certificate, private_key
+        self, data, certificate, private_key
     ):
         enveloped = load_vectors_from_file(
             os.path.join("pkcs7", "enveloped-rsa-oaep.pem"),
@@ -1411,7 +1401,7 @@ class TestPKCS7Decrypt:
             pkcs7.pkcs7_decrypt_pem(enveloped, certificate, private_key, [])
 
     def test_smime_decrypt_unsupported_content_encryption_algorithm(
-        self, backend, data, certificate, private_key
+        self, data, certificate, private_key
     ):
         enveloped = load_vectors_from_file(
             os.path.join("pkcs7", "enveloped-triple-des.pem"),
@@ -1422,9 +1412,7 @@ class TestPKCS7Decrypt:
         with pytest.raises(exceptions.UnsupportedAlgorithm):
             pkcs7.pkcs7_decrypt_pem(enveloped, certificate, private_key, [])
 
-    def test_smime_decrypt_not_enveloped(
-        self, backend, data, certificate, private_key
-    ):
+    def test_smime_decrypt_not_enveloped(self, data, certificate, private_key):
         # Create a signed email
         cert, key = _load_cert_key()
         options = [pkcs7.PKCS7Options.DetachedSignature]
@@ -1439,9 +1427,7 @@ class TestPKCS7Decrypt:
         with pytest.raises(ValueError):
             pkcs7.pkcs7_decrypt_der(signed, certificate, private_key, [])
 
-    def test_smime_decrypt_smime_not_encrypted(
-        self, backend, certificate, private_key
-    ):
+    def test_smime_decrypt_smime_not_encrypted(self, certificate, private_key):
         # Create a plain email
         email_message = EmailMessage()
         email_message.set_content("Hello world!")
@@ -1461,7 +1447,7 @@ class TestPKCS7SerializeCerts:
             (serialization.Encoding.DER, pkcs7.load_der_pkcs7_certificates),
         ],
     )
-    def test_roundtrip(self, encoding, loader, backend):
+    def test_roundtrip(self, encoding, loader):
         certs = load_vectors_from_file(
             os.path.join("pkcs7", "amazon-roots.der"),
             lambda derfile: pkcs7.load_der_pkcs7_certificates(derfile.read()),
@@ -1471,7 +1457,7 @@ class TestPKCS7SerializeCerts:
         certs2 = loader(p7)
         assert certs == certs2
 
-    def test_ordering(self, backend):
+    def test_ordering(self):
         certs = load_vectors_from_file(
             os.path.join("pkcs7", "amazon-roots.der"),
             lambda derfile: pkcs7.load_der_pkcs7_certificates(derfile.read()),
@@ -1483,7 +1469,7 @@ class TestPKCS7SerializeCerts:
         certs2 = pkcs7.load_der_pkcs7_certificates(p7)
         assert certs == certs2
 
-    def test_pem_matches_vector(self, backend):
+    def test_pem_matches_vector(self):
         p7_pem = load_vectors_from_file(
             os.path.join("pkcs7", "isrg.pem"),
             lambda p: p.read(),
@@ -1493,7 +1479,7 @@ class TestPKCS7SerializeCerts:
         p7 = pkcs7.serialize_certificates(certs, serialization.Encoding.PEM)
         assert p7 == p7_pem
 
-    def test_der_matches_vector(self, backend):
+    def test_der_matches_vector(self):
         p7_der = load_vectors_from_file(
             os.path.join("pkcs7", "amazon-roots.der"),
             lambda p: p.read(),
@@ -1533,7 +1519,7 @@ class TestPKCS7SerializeCerts:
     skip_message="Requires OpenSSL with no PKCS1 v1.5 padding support",
 )
 class TestPKCS7EnvelopeBuilderUnsupported:
-    def test_envelope_builder_unsupported(self, backend):
+    def test_envelope_builder_unsupported(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
             pkcs7.PKCS7EnvelopeBuilder()
 
@@ -1546,7 +1532,7 @@ class TestPKCS7EnvelopeBuilderUnsupported:
     skip_message="Requires OpenSSL with no PKCS1 v1.5 padding support",
 )
 class TestPKCS7DecryptUnsupported:
-    def test_pkcs7_decrypt_unsupported(self, backend):
+    def test_pkcs7_decrypt_unsupported(self):
         cert, key = _load_rsa_cert_key()
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
             pkcs7.pkcs7_decrypt_der(b"", cert, key, [])


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (FIPS checks, `*_supported()` probes, or helpers that do) are left untouched.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_