### PR TITLE
reject non-zero version in pkcs7 enveloped data decryption

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,10 @@ Changelog
   or response whose ``version`` field is not ``v1``, the only version defined
   by RFC 6960, matching the version validation already performed when loading
   certificates, CSRs and CRLs.
+* Decrypting a PKCS7 ``EnvelopedData`` structure now rejects a non-zero
+  ``EnvelopedData`` or ``RecipientInfo`` ``version``, which RFC 5652 fixes at
+  ``0`` for the structure shape that is accepted, instead of ignoring the
+  field.
 * :class:`~cryptography.hazmat.primitives.hashes.XOFHash` is now supported
   when building against AWS-LC.
 * HMAC (and therefore PBKDF2-HMAC) with SHA-3 hashes is now supported when

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -248,6 +248,18 @@ fn decrypt_der<'p>(
             // Extract enveloped data
             let enveloped_data = data.into_inner();
 
+            // For the structure we accept here (no originatorInfo and no
+            // unprotectedAttrs), RFC 5652 6.1 fixes the EnvelopedData version at
+            // 0, so anything else is malformed input.
+            if enveloped_data.version != 0 {
+                return Err(CryptographyError::from(
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "{} is not a valid EnvelopedData version",
+                        enveloped_data.version
+                    )),
+                ));
+            }
+
             // Get recipients, and the one matching with the given certificate (if any)
             let mut recipient_infos = enveloped_data.recipient_infos.unwrap_read().clone();
             let recipient_certificate = certificate.get().raw.borrow_dependent();
@@ -269,6 +281,18 @@ fn decrypt_der<'p>(
                     ));
                 }
             };
+
+            // A KeyTransRecipientInfo that identifies the recipient by
+            // issuerAndSerialNumber (the only form we parse) is version 0 per
+            // RFC 5652 6.2.1; reject any other value as malformed.
+            if recipient_info.version != 0 {
+                return Err(CryptographyError::from(
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "{} is not a valid RecipientInfo version",
+                        recipient_info.version
+                    )),
+                ));
+            }
 
             // Raise error when the key encryption algorithm is not RSA
             let key = match recipient_info.key_encryption_algorithm.oid() {

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -1326,6 +1326,37 @@ class TestPKCS7Decrypt:
         with pytest.raises(ValueError):
             pkcs7.pkcs7_decrypt_der(enveloped, certificate, private_key, [])
 
+    @pytest.mark.parametrize("occurrence", [0, 1])
+    def test_pkcs7_decrypt_der_invalid_version(
+        self, occurrence, data, certificate, private_key
+    ):
+        # occurrence 0 is the EnvelopedData version, occurrence 1 is the
+        # RecipientInfo version; both are the only "INTEGER 0" fields that
+        # appear before the (large) serial number, and RFC 5652 fixes both at 0
+        # for the structure we accept.
+        builder = (
+            pkcs7.PKCS7EnvelopeBuilder()
+            .set_data(data)
+            .add_recipient(certificate)
+        )
+        enveloped = bytearray(builder.encrypt(serialization.Encoding.DER, []))
+
+        positions = []
+        start = 0
+        while True:
+            i = enveloped.find(b"\x02\x01\x00", start)
+            if i == -1:
+                break
+            positions.append(i)
+            start = i + 3
+        # Bump the value byte to a version RFC 5652 does not permit here.
+        enveloped[positions[occurrence] + 2] = 0x2A
+
+        with pytest.raises(ValueError):
+            pkcs7.pkcs7_decrypt_der(
+                bytes(enveloped), certificate, private_key, []
+            )
+
     def test_pkcs7_decrypt_text_no_header(
         self, data, certificate, private_key
     ):


### PR DESCRIPTION
When decrypting a PKCS7 EnvelopedData we read the EnvelopedData and RecipientInfo version fields but never check them, so a message whose version is not zero is accepted and decrypted even though it is malformed. For the shape we accept here, with no originatorInfo or unprotected attributes and a recipient identified by issuer and serial number, RFC 5652 6.1 and 6.2.1 fix both versions at zero, so any other value is out of spec. This rejects it in both places, matching the version validation the certificate, CSR, CRL and OCSP loaders already do.