### PR TITLE
Remove no-op backend arguments in PBKDF2 and Scrypt tests

### DIFF
--- a/tests/hazmat/primitives/test_pbkdf2hmac.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac.py
@@ -16,78 +16,72 @@ from ...utils import raises_unsupported_algorithm
 
 
 class TestPBKDF2HMAC:
-    def test_already_finalized(self, backend):
-        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+    def test_already_finalized(self):
+        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         kdf.derive(b"password")
         with pytest.raises(AlreadyFinalized):
             kdf.derive(b"password2")
 
-        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         key = kdf.derive(b"password")
         with pytest.raises(AlreadyFinalized):
             kdf.verify(b"password", key)
 
-        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         kdf.verify(b"password", key)
         with pytest.raises(AlreadyFinalized):
             kdf.verify(b"password", key)
 
-    def test_unsupported_algorithm(self, backend):
+    def test_unsupported_algorithm(self):
         with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_HASH):
-            PBKDF2HMAC(DummyHashAlgorithm(), 20, b"salt", 10, backend)
+            PBKDF2HMAC(DummyHashAlgorithm(), 20, b"salt", 10)
 
-    def test_invalid_key(self, backend):
-        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+    def test_invalid_key(self):
+        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         key = kdf.derive(b"password")
 
-        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         with pytest.raises(InvalidKey):
             kdf.verify(b"password2", key)
 
-    def test_unicode_error_with_salt(self, backend):
+    def test_unicode_error_with_salt(self):
         with pytest.raises(TypeError):
-            PBKDF2HMAC(
-                hashes.SHA1(),
-                20,
-                typing.cast(typing.Any, "salt"),
-                10,
-                backend,
-            )
+            PBKDF2HMAC(hashes.SHA1(), 20, typing.cast(typing.Any, "salt"), 10)
 
-    def test_unicode_error_with_key_material(self, backend):
-        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+    def test_unicode_error_with_key_material(self):
+        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         with pytest.raises(TypeError):
             kdf.derive(typing.cast(typing.Any, "unicode here"))
 
-    def test_buffer_protocol(self, backend):
-        kdf = PBKDF2HMAC(hashes.SHA1(), 10, b"salt", 10, backend)
+    def test_buffer_protocol(self):
+        kdf = PBKDF2HMAC(hashes.SHA1(), 10, b"salt", 10)
         data = bytearray(b"data")
         assert kdf.derive(data) == b"\xe9n\xaa\x81\xbbt\xa4\xf6\x08\xce"
 
-    def test_derive_into(self, backend):
-        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+    def test_derive_into(self):
+        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         buf = bytearray(20)
         n = kdf.derive_into(b"password", buf)
         assert n == 20
         # Verify the output matches what derive would produce
-        kdf2 = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+        kdf2 = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         expected = kdf2.derive(b"password")
         assert buf == expected
 
     @pytest.mark.parametrize(("buflen", "outlen"), [(19, 20), (21, 20)])
-    def test_derive_into_buffer_incorrect_size(self, buflen, outlen, backend):
-        kdf = PBKDF2HMAC(hashes.SHA1(), outlen, b"salt", 10, backend)
+    def test_derive_into_buffer_incorrect_size(self, buflen, outlen):
+        kdf = PBKDF2HMAC(hashes.SHA1(), outlen, b"salt", 10)
         buf = bytearray(buflen)
         with pytest.raises(ValueError, match="buffer must be"):
             kdf.derive_into(b"password", buf)
 
-    def test_derive_into_already_finalized(self, backend):
-        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10, backend)
+    def test_derive_into_already_finalized(self):
+        kdf = PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 10)
         buf = bytearray(20)
         kdf.derive_into(b"password", buf)
         with pytest.raises(AlreadyFinalized):
             kdf.derive_into(b"password2", buf)
 
-    def test_zero_iterations(self, backend):
+    def test_zero_iterations(self):
         with pytest.raises(ValueError, match="iterations must be"):
-            PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 0, backend)
+            PBKDF2HMAC(hashes.SHA1(), 20, b"salt", 0)

--- a/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
+++ b/tests/hazmat/primitives/test_pbkdf2hmac_vectors.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from ...utils import load_nist_vectors, load_vectors_from_file
 
 
-def test_pbkdf2_hmacsha1_vectors(subtests, backend):
+def test_pbkdf2_hmacsha1_vectors(subtests):
     params = load_vectors_from_file(
         os.path.join("KDF", "rfc-6070-PBKDF2-SHA1.txt"),
         load_nist_vectors,

--- a/tests/hazmat/primitives/test_scrypt.py
+++ b/tests/hazmat/primitives/test_scrypt.py
@@ -53,7 +53,7 @@ def test_memory_limit_skip():
     only_if=lambda backend: not backend.scrypt_supported(),
     skip_message="Supports scrypt so can't test unsupported path",
 )
-def test_unsupported_backend(backend):
+def test_unsupported_backend():
     # This test is currently exercised by LibreSSL, which does
     # not support scrypt
     with raises_unsupported_algorithm(None):
@@ -66,7 +66,7 @@ def test_unsupported_backend(backend):
 )
 class TestScrypt:
     @pytest.mark.parametrize("params", vectors)
-    def test_derive(self, backend, params):
+    def test_derive(self, params):
         _skip_if_memory_limited(_MEM_LIMIT, params)
         password = params["password"]
         work_factor = int(params["n"])
@@ -77,16 +77,11 @@ class TestScrypt:
         derived_key = params["derived_key"]
 
         scrypt = Scrypt(
-            salt,
-            length,
-            work_factor,
-            block_size,
-            parallelization_factor,
-            backend,
+            salt, length, work_factor, block_size, parallelization_factor
         )
         assert binascii.hexlify(scrypt.derive(password)) == derived_key
 
-    def test_salt_not_bytes(self, backend):
+    def test_salt_not_bytes(self):
         work_factor = 1024
         block_size = 8
         parallelization_factor = 16
@@ -100,11 +95,10 @@ class TestScrypt:
                 work_factor,
                 block_size,
                 parallelization_factor,
-                backend,
             )
 
     @pytest.mark.malloc_failure
-    def test_scrypt_malloc_failure(self, backend):
+    def test_scrypt_malloc_failure(self):
         password = b"NaCl"
         work_factor = 1024**3
         block_size = 589824
@@ -113,18 +107,13 @@ class TestScrypt:
         salt = b"NaCl"
 
         scrypt = Scrypt(
-            salt,
-            length,
-            work_factor,
-            block_size,
-            parallelization_factor,
-            backend,
+            salt, length, work_factor, block_size, parallelization_factor
         )
 
         with pytest.raises(MemoryError):
             scrypt.derive(password)
 
-    def test_password_not_bytes(self, backend):
+    def test_password_not_bytes(self):
         password = 1
         work_factor = 1024
         block_size = 8
@@ -133,18 +122,13 @@ class TestScrypt:
         salt = b"NaCl"
 
         scrypt = Scrypt(
-            salt,
-            length,
-            work_factor,
-            block_size,
-            parallelization_factor,
-            backend,
+            salt, length, work_factor, block_size, parallelization_factor
         )
 
         with pytest.raises(TypeError):
             scrypt.derive(typing.cast(typing.Any, password))
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         password = bytearray(b"password")
         work_factor = 256
         block_size = 8
@@ -153,18 +137,13 @@ class TestScrypt:
         salt = b"NaCl"
 
         scrypt = Scrypt(
-            salt,
-            length,
-            work_factor,
-            block_size,
-            parallelization_factor,
-            backend,
+            salt, length, work_factor, block_size, parallelization_factor
         )
 
         assert scrypt.derive(password) == b"\xf4\x92\x86\xb2\x06\x0c\x848W\x87"
 
     @pytest.mark.parametrize("params", vectors)
-    def test_verify(self, backend, params):
+    def test_verify(self, params):
         _skip_if_memory_limited(_MEM_LIMIT, params)
         password = params["password"]
         work_factor = int(params["n"])
@@ -175,16 +154,11 @@ class TestScrypt:
         derived_key = params["derived_key"]
 
         scrypt = Scrypt(
-            salt,
-            length,
-            work_factor,
-            block_size,
-            parallelization_factor,
-            backend,
+            salt, length, work_factor, block_size, parallelization_factor
         )
         scrypt.verify(password, binascii.unhexlify(derived_key))
 
-    def test_invalid_verify(self, backend):
+    def test_invalid_verify(self):
         password = b"password"
         work_factor = 1024
         block_size = 8
@@ -194,18 +168,13 @@ class TestScrypt:
         derived_key = b"fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e773"
 
         scrypt = Scrypt(
-            salt,
-            length,
-            work_factor,
-            block_size,
-            parallelization_factor,
-            backend,
+            salt, length, work_factor, block_size, parallelization_factor
         )
 
         with pytest.raises(InvalidKey):
             scrypt.verify(password, binascii.unhexlify(derived_key))
 
-    def test_already_finalized(self, backend):
+    def test_already_finalized(self):
         password = b"password"
         work_factor = 1024
         block_size = 8
@@ -214,55 +183,50 @@ class TestScrypt:
         salt = b"NaCl"
 
         scrypt = Scrypt(
-            salt,
-            length,
-            work_factor,
-            block_size,
-            parallelization_factor,
-            backend,
+            salt, length, work_factor, block_size, parallelization_factor
         )
         scrypt.derive(password)
         with pytest.raises(AlreadyFinalized):
             scrypt.derive(password)
 
-    def test_invalid_n(self, backend):
+    def test_invalid_n(self):
         # n is less than 2
         with pytest.raises(ValueError):
-            Scrypt(b"NaCl", 64, 1, 8, 16, backend)
+            Scrypt(b"NaCl", 64, 1, 8, 16)
 
         # n is not a power of 2
         with pytest.raises(ValueError):
-            Scrypt(b"NaCl", 64, 3, 8, 16, backend)
+            Scrypt(b"NaCl", 64, 3, 8, 16)
 
-    def test_invalid_r(self, backend):
+    def test_invalid_r(self):
         with pytest.raises(ValueError):
-            Scrypt(b"NaCl", 64, 2, 0, 16, backend)
+            Scrypt(b"NaCl", 64, 2, 0, 16)
 
-    def test_invalid_p(self, backend):
+    def test_invalid_p(self):
         with pytest.raises(ValueError):
-            Scrypt(b"NaCl", 64, 2, 8, 0, backend)
+            Scrypt(b"NaCl", 64, 2, 8, 0)
 
-    def test_derive_into(self, backend):
-        scrypt = Scrypt(b"NaCl", 64, 1024, 8, 16, backend)
+    def test_derive_into(self):
+        scrypt = Scrypt(b"NaCl", 64, 1024, 8, 16)
         buf = bytearray(64)
         n = scrypt.derive_into(b"password", buf)
         assert n == 64
         # Verify the output matches what derive would produce
-        scrypt2 = Scrypt(b"NaCl", 64, 1024, 8, 16, backend)
+        scrypt2 = Scrypt(b"NaCl", 64, 1024, 8, 16)
         expected = scrypt2.derive(b"password")
         assert buf == expected
 
     @pytest.mark.parametrize(
         ("buflen", "outlen"), [(63, 64), (65, 64), (32, 64), (128, 64)]
     )
-    def test_derive_into_buffer_incorrect_size(self, buflen, outlen, backend):
-        scrypt = Scrypt(b"NaCl", outlen, 1024, 8, 16, backend)
+    def test_derive_into_buffer_incorrect_size(self, buflen, outlen):
+        scrypt = Scrypt(b"NaCl", outlen, 1024, 8, 16)
         buf = bytearray(buflen)
         with pytest.raises(ValueError, match="buffer must be"):
             scrypt.derive_into(b"password", buf)
 
-    def test_derive_into_already_finalized(self, backend):
-        scrypt = Scrypt(b"NaCl", 64, 1024, 8, 16, backend)
+    def test_derive_into_already_finalized(self):
+        scrypt = Scrypt(b"NaCl", 64, 1024, 8, 16)
         buf = bytearray(64)
         scrypt.derive_into(b"password", buf)
         with pytest.raises(AlreadyFinalized):


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_