### PR TITLE
Don't leak how PKCS#7 encryptedKey decryption failed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* **SECURITY ISSUE**:
+  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.pkcs7_decrypt_der`
+  and its PEM and S/MIME variants no longer expose distinguishable errors or
+  timing when unwrapping a ``RecipientInfo``'s ``encryptedKey``, which could
+  act as a Bleichenbacher oracle for callers that decrypt untrusted messages.
+  A random key is now substituted on failure, as described in :rfc:`3218`.
+  Credit to **@X1AOxiang** for reporting the issue
 * Deprecated Diffie-Hellman key exchange over finite fields (FFDH).
   Everything FFDH is deprecated, including the types in
   ``cryptography.hazmat.primitives.asymmetric.dh`` and loading FFDH keys or

--- a/docs/hazmat/primitives/asymmetric/serialization.rst
+++ b/docs/hazmat/primitives/asymmetric/serialization.rst
@@ -1445,6 +1445,15 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
     most of this implementation follows S/MIME 2.0 (RFC 2311). A small subset of :rfc:`2632`,
     also known as S/MIME version 3 is supported.
 
+    .. warning::
+
+        ``EnvelopedData`` does not authenticate its content. An application
+        that decrypts attacker-supplied messages and reveals whether
+        decryption succeeded -- through an error, a status code, or timing --
+        gives the attacker a CBC padding oracle sufficient to recover the
+        plaintext. This is a property of PKCS#7 and cannot be fixed here,
+        so avoid decrypting untrusted ``EnvelopedData``.
+
     :param data: The data, encoded in DER format.
     :type data: bytes
 
@@ -1501,6 +1510,12 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
     Deserialize and decrypt a PEM-encoded PKCS7 message. PKCS7 (or S/MIME) has multiple versions,
     most of this implementation follows S/MIME 2.0 (RFC 2311). A small subset of :rfc:`2632`,
     also known as S/MIME version 3 is supported.
+
+    .. warning::
+
+        The padding oracle described in
+        :func:`~cryptography.hazmat.primitives.serialization.pkcs7.pkcs7_decrypt_der`
+        applies equally here.
 
     :param data: The data, encoded in PEM format.
     :type data: bytes
@@ -1559,6 +1574,12 @@ contain certificates, CRLs, and much more. PKCS7 files commonly have a ``p7b``,
     Deserialize and decrypt a S/MIME-encoded PKCS7 message. PKCS7 (or S/MIME) has multiple versions,
     most of this implementation follows S/MIME 2.0 (RFC 2311). A small subset of :rfc:`2632`,
     also known as S/MIME version 3 is supported.
+
+    .. warning::
+
+        The padding oracle described in
+        :func:`~cryptography.hazmat.primitives.serialization.pkcs7.pkcs7_decrypt_der`
+        applies equally here.
 
     :param data: The data. It should be in S/MIME format, meaning MIME with content type
         ``application/pkcs7-mime`` or ``application/x-pkcs7-mime``.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -173,6 +173,7 @@ unencrypted
 unicode
 uninstantiated
 unpadded
+untrusted
 unpadding
 unsafety
 validator

--- a/src/rust/src/pkcs7.rs
+++ b/src/rust/src/pkcs7.rs
@@ -270,27 +270,6 @@ fn decrypt_der<'p>(
                 }
             };
 
-            // Raise error when the key encryption algorithm is not RSA
-            let key = match recipient_info.key_encryption_algorithm.oid() {
-                &oid::RSA_OID => {
-                    let padding = types::PKCS1V15.get(py)?.call0()?;
-                    private_key
-                        .call_method1(
-                            pyo3::intern!(py, "decrypt"),
-                            (recipient_info.encrypted_key, &padding),
-                        )?
-                        .extract::<pyo3::pybacked::PyBackedBytes>()?
-                }
-                _ => {
-                    return Err(CryptographyError::from(
-                        exceptions::UnsupportedAlgorithm::new_err((
-                            "Only RSA with PKCS #1 v1.5 padding is currently supported for key decryption.",
-                            exceptions::Reasons::UNSUPPORTED_SERIALIZATION,
-                        )),
-                    ));
-                }
-            };
-
             // The function can decrypt content encrypted with AES-128-CBC, which the S/MIME v3.2
             // RFC specifies as MUST support, and AES-256-CBC, which is specified as SHOULD+
             // support. More info: https://datatracker.ietf.org/doc/html/rfc5751#section-2.7
@@ -298,19 +277,9 @@ fn decrypt_der<'p>(
             let algorithm_identifier = enveloped_data
                 .encrypted_content_info
                 .content_encryption_algorithm;
-            let (algorithm, mode) = match algorithm_identifier.params {
-                AlgorithmParameters::Aes128Cbc(iv) => (
-                    types::AES128.get(py)?.call1((key,))?,
-                    types::CBC
-                        .get(py)?
-                        .call1((pyo3::types::PyBytes::new(py, &iv),))?,
-                ),
-                AlgorithmParameters::Aes256Cbc(iv) => (
-                    types::AES256.get(py)?.call1((key,))?,
-                    types::CBC
-                        .get(py)?
-                        .call1((pyo3::types::PyBytes::new(py, &iv),))?,
-                ),
+            let (algorithm_type, key_size, iv) = match algorithm_identifier.params {
+                AlgorithmParameters::Aes128Cbc(iv) => (&types::AES128, 16, iv),
+                AlgorithmParameters::Aes256Cbc(iv) => (&types::AES256, 32, iv),
                 _ => {
                     return Err(CryptographyError::from(
                         exceptions::UnsupportedAlgorithm::new_err((
@@ -320,6 +289,50 @@ fn decrypt_der<'p>(
                     ));
                 }
             };
+
+            // Raise error when the key encryption algorithm is not RSA
+            if recipient_info.key_encryption_algorithm.oid() != &oid::RSA_OID {
+                return Err(CryptographyError::from(
+                    exceptions::UnsupportedAlgorithm::new_err((
+                        "Only RSA with PKCS #1 v1.5 padding is currently supported for key decryption.",
+                        exceptions::Reasons::UNSUPPORTED_SERIALIZATION,
+                    )),
+                ));
+            }
+
+            // Unwrap the content encryption key. RFC 3218 requires that a
+            // failure to recover a usable key is not distinguishable from
+            // recovering a key that simply isn't the right one -- otherwise
+            // this becomes a Bleichenbacher oracle for anything that decrypts
+            // attacker-supplied data. We substitute a random key of the
+            // expected size, so that every failure surfaces as the same
+            // content decryption error.
+            let padding = types::PKCS1V15.get(py)?.call0()?;
+            let random_key = crate::backend::rand::get_rand_bytes(py, key_size)?;
+            let key = match private_key.call_method1(
+                pyo3::intern!(py, "decrypt"),
+                (recipient_info.encrypted_key, &padding),
+            ) {
+                Ok(key) => {
+                    let key = key.extract::<pyo3::Bound<'_, pyo3::types::PyBytes>>()?;
+                    if key.as_bytes().len() == key_size {
+                        key
+                    } else {
+                        random_key
+                    }
+                }
+                // A ValueError here is entirely attacker controlled (invalid
+                // padding, or an encrypted key of the wrong length) and must
+                // stay silent. Any other exception reflects a caller mistake
+                // rather than the contents of the message.
+                Err(e) if e.is_instance_of::<pyo3::exceptions::PyValueError>(py) => random_key,
+                Err(e) => return Err(e.into()),
+            };
+
+            let algorithm = algorithm_type.get(py)?.call1((key,))?;
+            let mode = types::CBC
+                .get(py)?
+                .call1((pyo3::types::PyBytes::new(py, &iv),))?;
 
             // Decrypt the content using the key and proper algorithm
             let encrypted_content = match enveloped_data.encrypted_content_info.encrypted_content {

--- a/tests/doubles.py
+++ b/tests/doubles.py
@@ -2,6 +2,7 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+from __future__ import annotations
 
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, padding, rsa

--- a/tests/doubles.py
+++ b/tests/doubles.py
@@ -100,7 +100,7 @@ class DummyRSAPrivateKey(rsa.RSAPrivateKey):
     def decrypt(
         self, ciphertext: bytes, padding: padding.AsymmetricPadding
     ) -> bytes:
-        raise TypeError("the smartcard is unplugged")
+        raise TypeError("TypeError for testing")
 
     @property
     def key_size(self) -> int:

--- a/tests/doubles.py
+++ b/tests/doubles.py
@@ -4,7 +4,8 @@
 
 
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ed25519, padding
+from cryptography.hazmat.primitives.asymmetric import ed25519, padding, rsa
+from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
 from cryptography.hazmat.primitives.ciphers import (
     BlockCipherAlgorithm,
     CipherAlgorithm,
@@ -85,4 +86,51 @@ class DummyEd25519PublicKey(ed25519.Ed25519PublicKey):
         raise NotImplementedError
 
     def __deepcopy__(self, memo: dict) -> ed25519.Ed25519PublicKey:
+        raise NotImplementedError
+
+
+class DummyRSAPrivateKey(rsa.RSAPrivateKey):
+    """
+    A fake RSAPrivateKey whose decrypt() raises a non-ValueError. Used for
+    testing that a failure originating outside of this library is not
+    mistaken for an attacker controlled decryption failure.
+    """
+
+    def decrypt(
+        self, ciphertext: bytes, padding: padding.AsymmetricPadding
+    ) -> bytes:
+        raise TypeError("the smartcard is unplugged")
+
+    @property
+    def key_size(self) -> int:
+        raise NotImplementedError
+
+    def public_key(self) -> rsa.RSAPublicKey:
+        raise NotImplementedError
+
+    def sign(
+        self,
+        data: bytes,
+        padding: padding.AsymmetricPadding,
+        algorithm: asym_utils.Prehashed
+        | hashes.HashAlgorithm
+        | asym_utils.NoDigestInfo,
+    ) -> bytes:
+        raise NotImplementedError
+
+    def private_numbers(self) -> rsa.RSAPrivateNumbers:
+        raise NotImplementedError
+
+    def private_bytes(
+        self,
+        encoding: serialization.Encoding,
+        format: serialization.PrivateFormat,
+        encryption_algorithm: serialization.KeySerializationEncryption,
+    ) -> bytes:
+        raise NotImplementedError
+
+    def __copy__(self) -> rsa.RSAPrivateKey:
+        raise NotImplementedError
+
+    def __deepcopy__(self, memo: dict) -> rsa.RSAPrivateKey:
         raise NotImplementedError

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -1491,7 +1491,7 @@ class TestPKCS7Decrypt:
             .encrypt(serialization.Encoding.DER, [])
         )
 
-        with pytest.raises(TypeError, match="the smartcard is unplugged"):
+        with pytest.raises(TypeError, match="TypeError for testing"):
             pkcs7.pkcs7_decrypt_der(
                 enveloped, certificate, DummyRSAPrivateKey(), []
             )

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -1434,6 +1434,51 @@ class TestPKCS7Decrypt:
                 email_message.as_bytes(), certificate, private_key, []
             )
 
+    def test_decrypt_encrypted_key_is_not_an_oracle(
+        self, data, certificate, private_key
+    ):
+        # An attacker who replaces the encryptedKey must not be able to tell
+        # the RSA decryption outcomes apart. Recovering an unusable key, or
+        # failing to recover one at all, has to look exactly like recovering
+        # a key of the right length that simply isn't the right key. See
+        # RFC 3218 and Bleichenbacher's '98 attack.
+        enveloped = (
+            pkcs7.PKCS7EnvelopeBuilder()
+            .set_data(data)
+            .add_recipient(certificate)
+        )
+        der = enveloped.encrypt(serialization.Encoding.DER, [])
+
+        public_key = certificate.public_key()
+        assert isinstance(public_key, rsa.RSAPublicKey)
+
+        # The encryptedKey is the only OCTET STRING in the structure as long
+        # as the RSA modulus, so it can be located by its DER header.
+        key_bytes = public_key.key_size // 8
+        marker = b"\x04\x82" + key_bytes.to_bytes(2, "big")
+        assert der.count(marker) == 1
+        offset = der.index(marker) + len(marker)
+
+        for encrypted_key in [
+            # Invalid PKCS#1 v1.5 padding.
+            b"\x00" * key_bytes,
+            # Valid padding concealing a key of the wrong length.
+            public_key.encrypt(b"A" * 15, padding.PKCS1v15()),
+            public_key.encrypt(b"A" * 17, padding.PKCS1v15()),
+            public_key.encrypt(b"A" * 32, padding.PKCS1v15()),
+            # Valid padding concealing a correctly sized but wrong key.
+            public_key.encrypt(b"A" * 16, padding.PKCS1v15()),
+        ]:
+            tampered = der[:offset] + encrypted_key + der[offset + key_bytes :]
+            try:
+                pkcs7.pkcs7_decrypt_der(tampered, certificate, private_key, [])
+            except ValueError as exc:
+                # Decrypting under a substituted random key leaves plausible
+                # PKCS#7 padding roughly one time in 256, in which case the
+                # caller gets garbage instead of an error. That is equally
+                # uninformative, so it is an acceptable outcome here.
+                assert str(exc) == "Invalid padding bytes."
+
 
 class TestPKCS7SerializeCerts:
     @pytest.mark.parametrize(

--- a/tests/hazmat/primitives/test_pkcs7.py
+++ b/tests/hazmat/primitives/test_pkcs7.py
@@ -23,6 +23,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, padding, rsa
 from cryptography.hazmat.primitives.ciphers import algorithms
 from cryptography.hazmat.primitives.serialization import pkcs7
+from tests.doubles import DummyRSAPrivateKey
 from tests.x509.test_x509 import _generate_ca_and_leaf
 
 from ...hazmat.primitives.fixtures_rsa import (
@@ -1478,6 +1479,22 @@ class TestPKCS7Decrypt:
                 # caller gets garbage instead of an error. That is equally
                 # uninformative, so it is an acceptable outcome here.
                 assert str(exc) == "Invalid padding bytes."
+
+    def test_decrypt_key_error_is_not_swallowed(self, data, certificate):
+        # Only a ValueError from unwrapping the key is attacker controlled and
+        # therefore silenced. A private key implemented outside this library
+        # can fail in other ways, and those must still reach the caller.
+        enveloped = (
+            pkcs7.PKCS7EnvelopeBuilder()
+            .set_data(data)
+            .add_recipient(certificate)
+            .encrypt(serialization.Encoding.DER, [])
+        )
+
+        with pytest.raises(TypeError, match="the smartcard is unplugged"):
+            pkcs7.pkcs7_decrypt_der(
+                enveloped, certificate, DummyRSAPrivateKey(), []
+            )
 
 
 class TestPKCS7SerializeCerts:

--- a/tests/test_doubles.py
+++ b/tests/test_doubles.py
@@ -6,9 +6,10 @@ import copy
 
 import pytest
 
-from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 
-from .doubles import DummyEd25519PublicKey
+from .doubles import DummyEd25519PublicKey, DummyRSAPrivateKey
 
 
 class TestDummyEd25519PublicKey:
@@ -44,5 +45,51 @@ class TestDummyEd25519PublicKey:
 
     def test_deepcopy_not_implemented(self):
         key = DummyEd25519PublicKey(b"test data")
+        with pytest.raises(NotImplementedError):
+            copy.deepcopy(key)
+
+
+class TestDummyRSAPrivateKey:
+    def test_decrypt(self):
+        key = DummyRSAPrivateKey()
+        with pytest.raises(TypeError):
+            key.decrypt(b"ciphertext", padding.PKCS1v15())
+
+    def test_key_size_not_implemented(self):
+        key = DummyRSAPrivateKey()
+        with pytest.raises(NotImplementedError):
+            key.key_size
+
+    def test_public_key_not_implemented(self):
+        key = DummyRSAPrivateKey()
+        with pytest.raises(NotImplementedError):
+            key.public_key()
+
+    def test_sign_not_implemented(self):
+        key = DummyRSAPrivateKey()
+        with pytest.raises(NotImplementedError):
+            key.sign(b"data", padding.PKCS1v15(), hashes.SHA256())
+
+    def test_private_numbers_not_implemented(self):
+        key = DummyRSAPrivateKey()
+        with pytest.raises(NotImplementedError):
+            key.private_numbers()
+
+    def test_private_bytes_not_implemented(self):
+        key = DummyRSAPrivateKey()
+        with pytest.raises(NotImplementedError):
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+
+    def test_copy_not_implemented(self):
+        key = DummyRSAPrivateKey()
+        with pytest.raises(NotImplementedError):
+            copy.copy(key)
+
+    def test_deepcopy_not_implemented(self):
+        key = DummyRSAPrivateKey()
         with pytest.raises(NotImplementedError):
             copy.deepcopy(key)


### PR DESCRIPTION
pkcs7_decrypt_der and its PEM and S/MIME variants reported invalid RSA PKCS#1 v1.5 padding, a recovered key of the wrong length, and a wrong key as three distinct errors, and the middle one disclosed the exact recovered length. That is a Bleichenbacher oracle for any caller that decrypts untrusted messages. The wrong-length case also returned before the AES-CBC pass, so the same distinction was observable by timing, proportional to a content size the attacker chooses.

Substitute a random key of the expected length on failure, per RFC 3218, and continue down an identical path so that every outcome looks alike.

EnvelopedData still authenticates nothing, so revealing whether decryption succeeded remains a CBC padding oracle regardless. That is a property of PKCS#7 rather than of this implementation, and is now documented instead.