### PR TITLE
Key the macOS Rust cache on the resolved Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,19 +302,25 @@ jobs:
         timeout-minutes: 3
         with:
           persist-credentials: false
-      - name: Cache rust and pip
-        uses: ./.github/actions/cache
-        timeout-minutes: 2
-        with:
-          key: ${{ matrix.PYTHON.NOXSESSION }}-${{ matrix.PYTHON.VERSION }}
-
       - name: Setup python
+        id: setup-python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           cache: pip
           cache-dependency-path: ci-constraints-requirements.txt
         timeout-minutes: 3
+      # Keyed on the resolved interpreter version (like the linux and
+      # windows jobs), not just the matrix name: the alpha that a -dev
+      # entry resolves to moves over time, and a cached maturin/pyo3
+      # config built by an older alpha gets rewritten by maturin on every
+      # run, which re-dirties pyo3-ffi and recompiles it, pyo3, and every
+      # crate above them despite a warm cache.
+      - name: Cache rust and pip
+        uses: ./.github/actions/cache
+        timeout-minutes: 2
+        with:
+          key: ${{ matrix.PYTHON.NOXSESSION }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}
       - run: rustup component add llvm-tools-preview
 
       - run: python -m pip install -c ci-constraints-requirements.txt 'nox[uv]' 'tomli; python_version < "3.11"'


### PR DESCRIPTION
Split out of #15216, but a bug fix for current CI on its own.

The macOS jobs key their Rust cache only on the matrix name (`3.15-dev`), unlike linux and windows, which include the resolved interpreter version. The alpha a `-dev` entry resolves to moves over time, so the separately cached maturin/pyo3 config eventually belongs to an older alpha: maturin rewrites it on every run, the fresh mtime re-dirties pyo3-ffi's `rerun-if-changed` on it, and pyo3-ffi + pyo3 + every crate above them recompile on every macOS `3.15-dev`/`3.15t-dev` job despite a warm cache. The stale cache never corrects itself because its key always hits. (Observed directly in #15216's warm-cache runs: those two jobs rebuilt the whole pyo3 chain while the stable-Python jobs didn't.)

Keying on the resolved version rotates the cache whenever the interpreter actually changes; this requires moving the cache step after setup-python, which is also the order the other jobs use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE

---
_Generated by [Claude Code](https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE)_