### PR TITLE
Annotate dtolnay/rust-toolchain SHA pin with its ref

### DIFF
--- a/.github/actions/windows-wheel/action.yml
+++ b/.github/actions/windows-wheel/action.yml
@@ -43,7 +43,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         architecture: ${{ inputs.arch }}
-    - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+    - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master, as of Aug 23, 2025
       with:
         toolchain: stable
         target: ${{ inputs.rust-triple }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           cache-dependency-path: ci-constraints-requirements.txt
         timeout-minutes: 3
       - name: Setup rust
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master, as of Aug 23, 2025
         with:
           toolchain: ${{ matrix.PYTHON.RUST }}
           components: rustfmt,clippy

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -248,7 +248,7 @@ jobs:
           name: openssl-macos-arm64
           path: "../openssl-macos-arm64/"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master, as of Aug 23, 2025
         with:
           toolchain: stable
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Every other SHA-pinned action carries a version comment; this one lacked it because` dtolnay/rust-toolchain` publishes no tags. 

This annotates the three uses with the branch and commit date **(master, as of Aug 23, 2025)**, matching the style used for the BoringSSL commit pins.