### PR TITLE
Don't fingerprint cryptography-cffi's build on the PYO3_PYTHON path

### DIFF
--- a/src/rust/cryptography-cffi/build.rs
+++ b/src/rust/cryptography-cffi/build.rs
@@ -27,7 +27,17 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     // FIXME: maybe pyo3-build-config should provide a way to do this?
     let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
-    println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+    // maturin/uv build isolation points PYO3_PYTHON at an ephemeral
+    // environment whose path changes on every build, so fingerprinting
+    // its value would rerun this script (and recompile this crate and
+    // its dependents) on every build. When a pyo3 config file is in use
+    // it fully identifies the target interpreter, so track it instead.
+    if let Ok(config_file) = env::var("PYO3_CONFIG_FILE") {
+        println!("cargo:rerun-if-env-changed=PYO3_CONFIG_FILE");
+        println!("cargo:rerun-if-changed={config_file}");
+    } else {
+        println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+    }
     println!("cargo:rerun-if-changed=../../_cffi_src/");
     println!("cargo:rerun-if-changed=../../cryptography/__about__.py");
     let output = Command::new(&python)


### PR DESCRIPTION
Split out of #15216, found via cargo's fingerprint logs there:

```
dirty: EnvVarChanged { name: "PYO3_PYTHON",
  old_value: Some("/Users/runner/.cache/uv/builds-v0/.tmpXqzoey/bin/python"), ... }
```

cryptography-cffi's build script declares `rerun-if-env-changed=PYO3_PYTHON`, but maturin under uv's build isolation points `PYO3_PYTHON` at an ephemeral environment whose path changes on every build — so the fingerprint can never match, and the build script (plus this crate and its cdylib dependent) rerun unconditionally whenever there's prior build state to reuse. The same applies to repeated local `uv pip install` builds sharing a target directory.

When a pyo3 config file is in use it fully identifies the target interpreter, so track `PYO3_CONFIG_FILE` (a stable path) and the file's contents instead; the interpreter still executes from `PYO3_PYTHON`, and plain cargo builds without maturin keep the old fingerprinting.

On its own this mostly removes a footgun; it's also the last prerequisite for reusing cached workspace builds in CI (#15216) — with it, warm-cache stable-Python macOS jobs stop recompiling cffi + cryptography-rust.

`nox -e rust` (fmt, clippy, cargo test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE

---
_Generated by [Claude Code](https://claude.ai/code/session_013MTT3EVJrxAz3oJZhh6rhE)_