### PR TITLE
Remove unused utils.cached_property

### DIFF
--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -9,7 +9,7 @@ import sys
 import types
 import typing
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 
 
 # We use a UserWarning subclass, instead of DeprecationWarning, because CPython
@@ -122,21 +122,6 @@ def deprecated(
     if name is not None:
         setattr(module, name, dv)
     return dv
-
-
-def cached_property(func: Callable) -> property:
-    cached_name = f"_cached_{func}"
-    sentinel = object()
-
-    def inner(instance: object):
-        cache = getattr(instance, cached_name, sentinel)
-        if cache is not sentinel:
-            return cache
-        result = func(instance)
-        setattr(instance, cached_name, result)
-        return result
-
-    return property(inner)
 
 
 # Python 3.10 changed representation of enums. We use well-defined object

--- a/tests/test_cryptography_utils.py
+++ b/tests/test_cryptography_utils.py
@@ -3,55 +3,8 @@
 # for complete details.
 
 import enum
-import typing
-
-import pytest
 
 from cryptography import utils
-
-
-class TestCachedProperty:
-    def test_simple(self):
-        class T:
-            @utils.cached_property
-            def t(self):
-                accesses.append(None)
-                return 14
-
-        accesses: list[typing.Optional[T]] = []
-
-        assert T.t
-        t = T()
-        assert t.t == 14
-        assert len(accesses) == 1
-        assert t.t == 14
-        assert len(accesses) == 1
-
-        t = T()
-        assert t.t == 14
-        assert len(accesses) == 2
-        assert t.t == 14
-        assert len(accesses) == 2
-
-    def test_set(self):
-        class T:
-            @utils.cached_property
-            def t(self):
-                accesses.append(None)
-                return 14
-
-        accesses: list[typing.Optional[T]] = []
-        t = T()
-        with pytest.raises(AttributeError):
-            t.t = None
-        assert len(accesses) == 0
-        assert t.t == 14
-        assert len(accesses) == 1
-        with pytest.raises(AttributeError):
-            t.t = None
-        assert len(accesses) == 1
-        assert t.t == 14
-        assert len(accesses) == 1
 
 
 def test_enum():


### PR DESCRIPTION
`utils.cached_property` has no callers in the codebase, and its cache-attribute name is buggy anyway: `f"_cached_{func}"` embeds the function repr (including its memory address) rather than its name.

Extracted from the import-time perf branch so it can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5bsKENedjVD9gcLApf1x4

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bsKENedjVD9gcLApf1x4)_