### PR TITLE
Don't write __pycache__ into _cffi_src from the build script

### DIFF
--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -32,6 +32,10 @@ fn main() {
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)
         .env("OUT_DIR", &out_dir)
+        // Writing __pycache__ into _cffi_src would bump the mtime of a
+        // directory this build script registers rerun-if-changed on,
+        // re-dirtying the crate on every subsequent build.
+        .env("PYTHONDONTWRITEBYTECODE", "1")
         .arg("../../_cffi_src/build_openssl.py")
         .output()
         .expect("failed to execute build_openssl.py");


### PR DESCRIPTION
cryptography-cffi's build script registers `rerun-if-changed` on `src/_cffi_src/` and then runs `build_openssl.py`, which imports modules from that directory — writing `__pycache__` into it. Creating/updating entries bumps the directory mtime that cargo compares against the recorded fingerprint, so the build script re-dirties *itself*: the next build reruns it and recompiles cryptography-cffi and its dependents with no actual change.

Concretely, this is why the second `maturin develop`/nox build after a fresh clone rebuilds cryptography-cffi and cryptography-rust (and why every CI build would, if workspace artifacts were cached). It's also why the `.pyc` files keep getting rewritten: cargo-triggered mtime churn invalidates the bytecode cache header, which rewrites the `.pyc`, which re-dirties the directory.

Running the script with `PYTHONDONTWRITEBYTECODE=1` leaves the source tree untouched. Verified locally that with this (plus the sibling `rerun-if` PR #15214) two consecutive builds with no changes go from recompiling 2 crates to recompiling nothing.

`nox -e rust` (fmt, clippy, cargo test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE

---
_Generated by [Claude Code](https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE)_