### PR TITLE
Remove no-op backend arguments in HKDF and X9.63 KDF tests

### DIFF
--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -19,7 +19,7 @@ from ...utils import load_nist_vectors, load_vectors_from_file
 
 
 class TestHKDF:
-    def test_overflow_protection_enormous_digest_size(self, backend):
+    def test_overflow_protection_enormous_digest_size(self):
         enormous_digest_size = sys.maxsize >> 3
         dummy_hash = DummyHashAlgorithm(enormous_digest_size)
 
@@ -28,54 +28,47 @@ class TestHKDF:
         ):
             HKDF(dummy_hash, 32, salt=None, info=None)
 
-    def test_length_limit(self, backend):
+    def test_length_limit(self):
         big_length = 255 * hashes.SHA256().digest_size + 1
 
         with pytest.raises(ValueError):
-            HKDF(
-                hashes.SHA256(),
-                big_length,
-                salt=None,
-                info=None,
-                backend=backend,
-            )
+            HKDF(hashes.SHA256(), big_length, salt=None, info=None)
 
-    def test_already_finalized(self, backend):
-        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None, backend=backend)
+    def test_already_finalized(self):
+        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None)
 
         hkdf.derive(b"\x01" * 16)
 
         with pytest.raises(AlreadyFinalized):
             hkdf.derive(b"\x02" * 16)
 
-        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None, backend=backend)
+        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None)
 
         hkdf.verify(b"\x01" * 16, b"gJ\xfb{\xb1Oi\xc5sMC\xb7\xe4@\xf7u")
 
         with pytest.raises(AlreadyFinalized):
             hkdf.verify(b"\x02" * 16, b"gJ\xfb{\xb1Oi\xc5sMC\xb7\xe4@\xf7u")
 
-        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None, backend=backend)
+        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None)
 
-    def test_verify(self, backend):
-        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None, backend=backend)
+    def test_verify(self):
+        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None)
 
         hkdf.verify(b"\x01" * 16, b"gJ\xfb{\xb1Oi\xc5sMC\xb7\xe4@\xf7u")
 
-    def test_verify_invalid(self, backend):
-        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None, backend=backend)
+    def test_verify_invalid(self):
+        hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None)
 
         with pytest.raises(InvalidKey):
             hkdf.verify(b"\x02" * 16, b"gJ\xfb{\xb1Oi\xc5sMC\xb7\xe4@\xf7u")
 
-    def test_unicode_typeerror(self, backend):
+    def test_unicode_typeerror(self):
         with pytest.raises(TypeError):
             HKDF(
                 hashes.SHA256(),
                 16,
                 salt=typing.cast(typing.Any, "foo"),
                 info=None,
-                backend=backend,
             )
 
         with pytest.raises(TypeError):
@@ -84,36 +77,29 @@ class TestHKDF:
                 16,
                 salt=None,
                 info=typing.cast(typing.Any, "foo"),
-                backend=backend,
             )
 
         with pytest.raises(TypeError):
-            hkdf = HKDF(
-                hashes.SHA256(), 16, salt=None, info=None, backend=backend
-            )
+            hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None)
 
             hkdf.derive(typing.cast(typing.Any, "foo"))
 
         with pytest.raises(TypeError):
-            hkdf = HKDF(
-                hashes.SHA256(), 16, salt=None, info=None, backend=backend
-            )
+            hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None)
 
             hkdf.verify(typing.cast(typing.Any, "foo"), b"bar")
 
         with pytest.raises(TypeError):
-            hkdf = HKDF(
-                hashes.SHA256(), 16, salt=None, info=None, backend=backend
-            )
+            hkdf = HKDF(hashes.SHA256(), 16, salt=None, info=None)
 
             hkdf.verify(b"foo", typing.cast(typing.Any, "bar"))
 
-    def test_derive_short_output(self, backend):
-        hkdf = HKDF(hashes.SHA256(), 4, salt=None, info=None, backend=backend)
+    def test_derive_short_output(self):
+        hkdf = HKDF(hashes.SHA256(), 4, salt=None, info=None)
 
         assert hkdf.derive(b"\x01" * 16) == b"gJ\xfb{"
 
-    def test_derive_long_output(self, backend):
+    def test_derive_long_output(self):
         vector = load_vectors_from_file(
             os.path.join("KDF", "hkdf-generated.txt"), load_nist_vectors
         )[0]
@@ -122,7 +108,6 @@ class TestHKDF:
             int(vector["l"]),
             salt=vector["salt"],
             info=vector["info"],
-            backend=backend,
         )
         ikm = binascii.unhexlify(vector["ikm"])
 
@@ -135,7 +120,7 @@ class TestHKDF:
         prk = hkdf._extract(b"0")  # type:ignore[attr-defined]
         assert len(prk) == 32
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         vector = load_vectors_from_file(
             os.path.join("KDF", "hkdf-generated.txt"), load_nist_vectors
         )[0]
@@ -144,7 +129,6 @@ class TestHKDF:
             int(vector["l"]),
             salt=vector["salt"],
             info=vector["info"],
-            backend=backend,
         )
         ikm = bytearray(binascii.unhexlify(vector["ikm"]))
 
@@ -175,7 +159,7 @@ class TestHKDF:
 
 
 class TestHKDFExpand:
-    def test_derive(self, backend):
+    def test_derive(self):
         prk = binascii.unhexlify(
             b"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
         )
@@ -186,11 +170,11 @@ class TestHKDFExpand:
         )
 
         info = binascii.unhexlify(b"f0f1f2f3f4f5f6f7f8f9")
-        hkdf = HKDFExpand(hashes.SHA256(), 42, info, backend)
+        hkdf = HKDFExpand(hashes.SHA256(), 42, info)
 
         assert binascii.hexlify(hkdf.derive(prk)) == okm
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         prk = bytearray(
             binascii.unhexlify(
                 b"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2"
@@ -204,11 +188,11 @@ class TestHKDFExpand:
         )
 
         info = binascii.unhexlify(b"f0f1f2f3f4f5f6f7f8f9")
-        hkdf = HKDFExpand(hashes.SHA256(), 42, info, backend)
+        hkdf = HKDFExpand(hashes.SHA256(), 42, info)
 
         assert binascii.hexlify(hkdf.derive(prk)) == okm
 
-    def test_verify(self, backend):
+    def test_verify(self):
         prk = binascii.unhexlify(
             b"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
         )
@@ -219,33 +203,33 @@ class TestHKDFExpand:
         )
 
         info = binascii.unhexlify(b"f0f1f2f3f4f5f6f7f8f9")
-        hkdf = HKDFExpand(hashes.SHA256(), 42, info, backend)
+        hkdf = HKDFExpand(hashes.SHA256(), 42, info)
 
         hkdf.verify(prk, binascii.unhexlify(okm))
 
-    def test_invalid_verify(self, backend):
+    def test_invalid_verify(self):
         prk = binascii.unhexlify(
             b"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
         )
 
         info = binascii.unhexlify(b"f0f1f2f3f4f5f6f7f8f9")
-        hkdf = HKDFExpand(hashes.SHA256(), 42, info, backend)
+        hkdf = HKDFExpand(hashes.SHA256(), 42, info)
 
         with pytest.raises(InvalidKey):
             hkdf.verify(prk, b"wrong key")
 
-    def test_already_finalized(self, backend):
+    def test_already_finalized(self):
         info = binascii.unhexlify(b"f0f1f2f3f4f5f6f7f8f9")
-        hkdf = HKDFExpand(hashes.SHA256(), 42, info, backend)
+        hkdf = HKDFExpand(hashes.SHA256(), 42, info)
 
         hkdf.derive(b"first")
 
         with pytest.raises(AlreadyFinalized):
             hkdf.derive(b"second")
 
-    def test_unicode_error(self, backend):
+    def test_unicode_error(self):
         info = binascii.unhexlify(b"f0f1f2f3f4f5f6f7f8f9")
-        hkdf = HKDFExpand(hashes.SHA256(), 42, info, backend)
+        hkdf = HKDFExpand(hashes.SHA256(), 42, info)
 
         with pytest.raises(TypeError):
             hkdf.derive(typing.cast(typing.Any, "first"))

--- a/tests/hazmat/primitives/test_x963kdf.py
+++ b/tests/hazmat/primitives/test_x963kdf.py
@@ -15,33 +15,33 @@ from cryptography.hazmat.primitives.kdf.x963kdf import X963KDF
 
 
 class TestX963KDF:
-    def test_length_limit(self, backend):
+    def test_length_limit(self):
         big_length = hashes.SHA256().digest_size * (2**32 - 1) + 1
         error = OverflowError if sys.maxsize <= 2**31 else ValueError
 
         with pytest.raises(error):
-            X963KDF(hashes.SHA256(), big_length, None, backend)
+            X963KDF(hashes.SHA256(), big_length, None)
 
-    def test_already_finalized(self, backend):
-        xkdf = X963KDF(hashes.SHA256(), 16, None, backend)
+    def test_already_finalized(self):
+        xkdf = X963KDF(hashes.SHA256(), 16, None)
 
         xkdf.derive(b"\x01" * 16)
 
         with pytest.raises(AlreadyFinalized):
             xkdf.derive(b"\x02" * 16)
 
-    def test_derive(self, backend):
+    def test_derive(self):
         key = binascii.unhexlify(
             b"96c05619d56c328ab95fe84b18264b08725b85e33fd34f08"
         )
 
         derivedkey = binascii.unhexlify(b"443024c3dae66b95e6f5670601558f71")
 
-        xkdf = X963KDF(hashes.SHA256(), 16, None, backend)
+        xkdf = X963KDF(hashes.SHA256(), 16, None)
 
         assert xkdf.derive(key) == derivedkey
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = bytearray(
             binascii.unhexlify(
                 b"96c05619d56c328ab95fe84b18264b08725b85e33fd34f08"
@@ -50,11 +50,11 @@ class TestX963KDF:
 
         derivedkey = binascii.unhexlify(b"443024c3dae66b95e6f5670601558f71")
 
-        xkdf = X963KDF(hashes.SHA256(), 16, None, backend)
+        xkdf = X963KDF(hashes.SHA256(), 16, None)
 
         assert xkdf.derive(key) == derivedkey
 
-    def test_verify(self, backend):
+    def test_verify(self):
         key = binascii.unhexlify(
             b"22518b10e70f2a3f243810ae3254139efbee04aa57c7af7d"
         )
@@ -68,74 +68,65 @@ class TestX963KDF:
             b"142d43525a78e5bc79a17f59676a5706dc54d54d4d1f0bd7e386128ec26afc21"
         )
 
-        xkdf = X963KDF(hashes.SHA256(), 128, sharedinfo, backend)
+        xkdf = X963KDF(hashes.SHA256(), 128, sharedinfo)
 
         xkdf.verify(key, derivedkey)
 
-    def test_invalid_verify(self, backend):
+    def test_invalid_verify(self):
         key = binascii.unhexlify(
             b"96c05619d56c328ab95fe84b18264b08725b85e33fd34f08"
         )
 
-        xkdf = X963KDF(hashes.SHA256(), 16, None, backend)
+        xkdf = X963KDF(hashes.SHA256(), 16, None)
 
         with pytest.raises(InvalidKey):
             xkdf.verify(key, b"wrong derived key")
 
-    def test_unicode_typeerror(self, backend):
+    def test_unicode_typeerror(self):
         with pytest.raises(TypeError):
             X963KDF(
-                hashes.SHA256(),
-                16,
-                sharedinfo=typing.cast(typing.Any, "foo"),
-                backend=backend,
+                hashes.SHA256(), 16, sharedinfo=typing.cast(typing.Any, "foo")
             )
 
         with pytest.raises(TypeError):
-            xkdf = X963KDF(
-                hashes.SHA256(), 16, sharedinfo=None, backend=backend
-            )
+            xkdf = X963KDF(hashes.SHA256(), 16, sharedinfo=None)
 
             xkdf.derive(typing.cast(typing.Any, "foo"))
 
         with pytest.raises(TypeError):
-            xkdf = X963KDF(
-                hashes.SHA256(), 16, sharedinfo=None, backend=backend
-            )
+            xkdf = X963KDF(hashes.SHA256(), 16, sharedinfo=None)
 
             xkdf.verify(typing.cast(typing.Any, "foo"), b"bar")
 
         with pytest.raises(TypeError):
-            xkdf = X963KDF(
-                hashes.SHA256(), 16, sharedinfo=None, backend=backend
-            )
+            xkdf = X963KDF(hashes.SHA256(), 16, sharedinfo=None)
 
             xkdf.verify(b"foo", typing.cast(typing.Any, "bar"))
 
-    def test_derive_into(self, backend):
+    def test_derive_into(self):
         key = binascii.unhexlify(
             b"96c05619d56c328ab95fe84b18264b08725b85e33fd34f08"
         )
-        xkdf = X963KDF(hashes.SHA256(), 16, None, backend)
+        xkdf = X963KDF(hashes.SHA256(), 16, None)
         buf = bytearray(16)
         n = xkdf.derive_into(key, buf)
         assert n == 16
         # Verify the output matches what derive would produce
-        xkdf2 = X963KDF(hashes.SHA256(), 16, None, backend)
+        xkdf2 = X963KDF(hashes.SHA256(), 16, None)
         expected = xkdf2.derive(key)
         assert buf == expected
 
     @pytest.mark.parametrize(
         ("buflen", "outlen"), [(15, 16), (17, 16), (8, 16), (32, 16)]
     )
-    def test_derive_into_buffer_incorrect_size(self, buflen, outlen, backend):
-        xkdf = X963KDF(hashes.SHA256(), outlen, None, backend)
+    def test_derive_into_buffer_incorrect_size(self, buflen, outlen):
+        xkdf = X963KDF(hashes.SHA256(), outlen, None)
         buf = bytearray(buflen)
         with pytest.raises(ValueError, match="buffer must be"):
             xkdf.derive_into(b"key", buf)
 
-    def test_derive_into_already_finalized(self, backend):
-        xkdf = X963KDF(hashes.SHA256(), 16, None, backend)
+    def test_derive_into_already_finalized(self):
+        xkdf = X963KDF(hashes.SHA256(), 16, None)
         buf = bytearray(16)
         xkdf.derive_into(b"key", buf)
         with pytest.raises(AlreadyFinalized):


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (such as `_skip_hashfn_unsupported` callers in `test_x963_vectors.py`, which is not touched) are left alone.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_