### PR TITLE
Remove no-op backend arguments in hash, HMAC, XOF, and Argon2 tests

### DIFF
--- a/tests/hazmat/primitives/test_argon2.py
+++ b/tests/hazmat/primitives/test_argon2.py
@@ -38,7 +38,7 @@ for clazz in variants:
     only_if=lambda backend: not backend.argon2_supported(),
     skip_message="Supports argon2 so can't test unsupported path",
 )
-def test_unsupported_backend(backend):
+def test_unsupported_backend():
     with raises_unsupported_algorithm(None):
         Argon2id(
             salt=b"salt" * 2, length=32, iterations=1, lanes=1, memory_cost=32
@@ -58,7 +58,7 @@ class TestArgon2:
     @pytest.mark.parametrize(
         "params", vectors, ids=lambda x: f"{x[0].__name__}-params"
     )
-    def test_derive(self, params, backend):
+    def test_derive(self, params):
         argon_clazz, params = params
         salt = binascii.unhexlify(params["salt"])
         ad = binascii.unhexlify(params["ad"]) if "ad" in params else None
@@ -85,7 +85,7 @@ class TestArgon2:
         )
         assert binascii.hexlify(variant.derive(password)) == derived_key
 
-    def test_invalid_types(self, clazz, backend):
+    def test_invalid_types(self, clazz):
         with pytest.raises(TypeError):
             clazz(
                 salt="notbytes",
@@ -130,7 +130,7 @@ class TestArgon2:
             (b"b" * 8, 32, 1, 32, 200),  # memory_cost < 8 * lanes
         ],
     )
-    def test_invalid_values(self, clazz, params, backend):
+    def test_invalid_values(self, clazz, params):
         (salt, length, iterations, lanes, memory_cost) = params
         with pytest.raises(ValueError):
             clazz(
@@ -142,7 +142,7 @@ class TestArgon2:
             )
 
     @pytest.mark.malloc_failure
-    def test_argon2_malloc_failure(self, clazz, backend):
+    def test_argon2_malloc_failure(self, clazz):
         # memory_cost is in KiB, so 2**32 - 1 KiB is ~4 TiB. This should
         # fail to allocate on any reasonable system.
         argon2 = clazz(
@@ -155,7 +155,7 @@ class TestArgon2:
         with pytest.raises(MemoryError):
             argon2.derive(b"password")
 
-    def test_already_finalized(self, clazz, backend):
+    def test_already_finalized(self, clazz):
         argon2id = clazz(
             salt=b"salt" * 2, length=32, iterations=1, lanes=1, memory_cost=32
         )
@@ -163,7 +163,7 @@ class TestArgon2:
         with pytest.raises(AlreadyFinalized):
             argon2id.derive(b"password")
 
-    def test_already_finalized_verify(self, clazz, backend):
+    def test_already_finalized_verify(self, clazz):
         argon2id = clazz(
             salt=b"salt" * 2, length=32, iterations=1, lanes=1, memory_cost=32
         )
@@ -172,14 +172,14 @@ class TestArgon2:
             argon2id.verify(b"password", digest)
 
     @pytest.mark.parametrize("digest", [b"invalidkey", b"0" * 32])
-    def test_invalid_verify(self, clazz, digest, backend):
+    def test_invalid_verify(self, clazz, digest):
         argon2id = clazz(
             salt=b"salt" * 2, length=32, iterations=1, lanes=1, memory_cost=32
         )
         with pytest.raises(InvalidKey):
             argon2id.verify(b"password", digest)
 
-    def test_verify(self, clazz, backend):
+    def test_verify(self, clazz):
         argon2id = clazz(
             salt=b"salt" * 2,
             length=32,
@@ -194,7 +194,7 @@ class TestArgon2:
             salt=b"salt" * 2, length=32, iterations=1, lanes=1, memory_cost=32
         ).verify(b"password", digest)
 
-    def test_derive_into(self, clazz, backend):
+    def test_derive_into(self, clazz):
         argon2 = clazz(
             salt=b"salt" * 2, length=32, iterations=1, lanes=1, memory_cost=32
         )
@@ -211,9 +211,7 @@ class TestArgon2:
     @pytest.mark.parametrize(
         ("buflen", "outlen"), [(31, 32), (33, 32), (16, 32), (64, 32)]
     )
-    def test_derive_into_buffer_incorrect_size(
-        self, clazz, buflen, outlen, backend
-    ):
+    def test_derive_into_buffer_incorrect_size(self, clazz, buflen, outlen):
         argon2 = clazz(
             salt=b"salt" * 2,
             length=outlen,
@@ -225,7 +223,7 @@ class TestArgon2:
         with pytest.raises(ValueError, match="buffer must be"):
             argon2.derive_into(b"password", buf)
 
-    def test_derive_into_already_finalized(self, clazz, backend):
+    def test_derive_into_already_finalized(self, clazz):
         argon2 = clazz(
             salt=b"salt" * 2, length=32, iterations=1, lanes=1, memory_cost=32
         )
@@ -234,7 +232,7 @@ class TestArgon2:
         with pytest.raises(AlreadyFinalized):
             argon2.derive_into(b"password2", buf)
 
-    def test_derive_phc_encoded(self, backend):
+    def test_derive_phc_encoded(self):
         # Test that we can generate a PHC formatted string
         argon2id = Argon2id(
             salt=b"0" * 8,

--- a/tests/hazmat/primitives/test_hash_vectors.py
+++ b/tests/hazmat/primitives/test_hash_vectors.py
@@ -198,7 +198,7 @@ class TestSHAKE128:
         hashes.SHAKE128(digest_size=16),
     )
 
-    def test_shake128_variable(self, backend, subtests):
+    def test_shake128_variable(self, subtests):
         vectors = _load_all_params(
             os.path.join("hashes", "SHAKE"),
             ["SHAKE128VariableOut.rsp"],
@@ -209,7 +209,7 @@ class TestSHAKE128:
                 output_length = int(vector["outputlen"]) // 8
                 msg = binascii.unhexlify(vector["msg"])
                 shake = hashes.SHAKE128(digest_size=output_length)
-                m = hashes.Hash(shake, backend=backend)
+                m = hashes.Hash(shake)
                 m.update(msg)
                 assert m.finalize() == binascii.unhexlify(vector["output"])
 
@@ -228,7 +228,7 @@ class TestSHAKE256:
         hashes.SHAKE256(digest_size=32),
     )
 
-    def test_shake256_variable(self, backend, subtests):
+    def test_shake256_variable(self, subtests):
         vectors = _load_all_params(
             os.path.join("hashes", "SHAKE"),
             ["SHAKE256VariableOut.rsp"],
@@ -239,7 +239,7 @@ class TestSHAKE256:
                 output_length = int(vector["outputlen"]) // 8
                 msg = binascii.unhexlify(vector["msg"])
                 shake = hashes.SHAKE256(digest_size=output_length)
-                m = hashes.Hash(shake, backend=backend)
+                m = hashes.Hash(shake)
                 m.update(msg)
                 assert m.finalize() == binascii.unhexlify(vector["output"])
 

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -17,17 +17,17 @@ from .utils import generate_base_hash_test
 
 
 class TestHashContext:
-    def test_hash_reject_unicode(self, backend):
-        m = hashes.Hash(hashes.SHA1(), backend=backend)
+    def test_hash_reject_unicode(self):
+        m = hashes.Hash(hashes.SHA1())
         with pytest.raises(TypeError):
             m.update(typing.cast(typing.Any, "\u00fc"))
 
-    def test_hash_algorithm_instance(self, backend):
+    def test_hash_algorithm_instance(self):
         with pytest.raises(TypeError):
-            hashes.Hash(typing.cast(typing.Any, hashes.SHA1), backend=backend)
+            hashes.Hash(typing.cast(typing.Any, hashes.SHA1))
 
-    def test_raises_after_finalize(self, backend):
-        h = hashes.Hash(hashes.SHA1(), backend=backend)
+    def test_raises_after_finalize(self):
+        h = hashes.Hash(hashes.SHA1())
         h.finalize()
 
         with pytest.raises(AlreadyFinalized):
@@ -39,9 +39,9 @@ class TestHashContext:
         with pytest.raises(AlreadyFinalized):
             h.finalize()
 
-    def test_unsupported_hash(self, backend):
+    def test_unsupported_hash(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):
-            hashes.Hash(DummyHashAlgorithm(), backend)
+            hashes.Hash(DummyHashAlgorithm())
 
 
 @pytest.mark.supported(
@@ -106,7 +106,7 @@ class TestBLAKE2b:
         digest_size=64,
     )
 
-    def test_invalid_digest_size(self, backend):
+    def test_invalid_digest_size(self):
         with pytest.raises(ValueError):
             hashes.BLAKE2b(digest_size=65)
 
@@ -129,7 +129,7 @@ class TestBLAKE2s:
         digest_size=32,
     )
 
-    def test_invalid_digest_size(self, backend):
+    def test_invalid_digest_size(self):
         with pytest.raises(ValueError):
             hashes.BLAKE2s(digest_size=33)
 
@@ -146,9 +146,9 @@ def test_non_contiguous_buffer_rejected():
         h.update(memoryview(bytearray(10))[::-1])
 
 
-def test_buffer_protocol_hash(backend):
+def test_buffer_protocol_hash():
     data = binascii.unhexlify(b"b4190e")
-    h = hashes.Hash(hashes.SHA256(), backend)
+    h = hashes.Hash(hashes.SHA256())
     h.update(bytearray(data))
     assert h.finalize() == binascii.unhexlify(
         b"dff2e73091f6c05e528896c4c831b9448653dc2ff043528f6769437bc7b975c2"

--- a/tests/hazmat/primitives/test_hmac.py
+++ b/tests/hazmat/primitives/test_hmac.py
@@ -31,21 +31,17 @@ class TestHMACCopy:
 
 
 class TestHMAC:
-    def test_hmac_reject_unicode(self, backend):
-        h = hmac.HMAC(b"mykey", hashes.SHA1(), backend=backend)
+    def test_hmac_reject_unicode(self):
+        h = hmac.HMAC(b"mykey", hashes.SHA1())
         with pytest.raises(TypeError):
             h.update(typing.cast(typing.Any, "\u00fc"))
 
-    def test_hmac_algorithm_instance(self, backend):
+    def test_hmac_algorithm_instance(self):
         with pytest.raises(TypeError):
-            hmac.HMAC(
-                b"key",
-                typing.cast(typing.Any, hashes.SHA1),
-                backend=backend,
-            )
+            hmac.HMAC(b"key", typing.cast(typing.Any, hashes.SHA1))
 
-    def test_raises_after_finalize(self, backend):
-        h = hmac.HMAC(b"key", hashes.SHA1(), backend=backend)
+    def test_raises_after_finalize(self):
+        h = hmac.HMAC(b"key", hashes.SHA1())
         h.finalize()
 
         with pytest.raises(AlreadyFinalized):
@@ -57,39 +53,39 @@ class TestHMAC:
         with pytest.raises(AlreadyFinalized):
             h.finalize()
 
-    def test_verify(self, backend):
-        h = hmac.HMAC(b"", hashes.SHA1(), backend=backend)
+    def test_verify(self):
+        h = hmac.HMAC(b"", hashes.SHA1())
         digest = h.finalize()
 
-        h = hmac.HMAC(b"", hashes.SHA1(), backend=backend)
+        h = hmac.HMAC(b"", hashes.SHA1())
         h.verify(digest)
 
         with pytest.raises(AlreadyFinalized):
             h.verify(b"")
 
-    def test_invalid_verify(self, backend):
-        h = hmac.HMAC(b"", hashes.SHA1(), backend=backend)
+    def test_invalid_verify(self):
+        h = hmac.HMAC(b"", hashes.SHA1())
         with pytest.raises(InvalidSignature):
             h.verify(b"")
 
         with pytest.raises(AlreadyFinalized):
             h.verify(b"")
 
-    def test_verify_reject_unicode(self, backend):
-        h = hmac.HMAC(b"", hashes.SHA1(), backend=backend)
+    def test_verify_reject_unicode(self):
+        h = hmac.HMAC(b"", hashes.SHA1())
         with pytest.raises(TypeError):
             h.verify(typing.cast(typing.Any, ""))
 
-    def test_unsupported_hash(self, backend):
+    def test_unsupported_hash(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):
-            hmac.HMAC(b"key", DummyHashAlgorithm(), backend)
+            hmac.HMAC(b"key", DummyHashAlgorithm())
 
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):
-            hmac.HMAC(b"key", hashes.SHAKE256(digest_size=256), backend)
+            hmac.HMAC(b"key", hashes.SHAKE256(digest_size=256))
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = bytearray(b"2b7e151628aed2a6abf7158809cf4f3c")
-        h = hmac.HMAC(key, hashes.SHA256(), backend)
+        h = hmac.HMAC(key, hashes.SHA256())
         h.update(bytearray(b"6bc1bee22e409f96e93d7e117393172a"))
         assert h.finalize() == binascii.unhexlify(
             b"a1bf7169c56a501c6585190ff4f07cad6e492a3ee187c0372614fb444b9fc3f0"

--- a/tests/hazmat/primitives/test_hmac_vectors.py
+++ b/tests/hazmat/primitives/test_hmac_vectors.py
@@ -78,8 +78,8 @@ class TestHMACSHA512:
     skip_message="Does not support BLAKE2",
 )
 class TestHMACBLAKE2:
-    def test_blake2b(self, backend):
-        h = hmac.HMAC(b"0" * 64, hashes.BLAKE2b(digest_size=64), backend)
+    def test_blake2b(self):
+        h = hmac.HMAC(b"0" * 64, hashes.BLAKE2b(digest_size=64))
         h.update(b"test")
         digest = h.finalize()
         assert digest == binascii.unhexlify(
@@ -87,8 +87,8 @@ class TestHMACBLAKE2:
             b"87dba4aeaa69e6bed7edc44f48d6b1be493a3ce583f9c737c53d6bacc09e2f32"
         )
 
-    def test_blake2s(self, backend):
-        h = hmac.HMAC(b"0" * 32, hashes.BLAKE2s(digest_size=32), backend)
+    def test_blake2s(self):
+        h = hmac.HMAC(b"0" * 32, hashes.BLAKE2s(digest_size=32))
         h.update(b"test")
         digest = h.finalize()
         assert digest == binascii.unhexlify(

--- a/tests/hazmat/primitives/test_xofhash.py
+++ b/tests/hazmat/primitives/test_xofhash.py
@@ -30,7 +30,7 @@ def _xof_supported() -> bool:
     only_if=lambda backend: not _xof_supported(),
     skip_message="Requires backend without XOF support",
 )
-def test_unsupported_xof(backend):
+def test_unsupported_xof():
     with pytest.raises(UnsupportedAlgorithm):
         hashes.XOFHash(hashes.SHAKE128(digest_size=32))
 
@@ -40,12 +40,12 @@ def test_unsupported_xof(backend):
     skip_message="Requires backend with XOF support",
 )
 class TestXOFHash:
-    def test_hash_reject_unicode(self, backend):
+    def test_hash_reject_unicode(self):
         m = hashes.XOFHash(hashes.SHAKE128(sys.maxsize))
         with pytest.raises(TypeError):
             m.update(typing.cast(typing.Any, "\u00fc"))
 
-    def test_incorrect_hash_algorithm_type(self, backend):
+    def test_incorrect_hash_algorithm_type(self):
         with pytest.raises(TypeError):
             # Instance required
             hashes.XOFHash(typing.cast(typing.Any, hashes.SHAKE128))
@@ -53,7 +53,7 @@ class TestXOFHash:
         with pytest.raises(TypeError):
             hashes.XOFHash(typing.cast(typing.Any, hashes.SHA256()))
 
-    def test_raises_update_after_squeeze(self, backend):
+    def test_raises_update_after_squeeze(self):
         h = hashes.XOFHash(hashes.SHAKE128(digest_size=256))
         h.update(b"foo")
         h.squeeze(5)
@@ -61,14 +61,14 @@ class TestXOFHash:
         with pytest.raises(AlreadyFinalized):
             h.update(b"bar")
 
-    def test_copy(self, backend):
+    def test_copy(self):
         h = hashes.XOFHash(hashes.SHAKE128(digest_size=256))
         h.update(b"foo")
         h.update(b"bar")
         h2 = h.copy()
         assert h2.squeeze(10) == h.squeeze(10)
 
-    def test_exhaust_bytes(self, backend):
+    def test_exhaust_bytes(self):
         h = hashes.XOFHash(hashes.SHAKE128(digest_size=256))
         h.update(b"foo")
         with pytest.raises(ValueError):
@@ -84,7 +84,7 @@ class TestXOFHash:
     skip_message="Requires backend with XOF support",
 )
 class TestXOFSHAKE128:
-    def test_shake128_variable(self, backend, subtests):
+    def test_shake128_variable(self, subtests):
         vectors = _load_all_params(
             os.path.join("hashes", "SHAKE"),
             ["SHAKE128VariableOut.rsp"],
@@ -112,7 +112,7 @@ class TestXOFSHAKE128:
     skip_message="Requires backend with XOF support",
 )
 class TestXOFSHAKE256:
-    def test_shake256_variable(self, backend, subtests):
+    def test_shake256_variable(self, subtests):
         vectors = _load_all_params(
             os.path.join("hashes", "SHAKE"),
             ["SHAKE256VariableOut.rsp"],


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions in `test_hashes.py`, `test_hash_vectors.py`, `test_hmac.py`, `test_hmac_vectors.py`, `test_xofhash.py`, and `test_argon2.py` that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (FIPS checks, `*_supported()` probes, or helpers that do) are left untouched.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_