### PR TITLE
Remove no-op backend arguments in ML-DSA and ML-KEM tests

### DIFF
--- a/tests/hazmat/primitives/test_mldsa.py
+++ b/tests/hazmat/primitives/test_mldsa.py
@@ -88,7 +88,7 @@ ML_DSA_VARIANTS = [
     only_if=lambda backend: not backend.mldsa_supported(),
     skip_message="Requires a backend without ML-DSA support",
 )
-def test_mldsa_unsupported(backend):
+def test_mldsa_unsupported():
     with raises_unsupported_algorithm(
         _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
     ):
@@ -141,13 +141,13 @@ def test_mldsa_unsupported(backend):
 )
 class TestMLDSA:
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_sign_verify(self, variant, backend):
+    def test_sign_verify(self, variant):
         key = variant.private_key_class.generate()
         sig = key.sign(b"test data")
         key.public_key().verify(sig, b"test data")
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_sign_verify_empty_message(self, variant, backend):
+    def test_sign_verify_empty_message(self, variant):
         key = variant.private_key_class.generate()
         sig = key.sign(b"")
         key.public_key().verify(sig, b"")
@@ -160,13 +160,13 @@ class TestMLDSA:
             b"a" * 255,
         ],
     )
-    def test_sign_verify_with_context(self, variant, backend, ctx):
+    def test_sign_verify_with_context(self, variant, ctx):
         key = variant.private_key_class.generate()
         sig = key.sign(b"test data", ctx)
         key.public_key().verify(sig, b"test data", ctx)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_empty_context_equivalence(self, variant, backend):
+    def test_empty_context_equivalence(self, variant):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         data = b"test data"
@@ -184,7 +184,7 @@ class TestMLDSA:
         return hashlib.shake_256(tr + m_prime).digest(64)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_sign_verify_mu(self, variant, backend):
+    def test_sign_verify_mu(self, variant):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         data = b"test data"
@@ -200,7 +200,7 @@ class TestMLDSA:
         pub.verify_mu(sig2, mu)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_sign_verify_mu_with_context(self, variant, backend):
+    def test_sign_verify_mu_with_context(self, variant):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         data = b"test data"
@@ -213,7 +213,7 @@ class TestMLDSA:
         pub.verify_mu(sig, mu)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_mu_wrong_length(self, variant, backend):
+    def test_mu_wrong_length(self, variant):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         with pytest.raises(ValueError):
@@ -225,7 +225,7 @@ class TestMLDSA:
             pub.verify_mu(sig, b"0" * 63)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_verify_mu_invalid(self, variant, backend):
+    def test_verify_mu_invalid(self, variant):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         mu = b"\x01" * 64
@@ -235,7 +235,7 @@ class TestMLDSA:
         with pytest.raises(InvalidSignature):
             pub.verify_mu(b"0" * variant.sig_size, mu)
 
-    def test_kat_vectors_44(self, backend, subtests):
+    def test_kat_vectors_44(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "MLDSA", "kat_MLDSA_44_det_pure.rsp"),
             load_nist_vectors,
@@ -256,7 +256,7 @@ class TestMLDSA:
                 pub = MLDSA44PublicKey.from_public_bytes(pk)
                 pub.verify(expected_sig, msg, ctx)
 
-    def test_kat_vectors_65(self, backend, subtests):
+    def test_kat_vectors_65(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "MLDSA", "kat_MLDSA_65_det_pure.rsp"),
             load_nist_vectors,
@@ -277,7 +277,7 @@ class TestMLDSA:
                 pub = MLDSA65PublicKey.from_public_bytes(pk)
                 pub.verify(expected_sig, msg, ctx)
 
-    def test_kat_vectors_87(self, backend, subtests):
+    def test_kat_vectors_87(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "MLDSA", "kat_MLDSA_87_det_pure.rsp"),
             load_nist_vectors,
@@ -299,7 +299,7 @@ class TestMLDSA:
                 pub.verify(expected_sig, msg, ctx)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_kat_vectors_external_mu(self, variant, backend, subtests):
+    def test_kat_vectors_external_mu(self, variant, subtests):
         # The deterministic pure KAT signatures come from an independent
         # reference implementation. mu is fully determined by the public key,
         # context, and message (FIPS 204 Algorithm 2), so deriving it and
@@ -337,7 +337,7 @@ class TestMLDSA:
     )
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
     @pytest.mark.parametrize("ctx", [b"", b"a context"])
-    def test_mu_hasher_matches_reference(self, variant, ctx, backend):
+    def test_mu_hasher_matches_reference(self, variant, ctx):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         data = b"the quick brown fox jumps over the lazy dog"
@@ -368,7 +368,7 @@ class TestMLDSA:
         skip_message="Requires SHAKE256 support for mu computation",
     )
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_mu_hasher_kat(self, variant, backend, subtests):
+    def test_mu_hasher_kat(self, variant, subtests):
         vectors = load_vectors_from_file(
             os.path.join(
                 "asymmetric", "MLDSA", f"kat_MLDSA_{variant.name}_det_pure.rsp"
@@ -398,20 +398,20 @@ class TestMLDSA:
         skip_message="Requires SHAKE256 support for mu computation",
     )
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_mu_hasher_context_too_long(self, variant, backend):
+    def test_mu_hasher_context_too_long(self, variant):
         pub = variant.private_key_class.generate().public_key()
         mldsa.MLDSAMuHasher(pub, b"a" * 255)
         with pytest.raises(ValueError):
             mldsa.MLDSAMuHasher(pub, b"a" * 256)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_mu_hasher_rejects_private_key(self, variant, backend):
+    def test_mu_hasher_rejects_private_key(self, variant):
         # mu computation is a public-key operation; private keys are rejected.
         key = variant.private_key_class.generate()
         with pytest.raises(TypeError):
             mldsa.MLDSAMuHasher(key)
 
-    def test_mu_hasher_invalid_key_type(self, backend):
+    def test_mu_hasher_invalid_key_type(self):
         with pytest.raises(TypeError):
             mldsa.MLDSAMuHasher(
                 typing.cast(typing.Any, ed25519.Ed25519PrivateKey.generate())
@@ -426,7 +426,7 @@ class TestMLDSA:
         skip_message="Requires SHAKE256 support for mu computation",
     )
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_mu_hasher_already_finalized(self, variant, backend):
+    def test_mu_hasher_already_finalized(self, variant):
         pub = variant.private_key_class.generate().public_key()
         hasher = mldsa.MLDSAMuHasher(pub)
         hasher.update(b"data")
@@ -445,7 +445,7 @@ class TestMLDSA:
         skip_message="Requires SHAKE256 support for mu computation",
     )
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_mu_hasher_copy(self, variant, backend):
+    def test_mu_hasher_copy(self, variant):
         pub = variant.private_key_class.generate().public_key()
         hasher = mldsa.MLDSAMuHasher(pub)
         hasher.update(b"common prefix")
@@ -468,7 +468,7 @@ class TestMLDSA:
         ),
         skip_message="Requires a backend without SHAKE256 support",
     )
-    def test_mu_hasher_unsupported(self, backend):
+    def test_mu_hasher_unsupported(self):
         # On backends with ML-DSA but no SHAKE256 through the EVP interface
         # (BoringSSL), sign_mu/verify_mu work but mu cannot be computed.
         pub = MLDSA65PrivateKey.generate().public_key()
@@ -476,7 +476,7 @@ class TestMLDSA:
             mldsa.MLDSAMuHasher(pub)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_private_bytes_raw_round_trip(self, variant, backend):
+    def test_private_bytes_raw_round_trip(self, variant):
         key = variant.private_key_class.generate()
         seed = key.private_bytes_raw()
         assert len(seed) == variant.seed_size
@@ -529,11 +529,11 @@ class TestMLDSA:
         ],
     )
     def test_round_trip_private_serialization(
-        self, variant, encoding, fmt, encryption, passwd, load_func, backend
+        self, variant, encoding, fmt, encryption, passwd, load_func
     ):
         key = variant.private_key_class.generate()
         serialized = key.private_bytes(encoding, fmt, encryption)
-        loaded_key = load_func(serialized, passwd, backend)
+        loaded_key = load_func(serialized, passwd)
         assert isinstance(loaded_key, variant.private_key_class)
         assert loaded_key.private_bytes_raw() == key.private_bytes_raw()
         sig = loaded_key.sign(b"test data")
@@ -556,17 +556,17 @@ class TestMLDSA:
         ],
     )
     def test_round_trip_public_serialization(
-        self, variant, encoding, fmt, load_func, backend
+        self, variant, encoding, fmt, load_func
     ):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         serialized = pub.public_bytes(encoding, fmt)
-        loaded_pub = load_func(serialized, backend)
+        loaded_pub = load_func(serialized)
         assert isinstance(loaded_pub, variant.public_key_class)
         assert loaded_pub == pub
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_invalid_signature(self, variant, backend):
+    def test_invalid_signature(self, variant):
         key = variant.private_key_class.generate()
         sig = key.sign(b"test data")
         with pytest.raises(InvalidSignature):
@@ -576,14 +576,14 @@ class TestMLDSA:
             key.public_key().verify(b"0" * variant.sig_size, b"test data")
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_context_wrong_context(self, variant, backend):
+    def test_context_wrong_context(self, variant):
         key = variant.private_key_class.generate()
         sig = key.sign(b"test data", b"ctx-a")
         with pytest.raises(InvalidSignature):
             key.public_key().verify(sig, b"test data", b"ctx-b")
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_context_too_long(self, variant, backend):
+    def test_context_too_long(self, variant):
         key = variant.private_key_class.generate()
         with pytest.raises(ValueError):
             key.sign(b"data", b"x" * 256)
@@ -591,27 +591,27 @@ class TestMLDSA:
             key.public_key().verify(b"sig", b"data", b"x" * 256)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_invalid_length_from_public_bytes(self, variant, backend):
+    def test_invalid_length_from_public_bytes(self, variant):
         with pytest.raises(ValueError):
             variant.public_key_class.from_public_bytes(b"a" * 10)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_invalid_length_from_seed_bytes(self, variant, backend):
+    def test_invalid_length_from_seed_bytes(self, variant):
         with pytest.raises(ValueError):
             variant.private_key_class.from_seed_bytes(b"a" * 10)
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_invalid_type_public_bytes(self, variant, backend):
+    def test_invalid_type_public_bytes(self, variant):
         with pytest.raises(TypeError):
             variant.public_key_class.from_public_bytes(object())
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_invalid_type_seed_bytes(self, variant, backend):
+    def test_invalid_type_seed_bytes(self, variant):
         with pytest.raises(TypeError):
             variant.private_key_class.from_seed_bytes(object())
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_invalid_private_bytes(self, variant, backend):
+    def test_invalid_private_bytes(self, variant):
         key = variant.private_key_class.generate()
         with pytest.raises(TypeError):
             key.private_bytes(
@@ -641,7 +641,7 @@ class TestMLDSA:
             )
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_invalid_public_bytes(self, variant, backend):
+    def test_invalid_public_bytes(self, variant):
         key = variant.private_key_class.generate().public_key()
         with pytest.raises(ValueError):
             key.public_bytes(
@@ -662,7 +662,7 @@ class TestMLDSA:
             )
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_public_key_equality(self, variant, backend):
+    def test_public_key_equality(self, variant):
         key = variant.private_key_class.generate()
         pub1 = key.public_key()
         pub2 = key.public_key()
@@ -675,27 +675,27 @@ class TestMLDSA:
             pub1 < pub2
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_public_key_copy(self, variant, backend):
+    def test_public_key_copy(self, variant):
         key = variant.private_key_class.generate()
         pub1 = key.public_key()
         pub2 = copy.copy(pub1)
         assert pub1 == pub2
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_public_key_deepcopy(self, variant, backend):
+    def test_public_key_deepcopy(self, variant):
         key = variant.private_key_class.generate()
         pub1 = key.public_key()
         pub2 = copy.deepcopy(pub1)
         assert pub1 == pub2
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_private_key_copy(self, variant, backend):
+    def test_private_key_copy(self, variant):
         key1 = variant.private_key_class.generate()
         key2 = copy.copy(key1)
         assert key1.private_bytes_raw() == key2.private_bytes_raw()
 
     @pytest.mark.parametrize("variant", ML_DSA_VARIANTS)
-    def test_private_key_deepcopy(self, variant, backend):
+    def test_private_key_deepcopy(self, variant):
         key1 = variant.private_key_class.generate()
         key2 = copy.deepcopy(key1)
         assert key1.private_bytes_raw() == key2.private_bytes_raw()
@@ -705,13 +705,11 @@ class TestMLDSA:
     only_if=lambda backend: backend.mldsa_supported(),
     skip_message="Requires a backend with ML-DSA support",
 )
-def test_mldsa65_private_key_no_seed(backend):
+def test_mldsa65_private_key_no_seed():
     pkcs8_der = load_vectors_from_file(
         os.path.join("asymmetric", "MLDSA", "mldsa65_noseed_priv.der"),
         lambda derfile: derfile.read(),
         mode="rb",
     )
     with pytest.raises(ValueError):
-        serialization.load_der_private_key(
-            pkcs8_der, password=None, backend=backend
-        )
+        serialization.load_der_private_key(pkcs8_der, password=None)

--- a/tests/hazmat/primitives/test_mlkem.py
+++ b/tests/hazmat/primitives/test_mlkem.py
@@ -66,7 +66,7 @@ ML_KEM_VARIANTS = [
     only_if=lambda backend: not backend.mlkem_supported(),
     skip_message="Requires a backend without ML-KEM support",
 )
-def test_mlkem_unsupported(backend):
+def test_mlkem_unsupported():
     with raises_unsupported_algorithm(
         _Reasons.UNSUPPORTED_PUBLIC_KEY_ALGORITHM
     ):
@@ -104,7 +104,7 @@ def test_mlkem_unsupported(backend):
 )
 class TestMLKEM:
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_encapsulate_decapsulate(self, variant, backend):
+    def test_encapsulate_decapsulate(self, variant):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         shared_secret, ciphertext = pub.encapsulate()
@@ -114,7 +114,7 @@ class TestMLKEM:
         assert len(ciphertext) == variant.ciphertext_size
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_private_bytes_raw(self, variant, backend):
+    def test_private_bytes_raw(self, variant):
         key = variant.private_key_class.generate()
         raw = key.private_bytes_raw()
         assert len(raw) == variant.seed_size
@@ -159,11 +159,11 @@ class TestMLKEM:
         ],
     )
     def test_round_trip_private_serialization(
-        self, variant, encoding, fmt, encryption, passwd, load_func, backend
+        self, variant, encoding, fmt, encryption, passwd, load_func
     ):
         key = variant.private_key_class.generate()
         serialized = key.private_bytes(encoding, fmt, encryption)
-        loaded_key = load_func(serialized, passwd, backend)
+        loaded_key = load_func(serialized, passwd)
         assert isinstance(loaded_key, variant.private_key_class)
         # Verify round-trip by checking seed matches
         assert loaded_key.private_bytes_raw() == key.private_bytes_raw()
@@ -185,26 +185,26 @@ class TestMLKEM:
         ],
     )
     def test_round_trip_public_serialization(
-        self, variant, encoding, fmt, load_func, backend
+        self, variant, encoding, fmt, load_func
     ):
         key = variant.private_key_class.generate()
         pub = key.public_key()
         serialized = pub.public_bytes(encoding, fmt)
-        loaded_pub = load_func(serialized, backend)
+        loaded_pub = load_func(serialized)
         assert isinstance(loaded_pub, variant.public_key_class)
         assert loaded_pub == pub
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_invalid_seed_length(self, variant, backend):
+    def test_invalid_seed_length(self, variant):
         with pytest.raises(ValueError):
             variant.private_key_class.from_seed_bytes(b"a" * 10)
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_invalid_type_seed(self, variant, backend):
+    def test_invalid_type_seed(self, variant):
         with pytest.raises(TypeError):
             variant.private_key_class.from_seed_bytes(object())
 
-    def test_kat_vectors_768(self, backend, subtests):
+    def test_kat_vectors_768(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "MLKEM", "kat_MLKEM_768.rsp"),
             load_nist_vectors,
@@ -234,7 +234,7 @@ class TestMLKEM:
                 ss_n = key.decapsulate(binascii.unhexlify(vector["ct_n"]))
                 assert ss_n == binascii.unhexlify(vector["ss_n"])
 
-    def test_kat_vectors_1024(self, backend, subtests):
+    def test_kat_vectors_1024(self, subtests):
         vectors = load_vectors_from_file(
             os.path.join("asymmetric", "MLKEM", "kat_MLKEM_1024.rsp"),
             load_nist_vectors,
@@ -313,14 +313,14 @@ class TestMLKEM:
         ],
     )
     def test_invalid_private_bytes(
-        self, variant, encoding, fmt, encryption, err, backend
+        self, variant, encoding, fmt, encryption, err
     ):
         key = variant.private_key_class.generate()
         with pytest.raises(err):
             key.private_bytes(encoding, fmt, encryption)
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_invalid_public_bytes(self, variant, backend):
+    def test_invalid_public_bytes(self, variant):
         key = variant.private_key_class.generate().public_key()
         with pytest.raises(ValueError):
             key.public_bytes(
@@ -339,7 +339,7 @@ class TestMLKEM:
             )
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_public_key_equality(self, variant, backend):
+    def test_public_key_equality(self, variant):
         key = variant.private_key_class.generate()
         pub1 = key.public_key()
         pub2 = key.public_key()
@@ -352,27 +352,27 @@ class TestMLKEM:
             pub1 < pub2
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_public_key_copy(self, variant, backend):
+    def test_public_key_copy(self, variant):
         key = variant.private_key_class.generate()
         pub1 = key.public_key()
         pub2 = copy.copy(pub1)
         assert pub1 == pub2
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_public_key_deepcopy(self, variant, backend):
+    def test_public_key_deepcopy(self, variant):
         key = variant.private_key_class.generate()
         pub1 = key.public_key()
         pub2 = copy.deepcopy(pub1)
         assert pub1 == pub2
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_private_key_copy(self, variant, backend):
+    def test_private_key_copy(self, variant):
         key1 = variant.private_key_class.generate()
         key2 = copy.copy(key1)
         assert key1.private_bytes_raw() == key2.private_bytes_raw()
 
     @pytest.mark.parametrize("variant", ML_KEM_VARIANTS)
-    def test_private_key_deepcopy(self, variant, backend):
+    def test_private_key_deepcopy(self, variant):
         key1 = variant.private_key_class.generate()
         key2 = copy.deepcopy(key1)
         assert key1.private_bytes_raw() == key2.private_bytes_raw()
@@ -382,7 +382,7 @@ class TestMLKEM:
     only_if=lambda backend: backend.mlkem_supported(),
     skip_message="Requires a backend with ML-KEM support",
 )
-def test_mlkem768_kat_serialization(backend):
+def test_mlkem768_kat_serialization():
     vectors = load_vectors_from_file(
         os.path.join("asymmetric", "MLKEM", "kat_MLKEM_768.rsp"),
         load_nist_vectors,


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_