### PR TITLE
Allow a ML-KEM public key to be used in X.509 certificates

### DIFF
--- a/src/cryptography/hazmat/_oid.py
+++ b/src/cryptography/hazmat/_oid.py
@@ -193,6 +193,8 @@ class PublicKeyAlgorithmOID:
     ML_DSA_44 = ObjectIdentifier("2.16.840.1.101.3.4.3.17")
     ML_DSA_65 = ObjectIdentifier("2.16.840.1.101.3.4.3.18")
     ML_DSA_87 = ObjectIdentifier("2.16.840.1.101.3.4.3.19")
+    ML_KEM_768 = ObjectIdentifier("2.16.840.1.101.3.4.4.2")
+    ML_KEM_1024 = ObjectIdentifier("2.16.840.1.101.3.4.4.3")
 
 
 class ExtendedKeyUsageOID:

--- a/src/cryptography/hazmat/primitives/asymmetric/types.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/types.py
@@ -75,7 +75,7 @@ CertificateIssuerPublicKeyTypes = typing.Union[
     mldsa.MLDSA65PublicKey,
     mldsa.MLDSA87PublicKey,
 ]
-# This type removes DHPublicKey. x448/x25519 can be a public key
+# This type removes DHPublicKey. x448/x25519/mlkem can be a public key
 # but cannot be used in signing so they are allowed here.
 CertificatePublicKeyTypes = typing.Union[
     dsa.DSAPublicKey,
@@ -86,6 +86,8 @@ CertificatePublicKeyTypes = typing.Union[
     mldsa.MLDSA44PublicKey,
     mldsa.MLDSA65PublicKey,
     mldsa.MLDSA87PublicKey,
+    mlkem.MLKEM768PublicKey,
+    mlkem.MLKEM1024PublicKey,
     x25519.X25519PublicKey,
     x448.X448PublicKey,
 ]

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -18,6 +18,7 @@ from cryptography.hazmat.primitives.asymmetric import (
     ed448,
     ed25519,
     mldsa,
+    mlkem,
     padding,
     rsa,
     x448,
@@ -372,6 +373,8 @@ class CertificateBuilder:
                 mldsa.MLDSA44PublicKey,
                 mldsa.MLDSA65PublicKey,
                 mldsa.MLDSA87PublicKey,
+                mlkem.MLKEM768PublicKey,
+                mlkem.MLKEM1024PublicKey,
                 x25519.X25519PublicKey,
                 x448.X448PublicKey,
             ),
@@ -380,8 +383,8 @@ class CertificateBuilder:
                 "Expecting one of DSAPublicKey, RSAPublicKey,"
                 " EllipticCurvePublicKey, Ed25519PublicKey,"
                 " Ed448PublicKey, MLDSA44PublicKey, MLDSA65PublicKey,"
-                " MLDSA87PublicKey, X25519PublicKey, or "
-                "X448PublicKey."
+                " MLDSA87PublicKey, MLKEM768PublicKey, MLKEM1024PublicKey,"
+                " X25519PublicKey or X448PublicKey."
             )
         if rsa_padding is not None:
             if rsa_padding is not padding.PSS:

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -23,6 +23,7 @@ from cryptography.hazmat.primitives.asymmetric import (
     ed448,
     ed25519,
     mldsa,
+    mlkem,
     padding,
     rsa,
     types,
@@ -4090,6 +4091,108 @@ class TestCertificateBuilder:
         assert cert.signature_hash_algorithm is None
         assert cert.signature_algorithm_parameters is None
         assert isinstance(cert.public_key(), pub_key_cls)
+        assert cert.public_key_algorithm_oid == pub_oid
+        assert cert.version is x509.Version.v3
+
+    @pytest.mark.supported(
+        only_if=lambda backend: (
+            backend.mldsa_supported() and backend.mlkem_supported()
+        ),
+        skip_message="Requires a backend with ML-DSA and ML-KEM support",
+    )
+    @pytest.mark.parametrize(
+        (
+            "issuer_key_cls",
+            "priv_subject_key_cls",
+            "pub_subject_key_cls",
+            "sig_oid",
+            "pub_oid",
+        ),
+        [
+            (
+                mldsa.MLDSA44PrivateKey,
+                mlkem.MLKEM768PrivateKey,
+                mlkem.MLKEM768PublicKey,
+                SignatureAlgorithmOID.ML_DSA_44,
+                PublicKeyAlgorithmOID.ML_KEM_768,
+            ),
+            (
+                mldsa.MLDSA65PrivateKey,
+                mlkem.MLKEM768PrivateKey,
+                mlkem.MLKEM768PublicKey,
+                SignatureAlgorithmOID.ML_DSA_65,
+                PublicKeyAlgorithmOID.ML_KEM_768,
+            ),
+            (
+                mldsa.MLDSA87PrivateKey,
+                mlkem.MLKEM768PrivateKey,
+                mlkem.MLKEM768PublicKey,
+                SignatureAlgorithmOID.ML_DSA_87,
+                PublicKeyAlgorithmOID.ML_KEM_768,
+            ),
+            (
+                mldsa.MLDSA44PrivateKey,
+                mlkem.MLKEM1024PrivateKey,
+                mlkem.MLKEM1024PublicKey,
+                SignatureAlgorithmOID.ML_DSA_44,
+                PublicKeyAlgorithmOID.ML_KEM_1024,
+            ),
+            (
+                mldsa.MLDSA65PrivateKey,
+                mlkem.MLKEM1024PrivateKey,
+                mlkem.MLKEM1024PublicKey,
+                SignatureAlgorithmOID.ML_DSA_65,
+                PublicKeyAlgorithmOID.ML_KEM_1024,
+            ),
+            (
+                mldsa.MLDSA87PrivateKey,
+                mlkem.MLKEM1024PrivateKey,
+                mlkem.MLKEM1024PublicKey,
+                SignatureAlgorithmOID.ML_DSA_87,
+                PublicKeyAlgorithmOID.ML_KEM_1024,
+            ),
+        ],
+    )
+    def test_build_cert_with_public_mlkem_mldsa_sig(
+        self,
+        issuer_key_cls,
+        priv_subject_key_cls,
+        pub_subject_key_cls,
+        sig_oid,
+        pub_oid,
+    ):
+        issuer_private_key = issuer_key_cls.generate()
+        subject_private_key = priv_subject_key_cls.generate()
+
+        not_valid_before = datetime.datetime(2002, 1, 1, 12, 1)
+        not_valid_after = datetime.datetime(2030, 12, 31, 8, 30)
+
+        builder = (
+            x509.CertificateBuilder()
+            .serial_number(777)
+            .issuer_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+            )
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, "US")])
+            )
+            .public_key(subject_private_key.public_key())
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                True,
+            )
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+        )
+
+        cert = builder.sign(issuer_private_key, None)
+        issuer_private_key.public_key().verify(
+            cert.signature, cert.tbs_certificate_bytes
+        )
+        assert cert.signature_algorithm_oid == sig_oid
+        assert cert.signature_hash_algorithm is None
+        assert cert.signature_algorithm_parameters is None
+        assert isinstance(cert.public_key(), pub_subject_key_cls)
         assert cert.public_key_algorithm_oid == pub_oid
         assert cert.version is x509.Version.v3
 


### PR DESCRIPTION
This PR allows ML-KEM public keys to be used as `subjectPublicKeyInfo` in X.509 certificates as mentioned in #15263. 