### PR TITLE
Remove dead PUBLISH_REQUIREMENTS_PATH env from pypi-publish.yml

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,9 +15,6 @@ on:
     workflows: ["Wheel Builder"]
     types: [completed]
 
-env:
-  PUBLISH_REQUIREMENTS_PATH: .github/requirements/publish-requirements.txt
-
 permissions:
   contents: read
 


### PR DESCRIPTION
PUBLISH_REQUIREMENTS_PATH points at .github/requirements/publish-requirements.txt, which no longer exists, and no step in the workflow reads the variable. 

This removes the dead env block.