### PR TITLE
reopen main for development

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+.. _v51-0-0:
+
+51.0.0 - `main`_
+~~~~~~~~~~~~~~~~
+
+.. note:: This version is not yet released and is under active development.
+
 .. _v50-0-0:
 
 50.0.0 - 2026-07-31

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cryptography-cffi"
-version = "0.50.0"
+version = "0.51.0-dev1"
 dependencies = [
  "cc",
  "openssl-sys",
@@ -63,21 +63,21 @@ dependencies = [
 
 [[package]]
 name = "cryptography-crypto"
-version = "0.50.0"
+version = "0.51.0-dev1"
 dependencies = [
  "openssl",
 ]
 
 [[package]]
 name = "cryptography-keepalive"
-version = "0.50.0"
+version = "0.51.0-dev1"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "cryptography-key-parsing"
-version = "0.50.0"
+version = "0.51.0-dev1"
 dependencies = [
  "asn1",
  "cfg-if",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography-openssl"
-version = "0.50.0"
+version = "0.51.0-dev1"
 dependencies = [
  "cfg-if",
  "foreign-types",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography-rust"
-version = "0.50.0"
+version = "0.51.0-dev1"
 dependencies = [
  "asn1",
  "base64",
@@ -125,14 +125,14 @@ dependencies = [
 
 [[package]]
 name = "cryptography-x509"
-version = "0.50.0"
+version = "0.51.0-dev1"
 dependencies = [
  "asn1",
 ]
 
 [[package]]
 name = "cryptography-x509-verification"
-version = "0.50.0"
+version = "0.51.0-dev1"
 dependencies = [
  "asn1",
  "cryptography-x509",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.50.0"
+version = "0.51.0-dev1"
 authors = ["The cryptography developers <cryptography-dev@python.org>"]
 edition = "2021"
 publish = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "maturin"
 
 [project]
 name = "cryptography"
-version = "50.0.0"
+version = "51.0.0-dev1"
 authors = [
     { name = "The Python Cryptographic Authority and individual contributors", email = "cryptography-dev@python.org" },
 ]
@@ -76,7 +76,7 @@ dev = [
 ]
 nox = ["nox[uv] >=2024.04.15"]
 test = [
-    "cryptography_vectors==50.0.0",
+    "cryptography_vectors",
     "pytest >=7.4.0",
     "pytest-benchmark >=4.0",
     "pytest-cov >=2.10.1",

--- a/src/cryptography/__about__.py
+++ b/src/cryptography/__about__.py
@@ -10,7 +10,7 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "50.0.0"
+__version__ = "51.0.0-dev1"
 
 
 __author__ = "The Python Cryptographic Authority and individual contributors"

--- a/vectors/cryptography_vectors/__about__.py
+++ b/vectors/cryptography_vectors/__about__.py
@@ -6,4 +6,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "50.0.0"
+__version__ = "51.0.0-dev1"

--- a/vectors/pyproject.toml
+++ b/vectors/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 
 [project]
 name = "cryptography_vectors"
-version = "50.0.0"
+version = "51.0.0-dev1"
 authors = [
     {name = "The Python Cryptographic Authority and individual contributors", email = "cryptography-dev@python.org"}
 ]


### PR DESCRIPTION
Post-release housekeeping after 50.0.0.

* `python release.py bump-version 51.0.0-dev1`, which updates `pyproject.toml`, `src/cryptography/__about__.py`, `vectors/pyproject.toml`, `vectors/cryptography_vectors/__about__.py`, the workspace version in `Cargo.toml` (crate version `0.51.0-dev1`) and `Cargo.lock`. It also relaxes the test dependency from `cryptography_vectors==50.0.0` back to unpinned `cryptography_vectors`, since the version is now a pre-release.
* Adds the `51.0.0 - main`_ changelog section with the "not yet released and is under active development" note.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFSYJJ1k7PDnNV7stHJgLg)_