### PR TITLE
Release the GIL in one-shot AEAD encrypt/decrypt

### DIFF
--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -26,6 +26,34 @@ pub(crate) enum Aad<'a> {
     List(pyo3::Bound<'a, pyo3::types::PyList>),
 }
 
+enum ExtractedAad<'a> {
+    None,
+    Single(CffiBuf<'a>),
+    List(Vec<CffiBuf<'a>>),
+}
+
+/// Extracts and length-checks every AAD buffer. This must happen while
+/// attached to the interpreter; the returned buffers keep the underlying
+/// Python objects alive so the borrowed slices stay valid afterwards.
+fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<ExtractedAad<'_>> {
+    match aad {
+        None => Ok(ExtractedAad::None),
+        Some(Aad::Single(ad)) => {
+            check_length(ad.as_bytes())?;
+            Ok(ExtractedAad::Single(ad))
+        }
+        Some(Aad::List(ads)) => {
+            let mut bufs = Vec::with_capacity(ads.len());
+            for ad in ads.iter() {
+                let buf = ad.extract::<CffiBuf<'_>>()?;
+                check_length(buf.as_bytes())?;
+                bufs.push(buf);
+            }
+            Ok(ExtractedAad::List(bufs))
+        }
+    }
+}
+
 pub(crate) enum AeadCipher {
     Static(&'static openssl::cipher::CipherRef),
     #[cfg(not(any(
@@ -96,21 +124,10 @@ impl EvpCipherAead {
 
     fn process_aad(
         ctx: &mut openssl::cipher_ctx::CipherCtx,
-        aad: Option<Aad<'_>>,
+        aad_slices: &[&[u8]],
     ) -> CryptographyResult<()> {
-        match aad {
-            Some(Aad::Single(ad)) => {
-                check_length(ad.as_bytes())?;
-                ctx.cipher_update(ad.as_bytes(), None)?;
-            }
-            Some(Aad::List(ads)) => {
-                for ad in ads.iter() {
-                    let ad = ad.extract::<CffiBuf<'_>>()?;
-                    check_length(ad.as_bytes())?;
-                    ctx.cipher_update(ad.as_bytes(), None)?;
-                }
-            }
-            None => {}
+        for ad in aad_slices {
+            ctx.cipher_update(ad, None)?;
         }
 
         Ok(())
@@ -205,8 +222,6 @@ impl EvpCipherAead {
             ctx.encrypt_init(None, None, nonce)?;
         }
 
-        Self::process_aad(&mut ctx, aad)?;
-
         let ciphertext;
         let tag;
         if self.tag_first {
@@ -215,9 +230,34 @@ impl EvpCipherAead {
             (ciphertext, tag) = buf.split_at_mut(plaintext.len());
         }
 
-        Self::process_data(&mut ctx, plaintext, ciphertext, self.is_ccm)?;
+        // Extract the AAD buffers while attached to the interpreter; the
+        // buffer owners are kept alive by this frame, so the borrowed
+        // slices remain valid while detached.
+        let extracted_aad = extract_aad(aad)?;
+        let single_storage;
+        let list_storage;
+        let aad_slices: &[&[u8]] = match &extracted_aad {
+            ExtractedAad::None => &[],
+            ExtractedAad::Single(b) => {
+                single_storage = [b.as_bytes()];
+                &single_storage
+            }
+            ExtractedAad::List(bufs) => {
+                list_storage = bufs.iter().map(|b| b.as_bytes()).collect::<Vec<_>>();
+                &list_storage
+            }
+        };
+        let aad_len: usize = aad_slices.iter().map(|s| s.len()).sum();
 
-        ctx.tag(tag).map_err(CryptographyError::from)?;
+        let is_ccm = self.is_ccm;
+        let mut work = |ctx: &mut openssl::cipher_ctx::CipherCtx| -> CryptographyResult<()> {
+            Self::process_aad(ctx, aad_slices)?;
+            Self::process_data(ctx, plaintext, ciphertext, is_ccm)?;
+            ctx.tag(tag).map_err(CryptographyError::from)?;
+            Ok(())
+        };
+
+        crate::backend::run_with_gil_detached(py, plaintext.len() + aad_len, || work(&mut ctx))?;
 
         Ok(())
     }
@@ -270,10 +310,36 @@ impl EvpCipherAead {
             ctx.set_tag(tag)?;
         }
 
-        Self::process_aad(&mut ctx, aad)?;
+        // Extract the AAD buffers while attached to the interpreter; the
+        // buffer owners are kept alive by this frame, so the borrowed
+        // slices remain valid while detached.
+        let extracted_aad = extract_aad(aad)?;
+        let single_storage;
+        let list_storage;
+        let aad_slices: &[&[u8]] = match &extracted_aad {
+            ExtractedAad::None => &[],
+            ExtractedAad::Single(b) => {
+                single_storage = [b.as_bytes()];
+                &single_storage
+            }
+            ExtractedAad::List(bufs) => {
+                list_storage = bufs.iter().map(|b| b.as_bytes()).collect::<Vec<_>>();
+                &list_storage
+            }
+        };
+        let aad_len: usize = aad_slices.iter().map(|s| s.len()).sum();
 
-        Self::process_data(&mut ctx, ciphertext_data, buf, self.is_ccm)
-            .map_err(|_| exceptions::InvalidTag::new_err(()))?;
+        let is_ccm = self.is_ccm;
+        let mut work = |ctx: &mut openssl::cipher_ctx::CipherCtx| -> CryptographyResult<()> {
+            Self::process_aad(ctx, aad_slices)?;
+            Self::process_data(ctx, ciphertext_data, buf, is_ccm)
+                .map_err(|_| exceptions::InvalidTag::new_err(()))?;
+            Ok(())
+        };
+
+        crate::backend::run_with_gil_detached(py, ciphertext_data.len() + aad_len, || {
+            work(&mut ctx)
+        })?;
 
         Ok(())
     }

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -35,31 +35,25 @@ enum ExtractedAad<'a> {
     List(Vec<CffiBuf<'a>>),
 }
 
-impl ExtractedAad<'_> {
-    fn len(&self) -> usize {
-        match self {
-            ExtractedAad::None => 0,
-            ExtractedAad::Single(buf) => buf.as_bytes().len(),
-            ExtractedAad::List(bufs) => bufs.iter().map(|b| b.as_bytes().len()).sum(),
-        }
-    }
-}
-
-fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<ExtractedAad<'_>> {
+/// Returns the extracted AAD and its total length in bytes.
+fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<(ExtractedAad<'_>, usize)> {
     match aad {
-        None => Ok(ExtractedAad::None),
+        None => Ok((ExtractedAad::None, 0)),
         Some(Aad::Single(ad)) => {
             check_length(ad.as_bytes())?;
-            Ok(ExtractedAad::Single(ad))
+            let len = ad.as_bytes().len();
+            Ok((ExtractedAad::Single(ad), len))
         }
         Some(Aad::List(ads)) => {
             let mut bufs = Vec::with_capacity(ads.len());
+            let mut len = 0;
             for ad in ads.iter() {
                 let buf = ad.extract::<CffiBuf<'_>>()?;
                 check_length(buf.as_bytes())?;
+                len += buf.as_bytes().len();
                 bufs.push(buf);
             }
-            Ok(ExtractedAad::List(bufs))
+            Ok((ExtractedAad::List(bufs), len))
         }
     }
 }
@@ -248,12 +242,12 @@ impl EvpCipherAead {
             (ciphertext, tag) = buf.split_at_mut(plaintext.len());
         }
 
-        let aad = extract_aad(aad)?;
+        let (aad, aad_len) = extract_aad(aad)?;
 
         let is_ccm = self.is_ccm;
         crate::backend::run_with_gil_detached(
             py,
-            plaintext.len() + aad.len(),
+            plaintext.len() + aad_len,
             || -> CryptographyResult<()> {
                 Self::process_aad(&mut ctx, &aad)?;
                 Self::process_data(&mut ctx, plaintext, ciphertext, is_ccm)?;
@@ -313,12 +307,12 @@ impl EvpCipherAead {
             ctx.set_tag(tag)?;
         }
 
-        let aad = extract_aad(aad)?;
+        let (aad, aad_len) = extract_aad(aad)?;
 
         let is_ccm = self.is_ccm;
         crate::backend::run_with_gil_detached(
             py,
-            ciphertext_data.len() + aad.len(),
+            ciphertext_data.len() + aad_len,
             || -> CryptographyResult<()> {
                 Self::process_aad(&mut ctx, &aad)?;
                 Self::process_data(&mut ctx, ciphertext_data, buf, is_ccm)

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -26,66 +26,40 @@ pub(crate) enum Aad<'a> {
     List(pyo3::Bound<'a, pyo3::types::PyList>),
 }
 
-/// Keeps the Python buffer objects backing an `ExtractedAad` alive and
-/// pinned; must outlive all uses of the corresponding slices.
-enum AadOwner<'a> {
-    None,
-    Single(#[allow(dead_code)] CffiBuf<'a>),
-    List(#[allow(dead_code)] Vec<CffiBuf<'a>>),
-}
-
-/// Length-checked raw AAD slices plus their total length. Contains no
-/// Python references, so it may be freely used while detached.
+/// AAD that has been extracted and length-checked while attached to the
+/// interpreter. `CffiBuf` holds no GIL-bound references, so this may be
+/// used from a detached region.
 enum ExtractedAad<'a> {
     None,
-    Single([&'a [u8]; 1], usize),
-    List(Vec<&'a [u8]>, usize),
+    Single(CffiBuf<'a>),
+    List(Vec<CffiBuf<'a>>),
 }
 
-impl<'a> ExtractedAad<'a> {
-    fn slices(&self) -> &[&'a [u8]] {
-        match self {
-            ExtractedAad::None => &[],
-            ExtractedAad::Single(slice, _) => slice,
-            ExtractedAad::List(slices, _) => slices,
-        }
-    }
-
+impl ExtractedAad<'_> {
     fn len(&self) -> usize {
         match self {
             ExtractedAad::None => 0,
-            ExtractedAad::Single(_, len) | ExtractedAad::List(_, len) => *len,
+            ExtractedAad::Single(buf) => buf.as_bytes().len(),
+            ExtractedAad::List(bufs) => bufs.iter().map(|b| b.as_bytes().len()).sum(),
         }
     }
 }
 
-/// Extracts and length-checks the AAD. This must happen while attached to
-/// the interpreter; the returned `AadOwner` keeps the underlying Python
-/// buffers alive for as long as the `ExtractedAad` slices are in use.
-fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<(AadOwner<'_>, ExtractedAad<'_>)> {
+fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<ExtractedAad<'_>> {
     match aad {
-        None => Ok((AadOwner::None, ExtractedAad::None)),
+        None => Ok(ExtractedAad::None),
         Some(Aad::Single(ad)) => {
-            let slice = ad.as_bytes_full();
-            check_length(slice)?;
-            Ok((
-                AadOwner::Single(ad),
-                ExtractedAad::Single([slice], slice.len()),
-            ))
+            check_length(ad.as_bytes())?;
+            Ok(ExtractedAad::Single(ad))
         }
         Some(Aad::List(ads)) => {
             let mut bufs = Vec::with_capacity(ads.len());
-            let mut slices = Vec::with_capacity(ads.len());
-            let mut len = 0;
             for ad in ads.iter() {
                 let buf = ad.extract::<CffiBuf<'_>>()?;
-                let slice = buf.as_bytes_full();
-                check_length(slice)?;
-                len += slice.len();
-                slices.push(slice);
+                check_length(buf.as_bytes())?;
                 bufs.push(buf);
             }
-            Ok((AadOwner::List(bufs), ExtractedAad::List(slices, len)))
+            Ok(ExtractedAad::List(bufs))
         }
     }
 }
@@ -162,8 +136,16 @@ impl EvpCipherAead {
         ctx: &mut openssl::cipher_ctx::CipherCtx,
         aad: &ExtractedAad<'_>,
     ) -> CryptographyResult<()> {
-        for ad in aad.slices() {
-            ctx.cipher_update(ad, None)?;
+        match aad {
+            ExtractedAad::None => {}
+            ExtractedAad::Single(ad) => {
+                ctx.cipher_update(ad.as_bytes(), None)?;
+            }
+            ExtractedAad::List(ads) => {
+                for ad in ads {
+                    ctx.cipher_update(ad.as_bytes(), None)?;
+                }
+            }
         }
 
         Ok(())
@@ -266,7 +248,7 @@ impl EvpCipherAead {
             (ciphertext, tag) = buf.split_at_mut(plaintext.len());
         }
 
-        let (_aad_owner, aad) = extract_aad(aad)?;
+        let aad = extract_aad(aad)?;
 
         let is_ccm = self.is_ccm;
         crate::backend::run_with_gil_detached(
@@ -331,7 +313,7 @@ impl EvpCipherAead {
             ctx.set_tag(tag)?;
         }
 
-        let (_aad_owner, aad) = extract_aad(aad)?;
+        let aad = extract_aad(aad)?;
 
         let is_ccm = self.is_ccm;
         crate::backend::run_with_gil_detached(

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -26,45 +26,51 @@ pub(crate) enum Aad<'a> {
     List(pyo3::Bound<'a, pyo3::types::PyList>),
 }
 
-enum AadBuffers<'a> {
+/// Keeps the Python buffer objects backing an `ExtractedAad` alive and
+/// pinned; must outlive all uses of the corresponding slices.
+enum AadOwner<'a> {
     None,
-    Single {
-        _buf: CffiBuf<'a>,
-        slice: [&'a [u8]; 1],
-    },
-    List {
-        _bufs: Vec<CffiBuf<'a>>,
-        slices: Vec<&'a [u8]>,
-    },
+    Single(#[allow(dead_code)] CffiBuf<'a>),
+    List(#[allow(dead_code)] Vec<CffiBuf<'a>>),
 }
 
-impl<'a> AadBuffers<'a> {
+/// Length-checked raw AAD slices plus their total length. Contains no
+/// Python references, so it may be freely used while detached.
+enum ExtractedAad<'a> {
+    None,
+    Single([&'a [u8]; 1], usize),
+    List(Vec<&'a [u8]>, usize),
+}
+
+impl<'a> ExtractedAad<'a> {
     fn slices(&self) -> &[&'a [u8]] {
         match self {
-            AadBuffers::None => &[],
-            AadBuffers::Single { slice, .. } => slice,
-            AadBuffers::List { slices, .. } => slices,
+            ExtractedAad::None => &[],
+            ExtractedAad::Single(slice, _) => slice,
+            ExtractedAad::List(slices, _) => slices,
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            ExtractedAad::None => 0,
+            ExtractedAad::Single(_, len) | ExtractedAad::List(_, len) => *len,
         }
     }
 }
 
-/// Extracts and length-checks the AAD while attached to the interpreter,
-/// returning the buffers and the total AAD length. The `CffiBuf`s keep
-/// the underlying Python buffers alive and pinned; only `slices()` and
-/// the length (which never touch Python objects) may be used while
-/// detached.
-fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<(AadBuffers<'_>, usize)> {
+/// Extracts and length-checks the AAD. This must happen while attached to
+/// the interpreter; the returned `AadOwner` keeps the underlying Python
+/// buffers alive for as long as the `ExtractedAad` slices are in use.
+fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<(AadOwner<'_>, ExtractedAad<'_>)> {
     match aad {
-        None => Ok((AadBuffers::None, 0)),
+        None => Ok((AadOwner::None, ExtractedAad::None)),
         Some(Aad::Single(ad)) => {
             let slice = ad.as_bytes_full();
             check_length(slice)?;
             Ok((
-                AadBuffers::Single {
-                    _buf: ad,
-                    slice: [slice],
-                },
-                slice.len(),
+                AadOwner::Single(ad),
+                ExtractedAad::Single([slice], slice.len()),
             ))
         }
         Some(Aad::List(ads)) => {
@@ -79,13 +85,7 @@ fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<(AadBuffers<'_>, usiz
                 slices.push(slice);
                 bufs.push(buf);
             }
-            Ok((
-                AadBuffers::List {
-                    _bufs: bufs,
-                    slices,
-                },
-                len,
-            ))
+            Ok((AadOwner::List(bufs), ExtractedAad::List(slices, len)))
         }
     }
 }
@@ -160,9 +160,9 @@ impl EvpCipherAead {
 
     fn process_aad(
         ctx: &mut openssl::cipher_ctx::CipherCtx,
-        aad_slices: &[&[u8]],
+        aad: &ExtractedAad<'_>,
     ) -> CryptographyResult<()> {
-        for ad in aad_slices {
+        for ad in aad.slices() {
             ctx.cipher_update(ad, None)?;
         }
 
@@ -266,18 +266,19 @@ impl EvpCipherAead {
             (ciphertext, tag) = buf.split_at_mut(plaintext.len());
         }
 
-        let (aad_buffers, aad_len) = extract_aad(aad)?;
-        let aad_slices = aad_buffers.slices();
+        let (_aad_owner, aad) = extract_aad(aad)?;
 
         let is_ccm = self.is_ccm;
-        let mut work = |ctx: &mut openssl::cipher_ctx::CipherCtx| -> CryptographyResult<()> {
-            Self::process_aad(ctx, aad_slices)?;
-            Self::process_data(ctx, plaintext, ciphertext, is_ccm)?;
-            ctx.tag(tag).map_err(CryptographyError::from)?;
-            Ok(())
-        };
-
-        crate::backend::run_with_gil_detached(py, plaintext.len() + aad_len, || work(&mut ctx))?;
+        crate::backend::run_with_gil_detached(
+            py,
+            plaintext.len() + aad.len(),
+            || -> CryptographyResult<()> {
+                Self::process_aad(&mut ctx, &aad)?;
+                Self::process_data(&mut ctx, plaintext, ciphertext, is_ccm)?;
+                ctx.tag(tag).map_err(CryptographyError::from)?;
+                Ok(())
+            },
+        )?;
 
         Ok(())
     }
@@ -330,20 +331,19 @@ impl EvpCipherAead {
             ctx.set_tag(tag)?;
         }
 
-        let (aad_buffers, aad_len) = extract_aad(aad)?;
-        let aad_slices = aad_buffers.slices();
+        let (_aad_owner, aad) = extract_aad(aad)?;
 
         let is_ccm = self.is_ccm;
-        let mut work = |ctx: &mut openssl::cipher_ctx::CipherCtx| -> CryptographyResult<()> {
-            Self::process_aad(ctx, aad_slices)?;
-            Self::process_data(ctx, ciphertext_data, buf, is_ccm)
-                .map_err(|_| exceptions::InvalidTag::new_err(()))?;
-            Ok(())
-        };
-
-        crate::backend::run_with_gil_detached(py, ciphertext_data.len() + aad_len, || {
-            work(&mut ctx)
-        })?;
+        crate::backend::run_with_gil_detached(
+            py,
+            ciphertext_data.len() + aad.len(),
+            || -> CryptographyResult<()> {
+                Self::process_aad(&mut ctx, &aad)?;
+                Self::process_data(&mut ctx, ciphertext_data, buf, is_ccm)
+                    .map_err(|_| exceptions::InvalidTag::new_err(()))?;
+                Ok(())
+            },
+        )?;
 
         Ok(())
     }

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -38,18 +38,9 @@ enum AadBuffers<'a> {
     },
 }
 
-/// AAD that has been extracted and length-checked while attached to the
-/// interpreter. The `CffiBuf`s keep the underlying Python buffers alive
-/// and pinned; only `slices()` and `len` (which never touch Python
-/// objects) may be used while detached.
-struct ExtractedAad<'a> {
-    buffers: AadBuffers<'a>,
-    len: usize,
-}
-
-impl<'a> ExtractedAad<'a> {
+impl<'a> AadBuffers<'a> {
     fn slices(&self) -> &[&'a [u8]] {
-        match &self.buffers {
+        match self {
             AadBuffers::None => &[],
             AadBuffers::Single { slice, .. } => slice,
             AadBuffers::List { slices, .. } => slices,
@@ -57,22 +48,24 @@ impl<'a> ExtractedAad<'a> {
     }
 }
 
-fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<ExtractedAad<'_>> {
+/// Extracts and length-checks the AAD while attached to the interpreter,
+/// returning the buffers and the total AAD length. The `CffiBuf`s keep
+/// the underlying Python buffers alive and pinned; only `slices()` and
+/// the length (which never touch Python objects) may be used while
+/// detached.
+fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<(AadBuffers<'_>, usize)> {
     match aad {
-        None => Ok(ExtractedAad {
-            buffers: AadBuffers::None,
-            len: 0,
-        }),
+        None => Ok((AadBuffers::None, 0)),
         Some(Aad::Single(ad)) => {
             let slice = ad.as_bytes_full();
             check_length(slice)?;
-            Ok(ExtractedAad {
-                len: slice.len(),
-                buffers: AadBuffers::Single {
+            Ok((
+                AadBuffers::Single {
                     _buf: ad,
                     slice: [slice],
                 },
-            })
+                slice.len(),
+            ))
         }
         Some(Aad::List(ads)) => {
             let mut bufs = Vec::with_capacity(ads.len());
@@ -86,13 +79,13 @@ fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<ExtractedAad<'_>> {
                 slices.push(slice);
                 bufs.push(buf);
             }
-            Ok(ExtractedAad {
-                buffers: AadBuffers::List {
+            Ok((
+                AadBuffers::List {
                     _bufs: bufs,
                     slices,
                 },
                 len,
-            })
+            ))
         }
     }
 }
@@ -273,8 +266,8 @@ impl EvpCipherAead {
             (ciphertext, tag) = buf.split_at_mut(plaintext.len());
         }
 
-        let aad = extract_aad(aad)?;
-        let aad_slices = aad.slices();
+        let (aad_buffers, aad_len) = extract_aad(aad)?;
+        let aad_slices = aad_buffers.slices();
 
         let is_ccm = self.is_ccm;
         let mut work = |ctx: &mut openssl::cipher_ctx::CipherCtx| -> CryptographyResult<()> {
@@ -284,7 +277,7 @@ impl EvpCipherAead {
             Ok(())
         };
 
-        crate::backend::run_with_gil_detached(py, plaintext.len() + aad.len, || work(&mut ctx))?;
+        crate::backend::run_with_gil_detached(py, plaintext.len() + aad_len, || work(&mut ctx))?;
 
         Ok(())
     }
@@ -337,8 +330,8 @@ impl EvpCipherAead {
             ctx.set_tag(tag)?;
         }
 
-        let aad = extract_aad(aad)?;
-        let aad_slices = aad.slices();
+        let (aad_buffers, aad_len) = extract_aad(aad)?;
+        let aad_slices = aad_buffers.slices();
 
         let is_ccm = self.is_ccm;
         let mut work = |ctx: &mut openssl::cipher_ctx::CipherCtx| -> CryptographyResult<()> {
@@ -348,7 +341,7 @@ impl EvpCipherAead {
             Ok(())
         };
 
-        crate::backend::run_with_gil_detached(py, ciphertext_data.len() + aad.len, || {
+        crate::backend::run_with_gil_detached(py, ciphertext_data.len() + aad_len, || {
             work(&mut ctx)
         })?;
 

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -26,30 +26,73 @@ pub(crate) enum Aad<'a> {
     List(pyo3::Bound<'a, pyo3::types::PyList>),
 }
 
-enum ExtractedAad<'a> {
+enum AadBuffers<'a> {
     None,
-    Single(CffiBuf<'a>),
-    List(Vec<CffiBuf<'a>>),
+    Single {
+        _buf: CffiBuf<'a>,
+        slice: [&'a [u8]; 1],
+    },
+    List {
+        _bufs: Vec<CffiBuf<'a>>,
+        slices: Vec<&'a [u8]>,
+    },
 }
 
-/// Extracts and length-checks every AAD buffer. This must happen while
-/// attached to the interpreter; the returned buffers keep the underlying
-/// Python objects alive so the borrowed slices stay valid afterwards.
+/// AAD that has been extracted and length-checked while attached to the
+/// interpreter. The `CffiBuf`s keep the underlying Python buffers alive
+/// and pinned; only `slices()` and `len` (which never touch Python
+/// objects) may be used while detached.
+struct ExtractedAad<'a> {
+    buffers: AadBuffers<'a>,
+    len: usize,
+}
+
+impl<'a> ExtractedAad<'a> {
+    fn slices(&self) -> &[&'a [u8]] {
+        match &self.buffers {
+            AadBuffers::None => &[],
+            AadBuffers::Single { slice, .. } => slice,
+            AadBuffers::List { slices, .. } => slices,
+        }
+    }
+}
+
 fn extract_aad(aad: Option<Aad<'_>>) -> CryptographyResult<ExtractedAad<'_>> {
     match aad {
-        None => Ok(ExtractedAad::None),
+        None => Ok(ExtractedAad {
+            buffers: AadBuffers::None,
+            len: 0,
+        }),
         Some(Aad::Single(ad)) => {
-            check_length(ad.as_bytes())?;
-            Ok(ExtractedAad::Single(ad))
+            let slice = ad.as_bytes_full();
+            check_length(slice)?;
+            Ok(ExtractedAad {
+                len: slice.len(),
+                buffers: AadBuffers::Single {
+                    _buf: ad,
+                    slice: [slice],
+                },
+            })
         }
         Some(Aad::List(ads)) => {
             let mut bufs = Vec::with_capacity(ads.len());
+            let mut slices = Vec::with_capacity(ads.len());
+            let mut len = 0;
             for ad in ads.iter() {
                 let buf = ad.extract::<CffiBuf<'_>>()?;
-                check_length(buf.as_bytes())?;
+                let slice = buf.as_bytes_full();
+                check_length(slice)?;
+                len += slice.len();
+                slices.push(slice);
                 bufs.push(buf);
             }
-            Ok(ExtractedAad::List(bufs))
+            Ok(ExtractedAad {
+                buffers: AadBuffers::List {
+                    _bufs: bufs,
+                    slices,
+                },
+                len,
+            })
         }
     }
 }
@@ -230,24 +273,8 @@ impl EvpCipherAead {
             (ciphertext, tag) = buf.split_at_mut(plaintext.len());
         }
 
-        // Extract the AAD buffers while attached to the interpreter; the
-        // buffer owners are kept alive by this frame, so the borrowed
-        // slices remain valid while detached.
-        let extracted_aad = extract_aad(aad)?;
-        let single_storage;
-        let list_storage;
-        let aad_slices: &[&[u8]] = match &extracted_aad {
-            ExtractedAad::None => &[],
-            ExtractedAad::Single(b) => {
-                single_storage = [b.as_bytes()];
-                &single_storage
-            }
-            ExtractedAad::List(bufs) => {
-                list_storage = bufs.iter().map(|b| b.as_bytes()).collect::<Vec<_>>();
-                &list_storage
-            }
-        };
-        let aad_len: usize = aad_slices.iter().map(|s| s.len()).sum();
+        let aad = extract_aad(aad)?;
+        let aad_slices = aad.slices();
 
         let is_ccm = self.is_ccm;
         let mut work = |ctx: &mut openssl::cipher_ctx::CipherCtx| -> CryptographyResult<()> {
@@ -257,7 +284,7 @@ impl EvpCipherAead {
             Ok(())
         };
 
-        crate::backend::run_with_gil_detached(py, plaintext.len() + aad_len, || work(&mut ctx))?;
+        crate::backend::run_with_gil_detached(py, plaintext.len() + aad.len, || work(&mut ctx))?;
 
         Ok(())
     }
@@ -310,24 +337,8 @@ impl EvpCipherAead {
             ctx.set_tag(tag)?;
         }
 
-        // Extract the AAD buffers while attached to the interpreter; the
-        // buffer owners are kept alive by this frame, so the borrowed
-        // slices remain valid while detached.
-        let extracted_aad = extract_aad(aad)?;
-        let single_storage;
-        let list_storage;
-        let aad_slices: &[&[u8]] = match &extracted_aad {
-            ExtractedAad::None => &[],
-            ExtractedAad::Single(b) => {
-                single_storage = [b.as_bytes()];
-                &single_storage
-            }
-            ExtractedAad::List(bufs) => {
-                list_storage = bufs.iter().map(|b| b.as_bytes()).collect::<Vec<_>>();
-                &list_storage
-            }
-        };
-        let aad_len: usize = aad_slices.iter().map(|s| s.len()).sum();
+        let aad = extract_aad(aad)?;
+        let aad_slices = aad.slices();
 
         let is_ccm = self.is_ccm;
         let mut work = |ctx: &mut openssl::cipher_ctx::CipherCtx| -> CryptographyResult<()> {
@@ -337,7 +348,7 @@ impl EvpCipherAead {
             Ok(())
         };
 
-        crate::backend::run_with_gil_detached(py, ciphertext_data.len() + aad_len, || {
+        crate::backend::run_with_gil_detached(py, ciphertext_data.len() + aad.len, || {
             work(&mut ctx)
         })?;
 

--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -78,10 +78,14 @@ fn _extract_buffer_length<'p>(
     Ok((bufobj, ptrval, len))
 }
 
+// Fields are deliberately GIL-independent (`Py` rather than `Bound`,
+// and `PyBuffer` is `Send + Sync`) so that a `CffiBuf` may be used from
+// a detached (GIL-released) region while the calling frame keeps it
+// alive.
 pub(crate) struct CffiBuf<'p> {
-    pyobj: pyo3::Bound<'p, pyo3::PyAny>,
+    pyobj: pyo3::Py<pyo3::PyAny>,
     #[cfg(not(Py_3_11))]
-    _bufobj: pyo3::Bound<'p, pyo3::PyAny>,
+    _bufobj: pyo3::Py<pyo3::PyAny>,
     #[cfg(Py_3_11)]
     _bufobj: Option<pyo3::buffer::PyBuffer<u8>>,
     buf: &'p [u8],
@@ -90,11 +94,11 @@ pub(crate) struct CffiBuf<'p> {
 impl<'a> CffiBuf<'a> {
     pub(crate) fn from_bytes(py: pyo3::Python<'a>, buf: &'a [u8]) -> Self {
         CffiBuf {
-            pyobj: py.None().into_bound(py),
+            pyobj: py.None(),
             #[cfg(Py_3_11)]
             _bufobj: None,
             #[cfg(not(Py_3_11))]
-            _bufobj: py.None().into_bound(py),
+            _bufobj: py.None(),
             buf,
         }
     }
@@ -103,16 +107,8 @@ impl<'a> CffiBuf<'a> {
         self.buf
     }
 
-    /// Like `as_bytes`, but the returned slice carries the full `'p`
-    /// lifetime instead of borrowing from `self`. The caller is
-    /// responsible for keeping this `CffiBuf` (which keeps the underlying
-    /// buffer alive and pinned) around for as long as the slice is used.
-    pub(crate) fn as_bytes_full(&self) -> &'a [u8] {
-        self.buf
-    }
-
-    pub(crate) fn into_pyobj(self) -> pyo3::Bound<'a, pyo3::PyAny> {
-        self.pyobj
+    pub(crate) fn into_pyobj(self, py: pyo3::Python<'a>) -> pyo3::Bound<'a, pyo3::PyAny> {
+        self.pyobj.into_bound(py)
     }
 }
 
@@ -135,8 +131,11 @@ impl<'p> pyo3::conversion::FromPyObject<'_, 'p> for CffiBuf<'p> {
             unsafe { slice::from_raw_parts(ptrval as *const u8, len) }
         };
         Ok(CffiBuf {
-            pyobj: pyobj.to_owned(),
+            pyobj: pyobj.to_owned().unbind(),
+            #[cfg(Py_3_11)]
             _bufobj: bufobj,
+            #[cfg(not(Py_3_11))]
+            _bufobj: bufobj.unbind(),
             buf,
         })
     }

--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -78,6 +78,8 @@ fn _extract_buffer_length<'p>(
     Ok((bufobj, ptrval, len))
 }
 
+// Contains no GIL-bound references, so it is sound to use while the GIL
+// is released, as long as it's kept alive.
 pub(crate) struct CffiBuf<'p> {
     pyobj: pyo3::Py<pyo3::PyAny>,
     #[cfg(not(Py_3_11))]

--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -103,6 +103,14 @@ impl<'a> CffiBuf<'a> {
         self.buf
     }
 
+    /// Like `as_bytes`, but the returned slice carries the full `'p`
+    /// lifetime instead of borrowing from `self`. The caller is
+    /// responsible for keeping this `CffiBuf` (which keeps the underlying
+    /// buffer alive and pinned) around for as long as the slice is used.
+    pub(crate) fn as_bytes_full(&self) -> &'a [u8] {
+        self.buf
+    }
+
     pub(crate) fn into_pyobj(self) -> pyo3::Bound<'a, pyo3::PyAny> {
         self.pyobj
     }

--- a/src/rust/src/buf.rs
+++ b/src/rust/src/buf.rs
@@ -78,10 +78,6 @@ fn _extract_buffer_length<'p>(
     Ok((bufobj, ptrval, len))
 }
 
-// Fields are deliberately GIL-independent (`Py` rather than `Bound`,
-// and `PyBuffer` is `Send + Sync`) so that a `CffiBuf` may be used from
-// a detached (GIL-released) region while the calling frame keeps it
-// alive.
 pub(crate) struct CffiBuf<'p> {
     pyobj: pyo3::Py<pyo3::PyAny>,
     #[cfg(not(Py_3_11))]

--- a/src/rust/src/padding.rs
+++ b/src/rust/src/padding.rs
@@ -83,12 +83,13 @@ impl PKCS7PaddingContext {
 
     pub(crate) fn update<'a>(
         &mut self,
+        py: pyo3::Python<'a>,
         buf: CffiBuf<'a>,
     ) -> CryptographyResult<pyo3::Bound<'a, pyo3::PyAny>> {
         match self.length_seen.as_mut() {
             Some(v) => {
                 *v += buf.as_bytes().len();
-                Ok(buf.into_pyobj())
+                Ok(buf.into_pyobj(py))
             }
             None => Err(exceptions::already_finalized_error()),
         }
@@ -127,12 +128,13 @@ impl ANSIX923PaddingContext {
 
     pub(crate) fn update<'a>(
         &mut self,
+        py: pyo3::Python<'a>,
         buf: CffiBuf<'a>,
     ) -> CryptographyResult<pyo3::Bound<'a, pyo3::PyAny>> {
         match self.length_seen.as_mut() {
             Some(v) => {
                 *v += buf.as_bytes().len();
-                Ok(buf.into_pyobj())
+                Ok(buf.into_pyobj(py))
             }
             None => Err(exceptions::already_finalized_error()),
         }

--- a/src/rust/src/pkcs12.rs
+++ b/src/rust/src/pkcs12.rs
@@ -106,7 +106,7 @@ pub(crate) fn symmetric_encrypt(
     let n = cipher.update_into(py, data, &mut ciphertext)?;
 
     let mut padder = PKCS7PaddingContext::new(block_size);
-    assert!(padder.update(CffiBuf::from_bytes(py, data))?.is_none());
+    assert!(padder.update(py, CffiBuf::from_bytes(py, data))?.is_none());
     let padding = padder.finalize(py)?;
 
     let pad_n = cipher.update_into(py, padding.as_bytes(), &mut ciphertext[n..])?;


### PR DESCRIPTION
Follow-up to #15359, carrying the AEAD portion that was split out during review: `EvpCipherAead` encrypt/decrypt (the AESGCM, ChaCha20Poly1305, AESGCMSIV, AESOCB3, AESSIV, and AESCCM one-shot APIs) now run the process_aad + process_data + tag region via `run_with_gil_detached` when plaintext + AAD is at least the 2KiB threshold.

Because the detached region must not touch Python objects, the AAD buffers are extracted and length-checked up front (`extract_aad`), keeping the `CffiBuf`s alive on the calling frame while only borrowed slices cross into the detached closure. The BoringSSL/AWS-LC `EvpAead` path is unchanged.

Benchmarks (Linux x86-64, 4 cores, CPython 3.11, release build):

    4 threads each AESGCM-encrypting 16MiB:
        9.3 ms -> 5.1 ms wall (1.8x; memory-bandwidth bound)
    AESGCM encrypt 64B: 617 -> 630 ns (noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5bsKENedjVD9gcLApf1x4

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bsKENedjVD9gcLApf1x4)_