### PR TITLE
Remove no-op backend arguments in block cipher tests

### DIFF
--- a/tests/hazmat/primitives/test_aes.py
+++ b/tests/hazmat/primitives/test_aes.py
@@ -295,7 +295,7 @@ def test_alternate_aes_classes(mode, alg_cls, backend):
     assert pt == data
 
 
-def test_reset_nonce(backend):
+def test_reset_nonce():
     data = b"helloworld" * 10
     nonce = b"\x00" * 16
     nonce_alt = b"\xee" * 16
@@ -339,7 +339,7 @@ def test_reset_nonce(backend):
         dec.reset_nonce(nonce)
 
 
-def test_reset_nonce_invalid_mode(backend):
+def test_reset_nonce_invalid_mode():
     iv = b"\x00" * 16
     c = base.Cipher(
         algorithms.AES(b"\x00" * 16),

--- a/tests/hazmat/primitives/test_aes_gcm.py
+++ b/tests/hazmat/primitives/test_aes_gcm.py
@@ -32,40 +32,34 @@ class TestAESModeGCM:
         modes.GCM,
     )
 
-    def test_gcm_tag_with_only_aad(self, backend):
+    def test_gcm_tag_with_only_aad(self):
         key = binascii.unhexlify(b"5211242698bed4774a090620a6ca56f3")
         iv = binascii.unhexlify(b"b1e1349120b6e832ef976f5d")
         aad = binascii.unhexlify(b"b6d729aab8e6416d7002b9faa794c410d8d2f193")
         tag = binascii.unhexlify(b"0f247e7f9c2505de374006738018493b")
 
-        cipher = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv), backend=backend
-        )
+        cipher = base.Cipher(algorithms.AES(key), modes.GCM(iv))
         encryptor = cipher.encryptor()
         encryptor.authenticate_additional_data(aad)
         encryptor.finalize()
         assert encryptor.tag == tag
 
-    def test_gcm_ciphertext_with_no_aad(self, backend):
+    def test_gcm_ciphertext_with_no_aad(self):
         key = binascii.unhexlify(b"e98b72a9881a84ca6b76e0f43e68647a")
         iv = binascii.unhexlify(b"8b23299fde174053f3d652ba")
         ct = binascii.unhexlify(b"5a3c1cf1985dbb8bed818036fdd5ab42")
         tag = binascii.unhexlify(b"23c7ab0f952b7091cd324835043b5eb5")
         pt = binascii.unhexlify(b"28286a321293253c3e0aa2704a278032")
 
-        cipher = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv), backend=backend
-        )
+        cipher = base.Cipher(algorithms.AES(key), modes.GCM(iv))
         encryptor = cipher.encryptor()
         computed_ct = encryptor.update(pt) + encryptor.finalize()
         assert computed_ct == ct
         assert encryptor.tag == tag
 
-    def test_gcm_ciphertext_limit(self, backend):
+    def test_gcm_ciphertext_limit(self):
         cipher = base.Cipher(
-            algorithms.AES(b"\x00" * 16),
-            modes.GCM(b"\x01" * 16),
-            backend=backend,
+            algorithms.AES(b"\x00" * 16), modes.GCM(b"\x01" * 16)
         )
         encryptor = cipher.encryptor()
         rust_openssl.ciphers._advance(
@@ -87,11 +81,9 @@ class TestAESModeGCM:
         with pytest.raises(ValueError):
             decryptor.update_into(b"0", bytearray(1))
 
-    def test_gcm_aad_limit(self, backend):
+    def test_gcm_aad_limit(self):
         cipher = base.Cipher(
-            algorithms.AES(b"\x00" * 16),
-            modes.GCM(b"\x01" * 16),
-            backend=backend,
+            algorithms.AES(b"\x00" * 16), modes.GCM(b"\x01" * 16)
         )
         encryptor = cipher.encryptor()
         rust_openssl.ciphers._advance_aad(
@@ -109,75 +101,64 @@ class TestAESModeGCM:
         with pytest.raises(ValueError):
             decryptor.authenticate_additional_data(b"0")
 
-    def test_gcm_tag_decrypt_none(self, backend):
+    def test_gcm_tag_decrypt_none(self):
         key = binascii.unhexlify(b"5211242698bed4774a090620a6ca56f3")
         iv = binascii.unhexlify(b"b1e1349120b6e832ef976f5d")
         aad = binascii.unhexlify(b"b6d729aab8e6416d7002b9faa794c410d8d2f193")
 
-        encryptor = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv), backend=backend
-        ).encryptor()
+        encryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).encryptor()
         encryptor.authenticate_additional_data(aad)
         encryptor.finalize()
 
-        decryptor = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv), backend=backend
-        ).decryptor()
+        decryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).decryptor()
         decryptor.authenticate_additional_data(aad)
         with pytest.raises(ValueError):
             decryptor.finalize()
 
-    def test_gcm_tag_decrypt_mode(self, backend):
+    def test_gcm_tag_decrypt_mode(self):
         key = binascii.unhexlify(b"5211242698bed4774a090620a6ca56f3")
         iv = binascii.unhexlify(b"b1e1349120b6e832ef976f5d")
         aad = binascii.unhexlify(b"b6d729aab8e6416d7002b9faa794c410d8d2f193")
 
-        encryptor = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv), backend=backend
-        ).encryptor()
+        encryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).encryptor()
         encryptor.authenticate_additional_data(aad)
         encryptor.finalize()
         tag = encryptor.tag
 
         decryptor = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv, tag), backend=backend
+            algorithms.AES(key), modes.GCM(iv, tag)
         ).decryptor()
         decryptor.authenticate_additional_data(aad)
         decryptor.finalize()
 
-    def test_gcm_tag_decrypt_finalize(self, backend):
+    def test_gcm_tag_decrypt_finalize(self):
         key = binascii.unhexlify(b"5211242698bed4774a090620a6ca56f3")
         iv = binascii.unhexlify(b"b1e1349120b6e832ef976f5d")
         aad = binascii.unhexlify(b"b6d729aab8e6416d7002b9faa794c410d8d2f193")
 
-        encryptor = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv), backend=backend
-        ).encryptor()
+        encryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).encryptor()
         encryptor.authenticate_additional_data(aad)
         encryptor.finalize()
         tag = encryptor.tag
 
-        decryptor = base.Cipher(
-            algorithms.AES(key), modes.GCM(iv), backend=backend
-        ).decryptor()
+        decryptor = base.Cipher(algorithms.AES(key), modes.GCM(iv)).decryptor()
         decryptor.authenticate_additional_data(aad)
 
         decryptor.finalize_with_tag(tag)
 
     @pytest.mark.parametrize("tag", [b"tagtooshort", b"toolong" * 12])
-    def test_gcm_tag_decrypt_finalize_tag_length(self, tag, backend):
+    def test_gcm_tag_decrypt_finalize_tag_length(self, tag):
         decryptor = base.Cipher(
-            algorithms.AES(b"0" * 16), modes.GCM(b"0" * 12), backend=backend
+            algorithms.AES(b"0" * 16), modes.GCM(b"0" * 12)
         ).decryptor()
         with pytest.raises(ValueError):
             decryptor.finalize_with_tag(tag)
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         data = bytearray(b"helloworld")
         c = base.Cipher(
             algorithms.AES(bytearray(b"\x00" * 16)),
             modes.GCM(bytearray(b"\x00" * 12)),
-            backend,
         )
         enc = c.encryptor()
         enc.authenticate_additional_data(bytearray(b"foo"))
@@ -215,10 +196,10 @@ class TestAESModeGCM:
         assert pt == payload
 
     @pytest.mark.parametrize("alg", [algorithms.AES128, algorithms.AES256])
-    def test_alternate_aes_classes(self, alg, backend):
+    def test_alternate_aes_classes(self, alg):
         data = bytearray(b"sixteen_byte_msg")
         cipher = base.Cipher(
-            alg(b"0" * (alg.key_size // 8)), modes.GCM(b"\x00" * 12), backend
+            alg(b"0" * (alg.key_size // 8)), modes.GCM(b"\x00" * 12)
         )
         enc = cipher.encryptor()
         ct = enc.update(data) + enc.finalize()
@@ -226,7 +207,7 @@ class TestAESModeGCM:
         pt = dec.update(ct) + dec.finalize_with_tag(enc.tag)
         assert pt == data
 
-    def test_reset_nonce_invalid_mode(self, backend):
+    def test_reset_nonce_invalid_mode(self):
         nonce = b"\x00" * 12
         c = base.Cipher(
             algorithms.AES(b"\x00" * 16),

--- a/tests/hazmat/primitives/test_block.py
+++ b/tests/hazmat/primitives/test_block.py
@@ -26,38 +26,31 @@ from .utils import (
 
 
 class TestCipher:
-    def test_creates_encryptor(self, backend):
+    def test_creates_encryptor(self):
         cipher = Cipher(
             algorithms.AES(binascii.unhexlify(b"0" * 32)),
             modes.CBC(binascii.unhexlify(b"0" * 32)),
-            backend,
         )
         assert isinstance(cipher.encryptor(), base.CipherContext)
 
-    def test_creates_decryptor(self, backend):
+    def test_creates_decryptor(self):
         cipher = Cipher(
             algorithms.AES(binascii.unhexlify(b"0" * 32)),
             modes.CBC(binascii.unhexlify(b"0" * 32)),
-            backend,
         )
         assert isinstance(cipher.decryptor(), base.CipherContext)
 
-    def test_instantiate_with_non_algorithm(self, backend):
+    def test_instantiate_with_non_algorithm(self):
         algorithm = object()
         with pytest.raises(TypeError):
-            Cipher(
-                typing.cast(typing.Any, algorithm),
-                mode=None,
-                backend=backend,
-            )
+            Cipher(typing.cast(typing.Any, algorithm), mode=None)
 
 
 class TestCipherContext:
-    def test_use_after_finalize(self, backend):
+    def test_use_after_finalize(self):
         cipher = Cipher(
             algorithms.AES(binascii.unhexlify(b"0" * 32)),
             modes.CBC(binascii.unhexlify(b"0" * 32)),
-            backend,
         )
         encryptor = cipher.encryptor()
         encryptor.update(b"a" * 16)
@@ -74,11 +67,10 @@ class TestCipherContext:
         with pytest.raises(AlreadyFinalized):
             decryptor.finalize()
 
-    def test_use_update_into_after_finalize(self, backend):
+    def test_use_update_into_after_finalize(self):
         cipher = Cipher(
             algorithms.AES(binascii.unhexlify(b"0" * 32)),
             modes.CBC(binascii.unhexlify(b"0" * 32)),
-            backend,
         )
         encryptor = cipher.encryptor()
         encryptor.update(b"a" * 16)
@@ -87,9 +79,9 @@ class TestCipherContext:
             buf = bytearray(31)
             encryptor.update_into(b"b" * 16, buf)
 
-    def test_unaligned_block_encryption(self, backend):
+    def test_unaligned_block_encryption(self):
         cipher = Cipher(
-            algorithms.AES(binascii.unhexlify(b"0" * 32)), modes.ECB(), backend
+            algorithms.AES(binascii.unhexlify(b"0" * 32)), modes.ECB()
         )
         encryptor = cipher.encryptor()
         ct = encryptor.update(b"a" * 15)
@@ -106,18 +98,16 @@ class TestCipherContext:
         decryptor.finalize()
 
     @pytest.mark.parametrize("mode", [DummyMode(), None])
-    def test_nonexistent_cipher(self, backend, mode):
-        cipher = Cipher(DummyCipherAlgorithm(), mode, backend)
+    def test_nonexistent_cipher(self, mode):
+        cipher = Cipher(DummyCipherAlgorithm(), mode)
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
             cipher.encryptor()
 
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
             cipher.decryptor()
 
-    def test_incorrectly_padded(self, backend):
-        cipher = Cipher(
-            algorithms.AES(b"\x00" * 16), modes.CBC(b"\x00" * 16), backend
-        )
+    def test_incorrectly_padded(self):
+        cipher = Cipher(algorithms.AES(b"\x00" * 16), modes.CBC(b"\x00" * 16))
         encryptor = cipher.encryptor()
         encryptor.update(b"1")
         with pytest.raises(ValueError):
@@ -141,45 +131,25 @@ class TestAEADCipherContext:
 
 
 class TestModeValidation:
-    def test_cbc(self, backend):
+    def test_cbc(self):
         with pytest.raises(ValueError):
-            Cipher(
-                algorithms.AES(b"\x00" * 16),
-                modes.CBC(b"abc"),
-                backend,
-            )
+            Cipher(algorithms.AES(b"\x00" * 16), modes.CBC(b"abc"))
 
-    def test_ofb(self, backend):
+    def test_ofb(self):
         with pytest.raises(ValueError):
-            Cipher(
-                algorithms.AES(b"\x00" * 16),
-                OFB(b"abc"),
-                backend,
-            )
+            Cipher(algorithms.AES(b"\x00" * 16), OFB(b"abc"))
 
-    def test_cfb(self, backend):
+    def test_cfb(self):
         with pytest.raises(ValueError):
-            Cipher(
-                algorithms.AES(b"\x00" * 16),
-                CFB(b"abc"),
-                backend,
-            )
+            Cipher(algorithms.AES(b"\x00" * 16), CFB(b"abc"))
 
-    def test_cfb8(self, backend):
+    def test_cfb8(self):
         with pytest.raises(ValueError):
-            Cipher(
-                algorithms.AES(b"\x00" * 16),
-                CFB8(b"abc"),
-                backend,
-            )
+            Cipher(algorithms.AES(b"\x00" * 16), CFB8(b"abc"))
 
-    def test_ctr(self, backend):
+    def test_ctr(self):
         with pytest.raises(ValueError):
-            Cipher(
-                algorithms.AES(b"\x00" * 16),
-                modes.CTR(b"abc"),
-                backend,
-            )
+            Cipher(algorithms.AES(b"\x00" * 16), modes.CTR(b"abc"))
 
     def test_gcm(self):
         with pytest.raises(ValueError):

--- a/tests/hazmat/primitives/test_ciphers.py
+++ b/tests/hazmat/primitives/test_ciphers.py
@@ -57,9 +57,9 @@ class TestAES:
 
 class TestAESXTS:
     @pytest.mark.parametrize("mode", (modes.CBC, modes.CTR, CFB, CFB8, OFB))
-    def test_invalid_key_size_with_mode(self, mode, backend):
+    def test_invalid_key_size_with_mode(self, mode):
         with pytest.raises(ValueError):
-            ciphers.Cipher(AES(b"0" * 64), mode(b"0" * 16), backend)
+            ciphers.Cipher(AES(b"0" * 64), mode(b"0" * 16))
 
     def test_xts_tweak_not_bytes(self):
         with pytest.raises(TypeError):
@@ -69,9 +69,9 @@ class TestAESXTS:
         with pytest.raises(ValueError):
             modes.XTS(b"0")
 
-    def test_xts_wrong_key_size(self, backend):
+    def test_xts_wrong_key_size(self):
         with pytest.raises(ValueError):
-            ciphers.Cipher(AES(b"0" * 16), modes.XTS(b"0" * 16), backend)
+            ciphers.Cipher(AES(b"0" * 16), modes.XTS(b"0" * 16))
 
 
 class TestGCM:
@@ -114,57 +114,53 @@ class TestCipherUpdateInto:
             load_nist_vectors,
         ),
     )
-    def test_update_into(self, params, backend):
+    def test_update_into(self, params):
         key = binascii.unhexlify(params["key"])
         pt = binascii.unhexlify(params["plaintext"])
         ct = binascii.unhexlify(params["ciphertext"])
-        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        c = ciphers.Cipher(AES(key), modes.ECB())
         encryptor = c.encryptor()
         buf = bytearray(len(pt) + 15)
         res = encryptor.update_into(pt, buf)
         assert res == len(pt)
         assert bytes(buf)[:res] == ct
 
-    def test_update_into_gcm(self, backend):
+    def test_update_into_gcm(self):
         key = binascii.unhexlify(b"e98b72a9881a84ca6b76e0f43e68647a")
         iv = binascii.unhexlify(b"8b23299fde174053f3d652ba")
         ct = binascii.unhexlify(b"5a3c1cf1985dbb8bed818036fdd5ab42")
         pt = binascii.unhexlify(b"28286a321293253c3e0aa2704a278032")
-        c = ciphers.Cipher(AES(key), modes.GCM(iv), backend)
+        c = ciphers.Cipher(AES(key), modes.GCM(iv))
         encryptor = c.encryptor()
         buf = bytearray(len(pt) + 15)
         res = encryptor.update_into(pt, buf)
         assert res == len(pt)
         assert bytes(buf)[:res] == ct
         encryptor.finalize()
-        c = ciphers.Cipher(AES(key), modes.GCM(iv, encryptor.tag), backend)
+        c = ciphers.Cipher(AES(key), modes.GCM(iv, encryptor.tag))
         decryptor = c.decryptor()
         res = decryptor.update_into(ct, buf)
         decryptor.finalize()
         assert res == len(pt)
         assert bytes(buf)[:res] == pt
 
-    def test_finalize_with_tag_already_finalized(self, backend):
+    def test_finalize_with_tag_already_finalized(self):
         key = binascii.unhexlify(b"e98b72a9881a84ca6b76e0f43e68647a")
         iv = binascii.unhexlify(b"8b23299fde174053f3d652ba")
-        encryptor = ciphers.Cipher(
-            AES(key), modes.GCM(iv), backend
-        ).encryptor()
+        encryptor = ciphers.Cipher(AES(key), modes.GCM(iv)).encryptor()
         ciphertext = encryptor.update(b"abc") + encryptor.finalize()
 
         decryptor = ciphers.Cipher(
-            AES(key), modes.GCM(iv, tag=encryptor.tag), backend
+            AES(key), modes.GCM(iv, tag=encryptor.tag)
         ).decryptor()
         decryptor.update(ciphertext)
         decryptor.finalize()
         with pytest.raises(AlreadyFinalized):
             decryptor.finalize_with_tag(encryptor.tag)
 
-    def test_finalize_with_tag_duplicate_tag(self, backend):
+    def test_finalize_with_tag_duplicate_tag(self):
         decryptor = ciphers.Cipher(
-            AES(b"\x00" * 16),
-            modes.GCM(b"\x00" * 12, tag=b"\x00" * 16),
-            backend,
+            AES(b"\x00" * 16), modes.GCM(b"\x00" * 12, tag=b"\x00" * 16)
         ).decryptor()
         with pytest.raises(ValueError):
             decryptor.finalize_with_tag(b"\x00" * 16)
@@ -176,11 +172,11 @@ class TestCipherUpdateInto:
             load_nist_vectors,
         ),
     )
-    def test_update_into_multiple_calls(self, params, backend):
+    def test_update_into_multiple_calls(self, params):
         key = binascii.unhexlify(params["key"])
         pt = binascii.unhexlify(params["plaintext"])
         ct = binascii.unhexlify(params["ciphertext"])
-        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        c = ciphers.Cipher(AES(key), modes.ECB())
         encryptor = c.encryptor()
         buf = bytearray(len(pt) + 15)
         res = encryptor.update_into(pt[:3], buf)
@@ -189,33 +185,33 @@ class TestCipherUpdateInto:
         assert res == len(pt)
         assert bytes(buf)[:res] == ct
 
-    def test_update_into_buffer_too_small(self, backend):
+    def test_update_into_buffer_too_small(self):
         key = b"\x00" * 16
-        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        c = ciphers.Cipher(AES(key), modes.ECB())
         encryptor = c.encryptor()
         buf = bytearray(16)
         with pytest.raises(ValueError):
             encryptor.update_into(b"testing", buf)
 
-    def test_update_into_immutable(self, backend):
+    def test_update_into_immutable(self):
         key = b"\x00" * 16
-        c = ciphers.Cipher(AES(key), modes.ECB(), backend)
+        c = ciphers.Cipher(AES(key), modes.ECB())
         encryptor = c.encryptor()
         buf = b"\x00" * 32
         with pytest.raises((TypeError, BufferError)):
             encryptor.update_into(b"testing", buf)
 
-    def test_update_into_buffer_too_small_gcm(self, backend):
+    def test_update_into_buffer_too_small_gcm(self):
         key = b"\x00" * 16
-        c = ciphers.Cipher(AES(key), modes.GCM(b"\x00" * 12), backend)
+        c = ciphers.Cipher(AES(key), modes.GCM(b"\x00" * 12))
         encryptor = c.encryptor()
         buf = bytearray(5)
         with pytest.raises(ValueError):
             encryptor.update_into(b"testing", buf)
 
-    def test_update_with_invalid_type(self, backend):
+    def test_update_with_invalid_type(self):
         key = b"\x00" * 16
-        c = ciphers.Cipher(AES(key), modes.GCM(b"\x00" * 12), backend)
+        c = ciphers.Cipher(AES(key), modes.GCM(b"\x00" * 12))
         encryptor = c.encryptor()
         with pytest.raises(TypeError, match=r"bytestring instead\?"):
             encryptor.update(typing.cast(typing.Any, "hello"))


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions in `test_aes.py`, `test_aes_gcm.py`, `test_block.py`, and `test_ciphers.py` that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (FIPS checks, `cipher_supported()` probes, or helpers that do) are left untouched.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_