### PR TITLE
Fetch test vectors via codeload tarballs instead of git clones

### DIFF
--- a/.github/actions/fetch-vectors/action.yml
+++ b/.github/actions/fetch-vectors/action.yml
@@ -1,22 +1,34 @@
-name: Clone test vectors
-description: Clones the wycheproof and x509-limbo repositories
+name: Fetch test vectors
+description: Fetches the wycheproof and x509-limbo repositories
 
 runs:
   using: "composite"
 
   steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: "C2SP/wycheproof"
-        path: "wycheproof"
+    # Codeload snapshots skip the git protocol entirely: no ref
+    # negotiation, no server-side pack generation, no client-side object
+    # hashing, and no .git directory to write. The two downloads run in
+    # parallel.
+    - name: Download test vectors
+      shell: bash
+      run: |
+        download() {
+          curl --fail --silent --show-error \
+            --retry 4 --retry-all-errors --retry-delay 2 \
+            --output "$2.tar.gz" \
+            "https://codeload.github.com/$1/tar.gz/$3"
+          mkdir "$2"
+          tar -xzf "$2.tar.gz" --strip-components=1 -C "$2"
+          rm "$2.tar.gz"
+        }
+        download C2SP/wycheproof wycheproof "$WYCHEPROOF_REF" &
+        wycheproof_pid=$!
+        download C2SP/x509-limbo x509-limbo "$X509_LIMBO_REF" &
+        x509_limbo_pid=$!
+        wait "$wycheproof_pid"
+        wait "$x509_limbo_pid"
+      env:
         # Latest commit on the wycheproof main branch, as of Jul 03, 2026.
-        ref: "d0db6205a1570feb1e5918a735f7e57f6ad7b3f6" # wycheproof-ref
-        persist-credentials: false
-
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: "C2SP/x509-limbo"
-        path: "x509-limbo"
+        WYCHEPROOF_REF: "d0db6205a1570feb1e5918a735f7e57f6ad7b3f6" # wycheproof-ref
         # Latest commit on the x509-limbo main branch, as of Jun 30, 2026.
-        ref: "8a2e6f41023b1716dc16fe63335e4bb972e4c3f6" # x509-limbo-ref
-        persist-credentials: false
+        X509_LIMBO_REF: "8a2e6f41023b1716dc16fe63335e4bb972e4c3f6" # x509-limbo-ref

--- a/.github/workflows/x509-limbo-version-bump.yml
+++ b/.github/workflows/x509-limbo-version-bump.yml
@@ -24,8 +24,8 @@ jobs:
             --repo-url "https://github.com/C2SP/x509-limbo" \
             --branch "main" \
             --file-path ".github/actions/fetch-vectors/action.yml" \
-            --current-version-pattern 'ref: "([a-f0-9]{40})" # x509-limbo-ref' \
-            --update-pattern 'ref: "{new_version}" # x509-limbo-ref' \
+            --current-version-pattern 'X509_LIMBO_REF: "([a-f0-9]{40})" # x509-limbo-ref' \
+            --update-pattern 'X509_LIMBO_REF: "{new_version}" # x509-limbo-ref' \
             --comment-pattern 'Latest commit on the x509-limbo main branch.*?\.'
       - id: bump-wycheproof
         run: |
@@ -34,8 +34,8 @@ jobs:
             --repo-url "https://github.com/C2SP/wycheproof" \
             --branch "main" \
             --file-path ".github/actions/fetch-vectors/action.yml" \
-            --current-version-pattern 'ref: "([a-f0-9]{40})" # wycheproof-ref' \
-            --update-pattern 'ref: "{new_version}" # wycheproof-ref' \
+            --current-version-pattern 'WYCHEPROOF_REF: "([a-f0-9]{40})" # wycheproof-ref' \
+            --update-pattern 'WYCHEPROOF_REF: "{new_version}" # wycheproof-ref' \
             --comment-pattern 'Latest commit on the wycheproof main branch.*?\.'
       - name: Check for updates
         run: git status


### PR DESCRIPTION
Tests whether codeload snapshot tarballs are faster than the two `actions/checkout` clones for fetching wycheproof and x509-limbo. Baseline from main's runs on 2026-07-06: the "Clone test vectors" step costs ~11–18s per job.

- The vectors are fetched as `https://codeload.github.com/<repo>/tar.gz/<sha>` downloads, extracted in parallel. This skips git ref negotiation, server-side pack generation, client-side object hashing, and writing ~40MB of `.git` directories. `curl --retry` handles transient failures, and a failed download fails the step.
- The pinned refs move from checkout `ref:` values to env vars on the download step. The `bump_dependency.py` patterns in `x509-limbo-version-bump.yml` are updated to match; verified by running the bump script against the new file (it matches the current SHAs).
- One thing this run answers: whether the container jobs' images (alpine, distros) all have `curl` — the checkout action brought its own node runtime, `curl`/`tar` come from the image.

To evaluate: compare the "Clone test vectors" step duration against main's ~11–18s. Note codeload only serves gzip (no zstd option — the `.tar.gz` is the payload, not a transport encoding, so `Accept-Encoding` can't upgrade it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE