### PR TITLE
Deny unsafe_op_in_unsafe_fn in crates containing unsafe code

### DIFF
--- a/src/rust/cryptography-cffi/src/lib.rs
+++ b/src/rust/cryptography-cffi/src/lib.rs
@@ -2,7 +2,11 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-#![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
+#![deny(
+    rust_2018_idioms,
+    unsafe_op_in_unsafe_fn,
+    clippy::undocumented_unsafe_blocks
+)]
 
 #[cfg(python_implementation = "PyPy")]
 extern "C" {

--- a/src/rust/cryptography-keepalive/src/lib.rs
+++ b/src/rust/cryptography-keepalive/src/lib.rs
@@ -2,7 +2,11 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-#![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
+#![deny(
+    rust_2018_idioms,
+    unsafe_op_in_unsafe_fn,
+    clippy::undocumented_unsafe_blocks
+)]
 
 use std::cell::UnsafeCell;
 use std::ops::Deref;

--- a/src/rust/cryptography-openssl/src/lib.rs
+++ b/src/rust/cryptography-openssl/src/lib.rs
@@ -2,7 +2,11 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-#![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
+#![deny(
+    rust_2018_idioms,
+    unsafe_op_in_unsafe_fn,
+    clippy::undocumented_unsafe_blocks
+)]
 
 #[cfg(any(CRYPTOGRAPHY_IS_BORINGSSL, CRYPTOGRAPHY_IS_AWSLC))]
 pub mod aead;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -2,7 +2,11 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-#![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
+#![deny(
+    rust_2018_idioms,
+    unsafe_op_in_unsafe_fn,
+    clippy::undocumented_unsafe_blocks
+)]
 #![allow(unknown_lints, non_local_definitions, clippy::result_large_err)]
 
 #[cfg(not(any(


### PR DESCRIPTION
Adds `unsafe_op_in_unsafe_fn` to the existing `#![deny(...)]` in the four crates that contain unsafe code. 

Every unsafe operation inside an `unsafe fn` must now sit in an explicit `unsafe` block, which — combined with the already-denied `clippy::undocumented_unsafe_blocks` — means each one also carries a `SAFETY` comment. 

The codebase already complies (zero violations; ` cargo check --locked --workspace, cargo fmt --check,` and clippy all clean), so this only prevents silent regressions.