### PR TITLE
Add support for creating unsigned certificates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,8 @@ Changelog
   classes and the classes in
   :mod:`~cryptography.hazmat.primitives.asymmetric.padding` can now be
   compared with ``==``.
+* :class:`~cryptography.x509.CertificateBuilder` now supports creating unsigned
+  certificates (:rfc:`9925`) with the ``create_unsigned`` method.
 
 .. _v49-0-0:
 

--- a/docs/x509/reference.rst
+++ b/docs/x509/reference.rst
@@ -887,7 +887,7 @@ X.509 Certificate Builder
     .. versionadded:: 1.0
 
     .. note::
-       All methods, except :meth:`sign`, return a **new** CertificateBuilder
+       All methods, except :meth:`sign` and :meth:`create_unsigned`, return a **new** CertificateBuilder
        instance with the corresponding updated value. They do not modify the
        existing builder in place.
 
@@ -1077,6 +1077,14 @@ X.509 Certificate Builder
             key types **must** not pass a value other than ``None``.
 
         :type ecdsa_deterministic: ``None``, ``bool``
+
+        :returns: :class:`~cryptography.x509.Certificate`
+
+    .. method:: create_unsigned()
+
+        .. versionadded:: 50.0.0
+
+        Creates an unsigned certificate, per :rfc:`9925`.
 
         :returns: :class:`~cryptography.x509.Certificate`
 
@@ -3661,6 +3669,13 @@ instances. The following common OIDs are available as constants.
 
         Corresponds to the dotted string ``"2.5.4.17"``.
 
+    .. attribute:: UNSIGNED
+
+        .. versionadded:: 50.0.0
+
+        Corresponds to the dotted string ``"1.3.6.1.5.5.7.25.1"``. Used in
+        unsigned certificates. See :rfc:`9925`.
+
     .. attribute:: UNSTRUCTURED_NAME
 
         .. versionadded:: 3.0
@@ -3840,6 +3855,13 @@ instances. The following common OIDs are available as constants.
 
         Corresponds to the dotted string ``"2.16.840.1.101.3.4.3.19"``. This is
         a signature using an ML-DSA-87 key.
+
+    .. attribute:: UNSIGNED
+
+        .. versionadded:: 50.0.0
+
+        Corresponds to the dotted string ``"1.3.6.1.5.5.7.6.36"``. This indicates
+        that there is no signature. See :rfc:`9925`.
 
 
 .. class:: ExtendedKeyUsageOID

--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -87,6 +87,7 @@ class NameOID:
     OGRN = ObjectIdentifier("1.2.643.100.1")
     SNILS = ObjectIdentifier("1.2.643.100.3")
     UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2")
+    UNSIGNED = ObjectIdentifier("1.3.6.1.5.5.7.25.1")
 
 
 class SignatureAlgorithmOID:
@@ -125,6 +126,7 @@ class SignatureAlgorithmOID:
     GOSTR3411_94_WITH_3410_2001 = ObjectIdentifier("1.2.643.2.2.3")
     GOSTR3410_2012_WITH_3411_2012_256 = ObjectIdentifier("1.2.643.7.1.1.3.2")
     GOSTR3410_2012_WITH_3411_2012_512 = ObjectIdentifier("1.2.643.7.1.1.3.3")
+    UNSIGNED = ObjectIdentifier("1.3.6.1.5.5.7.6.36")
 
 
 _SIG_OIDS_TO_HASH: dict[ObjectIdentifier, hashes.HashAlgorithm | None] = {
@@ -159,6 +161,7 @@ _SIG_OIDS_TO_HASH: dict[ObjectIdentifier, hashes.HashAlgorithm | None] = {
     SignatureAlgorithmOID.GOSTR3411_94_WITH_3410_2001: None,
     SignatureAlgorithmOID.GOSTR3410_2012_WITH_3411_2012_256: None,
     SignatureAlgorithmOID.GOSTR3410_2012_WITH_3411_2012_512: None,
+    SignatureAlgorithmOID.UNSIGNED: None,
 }
 
 

--- a/src/cryptography/hazmat/bindings/_rust/x509.pyi
+++ b/src/cryptography/hazmat/bindings/_rust/x509.pyi
@@ -43,7 +43,7 @@ def parse_name_bytes(data: bytes) -> x509.Name: ...
 def encode_extension_value(extension: x509.ExtensionType) -> bytes: ...
 def create_x509_certificate(
     builder: x509.CertificateBuilder,
-    private_key: PrivateKeyTypes,
+    private_key: PrivateKeyTypes | None,
     hash_algorithm: hashes.HashAlgorithm | None,
     rsa_padding: PKCS1v15 | PSS | None,
     ecdsa_deterministic: bool | None,

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -548,6 +548,9 @@ class CertificateBuilder:
         if self._public_key is None:
             raise ValueError("A certificate must have a public key")
 
+        if private_key is None:
+            raise TypeError("Need private key to sign certificate")
+
         if rsa_padding is not None:
             if not isinstance(rsa_padding, (padding.PSS, padding.PKCS1v15)):
                 raise TypeError("Padding must be PSS or PKCS1v15")
@@ -566,6 +569,36 @@ class CertificateBuilder:
             algorithm,
             rsa_padding,
             ecdsa_deterministic,
+        )
+
+    def create_unsigned(self) -> Certificate:
+        """
+        Creates an unsigned certificate, per RFC 9925.
+        """
+        if self._subject_name is None:
+            raise ValueError("A certificate must have a subject name")
+
+        if self._issuer_name is None:
+            raise ValueError("A certificate must have an issuer name")
+
+        if self._serial_number is None:
+            raise ValueError("A certificate must have a serial number")
+
+        if self._not_valid_before is None:
+            raise ValueError("A certificate must have a not valid before time")
+
+        if self._not_valid_after is None:
+            raise ValueError("A certificate must have a not valid after time")
+
+        if self._public_key is None:
+            raise ValueError("A certificate must have a public key")
+
+        return rust_x509.create_x509_certificate(
+            self,
+            private_key=None,
+            hash_algorithm=None,
+            rsa_padding=None,
+            ecdsa_deterministic=None,
         )
 
 

--- a/src/rust/cryptography-x509/src/common.rs
+++ b/src/rust/cryptography-x509/src/common.rs
@@ -70,6 +70,9 @@ pub enum AlgorithmParameters<'a> {
     #[defined_by(oid::ML_KEM_1024_OID)]
     MlKem1024,
 
+    #[defined_by(oid::UNSIGNED_OID)]
+    Unsigned,
+
     // These encodings are only used in SPKI AlgorithmIdentifiers.
     #[defined_by(oid::EC_OID)]
     Ec(EcParameters<'a>),

--- a/src/rust/cryptography-x509/src/oid.rs
+++ b/src/rust/cryptography-x509/src/oid.rs
@@ -116,6 +116,8 @@ pub const ML_DSA_87_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101,
 pub const ML_KEM_768_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 4, 2);
 pub const ML_KEM_1024_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 4, 3);
 
+pub const UNSIGNED_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 6, 1, 5, 5, 7, 6, 36);
+
 // Hashes
 pub const SHA1_OID: asn1::ObjectIdentifier = asn1::oid!(1, 3, 14, 3, 2, 26);
 pub const SHA224_OID: asn1::ObjectIdentifier = asn1::oid!(2, 16, 840, 1, 101, 3, 4, 2, 4);

--- a/src/rust/src/x509/certificate.rs
+++ b/src/rust/src/x509/certificate.rs
@@ -1009,12 +1009,19 @@ pub(crate) fn create_x509_certificate(
     rsa_padding: &pyo3::Bound<'_, pyo3::PyAny>,
     ecdsa_deterministic: Option<bool>,
 ) -> CryptographyResult<Certificate> {
-    let sigalg = x509::sign::compute_signature_algorithm(
-        py,
-        private_key.clone(),
-        hash_algorithm.clone(),
-        rsa_padding.clone(),
-    )?;
+    let sigalg = if private_key.is_none() {
+        common::AlgorithmIdentifier {
+            oid: asn1::DefinedByMarker::marker(),
+            params: common::AlgorithmParameters::Unsigned,
+        }
+    } else {
+        x509::sign::compute_signature_algorithm(
+            py,
+            private_key.clone(),
+            hash_algorithm.clone(),
+            rsa_padding.clone(),
+        )?
+    };
 
     let spki_bytes = builder
         .getattr(pyo3::intern!(py, "_public_key"))?
@@ -1090,19 +1097,25 @@ pub(crate) fn create_x509_certificate(
         )?,
     };
 
-    let tbs_bytes = asn1::write_single(&tbs_cert)?;
-    let signature = x509::sign::sign_data(
-        py,
-        private_key.clone(),
-        hash_algorithm.clone(),
-        rsa_padding.clone(),
-        ecdsa_deterministic,
-        &tbs_bytes,
-    )?;
+    let sig_bytes = if private_key.is_none() {
+        None
+    } else {
+        let tbs_bytes = asn1::write_single(&tbs_cert)?;
+        Some(x509::sign::sign_data(
+            py,
+            private_key.clone(),
+            hash_algorithm.clone(),
+            rsa_padding.clone(),
+            ecdsa_deterministic,
+            &tbs_bytes,
+        )?)
+    };
+    let signature = sig_bytes.as_deref().unwrap_or(b"");
+
     let data = asn1::write_single(&cryptography_x509::certificate::Certificate {
         tbs_cert,
         signature_alg: sigalg,
-        signature: asn1::BitString::new(&signature, 0).unwrap(),
+        signature: asn1::BitString::new(signature, 0).unwrap(),
     })?;
     load_der_x509_certificate(py, pyo3::types::PyBytes::new(py, &data).unbind(), None)
 }

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -2988,6 +2988,8 @@ class TestCertificateBuilder:
         )
         with pytest.raises(ValueError):
             builder.sign(subject_private_key, hashes.SHA256())
+        with pytest.raises(ValueError):
+            builder.create_unsigned()
 
     def test_no_issuer_name(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
@@ -3003,6 +3005,8 @@ class TestCertificateBuilder:
         )
         with pytest.raises(ValueError):
             builder.sign(subject_private_key, hashes.SHA256())
+        with pytest.raises(ValueError):
+            builder.create_unsigned()
 
     def test_no_public_key(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
@@ -3020,6 +3024,8 @@ class TestCertificateBuilder:
         )
         with pytest.raises(ValueError):
             builder.sign(subject_private_key, hashes.SHA256())
+        with pytest.raises(ValueError):
+            builder.create_unsigned()
 
     def test_no_not_valid_before(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
@@ -3037,6 +3043,8 @@ class TestCertificateBuilder:
         )
         with pytest.raises(ValueError):
             builder.sign(subject_private_key, hashes.SHA256())
+        with pytest.raises(ValueError):
+            builder.create_unsigned()
 
     def test_no_not_valid_after(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
@@ -3054,6 +3062,8 @@ class TestCertificateBuilder:
         )
         with pytest.raises(ValueError):
             builder.sign(subject_private_key, hashes.SHA256())
+        with pytest.raises(ValueError):
+            builder.create_unsigned()
 
     def test_no_serial_number(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
@@ -3071,6 +3081,8 @@ class TestCertificateBuilder:
         )
         with pytest.raises(ValueError):
             builder.sign(subject_private_key, hashes.SHA256())
+        with pytest.raises(ValueError):
+            builder.create_unsigned()
 
     def test_issuer_name_must_be_a_name_type(self):
         builder = x509.CertificateBuilder()
@@ -4784,6 +4796,62 @@ class TestCertificateBuilder:
         ext = cert.extensions.get_extension_for_oid(unrecognized.oid)
 
         assert ext.value == unrecognized
+
+    def test_sign_without_private_key(self, rsa_key_2048: rsa.RSAPrivateKey):
+        subject_private_key = rsa_key_2048
+
+        not_valid_before = datetime.datetime(2002, 1, 1, 12, 1)
+        not_valid_after = datetime.datetime(2030, 12, 31, 8, 30)
+
+        builder = (
+            x509.CertificateBuilder()
+            .serial_number(777)
+            .issuer_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "NO")])
+            )
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "NO")])
+            )
+            .public_key(subject_private_key.public_key())
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+        )
+
+        with pytest.raises(TypeError):
+            builder.sign(None, None)  # type:ignore[arg-type]
+
+    def test_build_unsigned_cert(self, rsa_key_2048: rsa.RSAPrivateKey):
+        subject_private_key = rsa_key_2048
+
+        not_valid_before = datetime.datetime(2002, 1, 1, 12, 1)
+        not_valid_after = datetime.datetime(2030, 12, 31, 8, 30)
+
+        builder = (
+            x509.CertificateBuilder()
+            .serial_number(777)
+            .issuer_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "NO")])
+            )
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "NO")])
+            )
+            .public_key(subject_private_key.public_key())
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+        )
+
+        cert = builder.create_unsigned()
+
+        assert cert.public_key() == subject_private_key.public_key()
+        assert cert.signature_algorithm_oid == SignatureAlgorithmOID.UNSIGNED
+        assert cert.signature_hash_algorithm is None
+        assert cert.signature_algorithm_parameters is None
+        assert cert.signature == b""
+
+        with pytest.raises(
+            ValueError, match="Unsupported signature algorithm"
+        ):
+            cert.verify_directly_issued_by(cert)
 
 
 class TestCertificateSigningRequestBuilder:


### PR DESCRIPTION
First try for #15241.

I wasn't sure if there should be any validation for the subject or the extensions in the `create_unsigned()` method, but since the CertificateBuilder doesn't really do much validation for those today, I opted to skip it.

Also wasn't sure if the unsigned alg oid belongs in the `_SIG_OIDS_TO_HASH`.