### PR TITLE
Remove no-op backend arguments in test_aead.py

### DIFF
--- a/tests/hazmat/primitives/test_aead.py
+++ b/tests/hazmat/primitives/test_aead.py
@@ -49,7 +49,7 @@ def large_mmap(length: int = 2**32):
     _aead_supported(ChaCha20Poly1305),
     reason="Requires OpenSSL without ChaCha20Poly1305 support",
 )
-def test_chacha20poly1305_unsupported_on_older_openssl(backend):
+def test_chacha20poly1305_unsupported_on_older_openssl():
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
         ChaCha20Poly1305(ChaCha20Poly1305.generate_key())
 
@@ -80,7 +80,7 @@ class TestChaCha20Poly1305:
         key = ChaCha20Poly1305.generate_key()
         assert len(key) == 32
 
-    def test_bad_key(self, backend):
+    def test_bad_key(self):
         with pytest.raises(TypeError):
             ChaCha20Poly1305(typing.cast(typing.Any, object()))
 
@@ -95,9 +95,7 @@ class TestChaCha20Poly1305:
             [b"0" * 12, b"data", object()],
         ],
     )
-    def test_params_not_bytes_encrypt(
-        self, nonce, data, associated_data, backend
-    ):
+    def test_params_not_bytes_encrypt(self, nonce, data, associated_data):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         with pytest.raises(TypeError):
@@ -106,7 +104,7 @@ class TestChaCha20Poly1305:
         with pytest.raises(TypeError):
             chacha.decrypt(nonce, data, associated_data)
 
-    def test_nonce_not_12_bytes(self, backend):
+    def test_nonce_not_12_bytes(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         with pytest.raises(ValueError):
@@ -123,7 +121,7 @@ class TestChaCha20Poly1305:
             buf = bytearray(1)
             chacha.decrypt_into(b"00", b"hello", b"", buf)
 
-    def test_decrypt_data_too_short(self, backend):
+    def test_decrypt_data_too_short(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         with pytest.raises(InvalidTag):
@@ -133,7 +131,7 @@ class TestChaCha20Poly1305:
             buf = bytearray(16)
             chacha.decrypt_into(b"0" * 12, b"0", None, buf)
 
-    def test_associated_data_none_equal_to_empty_bytestring(self, backend):
+    def test_associated_data_none_equal_to_empty_bytestring(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         nonce = os.urandom(12)
@@ -144,7 +142,7 @@ class TestChaCha20Poly1305:
         pt2 = chacha.decrypt(nonce, ct2, b"")
         assert pt1 == pt2
 
-    def test_openssl_vectors(self, subtests, backend):
+    def test_openssl_vectors(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("ciphers", "ChaCha20Poly1305", "openssl.txt"),
             load_nist_vectors,
@@ -167,7 +165,7 @@ class TestChaCha20Poly1305:
                     computed_ct = chacha.encrypt(nonce, pt, aad)
                     assert computed_ct == ct + tag
 
-    def test_boringssl_vectors(self, subtests, backend):
+    def test_boringssl_vectors(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("ciphers", "ChaCha20Poly1305", "boringssl.txt"),
             load_nist_vectors,
@@ -192,7 +190,7 @@ class TestChaCha20Poly1305:
                 computed_ct = chacha.encrypt(nonce, pt, aad)
                 assert computed_ct == ct + tag
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         pt = b"encrypt me"
@@ -207,7 +205,7 @@ class TestChaCha20Poly1305:
         computed_pt2 = chacha2.decrypt(bytearray(nonce), ct2, ad)
         assert computed_pt2 == pt
 
-    def test_encrypt_into(self, backend):
+    def test_encrypt_into(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         nonce = os.urandom(12)
@@ -222,7 +220,7 @@ class TestChaCha20Poly1305:
     @pytest.mark.parametrize(
         ("ptlen", "buflen"), [(10, 25), (10, 27), (15, 30), (20, 37)]
     )
-    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen, backend):
+    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         nonce = os.urandom(12)
@@ -231,7 +229,7 @@ class TestChaCha20Poly1305:
         with pytest.raises(ValueError, match="buffer must be"):
             chacha.encrypt_into(nonce, pt, None, buf)
 
-    def test_decrypt_into(self, backend):
+    def test_decrypt_into(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         nonce = os.urandom(12)
@@ -246,7 +244,7 @@ class TestChaCha20Poly1305:
     @pytest.mark.parametrize(
         ("ctlen", "buflen"), [(26, 9), (26, 11), (31, 14), (36, 21)]
     )
-    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen, backend):
+    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         nonce = os.urandom(12)
@@ -255,7 +253,7 @@ class TestChaCha20Poly1305:
         with pytest.raises(ValueError, match="buffer must be"):
             chacha.decrypt_into(nonce, ct, None, buf)
 
-    def test_decrypt_into_invalid_tag(self, backend):
+    def test_decrypt_into_invalid_tag(self):
         key = ChaCha20Poly1305.generate_key()
         chacha = ChaCha20Poly1305(key)
         nonce = os.urandom(12)
@@ -292,7 +290,7 @@ class TestAESCCM:
         with pytest.raises(OverflowError):
             aesccm.encrypt(nonce, b"", large_data)
 
-    def test_default_tag_length(self, backend):
+    def test_default_tag_length(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         nonce = os.urandom(12)
@@ -300,7 +298,7 @@ class TestAESCCM:
         ct = aesccm.encrypt(nonce, pt, None)
         assert len(ct) == len(pt) + 16
 
-    def test_invalid_tag_length(self, backend):
+    def test_invalid_tag_length(self):
         key = AESCCM.generate_key(128)
         with pytest.raises(ValueError):
             AESCCM(key, tag_length=7)
@@ -311,7 +309,7 @@ class TestAESCCM:
         with pytest.raises(TypeError):
             AESCCM(key, tag_length=typing.cast(typing.Any, "notanint"))
 
-    def test_invalid_nonce_length(self, backend):
+    def test_invalid_nonce_length(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         pt = b"hello"
@@ -330,7 +328,7 @@ class TestAESCCM:
             buf = bytearray(16)
             aesccm.decrypt_into(nonce[:6], b"x" * 20, None, buf)
 
-    def test_vectors(self, subtests, backend):
+    def test_vectors(self, subtests):
         vectors = _load_all_params(
             os.path.join("ciphers", "AES", "CCM"),
             [
@@ -365,7 +363,7 @@ class TestAESCCM:
                     assert computed_pt == pt
                     assert aesccm.encrypt(nonce, pt, adata) == ct
 
-    def test_roundtrip(self, backend):
+    def test_roundtrip(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         pt = b"encrypt me"
@@ -375,7 +373,7 @@ class TestAESCCM:
         computed_pt = aesccm.decrypt(nonce, ct, ad)
         assert computed_pt == pt
 
-    def test_nonce_too_long(self, backend):
+    def test_nonce_too_long(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         pt = b"encrypt me" * 6600
@@ -395,27 +393,27 @@ class TestAESCCM:
             [b"0" * 12, b"data", object()],
         ],
     )
-    def test_params_not_bytes(self, nonce, data, associated_data, backend):
+    def test_params_not_bytes(self, nonce, data, associated_data):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         with pytest.raises(TypeError):
             aesccm.encrypt(nonce, data, associated_data)
 
-    def test_bad_key(self, backend):
+    def test_bad_key(self):
         with pytest.raises(TypeError):
             AESCCM(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESCCM(b"0" * 31)
 
-    def test_bad_generate_key(self, backend):
+    def test_bad_generate_key(self):
         with pytest.raises(TypeError):
             AESCCM.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESCCM.generate_key(129)
 
-    def test_associated_data_none_equal_to_empty_bytestring(self, backend):
+    def test_associated_data_none_equal_to_empty_bytestring(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         nonce = os.urandom(12)
@@ -426,7 +424,7 @@ class TestAESCCM:
         pt2 = aesccm.decrypt(nonce, ct2, b"")
         assert pt1 == pt2
 
-    def test_decrypt_data_too_short(self, backend):
+    def test_decrypt_data_too_short(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         with pytest.raises(InvalidTag):
@@ -436,7 +434,7 @@ class TestAESCCM:
             buf = bytearray(16)
             aesccm.decrypt_into(b"0" * 12, b"0", None, buf)
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         pt = b"encrypt me"
@@ -461,7 +459,7 @@ class TestAESCCM:
         decrypted_data = aesccm.decrypt(nonce, ciphertext, aad)
         assert decrypted_data == plaintext
 
-    def test_encrypt_into(self, backend):
+    def test_encrypt_into(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         nonce = os.urandom(12)
@@ -476,7 +474,7 @@ class TestAESCCM:
     @pytest.mark.parametrize(
         ("ptlen", "buflen"), [(10, 25), (10, 27), (15, 30), (20, 37)]
     )
-    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen, backend):
+    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         nonce = os.urandom(12)
@@ -485,7 +483,7 @@ class TestAESCCM:
         with pytest.raises(ValueError, match="buffer must be"):
             aesccm.encrypt_into(nonce, pt, None, buf)
 
-    def test_decrypt_into(self, backend):
+    def test_decrypt_into(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         nonce = os.urandom(12)
@@ -500,7 +498,7 @@ class TestAESCCM:
     @pytest.mark.parametrize(
         ("ctlen", "buflen"), [(26, 9), (26, 11), (31, 14), (36, 21)]
     )
-    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen, backend):
+    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         nonce = os.urandom(12)
@@ -509,7 +507,7 @@ class TestAESCCM:
         with pytest.raises(ValueError, match="buffer must be"):
             aesccm.decrypt_into(nonce, ct, None, buf)
 
-    def test_decrypt_into_invalid_tag(self, backend):
+    def test_decrypt_into_invalid_tag(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         nonce = os.urandom(12)
@@ -523,7 +521,7 @@ class TestAESCCM:
         with pytest.raises(InvalidTag):
             aesccm.decrypt_into(nonce, bytes(corrupted_ct), ad, buf)
 
-    def test_decrypt_into_nonce_too_long(self, backend):
+    def test_decrypt_into_nonce_too_long(self):
         key = AESCCM.generate_key(128)
         aesccm = AESCCM(key)
         pt = b"encrypt me" * 6600
@@ -612,7 +610,7 @@ class TestAESGCM:
             [b"0" * 12, b"data", object()],
         ],
     )
-    def test_params_not_bytes(self, nonce, data, associated_data, backend):
+    def test_params_not_bytes(self, nonce, data, associated_data):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         with pytest.raises(TypeError):
@@ -641,21 +639,21 @@ class TestAESGCM:
             buf = bytearray(16)
             aesgcm.decrypt_into(b"\x00" * length, b"hi", None, buf)
 
-    def test_bad_key(self, backend):
+    def test_bad_key(self):
         with pytest.raises(TypeError):
             AESGCM(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESGCM(b"0" * 31)
 
-    def test_bad_generate_key(self, backend):
+    def test_bad_generate_key(self):
         with pytest.raises(TypeError):
             AESGCM.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESGCM.generate_key(129)
 
-    def test_associated_data_none_equal_to_empty_bytestring(self, backend):
+    def test_associated_data_none_equal_to_empty_bytestring(self):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         nonce = os.urandom(12)
@@ -666,7 +664,7 @@ class TestAESGCM:
         pt2 = aesgcm.decrypt(nonce, ct2, b"")
         assert pt1 == pt2
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         pt = b"encrypt me"
@@ -693,7 +691,7 @@ class TestAESGCM:
         computed_pt3 = aesgcm3.decrypt(m_nonce, m_ct3, m_ad)
         assert computed_pt3 == pt
 
-    def test_encrypt_into(self, backend):
+    def test_encrypt_into(self):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         nonce = os.urandom(12)
@@ -708,7 +706,7 @@ class TestAESGCM:
     @pytest.mark.parametrize(
         ("ptlen", "buflen"), [(10, 25), (10, 27), (15, 30), (20, 37)]
     )
-    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen, backend):
+    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         nonce = os.urandom(12)
@@ -717,7 +715,7 @@ class TestAESGCM:
         with pytest.raises(ValueError, match="buffer must be"):
             aesgcm.encrypt_into(nonce, pt, None, buf)
 
-    def test_decrypt_into(self, backend):
+    def test_decrypt_into(self):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         nonce = os.urandom(12)
@@ -732,7 +730,7 @@ class TestAESGCM:
     @pytest.mark.parametrize(
         ("ctlen", "buflen"), [(26, 9), (26, 11), (31, 14), (36, 21)]
     )
-    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen, backend):
+    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         nonce = os.urandom(12)
@@ -741,7 +739,7 @@ class TestAESGCM:
         with pytest.raises(ValueError, match="buffer must be"):
             aesgcm.decrypt_into(nonce, ct, None, buf)
 
-    def test_decrypt_into_invalid_tag(self, backend):
+    def test_decrypt_into_invalid_tag(self):
         key = AESGCM.generate_key(128)
         aesgcm = AESGCM(key)
         nonce = os.urandom(12)
@@ -760,7 +758,7 @@ class TestAESGCM:
     _aead_supported(AESOCB3),
     reason="Requires OpenSSL without AESOCB3 support",
 )
-def test_aesocb3_unsupported_on_older_openssl(backend):
+def test_aesocb3_unsupported_on_older_openssl():
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
         AESOCB3(AESOCB3.generate_key(128))
 
@@ -787,7 +785,7 @@ class TestAESOCB3:
         with pytest.raises(OverflowError):
             aesocb3.encrypt(nonce, b"", large_data)
 
-    def test_vectors(self, backend, subtests):
+    def test_vectors(self, subtests):
         vectors = []
         for f in [
             "rfc7253.txt",
@@ -816,7 +814,7 @@ class TestAESOCB3:
                 computed_pt = aesocb3.decrypt(nonce, ct, aad)
                 assert computed_pt == pt
 
-    def test_vectors_invalid(self, backend, subtests):
+    def test_vectors_invalid(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("ciphers", "AES", "OCB3", "rfc7253.txt"),
             load_nist_vectors,
@@ -846,7 +844,7 @@ class TestAESOCB3:
             (256, b"\xd9\x0e\xb8\xe9\xc9w\xc8\x8by\xddy=\x7f\xfa\x16\x1c"),
         ],
     )
-    def test_rfc7253(self, backend, key_len, expected):
+    def test_rfc7253(self, key_len, expected):
         # This is derived from page 18 of RFC 7253, with a tag length of
         # 128 bits.
 
@@ -878,7 +876,7 @@ class TestAESOCB3:
             [b"0" * 12, b"data", object()],
         ],
     )
-    def test_params_not_bytes(self, nonce, data, associated_data, backend):
+    def test_params_not_bytes(self, nonce, data, associated_data):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         with pytest.raises(TypeError):
@@ -887,7 +885,7 @@ class TestAESOCB3:
         with pytest.raises(TypeError):
             aesocb3.decrypt(nonce, data, associated_data)
 
-    def test_invalid_nonce_length(self, backend):
+    def test_invalid_nonce_length(self):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         with pytest.raises(ValueError):
@@ -914,21 +912,21 @@ class TestAESOCB3:
             buf = bytearray(16)
             aesocb3.decrypt_into(b"\x00" * 16, b"x" * 20, None, buf)
 
-    def test_bad_key(self, backend):
+    def test_bad_key(self):
         with pytest.raises(TypeError):
             AESOCB3(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESOCB3(b"0" * 31)
 
-    def test_bad_generate_key(self, backend):
+    def test_bad_generate_key(self):
         with pytest.raises(TypeError):
             AESOCB3.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESOCB3.generate_key(129)
 
-    def test_associated_data_none_equal_to_empty_bytestring(self, backend):
+    def test_associated_data_none_equal_to_empty_bytestring(self):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         nonce = os.urandom(12)
@@ -939,7 +937,7 @@ class TestAESOCB3:
         pt2 = aesocb3.decrypt(nonce, ct2, b"")
         assert pt1 == pt2
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         pt = b"encrypt me"
@@ -954,7 +952,7 @@ class TestAESOCB3:
         computed_pt2 = aesocb3_.decrypt(bytearray(nonce), ct2, ad)
         assert computed_pt2 == pt
 
-    def test_encrypt_into(self, backend):
+    def test_encrypt_into(self):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         nonce = os.urandom(12)
@@ -969,7 +967,7 @@ class TestAESOCB3:
     @pytest.mark.parametrize(
         ("ptlen", "buflen"), [(10, 25), (10, 27), (15, 30), (20, 37)]
     )
-    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen, backend):
+    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         nonce = os.urandom(12)
@@ -978,7 +976,7 @@ class TestAESOCB3:
         with pytest.raises(ValueError, match="buffer must be"):
             aesocb3.encrypt_into(nonce, pt, None, buf)
 
-    def test_decrypt_into(self, backend):
+    def test_decrypt_into(self):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         nonce = os.urandom(12)
@@ -993,7 +991,7 @@ class TestAESOCB3:
     @pytest.mark.parametrize(
         ("ctlen", "buflen"), [(26, 9), (26, 11), (31, 14), (36, 21)]
     )
-    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen, backend):
+    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         nonce = os.urandom(12)
@@ -1002,7 +1000,7 @@ class TestAESOCB3:
         with pytest.raises(ValueError, match="buffer must be"):
             aesocb3.decrypt_into(nonce, ct, None, buf)
 
-    def test_decrypt_into_invalid_tag(self, backend):
+    def test_decrypt_into_invalid_tag(self):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         nonce = os.urandom(12)
@@ -1016,7 +1014,7 @@ class TestAESOCB3:
         with pytest.raises(InvalidTag):
             aesocb3.decrypt_into(nonce, bytes(corrupted_ct), ad, buf)
 
-    def test_decrypt_into_data_too_short(self, backend):
+    def test_decrypt_into_data_too_short(self):
         key = AESOCB3.generate_key(128)
         aesocb3 = AESOCB3(key)
         nonce = os.urandom(12)
@@ -1071,7 +1069,7 @@ class TestAESSIV:
         with pytest.raises(InvalidTag):
             aessiv.decrypt(b"", None)
 
-    def test_vectors(self, backend, subtests):
+    def test_vectors(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("ciphers", "AES", "SIV", "openssl.txt"),
             load_nist_vectors,
@@ -1097,7 +1095,7 @@ class TestAESSIV:
                 computed_pt = aessiv.decrypt(computed_ct, aad)
                 assert computed_pt == pt
 
-    def test_vectors_invalid(self, backend, subtests):
+    def test_vectors_invalid(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("ciphers", "AES", "SIV", "openssl.txt"),
             load_nist_vectors,
@@ -1134,7 +1132,7 @@ class TestAESSIV:
             [b"data" * 5, b""],
         ],
     )
-    def test_params_not_bytes(self, data, associated_data, backend):
+    def test_params_not_bytes(self, data, associated_data):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         with pytest.raises(TypeError):
@@ -1143,21 +1141,21 @@ class TestAESSIV:
         with pytest.raises(TypeError):
             aessiv.decrypt(data, associated_data)
 
-    def test_bad_key(self, backend):
+    def test_bad_key(self):
         with pytest.raises(TypeError):
             AESSIV(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESSIV(b"0" * 31)
 
-    def test_bad_generate_key(self, backend):
+    def test_bad_generate_key(self):
         with pytest.raises(TypeError):
             AESSIV.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESSIV.generate_key(128)
 
-    def test_data_too_short(self, backend):
+    def test_data_too_short(self):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         with pytest.raises(InvalidTag):
@@ -1166,7 +1164,7 @@ class TestAESSIV:
             buf = bytearray(16)
             aessiv.decrypt_into(b"tooshort", None, buf)
 
-    def test_associated_data_none_equal_to_empty_list(self, backend):
+    def test_associated_data_none_equal_to_empty_list(self):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         ct1 = aessiv.encrypt(b"some_data", None)
@@ -1176,7 +1174,7 @@ class TestAESSIV:
         pt2 = aessiv.decrypt(ct2, [])
         assert pt1 == pt2
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         pt = b"encrypt me"
@@ -1190,7 +1188,7 @@ class TestAESSIV:
         computed_pt2 = aessiv.decrypt(ct2, ad)
         assert computed_pt2 == pt
 
-    def test_encrypt_into(self, backend):
+    def test_encrypt_into(self):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         pt = b"encrypt me"
@@ -1204,7 +1202,7 @@ class TestAESSIV:
     @pytest.mark.parametrize(
         ("ptlen", "buflen"), [(10, 25), (10, 27), (15, 30), (20, 37)]
     )
-    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen, backend):
+    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         pt = b"x" * ptlen
@@ -1212,7 +1210,7 @@ class TestAESSIV:
         with pytest.raises(ValueError, match="buffer must be"):
             aessiv.encrypt_into(pt, None, buf)
 
-    def test_decrypt_into(self, backend):
+    def test_decrypt_into(self):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         pt = b"decrypt me"
@@ -1226,7 +1224,7 @@ class TestAESSIV:
     @pytest.mark.parametrize(
         ("ctlen", "buflen"), [(26, 9), (26, 11), (31, 14), (36, 21)]
     )
-    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen, backend):
+    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         ct = b"x" * ctlen
@@ -1234,7 +1232,7 @@ class TestAESSIV:
         with pytest.raises(ValueError, match="buffer must be"):
             aessiv.decrypt_into(ct, None, buf)
 
-    def test_decrypt_into_invalid_tag(self, backend):
+    def test_decrypt_into_invalid_tag(self):
         key = AESSIV.generate_key(256)
         aessiv = AESSIV(key)
         pt = b"some data"
@@ -1273,7 +1271,7 @@ class TestAESGCMSIV:
         with pytest.raises(OverflowError):
             aesgcmsiv.decrypt(nonce, b"very very irrelevant", large_data)
 
-    def test_invalid_nonce_length(self, backend):
+    def test_invalid_nonce_length(self):
         key = AESGCMSIV.generate_key(128)
         aesgcmsiv = AESGCMSIV(key)
         pt = b"hello"
@@ -1320,7 +1318,7 @@ class TestAESGCMSIV:
         with pytest.raises(InvalidTag):
             aesgcmsiv.decrypt(nonce, b"", None)
 
-    def test_vectors(self, backend, subtests):
+    def test_vectors(self, subtests):
         vectors = _load_all_params(
             os.path.join("ciphers", "AES", "GCM-SIV"),
             [
@@ -1353,7 +1351,7 @@ class TestAESGCMSIV:
                 computed_pt = aesgcmsiv.decrypt(nonce, computed_ct, aad)
                 assert computed_pt == pt
 
-    def test_vectors_invalid(self, backend, subtests):
+    def test_vectors_invalid(self, subtests):
         vectors = _load_all_params(
             os.path.join("ciphers", "AES", "GCM-SIV"),
             [
@@ -1394,7 +1392,7 @@ class TestAESGCMSIV:
             [b"0" * 12, b"data", object()],
         ],
     )
-    def test_params_not_bytes(self, nonce, data, associated_data, backend):
+    def test_params_not_bytes(self, nonce, data, associated_data):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         with pytest.raises(TypeError):
@@ -1403,7 +1401,7 @@ class TestAESGCMSIV:
         with pytest.raises(TypeError):
             aesgcmsiv.decrypt(nonce, data, associated_data)
 
-    def test_bad_key(self, backend):
+    def test_bad_key(self):
         with pytest.raises(TypeError):
             AESGCMSIV(typing.cast(typing.Any, object()))
 
@@ -1417,14 +1415,14 @@ class TestAESGCMSIV:
             with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
                 AESGCMSIV(b"0" * 24)
 
-    def test_bad_generate_key(self, backend):
+    def test_bad_generate_key(self):
         with pytest.raises(TypeError):
             AESGCMSIV.generate_key(typing.cast(typing.Any, object()))
 
         with pytest.raises(ValueError):
             AESGCMSIV.generate_key(129)
 
-    def test_associated_data_none_equal_to_empty_bytestring(self, backend):
+    def test_associated_data_none_equal_to_empty_bytestring(self):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         nonce = os.urandom(12)
@@ -1435,7 +1433,7 @@ class TestAESGCMSIV:
         pt2 = aesgcmsiv.decrypt(nonce, ct2, b"")
         assert pt1 == pt2
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         nonce = os.urandom(12)
@@ -1450,7 +1448,7 @@ class TestAESGCMSIV:
         computed_pt2 = aesgcmsiv.decrypt(nonce, ct2, ad)
         assert computed_pt2 == pt
 
-    def test_encrypt_into(self, backend):
+    def test_encrypt_into(self):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         nonce = os.urandom(12)
@@ -1465,7 +1463,7 @@ class TestAESGCMSIV:
     @pytest.mark.parametrize(
         ("ptlen", "buflen"), [(10, 25), (10, 27), (15, 30), (20, 37)]
     )
-    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen, backend):
+    def test_encrypt_into_buffer_incorrect_size(self, ptlen, buflen):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         nonce = os.urandom(12)
@@ -1474,7 +1472,7 @@ class TestAESGCMSIV:
         with pytest.raises(ValueError, match="buffer must be"):
             aesgcmsiv.encrypt_into(nonce, pt, None, buf)
 
-    def test_decrypt_into(self, backend):
+    def test_decrypt_into(self):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         nonce = os.urandom(12)
@@ -1489,7 +1487,7 @@ class TestAESGCMSIV:
     @pytest.mark.parametrize(
         ("ctlen", "buflen"), [(26, 9), (26, 11), (31, 14), (36, 21)]
     )
-    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen, backend):
+    def test_decrypt_into_buffer_incorrect_size(self, ctlen, buflen):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         nonce = os.urandom(12)
@@ -1498,7 +1496,7 @@ class TestAESGCMSIV:
         with pytest.raises(ValueError, match="buffer must be"):
             aesgcmsiv.decrypt_into(nonce, ct, None, buf)
 
-    def test_decrypt_into_invalid_tag(self, backend):
+    def test_decrypt_into_invalid_tag(self):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         nonce = os.urandom(12)
@@ -1512,7 +1510,7 @@ class TestAESGCMSIV:
         with pytest.raises(InvalidTag):
             aesgcmsiv.decrypt_into(nonce, bytes(corrupted_ct), ad, buf)
 
-    def test_decrypt_into_data_too_short(self, backend):
+    def test_decrypt_into_data_too_short(self):
         key = AESGCMSIV.generate_key(256)
         aesgcmsiv = AESGCMSIV(key)
         nonce = os.urandom(12)


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (FIPS checks, `*_supported()` probes, or helpers that do) are left untouched.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_