### PR TITLE
Remove no-op backend arguments in keywrap and two-factor tests

### DIFF
--- a/tests/hazmat/primitives/test_keywrap.py
+++ b/tests/hazmat/primitives/test_keywrap.py
@@ -15,7 +15,7 @@ from .utils import _load_all_params
 
 
 class TestAESKeyWrap:
-    def test_wrap(self, backend, subtests):
+    def test_wrap(self, subtests):
         params = _load_all_params(
             os.path.join("keywrap", "kwtestvectors"),
             ["KW_AE_128.txt", "KW_AE_192.txt", "KW_AE_256.txt"],
@@ -25,12 +25,10 @@ class TestAESKeyWrap:
             with subtests.test():
                 wrapping_key = binascii.unhexlify(param["k"])
                 key_to_wrap = binascii.unhexlify(param["p"])
-                wrapped_key = keywrap.aes_key_wrap(
-                    wrapping_key, key_to_wrap, backend
-                )
+                wrapped_key = keywrap.aes_key_wrap(wrapping_key, key_to_wrap)
                 assert param["c"] == binascii.hexlify(wrapped_key)
 
-    def test_unwrap(self, backend, subtests):
+    def test_unwrap(self, subtests):
         params = _load_all_params(
             os.path.join("keywrap", "kwtestvectors"),
             ["KW_AD_128.txt", "KW_AD_192.txt", "KW_AD_256.txt"],
@@ -42,45 +40,43 @@ class TestAESKeyWrap:
                 wrapped_key = binascii.unhexlify(param["c"])
                 if param.get("fail") is True:
                     with pytest.raises(keywrap.InvalidUnwrap):
-                        keywrap.aes_key_unwrap(
-                            wrapping_key, wrapped_key, backend
-                        )
+                        keywrap.aes_key_unwrap(wrapping_key, wrapped_key)
                 else:
                     unwrapped_key = keywrap.aes_key_unwrap(
-                        wrapping_key, wrapped_key, backend
+                        wrapping_key, wrapped_key
                     )
                     assert param["p"] == binascii.hexlify(unwrapped_key)
 
-    def test_wrap_invalid_key_length(self, backend):
+    def test_wrap_invalid_key_length(self):
         # The wrapping key must be of length [16, 24, 32]
         with pytest.raises(ValueError):
-            keywrap.aes_key_wrap(b"badkey", b"sixteen_byte_key", backend)
+            keywrap.aes_key_wrap(b"badkey", b"sixteen_byte_key")
 
-    def test_unwrap_invalid_key_length(self, backend):
+    def test_unwrap_invalid_key_length(self):
         with pytest.raises(ValueError):
-            keywrap.aes_key_unwrap(b"badkey", b"\x00" * 24, backend)
+            keywrap.aes_key_unwrap(b"badkey", b"\x00" * 24)
 
-    def test_wrap_invalid_key_to_wrap_length(self, backend):
+    def test_wrap_invalid_key_to_wrap_length(self):
         # Keys to wrap must be at least 16 bytes long
         with pytest.raises(ValueError):
-            keywrap.aes_key_wrap(b"sixteen_byte_key", b"\x00" * 15, backend)
+            keywrap.aes_key_wrap(b"sixteen_byte_key", b"\x00" * 15)
 
         # Keys to wrap must be a multiple of 8 bytes
         with pytest.raises(ValueError):
-            keywrap.aes_key_wrap(b"sixteen_byte_key", b"\x00" * 23, backend)
+            keywrap.aes_key_wrap(b"sixteen_byte_key", b"\x00" * 23)
 
-    def test_unwrap_invalid_wrapped_key_length(self, backend):
+    def test_unwrap_invalid_wrapped_key_length(self):
         # Keys to unwrap must be at least 24 bytes
         with pytest.raises(keywrap.InvalidUnwrap):
-            keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 16, backend)
+            keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 16)
 
         # Keys to unwrap must be a multiple of 8 bytes
         with pytest.raises(keywrap.InvalidUnwrap):
-            keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 27, backend)
+            keywrap.aes_key_unwrap(b"sixteen_byte_key", b"\x00" * 27)
 
 
 class TestAESKeyWrapWithPadding:
-    def test_wrap(self, backend, subtests):
+    def test_wrap(self, subtests):
         params = _load_all_params(
             os.path.join("keywrap", "kwtestvectors"),
             ["KWP_AE_128.txt", "KWP_AE_192.txt", "KWP_AE_256.txt"],
@@ -91,11 +87,11 @@ class TestAESKeyWrapWithPadding:
                 wrapping_key = binascii.unhexlify(param["k"])
                 key_to_wrap = binascii.unhexlify(param["p"])
                 wrapped_key = keywrap.aes_key_wrap_with_padding(
-                    wrapping_key, key_to_wrap, backend
+                    wrapping_key, key_to_wrap
                 )
                 assert param["c"] == binascii.hexlify(wrapped_key)
 
-    def test_wrap_additional_vectors(self, backend, subtests):
+    def test_wrap_additional_vectors(self, subtests):
         params = _load_all_params(
             "keywrap", ["kwp_botan.txt"], load_nist_vectors
         )
@@ -104,11 +100,11 @@ class TestAESKeyWrapWithPadding:
                 wrapping_key = binascii.unhexlify(param["key"])
                 key_to_wrap = binascii.unhexlify(param["input"])
                 wrapped_key = keywrap.aes_key_wrap_with_padding(
-                    wrapping_key, key_to_wrap, backend
+                    wrapping_key, key_to_wrap
                 )
                 assert wrapped_key == binascii.unhexlify(param["output"])
 
-    def test_unwrap(self, backend, subtests):
+    def test_unwrap(self, subtests):
         params = _load_all_params(
             os.path.join("keywrap", "kwtestvectors"),
             ["KWP_AD_128.txt", "KWP_AD_192.txt", "KWP_AD_256.txt"],
@@ -121,15 +117,15 @@ class TestAESKeyWrapWithPadding:
                 if param.get("fail") is True:
                     with pytest.raises(keywrap.InvalidUnwrap):
                         keywrap.aes_key_unwrap_with_padding(
-                            wrapping_key, wrapped_key, backend
+                            wrapping_key, wrapped_key
                         )
                 else:
                     unwrapped_key = keywrap.aes_key_unwrap_with_padding(
-                        wrapping_key, wrapped_key, backend
+                        wrapping_key, wrapped_key
                     )
                     assert param["p"] == binascii.hexlify(unwrapped_key)
 
-    def test_unwrap_additional_vectors(self, backend, subtests):
+    def test_unwrap_additional_vectors(self, subtests):
         params = _load_all_params(
             "keywrap", ["kwp_botan.txt"], load_nist_vectors
         )
@@ -138,31 +134,29 @@ class TestAESKeyWrapWithPadding:
                 wrapping_key = binascii.unhexlify(param["key"])
                 wrapped_key = binascii.unhexlify(param["output"])
                 unwrapped_key = keywrap.aes_key_unwrap_with_padding(
-                    wrapping_key, wrapped_key, backend
+                    wrapping_key, wrapped_key
                 )
                 assert unwrapped_key == binascii.unhexlify(param["input"])
 
-    def test_unwrap_invalid_wrapped_key_length(self, backend):
+    def test_unwrap_invalid_wrapped_key_length(self):
         # Keys to unwrap must be at least 16 bytes
         with pytest.raises(
             keywrap.InvalidUnwrap, match="Must be at least 16 bytes"
         ):
             keywrap.aes_key_unwrap_with_padding(
-                b"sixteen_byte_key", b"\x00" * 15, backend
+                b"sixteen_byte_key", b"\x00" * 15
             )
 
-    def test_wrap_empty_key_to_wrap(self, backend):
+    def test_wrap_empty_key_to_wrap(self):
         with pytest.raises(
             ValueError, match="key_to_wrap must be between 1 and 2\\^32 bytes"
         ):
-            keywrap.aes_key_wrap_with_padding(b"\x00" * 16, b"", backend)
+            keywrap.aes_key_wrap_with_padding(b"\x00" * 16, b"")
 
-    def test_wrap_invalid_key_length(self, backend):
+    def test_wrap_invalid_key_length(self):
         with pytest.raises(ValueError, match="must be a valid AES key length"):
-            keywrap.aes_key_wrap_with_padding(b"badkey", b"\x00", backend)
+            keywrap.aes_key_wrap_with_padding(b"badkey", b"\x00")
 
-    def test_unwrap_invalid_key_length(self, backend):
+    def test_unwrap_invalid_key_length(self):
         with pytest.raises(ValueError, match="must be a valid AES key length"):
-            keywrap.aes_key_unwrap_with_padding(
-                b"badkey", b"\x00" * 16, backend
-            )
+            keywrap.aes_key_unwrap_with_padding(b"badkey", b"\x00" * 16)

--- a/tests/hazmat/primitives/twofactor/test_hotp.py
+++ b/tests/hazmat/primitives/twofactor/test_hotp.py
@@ -18,75 +18,75 @@ vectors = load_vectors_from_file("twofactor/rfc-4226.txt", load_nist_vectors)
 
 
 class TestHOTP:
-    def test_invalid_key_length(self, backend):
+    def test_invalid_key_length(self):
         secret = os.urandom(10)
 
         with pytest.raises(ValueError):
-            HOTP(secret, 6, SHA1(), backend)
+            HOTP(secret, 6, SHA1())
 
-    def test_unenforced_invalid_kwy_length(self, backend):
+    def test_unenforced_invalid_kwy_length(self):
         secret = os.urandom(10)
-        HOTP(secret, 6, SHA1(), backend, enforce_key_length=False)
+        HOTP(secret, 6, SHA1(), enforce_key_length=False)
 
-    def test_invalid_hotp_length(self, backend):
+    def test_invalid_hotp_length(self):
         secret = os.urandom(16)
 
         with pytest.raises(ValueError):
-            HOTP(secret, 4, SHA1(), backend)
+            HOTP(secret, 4, SHA1())
 
-    def test_invalid_algorithm(self, backend):
+    def test_invalid_algorithm(self):
         secret = os.urandom(16)
 
         with pytest.raises(TypeError):
-            HOTP(secret, 6, typing.cast(typing.Any, MD5()), backend)
+            HOTP(secret, 6, typing.cast(typing.Any, MD5()))
 
     @pytest.mark.parametrize("params", vectors)
-    def test_truncate(self, backend, params):
+    def test_truncate(self, params):
         secret = params["secret"]
         counter = int(params["counter"])
         truncated = params["truncated"]
 
-        hotp = HOTP(secret, 6, SHA1(), backend)
+        hotp = HOTP(secret, 6, SHA1())
 
         assert hotp._dynamic_truncate(counter) == int(truncated.decode(), 16)
 
     @pytest.mark.parametrize("params", vectors)
-    def test_generate(self, backend, params):
+    def test_generate(self, params):
         secret = params["secret"]
         counter = int(params["counter"])
         hotp_value = params["hotp"]
 
-        hotp = HOTP(secret, 6, SHA1(), backend)
+        hotp = HOTP(secret, 6, SHA1())
 
         assert hotp.generate(counter) == hotp_value
 
     @pytest.mark.parametrize("params", vectors)
-    def test_verify(self, backend, params):
+    def test_verify(self, params):
         secret = params["secret"]
         counter = int(params["counter"])
         hotp_value = params["hotp"]
 
-        hotp = HOTP(secret, 6, SHA1(), backend)
+        hotp = HOTP(secret, 6, SHA1())
         hotp.verify(hotp_value, counter)
 
-    def test_invalid_verify(self, backend):
+    def test_invalid_verify(self):
         secret = b"12345678901234567890"
         counter = 0
 
-        hotp = HOTP(secret, 6, SHA1(), backend)
+        hotp = HOTP(secret, 6, SHA1())
 
         with pytest.raises(InvalidToken):
             hotp.verify(b"123456", counter)
 
-    def test_length_not_int(self, backend):
+    def test_length_not_int(self):
         secret = b"12345678901234567890"
 
         with pytest.raises(TypeError):
-            HOTP(secret, typing.cast(typing.Any, b"foo"), SHA1(), backend)
+            HOTP(secret, typing.cast(typing.Any, b"foo"), SHA1())
 
-    def test_get_provisioning_uri(self, backend):
+    def test_get_provisioning_uri(self):
         secret = b"12345678901234567890"
-        hotp = HOTP(secret, 6, SHA1(), backend)
+        hotp = HOTP(secret, 6, SHA1())
 
         assert hotp.get_provisioning_uri("Alice Smith", 1, None) == (
             "otpauth://hotp/Alice%20Smith?digits=6&secret=GEZDGNBV"
@@ -99,14 +99,14 @@ class TestHOTP:
             "&counter=1"
         )
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = bytearray(b"a long key with lots of entropy goes here")
-        hotp = HOTP(key, 6, SHA1(), backend)
+        hotp = HOTP(key, 6, SHA1())
         assert hotp.generate(10) == b"559978"
 
-    def test_invalid_counter(self, backend):
+    def test_invalid_counter(self):
         key = os.urandom(16)
-        hotp = HOTP(key, 6, SHA1(), backend)
+        hotp = HOTP(key, 6, SHA1())
 
         with pytest.raises(TypeError):
             hotp.generate(typing.cast(typing.Any, 2.5))

--- a/tests/hazmat/primitives/twofactor/test_totp.py
+++ b/tests/hazmat/primitives/twofactor/test_totp.py
@@ -20,89 +20,89 @@ class TestTOTP:
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA1"]
     )
-    def test_generate_sha1(self, backend, params):
+    def test_generate_sha1(self, params):
         secret = params["secret"]
         time = int(params["time"])
         totp_value = params["totp"]
 
-        totp = TOTP(secret, 8, hashes.SHA1(), 30, backend)
+        totp = TOTP(secret, 8, hashes.SHA1(), 30)
         assert totp.generate(time) == totp_value
 
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA256"]
     )
-    def test_generate_sha256(self, backend, params):
+    def test_generate_sha256(self, params):
         secret = params["secret"]
         time = int(params["time"])
         totp_value = params["totp"]
 
-        totp = TOTP(secret, 8, hashes.SHA256(), 30, backend)
+        totp = TOTP(secret, 8, hashes.SHA256(), 30)
         assert totp.generate(time) == totp_value
 
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA512"]
     )
-    def test_generate_sha512(self, backend, params):
+    def test_generate_sha512(self, params):
         secret = params["secret"]
         time = int(params["time"])
         totp_value = params["totp"]
 
-        totp = TOTP(secret, 8, hashes.SHA512(), 30, backend)
+        totp = TOTP(secret, 8, hashes.SHA512(), 30)
         assert totp.generate(time) == totp_value
 
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA1"]
     )
-    def test_verify_sha1(self, backend, params):
+    def test_verify_sha1(self, params):
         secret = params["secret"]
         time = int(params["time"])
         totp_value = params["totp"]
 
-        totp = TOTP(secret, 8, hashes.SHA1(), 30, backend)
+        totp = TOTP(secret, 8, hashes.SHA1(), 30)
         totp.verify(totp_value, time)
 
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA256"]
     )
-    def test_verify_sha256(self, backend, params):
+    def test_verify_sha256(self, params):
         secret = params["secret"]
         time = int(params["time"])
         totp_value = params["totp"]
 
-        totp = TOTP(secret, 8, hashes.SHA256(), 30, backend)
+        totp = TOTP(secret, 8, hashes.SHA256(), 30)
         totp.verify(totp_value, time)
 
     @pytest.mark.parametrize(
         "params", [i for i in vectors if i["mode"] == b"SHA512"]
     )
-    def test_verify_sha512(self, backend, params):
+    def test_verify_sha512(self, params):
         secret = params["secret"]
         time = int(params["time"])
         totp_value = params["totp"]
 
-        totp = TOTP(secret, 8, hashes.SHA512(), 30, backend)
+        totp = TOTP(secret, 8, hashes.SHA512(), 30)
         totp.verify(totp_value, time)
 
-    def test_invalid_verify(self, backend):
+    def test_invalid_verify(self):
         secret = b"12345678901234567890"
         time = 59
 
-        totp = TOTP(secret, 8, hashes.SHA1(), 30, backend)
+        totp = TOTP(secret, 8, hashes.SHA1(), 30)
 
         with pytest.raises(InvalidToken):
             totp.verify(b"12345678", time)
 
-    def test_floating_point_time_generate(self, backend):
+    def test_floating_point_time_generate(self):
         secret = b"12345678901234567890"
         time = 59.1
 
-        totp = TOTP(secret, 8, hashes.SHA1(), 30, backend)
+        totp = TOTP(secret, 8, hashes.SHA1(), 30)
 
         assert totp.generate(time) == b"94287082"
 
-    def test_get_provisioning_uri(self, backend):
+    def test_get_provisioning_uri(self):
         secret = b"12345678901234567890"
-        totp = TOTP(secret, 6, hashes.SHA1(), 30, backend=backend)
+        totp = TOTP(secret, 6, hashes.SHA1(), 30)
 
         assert totp.get_provisioning_uri("Alice Smith", None) == (
             "otpauth://totp/Alice%20Smith?digits=6&secret=GEZDGNBVG"
@@ -115,15 +115,15 @@ class TestTOTP:
             "&period=30"
         )
 
-    def test_buffer_protocol(self, backend):
+    def test_buffer_protocol(self):
         key = bytearray(b"a long key with lots of entropy goes here")
-        totp = TOTP(key, 8, hashes.SHA512(), 30, backend)
+        totp = TOTP(key, 8, hashes.SHA512(), 30)
         time = 60
         assert totp.generate(time) == b"53049576"
 
-    def test_invalid_time(self, backend):
+    def test_invalid_time(self):
         key = b"12345678901234567890"
-        totp = TOTP(key, 8, hashes.SHA1(), 30, backend)
+        totp = TOTP(key, 8, hashes.SHA1(), 30)
 
         with pytest.raises(TypeError):
             totp.generate(typing.cast(typing.Any, "test"))


### PR DESCRIPTION
The `backend` pytest fixture is autouse, so tests don't need to accept it to get its backend-support checks. This removes the `backend` argument from test functions in `test_keywrap.py`, `twofactor/test_hotp.py`, and `twofactor/test_totp.py` that either never use it, or only forward it to public APIs where the `backend` parameter is a deprecated no-op.

Part of a file-by-file series removing no-op `backend` arguments across the test suite. The combined change across the series was validated with `nox -e local`: test collection and results are identical before and after (3921 passed, 632 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbAhmdMqraTnNshGD636kL)_