### PR TITLE
Add shake xof classmethods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,10 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
 .. note:: This version is not yet released and is under active development.
-
+* Added the :meth:`~cryptography.hazmat.primitives.hashes.SHAKE128.xof`
+  and :meth:`~cryptography.hazmat.primitives.hashes.SHAKE256.xof`
+  class methods for constructing algorithm instances configured for use with
+  :class:`~cryptography.hazmat.primitives.hashes.XOFHash`.
 * The :mod:`X.509 verification <cryptography.x509.verification>` APIs are now
   considered stable and are subject to our API stability policy.
 * Added the :doc:`/cobblestone` recipe, an implementation of the

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
 .. note:: This version is not yet released and is under active development.
+
 * Added the :meth:`~cryptography.hazmat.primitives.hashes.SHAKE128.xof`
   and :meth:`~cryptography.hazmat.primitives.hashes.SHAKE256.xof`
   class methods for constructing algorithm instances configured for use with

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,9 +8,10 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
-* Added the :meth:`~cryptography.hazmat.primitives.hashes.SHAKE128.xof`
-  and :meth:`~cryptography.hazmat.primitives.hashes.SHAKE256.xof`
-  class methods for constructing algorithm instances configured for use with
+* Added ``xof()`` class methods to
+  :class:`~cryptography.hazmat.primitives.hashes.SHAKE128` and
+  :class:`~cryptography.hazmat.primitives.hashes.SHAKE256` for constructing
+  algorithm instances configured for use with
   :class:`~cryptography.hazmat.primitives.hashes.XOFHash`.
 * The :mod:`X.509 verification <cryptography.x509.verification>` APIs are now
   considered stable and are subject to our API stability policy.

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -98,9 +98,8 @@ Message digests (Hashing)
 
     .. doctest::
 
-        >>> import sys
         >>> from cryptography.hazmat.primitives import hashes
-        >>> digest = hashes.XOFHash(hashes.SHAKE128(digest_size=sys.maxsize))
+        >>> digest = hashes.XOFHash(hashes.SHAKE128.xof())
         >>> digest.update(b"abc")
         >>> digest.update(b"123")
         >>> digest.squeeze(16)

--- a/docs/hazmat/primitives/cryptographic-hashes.rst
+++ b/docs/hazmat/primitives/cryptographic-hashes.rst
@@ -325,6 +325,11 @@ Extendable Output Functions
 
     :raises ValueError: If the ``digest_size`` is invalid.
 
+    .. classmethod:: xof()
+
+        Returns a :class:`SHAKE128` instance configured for use with
+        :class:`XOFHash`.
+
 .. class:: SHAKE256(digest_size)
 
     .. versionadded:: 2.5
@@ -344,6 +349,11 @@ Extendable Output Functions
         zero.
 
     :raises ValueError: If the ``digest_size`` is invalid.
+
+    .. classmethod:: xof()
+
+        Returns a :class:`SHAKE256` instance configured for use with
+        :class:`XOFHash`.
 
 
 

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-import sys
 import abc
+import sys
 
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.utils import Buffer

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -258,6 +258,7 @@ class SHAKE128(HashAlgorithm, ExtendableOutputFunction):
     def xof(cls):
         return cls(sys.maxsize)
 
+
 class SHAKE256(HashAlgorithm, ExtendableOutputFunction):
     name = "shake256"
     block_size = None
@@ -284,6 +285,7 @@ class SHAKE256(HashAlgorithm, ExtendableOutputFunction):
     @classmethod
     def xof(cls):
         return cls(sys.maxsize)
+
 
 class MD5(HashAlgorithm):
     name = "md5"

--- a/src/cryptography/hazmat/primitives/hashes.py
+++ b/src/cryptography/hazmat/primitives/hashes.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import sys
 import abc
 
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
@@ -253,6 +254,9 @@ class SHAKE128(HashAlgorithm, ExtendableOutputFunction):
     def digest_size(self) -> int:
         return self._digest_size
 
+    @classmethod
+    def xof(cls):
+        return cls(sys.maxsize)
 
 class SHAKE256(HashAlgorithm, ExtendableOutputFunction):
     name = "shake256"
@@ -277,6 +281,9 @@ class SHAKE256(HashAlgorithm, ExtendableOutputFunction):
     def digest_size(self) -> int:
         return self._digest_size
 
+    @classmethod
+    def xof(cls):
+        return cls(sys.maxsize)
 
 class MD5(HashAlgorithm):
     name = "md5"

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -3,8 +3,8 @@
 # for complete details.
 
 
-import sys
 import binascii
+import sys
 import typing
 
 import pytest

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -260,6 +260,7 @@ class TestSHAKE:
         assert isinstance(algorithm, xof)
         assert algorithm.digest_size == sys.maxsize
 
+
 @pytest.mark.supported(
     only_if=lambda backend: backend.hash_supported(hashes.SM3()),
     skip_message="Does not support SM3",

--- a/tests/hazmat/primitives/test_hashes.py
+++ b/tests/hazmat/primitives/test_hashes.py
@@ -3,6 +3,7 @@
 # for complete details.
 
 
+import sys
 import binascii
 import typing
 
@@ -253,6 +254,11 @@ class TestSHAKE:
         with pytest.raises(ValueError):
             xof(digest_size=0)
 
+    @pytest.mark.parametrize("xof", [hashes.SHAKE128, hashes.SHAKE256])
+    def test_xof(self, xof):
+        algorithm = xof.xof()
+        assert isinstance(algorithm, xof)
+        assert algorithm.digest_size == sys.maxsize
 
 @pytest.mark.supported(
     only_if=lambda backend: backend.hash_supported(hashes.SM3()),

--- a/tests/hazmat/primitives/test_xofhash.py
+++ b/tests/hazmat/primitives/test_xofhash.py
@@ -78,10 +78,8 @@ class TestXOFHash:
             actual = hashes.XOFHash(algorithm.xof())
             actual.update(data)
 
-            assert (
-                actual.squeeze(16) + actual.squeeze(16)
-                == expected.squeeze(32)
-            )
+            actual_output = actual.squeeze(16) + actual.squeeze(16)
+            assert actual_output == expected.squeeze(32)
 
     def test_exhaust_bytes(self):
         h = hashes.XOFHash(hashes.SHAKE128(digest_size=256))

--- a/tests/hazmat/primitives/test_xofhash.py
+++ b/tests/hazmat/primitives/test_xofhash.py
@@ -78,7 +78,10 @@ class TestXOFHash:
             actual = hashes.XOFHash(algorithm.xof())
             actual.update(data)
 
-            assert actual.squeeze(16) + actual.squeeze(16) == expected.squeeze(32)
+            assert (
+                actual.squeeze(16) + actual.squeeze(16)
+                == expected.squeeze(32)
+            )
 
     def test_exhaust_bytes(self):
         h = hashes.XOFHash(hashes.SHAKE128(digest_size=256))

--- a/tests/hazmat/primitives/test_xofhash.py
+++ b/tests/hazmat/primitives/test_xofhash.py
@@ -68,6 +68,18 @@ class TestXOFHash:
         h2 = h.copy()
         assert h2.squeeze(10) == h.squeeze(10)
 
+    def test_xof_classmethod(self):
+        data = b"test data"
+
+        for algorithm in (hashes.SHAKE128, hashes.SHAKE256):
+            expected = hashes.XOFHash(algorithm(sys.maxsize))
+            expected.update(data)
+
+            actual = hashes.XOFHash(algorithm.xof())
+            actual.update(data)
+
+            assert actual.squeeze(16) + actual.squeeze(16) == expected.squeeze(32)
+
     def test_exhaust_bytes(self):
         h = hashes.XOFHash(hashes.SHAKE128(digest_size=256))
         h.update(b"foo")


### PR DESCRIPTION
## Summary

Adds `SHAKE128.xof()` and `SHAKE256.xof()` classmethods for creating SHAKE algorithm indicators configured for use with `XOFHash`.

This replaces the current verbose construction:

```python
hashes.XOFHash(hashes.SHAKE128(sys.maxsize))
```

with:

```python
hashes.XOFHash(hashes.SHAKE128.xof())
```

The classmethods are thin Python wrappers over the existing API and do not require changes to the Rust implementation.

## Changes

* Added `SHAKE128.xof()` and `SHAKE256.xof()`.
* Updated the SHAKE/XOF documentation.
* Added tests for the returned algorithm indicators and repeated squeezing through `XOFHash`.
* Added a changelog entry.

## Testing

Ran the relevant `test_hashes.py` and `test_xofhash.py` tests successfully.
