### PR TITLE
Promote Windows on ARM (win_arm64) to a fully supported platform

### DIFF
--- a/.github/actions/windows-wheel/action.yml
+++ b/.github/actions/windows-wheel/action.yml
@@ -88,10 +88,7 @@ runs:
       with:
         build-requirements-path: ${{ inputs.build-requirements-path }}
 
-    # Windows on ARM is in a stability validation period; build and
-    # smoke-test the wheel but do not upload it so it cannot be published.
-    - if: inputs.arch != 'arm64'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.wheel-artifact-name }}
         path: wheelhouse\

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,30 +366,22 @@ jobs:
           - {VERSION: "3.15-dev", NOXSESSION: "tests"}
           - {VERSION: "3.15t-dev", NOXSESSION: "tests"}
         include:
-          # Windows on ARM is in a stability validation period; the work
-          # step uses `continue-on-error` only for this entry so transient
-          # failures don't block PR validation.
           - WINDOWS: {ARCH: 'arm64', WINDOWS: 'arm64', RUNNER: 'windows-11-arm'}
             PYTHON: {VERSION: "3.14", NOXSESSION: "tests-nocoverage"}
+          - WINDOWS: {ARCH: 'arm64', WINDOWS: 'arm64', RUNNER: 'windows-11-arm'}
+            PYTHON: {VERSION: "3.15-dev", NOXSESSION: "tests-nocoverage"}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 3
         with:
           persist-credentials: false
-      - id: tests
-        continue-on-error: ${{ matrix.WINDOWS.ARCH == 'arm64' }}
-        uses: ./.github/actions/windows-tests
+      - uses: ./.github/actions/windows-tests
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           noxsession: ${{ matrix.PYTHON.NOXSESSION }}
           arch: ${{ matrix.WINDOWS.ARCH }}
           openssl-name: ${{ matrix.WINDOWS.WINDOWS }}
-      - name: Report soft failure
-        if: always() && matrix.WINDOWS.ARCH == 'arm64' && steps.tests.outcome != 'success'
-        shell: bash
-        run: |
-          echo "::warning title=windows-arm64 soft failure::A step failed but the job is reported as success while Windows on ARM is in stability validation."
 
       - uses: ./.github/actions/upload-coverage
 

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -304,14 +304,12 @@ jobs:
           - {VERSION: "3.14t"}
           - {VERSION: "pypy-3.11"}
         include:
-          # Windows on ARM is in a stability validation period; the work
-          # step uses `continue-on-error` only for these entries so transient
-          # failures don't block the release pipeline and no broken wheel
-          # is uploaded.
           - WINDOWS: {ARCH: 'arm64', WINDOWS: 'arm64', RUST_TRIPLE: 'aarch64-pc-windows-msvc', RUNNER: 'windows-11-arm'}
             PYTHON: {VERSION: "3.14", "ABI_VERSION": "py311"}
           - WINDOWS: {ARCH: 'arm64', WINDOWS: 'arm64', RUST_TRIPLE: 'aarch64-pc-windows-msvc', RUNNER: 'windows-11-arm'}
             PYTHON: {VERSION: "3.14t"}
+          - WINDOWS: {ARCH: 'arm64', WINDOWS: 'arm64', RUST_TRIPLE: 'aarch64-pc-windows-msvc', RUNNER: 'windows-11-arm'}
+            PYTHON: {VERSION: "3.15-dev", "ABI_VERSION": "py311"}
     name: "${{ matrix.PYTHON.VERSION }} ${{ matrix.WINDOWS.WINDOWS }} ${{ matrix.PYTHON.ABI_VERSION }}"
     steps:
       - name: Get build-requirements.txt from repository
@@ -327,9 +325,7 @@ jobs:
             .github/actions/wheel-smoketest/
           sparse-checkout-cone-mode: false
 
-      - id: build
-        continue-on-error: ${{ matrix.WINDOWS.ARCH == 'arm64' }}
-        uses: ./.github/actions/windows-wheel
+      - uses: ./.github/actions/windows-wheel
         with:
           python-version: ${{ matrix.PYTHON.VERSION }}
           abi-version: ${{ matrix.PYTHON.ABI_VERSION }}
@@ -339,8 +335,3 @@ jobs:
           build-requirements-path: ${{ env.BUILD_REQUIREMENTS_PATH }}
           uv-requirements-path: ${{ env.UV_REQUIREMENTS_PATH }}
           wheel-artifact-name: "cryptography-${{ github.event.inputs.version }}-${{ matrix.WINDOWS.WINDOWS }}-${{ matrix.PYTHON.VERSION }}-${{ matrix.PYTHON.ABI_VERSION }}"
-      - name: Report soft failure
-        if: always() && matrix.WINDOWS.ARCH == 'arm64' && steps.build.outcome != 'success'
-        shell: bash
-        run: |
-          echo "::warning title=windows-arm64 soft failure::A step failed but the job is reported as success while Windows on ARM is in stability validation."


### PR DESCRIPTION
Windows on ARM was previously kept in a stability validation period: its wheel was built and smoke-tested but not uploaded, and the arm64 test and wheel-build steps used continue-on-error with soft-failure warnings so problems would not block CI or releases.

This promotes win_arm64 to full support:

- Upload the arm64 wheel like every other platform (drop the arch guard in the windows-wheel action).
- Remove continue-on-error and the "Report soft failure" steps for the arm64 entries in ci.yml and wheel-builder.yml, so arm64 failures are treated as real failures.
- Add Python 3.15-dev arm64 entries for both tests (ci.yml) and wheel builds (wheel-builder.yml).

Maintenance support:
- Python for win_arm64 got promoted [to a Tier 2](https://peps.python.org/pep-0011/#tier-2)
- No issues with wheel builds or tests [were observed](https://github.com/CoreCollective-dev/windows-on-arm-wg/actions/workflows/monitoring_cryptography.yml) in the last months.
- You have me @khmyznikov and @paveliak if you suddenly start observing an issues on gh actions/runner side, in addition to [CoreCollective working group](https://github.com/CoreCollective-dev/windows-on-arm-wg).