### PR TITLE
ci: add names to dependency bump steps for readability

### DIFF
--- a/.github/workflows/boring-open-awslc-bump.yml
+++ b/.github/workflows/boring-open-awslc-bump.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           # Needed so we can push back to the repo
           persist-credentials: true
-      - id: bump-boringssl
+      - name: Bump BoringSSL pin
+        id: bump-boringssl
         run: |
           python3 .github/bin/bump_dependency.py \
             --name "BoringSSL" \
@@ -29,7 +30,8 @@ jobs:
             --comment-pattern 'Latest commit on the BoringSSL main branch.*?\.' \
             --commit-url-template "{repo_url}/+/{version}" \
             --diff-url-template "{repo_url}/+/{old_version}..{new_version}"
-      - id: bump-openssl
+      - name: Bump OpenSSL pin
+        id: bump-openssl
         run: |
           python3 .github/bin/bump_dependency.py \
             --name "OpenSSL" \
@@ -39,7 +41,8 @@ jobs:
             --current-version-pattern 'TYPE: "openssl", VERSION: "([a-f0-9]{40})"' \
             --update-pattern 'TYPE: "openssl", VERSION: "{new_version}"' \
             --comment-pattern 'Latest commit on the OpenSSL master branch.*?\.'
-      - id: bump-awslc
+      - name: Bump AWS-LC pin
+        id: bump-awslc
         run: |
           python3 .github/bin/bump_dependency.py \
             --name "AWS-LC" \

--- a/.github/workflows/x509-limbo-version-bump.yml
+++ b/.github/workflows/x509-limbo-version-bump.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           # Needed so we can push back to the repo
           persist-credentials: true
-      - id: bump-x509-limbo
+      - name: Bump x509-limbo pin
+        id: bump-x509-limbo
         run: |
           python3 .github/bin/bump_dependency.py \
             --name "x509-limbo" \
@@ -27,7 +28,8 @@ jobs:
             --current-version-pattern 'X509_LIMBO_REF: "([a-f0-9]{40})" # x509-limbo-ref' \
             --update-pattern 'X509_LIMBO_REF: "{new_version}" # x509-limbo-ref' \
             --comment-pattern 'Latest commit on the x509-limbo main branch.*?\.'
-      - id: bump-wycheproof
+      - name: Bump wycheproof pin
+        id: bump-wycheproof
         run: |
           python3 .github/bin/bump_dependency.py \
             --name "wycheproof" \


### PR DESCRIPTION
## Problem

In the scheduled dependency-bump workflows, several `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when a bump job fails or needs review.

## Changes

Semantics are unchanged: same step `id`s, same `bump_dependency.py` invocations, and the same `HAS_UPDATES` / `COMMIT_MSG` output wiring used by later steps.

### `.github/workflows/boring-open-awslc-bump.yml`
- Add names to `bump-boringssl`, `bump-openssl`, and `bump-awslc`

### `.github/workflows/x509-limbo-version-bump.yml`
- Add names to `bump-x509-limbo` and `bump-wycheproof`

## Test plan
- [ ] Confirm later `if:` conditions still reference the same `steps.bump-*.outputs.HAS_UPDATES`
- [ ] Confirm PR body templates still use `steps.bump-*.outputs.COMMIT_MSG`
