### PR TITLE
Declare rerun-if directives in build scripts that had none

### DIFF
--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -6,6 +6,14 @@ use std::env;
 
 #[allow(clippy::unusual_byte_groupings)]
 fn main() {
+    // Without any rerun-if directives cargo reruns the build script (and
+    // recompiles the crate) whenever any mtime in the package changes,
+    // which defeats CI build caching. Everything below depends only on
+    // this file, the environment variables it reads, and metadata from
+    // openssl-sys (which cargo tracks as a dependency on its own).
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CRYPTOGRAPHY_BUILD_OPENSSL_NO_LEGACY");
+
     pyo3_build_config::use_pyo3_cfgs();
 
     if let Ok(version) = env::var("DEP_OPENSSL_VERSION_NUMBER") {

--- a/src/rust/cryptography-key-parsing/build.rs
+++ b/src/rust/cryptography-key-parsing/build.rs
@@ -6,6 +6,13 @@ use std::env;
 
 #[allow(clippy::unusual_byte_groupings)]
 fn main() {
+    // Without any rerun-if directives cargo reruns the build script (and
+    // recompiles the crate) whenever any mtime in the package changes,
+    // which defeats CI build caching. Everything below depends only on
+    // this file and metadata from openssl-sys (which cargo tracks as a
+    // dependency on its own).
+    println!("cargo:rerun-if-changed=build.rs");
+
     if env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER").is_ok() {
         println!("cargo:rustc-cfg=CRYPTOGRAPHY_IS_LIBRESSL");
     }

--- a/src/rust/cryptography-openssl/build.rs
+++ b/src/rust/cryptography-openssl/build.rs
@@ -6,6 +6,13 @@ use std::env;
 
 #[allow(clippy::unusual_byte_groupings)]
 fn main() {
+    // Without any rerun-if directives cargo reruns the build script (and
+    // recompiles the crate) whenever any mtime in the package changes,
+    // which defeats CI build caching. Everything below depends only on
+    // this file and metadata from openssl-sys (which cargo tracks as a
+    // dependency on its own).
+    println!("cargo:rerun-if-changed=build.rs");
+
     if let Ok(version) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
         let version = u64::from_str_radix(&version, 16).unwrap();
 


### PR DESCRIPTION
A build script that emits no `rerun-if` directives makes cargo fall back to fingerprinting the entire package by its newest file mtime, so the script reruns — and the crate and its dependents recompile — whenever any file in the package is touched, even with no content change (visible with `CARGO_LOG=cargo::core::compiler::fingerprint=info` as `PrecalculatedComponentsChanged`). The three build scripts here (workspace root, cryptography-openssl, cryptography-key-parsing) depend only on themselves, `DEP_OPENSSL_*` metadata from openssl-sys (tracked by cargo as a unit dependency on its own), and in the root's case one environment variable — so `rerun-if-changed=build.rs` is the correct scope.

Two effects:

- The root `build.rs` now declares `rerun-if-env-changed=CRYPTOGRAPHY_BUILD_OPENSSL_NO_LEGACY`, which it reads but which cargo previously didn't track: changing it between builds didn't trigger a rerun unless something else happened to dirty the crate.
- Whole-package mtime fingerprinting is what makes these crates rebuild spuriously when file mtimes move without content changes — it's also a hard blocker for caching workspace-crate artifacts in CI (an equality check that no mtime restoration can satisfy), which is a follow-up I'd like to send.

`nox -e rust` (fmt, clippy, cargo test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE

---
_Generated by [Claude Code](https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE)_