### PR TITLE
Remove no-op backend arguments in Ed25519, Ed448, X25519, and X448 tests

### DIFF
--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -51,7 +51,7 @@ def test_ed25519_always_supported(backend):
 
 
 class TestEd25519Signing:
-    def test_sign_verify_input(self, backend, subtests):
+    def test_sign_verify_input(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "Ed25519", "sign.input"),
             load_ed25519_vectors,
@@ -75,7 +75,7 @@ class TestEd25519Signing:
                 )
                 public_key.verify(signature, message)
 
-    def test_pub_priv_bytes_raw(self, backend, subtests):
+    def test_pub_priv_bytes_raw(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "Ed25519", "sign.input"),
             load_ed25519_vectors,
@@ -89,7 +89,7 @@ class TestEd25519Signing:
                 public_key = Ed25519PublicKey.from_public_bytes(pk)
                 assert public_key.public_bytes_raw() == pk
 
-    def test_invalid_signature(self, backend):
+    def test_invalid_signature(self):
         key = Ed25519PrivateKey.generate()
         signature = key.sign(b"test data")
         with pytest.raises(InvalidSignature):
@@ -98,18 +98,18 @@ class TestEd25519Signing:
         with pytest.raises(InvalidSignature):
             key.public_key().verify(b"0" * 64, b"test data")
 
-    def test_sign_verify_buffer(self, backend):
+    def test_sign_verify_buffer(self):
         key = Ed25519PrivateKey.generate()
         data = bytearray(b"test data")
         signature = key.sign(data)
         key.public_key().verify(bytearray(signature), data)
 
-    def test_generate(self, backend):
+    def test_generate(self):
         key = Ed25519PrivateKey.generate()
         assert key
         assert key.public_key()
 
-    def test_load_public_bytes(self, backend):
+    def test_load_public_bytes(self):
         public_key = Ed25519PrivateKey.generate().public_key()
         public_bytes = public_key.public_bytes(
             serialization.Encoding.Raw, serialization.PublicFormat.Raw
@@ -119,31 +119,31 @@ class TestEd25519Signing:
             serialization.Encoding.Raw, serialization.PublicFormat.Raw
         )
 
-    def test_invalid_type_public_bytes(self, backend):
+    def test_invalid_type_public_bytes(self):
         with pytest.raises(TypeError):
             Ed25519PublicKey.from_public_bytes(
                 typing.cast(typing.Any, object())
             )
 
-    def test_invalid_type_private_bytes(self, backend):
+    def test_invalid_type_private_bytes(self):
         with pytest.raises(TypeError):
             Ed25519PrivateKey.from_private_bytes(
                 typing.cast(typing.Any, object())
             )
 
-    def test_invalid_length_from_public_bytes(self, backend):
+    def test_invalid_length_from_public_bytes(self):
         with pytest.raises(ValueError):
             Ed25519PublicKey.from_public_bytes(b"a" * 31)
         with pytest.raises(ValueError):
             Ed25519PublicKey.from_public_bytes(b"a" * 33)
 
-    def test_invalid_length_from_private_bytes(self, backend):
+    def test_invalid_length_from_private_bytes(self):
         with pytest.raises(ValueError):
             Ed25519PrivateKey.from_private_bytes(b"a" * 31)
         with pytest.raises(ValueError):
             Ed25519PrivateKey.from_private_bytes(b"a" * 33)
 
-    def test_invalid_private_bytes(self, backend):
+    def test_invalid_private_bytes(self):
         key = Ed25519PrivateKey.generate()
         with pytest.raises(TypeError):
             key.private_bytes(
@@ -179,7 +179,7 @@ class TestEd25519Signing:
                 serialization.NoEncryption(),
             )
 
-    def test_invalid_public_bytes(self, backend):
+    def test_invalid_public_bytes(self):
         key = Ed25519PrivateKey.generate().public_key()
         with pytest.raises(ValueError):
             key.public_bytes(
@@ -243,11 +243,11 @@ class TestEd25519Signing:
         ],
     )
     def test_round_trip_private_serialization(
-        self, encoding, fmt, encryption, passwd, load_func, backend
+        self, encoding, fmt, encryption, passwd, load_func
     ):
         key = Ed25519PrivateKey.generate()
         serialized = key.private_bytes(encoding, fmt, encryption)
-        loaded_key = load_func(serialized, passwd, backend)
+        loaded_key = load_func(serialized, passwd)
         assert isinstance(loaded_key, Ed25519PrivateKey)
 
     def test_invalid_public_key_pem(self):
@@ -259,7 +259,7 @@ class TestEd25519Signing:
             -----END PUBLIC KEY-----""").encode()
             )
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         private_bytes = os.urandom(32)
         key = Ed25519PrivateKey.from_private_bytes(bytearray(private_bytes))
         assert (
@@ -272,7 +272,7 @@ class TestEd25519Signing:
         )
 
 
-def test_public_key_equality(backend):
+def test_public_key_equality():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -289,7 +289,7 @@ def test_public_key_equality(backend):
         key1 < key2  # type: ignore[operator]
 
 
-def test_public_key_copy(backend):
+def test_public_key_copy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -301,7 +301,7 @@ def test_public_key_copy(backend):
     assert key1 == key2
 
 
-def test_public_key_deepcopy(backend):
+def test_public_key_deepcopy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -313,7 +313,7 @@ def test_public_key_deepcopy(backend):
     assert key1 == key2
 
 
-def test_private_key_copy(backend):
+def test_private_key_copy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -325,7 +325,7 @@ def test_private_key_copy(backend):
     assert key1 == key2
 
 
-def test_private_key_deepcopy(backend):
+def test_private_key_deepcopy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed25519", "ed25519-pkcs8.der"),
         lambda derfile: derfile.read(),

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -30,7 +30,7 @@ from ...utils import (
     only_if=lambda backend: not backend.ed448_supported(),
     skip_message="Requires OpenSSL without Ed448 support",
 )
-def test_ed448_unsupported(backend):
+def test_ed448_unsupported():
     with raises_unsupported_algorithm(
         _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
     ):
@@ -59,7 +59,7 @@ class TestEd448Signing:
             load_nist_vectors,
         ),
     )
-    def test_sign_input(self, vector, backend):
+    def test_sign_input(self, vector):
         if vector.get("context") is not None:
             pytest.skip("ed448 contexts are not currently supported")
 
@@ -79,7 +79,7 @@ class TestEd448Signing:
         )
         public_key.verify(signature, message)
 
-    def test_invalid_signature(self, backend):
+    def test_invalid_signature(self):
         key = Ed448PrivateKey.generate()
         signature = key.sign(b"test data")
         with pytest.raises(InvalidSignature):
@@ -88,13 +88,13 @@ class TestEd448Signing:
         with pytest.raises(InvalidSignature):
             key.public_key().verify(b"0" * 64, b"test data")
 
-    def test_sign_verify_buffer(self, backend):
+    def test_sign_verify_buffer(self):
         key = Ed448PrivateKey.generate()
         data = bytearray(b"test data")
         signature = key.sign(data)
         key.public_key().verify(bytearray(signature), data)
 
-    def test_generate(self, backend):
+    def test_generate(self):
         key = Ed448PrivateKey.generate()
         assert key
         assert key.public_key()
@@ -106,7 +106,7 @@ class TestEd448Signing:
             load_nist_vectors,
         ),
     )
-    def test_pub_priv_bytes_raw(self, vector, backend):
+    def test_pub_priv_bytes_raw(self, vector):
         sk = binascii.unhexlify(vector["secret"])
         pk = binascii.unhexlify(vector["public"])
         private_key = Ed448PrivateKey.from_private_bytes(sk)
@@ -169,36 +169,36 @@ class TestEd448Signing:
         ],
     )
     def test_round_trip_private_serialization(
-        self, encoding, fmt, encryption, passwd, load_func, backend
+        self, encoding, fmt, encryption, passwd, load_func
     ):
         key = Ed448PrivateKey.generate()
         serialized = key.private_bytes(encoding, fmt, encryption)
-        loaded_key = load_func(serialized, passwd, backend)
+        loaded_key = load_func(serialized, passwd)
         assert isinstance(loaded_key, Ed448PrivateKey)
 
-    def test_invalid_type_public_bytes(self, backend):
+    def test_invalid_type_public_bytes(self):
         with pytest.raises(TypeError):
             Ed448PublicKey.from_public_bytes(typing.cast(typing.Any, object()))
 
-    def test_invalid_type_private_bytes(self, backend):
+    def test_invalid_type_private_bytes(self):
         with pytest.raises(TypeError):
             Ed448PrivateKey.from_private_bytes(
                 typing.cast(typing.Any, object())
             )
 
-    def test_invalid_length_from_public_bytes(self, backend):
+    def test_invalid_length_from_public_bytes(self):
         with pytest.raises(ValueError):
             Ed448PublicKey.from_public_bytes(b"a" * 56)
         with pytest.raises(ValueError):
             Ed448PublicKey.from_public_bytes(b"a" * 58)
 
-    def test_invalid_length_from_private_bytes(self, backend):
+    def test_invalid_length_from_private_bytes(self):
         with pytest.raises(ValueError):
             Ed448PrivateKey.from_private_bytes(b"a" * 56)
         with pytest.raises(ValueError):
             Ed448PrivateKey.from_private_bytes(b"a" * 58)
 
-    def test_invalid_private_bytes(self, backend):
+    def test_invalid_private_bytes(self):
         key = Ed448PrivateKey.generate()
         with pytest.raises(TypeError):
             key.private_bytes(
@@ -227,7 +227,7 @@ class TestEd448Signing:
                 serialization.NoEncryption(),
             )
 
-    def test_invalid_public_bytes(self, backend):
+    def test_invalid_public_bytes(self):
         key = Ed448PrivateKey.generate().public_key()
         with pytest.raises(ValueError):
             key.public_bytes(
@@ -254,7 +254,7 @@ class TestEd448Signing:
             -----END PUBLIC KEY-----""").encode()
             )
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         private_bytes = os.urandom(57)
         key = Ed448PrivateKey.from_private_bytes(bytearray(private_bytes))
         assert (
@@ -266,7 +266,7 @@ class TestEd448Signing:
             == private_bytes
         )
 
-    def test_malleability(self, backend):
+    def test_malleability(self):
         # This is a signature where r > the group order. It should be
         # rejected to prevent signature malleability issues. This test can
         # be removed when wycheproof grows ed448 vectors
@@ -289,7 +289,7 @@ class TestEd448Signing:
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-def test_public_key_equality(backend):
+def test_public_key_equality():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed448", "ed448-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -310,7 +310,7 @@ def test_public_key_equality(backend):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-def test_public_key_copy(backend):
+def test_public_key_copy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed448", "ed448-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -326,7 +326,7 @@ def test_public_key_copy(backend):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-def test_public_key_deepcopy(backend):
+def test_public_key_deepcopy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed448", "ed448-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -342,7 +342,7 @@ def test_public_key_deepcopy(backend):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-def test_private_key_copy(backend):
+def test_private_key_copy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed448", "ed448-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -358,7 +358,7 @@ def test_private_key_copy(backend):
     only_if=lambda backend: backend.ed448_supported(),
     skip_message="Requires OpenSSL with Ed448 support",
 )
-def test_private_key_deepcopy(backend):
+def test_private_key_deepcopy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "Ed448", "ed448-pkcs8.der"),
         lambda derfile: derfile.read(),

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -31,7 +31,7 @@ from ...utils import (
     only_if=lambda backend: not backend.x25519_supported(),
     skip_message="Requires OpenSSL without X25519 support",
 )
-def test_x25519_unsupported(backend):
+def test_x25519_unsupported():
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
         X25519PublicKey.from_public_bytes(b"0" * 32)
 
@@ -54,7 +54,7 @@ class TestX25519Exchange:
             load_nist_vectors,
         ),
     )
-    def test_rfc7748(self, vector, backend):
+    def test_rfc7748(self, vector):
         private = binascii.unhexlify(vector["input_scalar"])
         public = binascii.unhexlify(vector["input_u"])
         shared_key = binascii.unhexlify(vector["output_u"])
@@ -63,7 +63,7 @@ class TestX25519Exchange:
         computed_shared_key = private_key.exchange(public_key)
         assert computed_shared_key == shared_key
 
-    def test_rfc7748_1000_iteration(self, backend):
+    def test_rfc7748_1000_iteration(self):
         old_private = private = public = binascii.unhexlify(
             b"0900000000000000000000000000000000000000000000000000000000000000"
         )
@@ -82,7 +82,7 @@ class TestX25519Exchange:
 
         assert computed_shared_key == shared_key
 
-    def test_null_shared_key_raises_error(self, backend):
+    def test_null_shared_key_raises_error(self):
         """
         The vector used here is taken from wycheproof's x25519 test vectors
         """
@@ -97,7 +97,7 @@ class TestX25519Exchange:
         with pytest.raises(ValueError):
             private_key.exchange(public_key)
 
-    def test_public_bytes_bad_args(self, backend):
+    def test_public_bytes_bad_args(self):
         key = X25519PrivateKey.generate().public_key()
         with pytest.raises(TypeError):
             key.public_bytes(
@@ -146,7 +146,7 @@ class TestX25519Exchange:
             ),
         ],
     )
-    def test_pub_priv_bytes_raw(self, private_bytes, public_bytes, backend):
+    def test_pub_priv_bytes_raw(self, private_bytes, public_bytes):
         private_key = X25519PrivateKey.from_private_bytes(private_bytes)
         assert (
             private_key.private_bytes(
@@ -173,31 +173,31 @@ class TestX25519Exchange:
         )
         assert public_key.public_bytes_raw() == public_bytes
 
-    def test_generate(self, backend):
+    def test_generate(self):
         key = X25519PrivateKey.generate()
         assert key
         assert key.public_key()
 
-    def test_invalid_type_exchange(self, backend):
+    def test_invalid_type_exchange(self):
         key = X25519PrivateKey.generate()
         with pytest.raises(TypeError):
             key.exchange(typing.cast(typing.Any, object()))
 
-    def test_invalid_length_from_public_bytes(self, backend):
+    def test_invalid_length_from_public_bytes(self):
         with pytest.raises(ValueError):
             X25519PublicKey.from_public_bytes(b"a" * 31)
 
         with pytest.raises(ValueError):
             X25519PublicKey.from_public_bytes(b"a" * 33)
 
-    def test_invalid_length_from_private_bytes(self, backend):
+    def test_invalid_length_from_private_bytes(self):
         with pytest.raises(ValueError):
             X25519PrivateKey.from_private_bytes(b"a" * 31)
 
         with pytest.raises(ValueError):
             X25519PrivateKey.from_private_bytes(b"a" * 33)
 
-    def test_invalid_private_bytes(self, backend):
+    def test_invalid_private_bytes(self):
         key = X25519PrivateKey.generate()
         with pytest.raises(TypeError):
             key.private_bytes(
@@ -268,7 +268,7 @@ class TestX25519Exchange:
                 serialization.NoEncryption(),
             )
 
-    def test_invalid_public_bytes(self, backend):
+    def test_invalid_public_bytes(self):
         key = X25519PrivateKey.generate().public_key()
         with pytest.raises(ValueError):
             key.public_bytes(
@@ -320,11 +320,11 @@ class TestX25519Exchange:
         ],
     )
     def test_round_trip_private_serialization(
-        self, encoding, fmt, encryption, passwd, load_func, backend
+        self, encoding, fmt, encryption, passwd, load_func
     ):
         key = X25519PrivateKey.generate()
         serialized = key.private_bytes(encoding, fmt, encryption)
-        loaded_key = load_func(serialized, passwd, backend)
+        loaded_key = load_func(serialized, passwd)
         assert isinstance(loaded_key, X25519PrivateKey)
 
     def test_invalid_public_key_pem(self):
@@ -336,7 +336,7 @@ class TestX25519Exchange:
             -----END PUBLIC KEY-----""").encode()
             )
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         private_bytes = bytearray(os.urandom(32))
         key = X25519PrivateKey.from_private_bytes(private_bytes)
         assert (
@@ -353,7 +353,7 @@ class TestX25519Exchange:
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-def test_public_key_equality(backend):
+def test_public_key_equality():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X25519", "x25519-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -373,7 +373,7 @@ def test_public_key_equality(backend):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-def test_public_key_copy(backend):
+def test_public_key_copy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X25519", "x25519-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -389,7 +389,7 @@ def test_public_key_copy(backend):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-def test_public_key_deepcopy(backend):
+def test_public_key_deepcopy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X25519", "x25519-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -408,7 +408,7 @@ def test_public_key_deepcopy(backend):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-def test_private_key_copy(backend):
+def test_private_key_copy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X25519", "x25519-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -424,7 +424,7 @@ def test_private_key_copy(backend):
     only_if=lambda backend: backend.x25519_supported(),
     skip_message="Requires OpenSSL with X25519 support",
 )
-def test_private_key_deepcopy(backend):
+def test_private_key_deepcopy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X25519", "x25519-pkcs8.der"),
         lambda derfile: derfile.read(),

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -30,7 +30,7 @@ from ...utils import (
     only_if=lambda backend: not backend.x448_supported(),
     skip_message="Requires OpenSSL without X448 support",
 )
-def test_x448_unsupported(backend):
+def test_x448_unsupported():
     with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_EXCHANGE_ALGORITHM):
         X448PublicKey.from_public_bytes(b"0" * 56)
 
@@ -53,7 +53,7 @@ class TestX448Exchange:
             load_nist_vectors,
         ),
     )
-    def test_rfc7748(self, vector, backend):
+    def test_rfc7748(self, vector):
         private = binascii.unhexlify(vector["input_scalar"])
         public = binascii.unhexlify(vector["input_u"])
         shared_key = binascii.unhexlify(vector["output_u"])
@@ -62,7 +62,7 @@ class TestX448Exchange:
         computed_shared_key = private_key.exchange(public_key)
         assert computed_shared_key == shared_key
 
-    def test_rfc7748_1000_iteration(self, backend):
+    def test_rfc7748_1000_iteration(self):
         old_private = private = public = binascii.unhexlify(
             b"05000000000000000000000000000000000000000000000000000000"
             b"00000000000000000000000000000000000000000000000000000000"
@@ -110,7 +110,7 @@ class TestX448Exchange:
             ),
         ],
     )
-    def test_pub_priv_bytes_raw(self, private_bytes, public_bytes, backend):
+    def test_pub_priv_bytes_raw(self, private_bytes, public_bytes):
         private_key = X448PrivateKey.from_private_bytes(private_bytes)
         assert (
             private_key.private_bytes(
@@ -171,38 +171,38 @@ class TestX448Exchange:
         ],
     )
     def test_round_trip_private_serialization(
-        self, encoding, fmt, encryption, passwd, load_func, backend
+        self, encoding, fmt, encryption, passwd, load_func
     ):
         key = X448PrivateKey.generate()
         serialized = key.private_bytes(encoding, fmt, encryption)
-        loaded_key = load_func(serialized, passwd, backend)
+        loaded_key = load_func(serialized, passwd)
         assert isinstance(loaded_key, X448PrivateKey)
 
-    def test_generate(self, backend):
+    def test_generate(self):
         key = X448PrivateKey.generate()
         assert key
         assert key.public_key()
 
-    def test_invalid_type_exchange(self, backend):
+    def test_invalid_type_exchange(self):
         key = X448PrivateKey.generate()
         with pytest.raises(TypeError):
             key.exchange(typing.cast(typing.Any, object()))
 
-    def test_invalid_length_from_public_bytes(self, backend):
+    def test_invalid_length_from_public_bytes(self):
         with pytest.raises(ValueError):
             X448PublicKey.from_public_bytes(b"a" * 55)
 
         with pytest.raises(ValueError):
             X448PublicKey.from_public_bytes(b"a" * 57)
 
-    def test_invalid_length_from_private_bytes(self, backend):
+    def test_invalid_length_from_private_bytes(self):
         with pytest.raises(ValueError):
             X448PrivateKey.from_private_bytes(b"a" * 55)
 
         with pytest.raises(ValueError):
             X448PrivateKey.from_private_bytes(b"a" * 57)
 
-    def test_invalid_private_bytes(self, backend):
+    def test_invalid_private_bytes(self):
         key = X448PrivateKey.generate()
         with pytest.raises(TypeError):
             key.private_bytes(
@@ -231,7 +231,7 @@ class TestX448Exchange:
                 serialization.NoEncryption(),
             )
 
-    def test_invalid_public_bytes(self, backend):
+    def test_invalid_public_bytes(self):
         key = X448PrivateKey.generate().public_key()
         with pytest.raises(ValueError):
             key.public_bytes(
@@ -258,7 +258,7 @@ class TestX448Exchange:
             -----END PUBLIC KEY-----""").encode()
             )
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         private_bytes = binascii.unhexlify(
             b"9a8f4925d1519f5775cf46b04b5800d4ee9ee8bae8bc5565d498c28d"
             b"d9c9baf574a9419744897391006382a6f127ab1d9ac2d8c0a598726b"
@@ -278,7 +278,7 @@ class TestX448Exchange:
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-def test_public_key_equality(backend):
+def test_public_key_equality():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -298,7 +298,7 @@ def test_public_key_equality(backend):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-def test_public_key_copy(backend):
+def test_public_key_copy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -314,7 +314,7 @@ def test_public_key_copy(backend):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-def test_public_key_deepcopy(backend):
+def test_public_key_deepcopy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -330,7 +330,7 @@ def test_public_key_deepcopy(backend):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-def test_private_key_copy(backend):
+def test_private_key_copy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
         lambda derfile: derfile.read(),
@@ -346,7 +346,7 @@ def test_private_key_copy(backend):
     only_if=lambda backend: backend.x448_supported(),
     skip_message="Requires OpenSSL with X448 support",
 )
-def test_private_key_deepcopy(backend):
+def test_private_key_deepcopy():
     key_bytes = load_vectors_from_file(
         os.path.join("asymmetric", "X448", "x448-pkcs8.der"),
         lambda derfile: derfile.read(),


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op. Functions that genuinely use the backend (e.g. `test_ed25519_always_supported`) are left untouched.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_