### PR TITLE
Use sort_by_cached_key when sorting candidate issuers

### DIFF
--- a/src/rust/cryptography-x509-verification/src/lib.rs
+++ b/src/rust/cryptography-x509-verification/src/lib.rs
@@ -396,7 +396,10 @@ impl<'a, 'chain, B: CryptoOps> ChainBuilder<'a, 'chain, B> {
         // likely untrusted one.
         //
         // See: <https://github.com/golang/go/blob/d00c67f297e/src/crypto/x509/cert_pool.go#L136>
-        candidates.sort_by_key(|candidate| {
+        // `sort_by_cached_key` rather than `sort_by_key`: the key function
+        // re-parses the candidate's extensions, so we only want to run it
+        // once per candidate rather than once per comparison.
+        candidates.sort_by_cached_key(|candidate| {
             let have_kid: Option<&[u8]> =
                 candidate.certificate().extensions().ok().and_then(|exts| {
                     exts.get_extension(&SUBJECT_KEY_IDENTIFIER_OID)


### PR DESCRIPTION
find_potential_parents sorts candidates with a key function that re-parses the candidate's extensions (fresh allocation + linear DER re-parse) on every comparison, i.e. O(n log n) parses. sort_by_cached_key computes the key once per candidate.

Benchmark (verify a leaf against a store of N same-DN CAs — the adversarial name-collision case the sort exists for; Linux x86-64, CPython 3.11, release build, min of 7 timeit repeats):

    N=4:     102.5 us -> 98.4 us
    N=32:    176.5 us -> 117.2 us  (1.5x)
    N=100:   359.9 us -> 151.1 us  (2.4x)


Claude-Session: https://claude.ai/code/session_01C5bsKENedjVD9gcLApf1x4