### PR TITLE
Add `from __future__ import annotations` to all src/ Python files

### DIFF
--- a/src/_cffi_src/__init__.py
+++ b/src/_cffi_src/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/_cffi_src/openssl/__init__.py
+++ b/src/_cffi_src/openssl/__init__.py
@@ -1,3 +1,5 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+
+from __future__ import annotations

--- a/src/cryptography/hazmat/asn1/__init__.py
+++ b/src/cryptography/hazmat/asn1/__init__.py
@@ -2,6 +2,8 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+from __future__ import annotations
+
 from cryptography.hazmat.asn1.asn1 import (
     TLV,
     BitString,

--- a/src/cryptography/hazmat/bindings/__init__.py
+++ b/src/cryptography/hazmat/bindings/__init__.py
@@ -1,3 +1,5 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+
+from __future__ import annotations

--- a/src/cryptography/hazmat/bindings/openssl/__init__.py
+++ b/src/cryptography/hazmat/bindings/openssl/__init__.py
@@ -1,3 +1,5 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+
+from __future__ import annotations

--- a/src/cryptography/hazmat/primitives/__init__.py
+++ b/src/cryptography/hazmat/primitives/__init__.py
@@ -1,3 +1,5 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+
+from __future__ import annotations

--- a/src/cryptography/hazmat/primitives/asymmetric/__init__.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/__init__.py
@@ -1,3 +1,5 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+
+from __future__ import annotations

--- a/src/cryptography/hazmat/primitives/serialization/base.py
+++ b/src/cryptography/hazmat/primitives/serialization/base.py
@@ -2,6 +2,8 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+from __future__ import annotations
+
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 
 load_pem_private_key = rust_openssl.keys.load_pem_private_key


### PR DESCRIPTION
96 of the 104 Python source files under `src/` already carried `from __future__ import annotations`. This adds it to the remaining 8 so the convention holds uniformly across the tree:

- `src/_cffi_src/__init__.py`
- `src/_cffi_src/openssl/__init__.py`
- `src/cryptography/hazmat/asn1/__init__.py`
- `src/cryptography/hazmat/bindings/__init__.py`
- `src/cryptography/hazmat/bindings/openssl/__init__.py`
- `src/cryptography/hazmat/primitives/__init__.py`
- `src/cryptography/hazmat/primitives/asymmetric/__init__.py`
- `src/cryptography/hazmat/primitives/serialization/base.py`

The import is placed after the license header, matching the placement in the files that already had it. `src/_cffi_src/__init__.py` was previously empty, so it now contains only the import line.

The `.pyi` stubs under `src/cryptography/hazmat/bindings/_rust/` are left alone — stub files are never evaluated at runtime and type checkers already treat their annotations lazily, so the import would be a no-op there.

No changelog entry, as there is no user-visible behavior change.

Verified with `nox -e flake` (`ruff check`, `ruff format --check`, `mypy`, `check-sdist`), all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxhHMqmQbqHobfoidB1iFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxhHMqmQbqHobfoidB1iFT)_