### PR TITLE
Remove no-op backend arguments in ChaCha20, CMAC, Poly1305, and SM4 tests

### DIFF
--- a/tests/hazmat/primitives/test_chacha20.py
+++ b/tests/hazmat/primitives/test_chacha20.py
@@ -32,7 +32,7 @@ class TestChaCha20:
             load_nist_vectors,
         ),
     )
-    def test_vectors(self, vector, backend):
+    def test_vectors(self, vector):
         key = binascii.unhexlify(vector["key"])
         nonce = binascii.unhexlify(vector["nonce"])
         # The 128-bit value is a 32-bit little-endian block counter followed
@@ -40,7 +40,7 @@ class TestChaCha20:
         ibc = struct.pack("<I", int(vector["initial_block_counter"]))
         pt = binascii.unhexlify(vector["plaintext"])
         encryptor = Cipher(
-            algorithms.ChaCha20(key, ibc + nonce), None, backend
+            algorithms.ChaCha20(key, ibc + nonce), None
         ).encryptor()
         computed_ct = encryptor.update(pt) + encryptor.finalize()
         assert binascii.hexlify(computed_ct) == vector["ciphertext"]
@@ -50,52 +50,44 @@ class TestChaCha20:
         # followed by a 12-byte nonce.
         return struct.pack("<I", counter) + b"\x00" * 12
 
-    def test_counter_overflow_single_update(self, backend):
+    def test_counter_overflow_single_update(self):
         key = b"\x00" * 32
         # A counter of 2**32 - 1 leaves room for exactly one 64-byte block
         # before the 32-bit counter would overflow.
         nonce = self._nonce_with_counter(2**32 - 1)
-        enc = Cipher(
-            algorithms.ChaCha20(key, nonce), None, backend
-        ).encryptor()
+        enc = Cipher(algorithms.ChaCha20(key, nonce), None).encryptor()
         with pytest.raises(ValueError):
             enc.update(b"\x00" * 65)
 
-    def test_counter_overflow_across_updates(self, backend):
+    def test_counter_overflow_across_updates(self):
         key = b"\x00" * 32
         nonce = self._nonce_with_counter(2**32 - 1)
-        enc = Cipher(
-            algorithms.ChaCha20(key, nonce), None, backend
-        ).encryptor()
+        enc = Cipher(algorithms.ChaCha20(key, nonce), None).encryptor()
         # Exactly one block is allowed.
         assert len(enc.update(b"\x00" * 64)) == 64
         with pytest.raises(ValueError):
             enc.update(b"\x00")
 
-    def test_counter_overflow_decrypt(self, backend):
+    def test_counter_overflow_decrypt(self):
         key = b"\x00" * 32
         nonce = self._nonce_with_counter(2**32 - 1)
-        dec = Cipher(
-            algorithms.ChaCha20(key, nonce), None, backend
-        ).decryptor()
+        dec = Cipher(algorithms.ChaCha20(key, nonce), None).decryptor()
         with pytest.raises(ValueError):
             dec.update(b"\x00" * 65)
 
-    def test_counter_overflow_update_into(self, backend):
+    def test_counter_overflow_update_into(self):
         key = b"\x00" * 32
         nonce = self._nonce_with_counter(2**32 - 1)
-        enc = Cipher(
-            algorithms.ChaCha20(key, nonce), None, backend
-        ).encryptor()
+        enc = Cipher(algorithms.ChaCha20(key, nonce), None).encryptor()
         buf = bytearray(65 + 64)
         with pytest.raises(ValueError):
             enc.update_into(b"\x00" * 65, buf)
 
-    def test_counter_overflow_after_reset_nonce(self, backend):
+    def test_counter_overflow_after_reset_nonce(self):
         key = b"\x00" * 32
         low = self._nonce_with_counter(0)
         high = self._nonce_with_counter(2**32 - 1)
-        enc = Cipher(algorithms.ChaCha20(key, low), None, backend).encryptor()
+        enc = Cipher(algorithms.ChaCha20(key, low), None).encryptor()
         # A zero counter allows plenty of data.
         enc.update(b"\x00" * 128)
         # Resetting to a near-overflow counter shrinks the available budget.
@@ -107,10 +99,10 @@ class TestChaCha20:
         enc.reset_nonce(low)
         enc.update(b"\x00" * 128)
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = bytearray(os.urandom(32))
         nonce = bytearray(os.urandom(16))
-        cipher = Cipher(algorithms.ChaCha20(key, nonce), None, backend)
+        cipher = Cipher(algorithms.ChaCha20(key, nonce), None)
         enc = cipher.encryptor()
         ct = enc.update(bytearray(b"hello")) + enc.finalize()
         dec = cipher.decryptor()
@@ -136,14 +128,14 @@ class TestChaCha20:
         with pytest.raises(TypeError, match="key must be bytes"):
             algorithms.ChaCha20(typing.cast(typing.Any, "0" * 32), b"0" * 16)
 
-    def test_partial_blocks(self, backend):
+    def test_partial_blocks(self):
         # Test that partial blocks and counter increments are handled
         # correctly. Successive calls to update should return the same
         # as if the entire input was passed in a single call:
         # update(pt[0:n]) + update(pt[n:m]) + update(pt[m:]) == update(pt)
         key = bytearray(os.urandom(32))
         nonce = bytearray(os.urandom(16))
-        cipher = Cipher(algorithms.ChaCha20(key, nonce), None, backend)
+        cipher = Cipher(algorithms.ChaCha20(key, nonce), None)
         pt = bytearray(os.urandom(96 * 3))
 
         enc_full = cipher.encryptor()
@@ -157,7 +149,7 @@ class TestChaCha20:
 
         assert ct_full == ct_partial_1 + ct_partial_2 + ct_partial_3
 
-    def test_reset_nonce(self, backend):
+    def test_reset_nonce(self):
         data = b"helloworld" * 10
         key = b"\x00" * 32
         nonce = b"\x00" * 16
@@ -195,7 +187,7 @@ class TestChaCha20:
         with pytest.raises(AlreadyFinalized):
             dec.reset_nonce(nonce)
 
-    def test_nonce_reset_invalid_length(self, backend):
+    def test_nonce_reset_invalid_length(self):
         key = b"\x00" * 32
         nonce = b"\x00" * 16
         cipher = Cipher(algorithms.ChaCha20(key, nonce), None)

--- a/tests/hazmat/primitives/test_cmac.py
+++ b/tests/hazmat/primitives/test_cmac.py
@@ -49,22 +49,22 @@ fake_key = b"\x00" * 16
 
 class TestCMAC:
     @pytest.mark.parametrize("params", vectors_aes)
-    def test_aes_generate(self, backend, params):
+    def test_aes_generate(self, params):
         key = params["key"]
         message = params["message"]
         output = params["output"]
 
-        cmac = CMAC(AES(binascii.unhexlify(key)), backend)
+        cmac = CMAC(AES(binascii.unhexlify(key)))
         cmac.update(binascii.unhexlify(message))
         assert binascii.hexlify(cmac.finalize()) == output
 
     @pytest.mark.parametrize("params", vectors_aes)
-    def test_aes_verify(self, backend, params):
+    def test_aes_verify(self, params):
         key = params["key"]
         message = params["message"]
         output = params["output"]
 
-        cmac = CMAC(AES(binascii.unhexlify(key)), backend)
+        cmac = CMAC(AES(binascii.unhexlify(key)))
         cmac.update(binascii.unhexlify(message))
         cmac.verify(binascii.unhexlify(output))
 
@@ -75,7 +75,7 @@ class TestCMAC:
         skip_message="Does not support CMAC.",
     )
     @pytest.mark.parametrize("params", vectors_3des)
-    def test_3des_generate(self, backend, params):
+    def test_3des_generate(self, params):
         key1 = params["key1"]
         key2 = params["key2"]
         key3 = params["key3"]
@@ -85,7 +85,7 @@ class TestCMAC:
         message = params["message"]
         output = params["output"]
 
-        cmac = CMAC(TripleDES(binascii.unhexlify(key)), backend)
+        cmac = CMAC(TripleDES(binascii.unhexlify(key)))
         cmac.update(binascii.unhexlify(message))
         assert binascii.hexlify(cmac.finalize()) == output
 
@@ -96,7 +96,7 @@ class TestCMAC:
         skip_message="Does not support CMAC.",
     )
     @pytest.mark.parametrize("params", vectors_3des)
-    def test_3des_verify(self, backend, params):
+    def test_3des_verify(self, params):
         key1 = params["key1"]
         key2 = params["key2"]
         key3 = params["key3"]
@@ -106,13 +106,13 @@ class TestCMAC:
         message = params["message"]
         output = params["output"]
 
-        cmac = CMAC(TripleDES(binascii.unhexlify(key)), backend)
+        cmac = CMAC(TripleDES(binascii.unhexlify(key)))
         cmac.update(binascii.unhexlify(message))
         cmac.verify(binascii.unhexlify(output))
 
-    def test_invalid_verify(self, backend):
+    def test_invalid_verify(self):
         key = b"2b7e151628aed2a6abf7158809cf4f3c"
-        cmac = CMAC(AES(key), backend)
+        cmac = CMAC(AES(key))
         cmac.update(b"6bc1bee22e409f96e93d7e117393172a")
 
         with pytest.raises(InvalidSignature):
@@ -122,17 +122,17 @@ class TestCMAC:
         only_if=lambda backend: backend.cipher_supported(ARC4(fake_key), None),
         skip_message="Does not support CMAC.",
     )
-    def test_invalid_algorithm(self, backend):
+    def test_invalid_algorithm(self):
         key = b"0102030405"
         with pytest.raises(TypeError):
-            CMAC(typing.cast(typing.Any, ARC4(key)), backend)
+            CMAC(typing.cast(typing.Any, ARC4(key)))
 
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_CIPHER):
-            CMAC(DummyBlockCipherAlgorithm(b"bad"), backend)
+            CMAC(DummyBlockCipherAlgorithm(b"bad"))
 
-    def test_raises_after_finalize(self, backend):
+    def test_raises_after_finalize(self):
         key = b"2b7e151628aed2a6abf7158809cf4f3c"
-        cmac = CMAC(AES(key), backend)
+        cmac = CMAC(AES(key))
         cmac.finalize()
 
         with pytest.raises(AlreadyFinalized):
@@ -147,9 +147,9 @@ class TestCMAC:
         with pytest.raises(AlreadyFinalized):
             cmac.verify(b"")
 
-    def test_verify_reject_unicode(self, backend):
+    def test_verify_reject_unicode(self):
         key = b"2b7e151628aed2a6abf7158809cf4f3c"
-        cmac = CMAC(AES(key), backend)
+        cmac = CMAC(AES(key))
 
         with pytest.raises(TypeError):
             cmac.update(typing.cast(typing.Any, ""))
@@ -157,16 +157,16 @@ class TestCMAC:
         with pytest.raises(TypeError):
             cmac.verify(typing.cast(typing.Any, ""))
 
-    def test_copy_with_backend(self, backend):
+    def test_copy_with_backend(self):
         key = b"2b7e151628aed2a6abf7158809cf4f3c"
-        cmac = CMAC(AES(key), backend)
+        cmac = CMAC(AES(key))
         cmac.update(b"6bc1bee22e409f96e93d7e117393172a")
         copy_cmac = cmac.copy()
         assert cmac.finalize() == copy_cmac.finalize()
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = bytearray(b"2b7e151628aed2a6abf7158809cf4f3c")
-        cmac = CMAC(AES(key), backend)
+        cmac = CMAC(AES(key))
         cmac.update(b"6bc1bee22e409f96e93d7e117393172a")
         assert cmac.finalize() == binascii.unhexlify(
             b"a21e6e647bfeaf5ca0a5e1bcd957dfad"

--- a/tests/hazmat/primitives/test_poly1305.py
+++ b/tests/hazmat/primitives/test_poly1305.py
@@ -27,7 +27,7 @@ from ...utils import (
     only_if=lambda backend: not backend.poly1305_supported(),
     skip_message="Requires OpenSSL without poly1305 support",
 )
-def test_poly1305_unsupported(backend):
+def test_poly1305_unsupported():
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_MAC):
         Poly1305(b"0" * 32)
 
@@ -43,7 +43,7 @@ class TestPoly1305:
             os.path.join("poly1305", "rfc7539.txt"), load_nist_vectors
         ),
     )
-    def test_vectors(self, vector, backend):
+    def test_vectors(self, vector):
         key = binascii.unhexlify(vector["key"])
         msg = binascii.unhexlify(vector["msg"])
         tag = binascii.unhexlify(vector["tag"])
@@ -54,11 +54,11 @@ class TestPoly1305:
         assert Poly1305.generate_tag(key, msg) == tag
         Poly1305.verify_tag(key, msg, tag)
 
-    def test_key_with_no_additional_references(self, backend):
+    def test_key_with_no_additional_references(self):
         poly = Poly1305(os.urandom(32))
         assert len(poly.finalize()) == 16
 
-    def test_raises_after_finalize(self, backend):
+    def test_raises_after_finalize(self):
         poly = Poly1305(b"0" * 32)
         poly.finalize()
 
@@ -68,7 +68,7 @@ class TestPoly1305:
         with pytest.raises(AlreadyFinalized):
             poly.finalize()
 
-    def test_reject_unicode(self, backend):
+    def test_reject_unicode(self):
         poly = Poly1305(b"0" * 32)
         with pytest.raises(TypeError):
             poly.update(typing.cast(typing.Any, ""))
@@ -76,7 +76,7 @@ class TestPoly1305:
         with pytest.raises(TypeError):
             Poly1305.generate_tag(b"0" * 32, typing.cast(typing.Any, ""))
 
-    def test_verify(self, backend):
+    def test_verify(self):
         poly = Poly1305(b"0" * 32)
         poly.update(b"msg")
         tag = poly.finalize()
@@ -90,7 +90,7 @@ class TestPoly1305:
 
         Poly1305.verify_tag(b"0" * 32, b"msg", tag)
 
-    def test_invalid_verify(self, backend):
+    def test_invalid_verify(self):
         poly = Poly1305(b"0" * 32)
         poly.update(b"msg")
         with pytest.raises(InvalidSignature):
@@ -104,7 +104,7 @@ class TestPoly1305:
         with pytest.raises(InvalidSignature):
             Poly1305.verify_tag(b"0" * 32, b"msg", b"\x00" * 16)
 
-    def test_verify_reject_unicode(self, backend):
+    def test_verify_reject_unicode(self):
         poly = Poly1305(b"0" * 32)
         with pytest.raises(TypeError):
             poly.verify(typing.cast(typing.Any, ""))
@@ -112,14 +112,14 @@ class TestPoly1305:
         with pytest.raises(TypeError):
             Poly1305.verify_tag(b"0" * 32, b"msg", typing.cast(typing.Any, ""))
 
-    def test_invalid_key_type(self, backend):
+    def test_invalid_key_type(self):
         with pytest.raises(TypeError):
             Poly1305(typing.cast(typing.Any, object()))
 
         with pytest.raises(TypeError):
             Poly1305.generate_tag(typing.cast(typing.Any, object()), b"msg")
 
-    def test_invalid_key_length(self, backend):
+    def test_invalid_key_length(self):
         with pytest.raises(ValueError):
             Poly1305(b"0" * 31)
 
@@ -132,7 +132,7 @@ class TestPoly1305:
         with pytest.raises(ValueError):
             Poly1305.generate_tag(b"0" * 33, b"msg")
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = binascii.unhexlify(
             b"1c9240a5eb55d38af333888604f6b5f0473917c1402b80099dca5cbc207075c0"
         )

--- a/tests/hazmat/primitives/test_sm4.py
+++ b/tests/hazmat/primitives/test_sm4.py
@@ -109,7 +109,7 @@ class TestSM4ModeGCM:
             load_nist_vectors,
         ),
     )
-    def test_encryption(self, vector, backend):
+    def test_encryption(self, vector):
         key = binascii.unhexlify(vector["key"])
         iv = binascii.unhexlify(vector["iv"])
         associated_data = binascii.unhexlify(vector["aad"])
@@ -131,7 +131,7 @@ class TestSM4ModeGCM:
             load_nist_vectors,
         ),
     )
-    def test_decryption(self, vector, backend):
+    def test_decryption(self, vector):
         key = binascii.unhexlify(vector["key"])
         iv = binascii.unhexlify(vector["iv"])
         associated_data = binascii.unhexlify(vector["aad"])
@@ -160,7 +160,7 @@ class TestSM4ModeGCM:
             load_nist_vectors,
         ),
     )
-    def test_invalid_tag(self, vector, backend):
+    def test_invalid_tag(self, vector):
         key = binascii.unhexlify(vector["key"])
         iv = binascii.unhexlify(vector["iv"])
         associated_data = binascii.unhexlify(vector["aad"])


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (FIPS checks, `*_supported()` probes, or helpers that do) are left untouched.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_