### PR TITLE
Import _serialization instead of serialization in x509/extensions

### DIFF
--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -14,7 +14,7 @@ from collections.abc import Iterable, Iterator
 from cryptography import utils
 from cryptography.hazmat.bindings._rust import asn1
 from cryptography.hazmat.bindings._rust import x509 as rust_x509
-from cryptography.hazmat.primitives import constant_time, serialization
+from cryptography.hazmat.primitives import _serialization, constant_time
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.asymmetric.types import (
@@ -53,19 +53,19 @@ def _key_identifier_from_public_key(
 ) -> bytes:
     if isinstance(public_key, RSAPublicKey):
         data = public_key.public_bytes(
-            serialization.Encoding.DER,
-            serialization.PublicFormat.PKCS1,
+            _serialization.Encoding.DER,
+            _serialization.PublicFormat.PKCS1,
         )
     elif isinstance(public_key, EllipticCurvePublicKey):
         data = public_key.public_bytes(
-            serialization.Encoding.X962,
-            serialization.PublicFormat.UncompressedPoint,
+            _serialization.Encoding.X962,
+            _serialization.PublicFormat.UncompressedPoint,
         )
     else:
         # This is a very slow way to do this.
         serialized = public_key.public_bytes(
-            serialization.Encoding.DER,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
+            _serialization.Encoding.DER,
+            _serialization.PublicFormat.SubjectPublicKeyInfo,
         )
         data = asn1.parse_spki_for_data(serialized)
 


### PR DESCRIPTION
`x509/extensions.py` only uses `serialization.Encoding` and `serialization.PublicFormat`, both defined in `_serialization` — the module that exists precisely to break this cycle, and which every asymmetric module already imports. Importing the `serialization` package pulled its whole `__init__` (and with it `ssh.py` and its dependency graph) into every `import cryptography.x509`.

Benchmark (release build, warm bytecode cache, `python -X importtime`, min of 5 warm runs):

    import cryptography.x509: 67.8 ms -> 53.7 ms (-21%)

Extracted from the import-time perf branch so it can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5bsKENedjVD9gcLApf1x4

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5bsKENedjVD9gcLApf1x4)_