### PR TITLE
Refactor the custom OpenSSL build into a reusable action

### DIFF
--- a/.github/actions/build-openssl/action.yml
+++ b/.github/actions/build-openssl/action.yml
@@ -1,0 +1,84 @@
+name: Build custom OpenSSL
+description: |
+  Builds OpenSSL/LibreSSL/BoringSSL/AWS-LC from source, caching the
+  installed tree, and exports the environment variables needed to build
+  cryptography against it (OPENSSL_DIR, CFLAGS, RUSTFLAGS).
+
+  The cache is restored and saved with explicit steps rather than
+  actions/cache's post-job save, so a build is written to the cache as
+  soon as it finishes instead of at the end of the job.
+
+inputs:
+  type:
+    description: "openssl, libressl, boringssl, or aws-lc"
+    required: true
+  version:
+    description: "Version to build, or a git commit for openssl/boringssl"
+    required: true
+  config-flags:
+    description: "Extra configure flags, appended to the defaults"
+    required: false
+    default: ""
+
+outputs:
+  hash:
+    description: "Hash of the build inputs, for use in other cache keys"
+    value: ${{ steps.config.outputs.hash }}
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Compute config hash and set config vars
+      id: config
+      run: |
+        DEFAULT_CONFIG_FLAGS="shared no-ssl2 no-ssl3"
+        CONFIG_FLAGS="$DEFAULT_CONFIG_FLAGS $CONFIG_FLAGS"
+        OPENSSL_HASH=$(echo "${TYPE}-${VERSION}-$CONFIG_FLAGS" | sha1sum | sed 's/ .*$//')
+        echo "hash=${OPENSSL_HASH}" >> $GITHUB_OUTPUT
+        # When altering the openssl build process you may need to increment
+        # the value on the end of this cache key so that you can prevent it
+        # from fetching the cache and skipping the build step.
+        echo "cache-key=${TYPE}-${VERSION}-${OPENSSL_HASH}-${SCRIPT_HASH}-0" >> $GITHUB_OUTPUT
+        echo "CONFIG_FLAGS=${CONFIG_FLAGS}" >> $GITHUB_ENV
+        echo "OPENSSL_HASH=${OPENSSL_HASH}" >> $GITHUB_ENV
+        echo "OSSL_INFO=${TYPE}-${VERSION}-${CONFIG_FLAGS}" >> $GITHUB_ENV
+        echo "OSSL_PATH=${GITHUB_WORKSPACE}/osslcache/${TYPE}-${VERSION}-${OPENSSL_HASH}" >> $GITHUB_ENV
+      env:
+        TYPE: ${{ inputs.type }}
+        VERSION: ${{ inputs.version }}
+        CONFIG_FLAGS: ${{ inputs.config-flags }}
+        SCRIPT_HASH: ${{ hashFiles('.github/bin/build_openssl.sh') }}
+      shell: bash
+
+    - name: Restore OpenSSL cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      id: ossl-cache
+      with:
+        path: ${{ github.workspace }}/osslcache
+        key: ${{ steps.config.outputs.cache-key }}
+
+    - name: Build custom OpenSSL/LibreSSL
+      run: .github/bin/build_openssl.sh
+      env:
+        TYPE: ${{ inputs.type }}
+        VERSION: ${{ inputs.version }}
+      shell: bash
+      if: steps.ossl-cache.outputs.cache-hit != 'true'
+
+    # Saving here, rather than letting actions/cache save in a post-job
+    # step, means the build survives a failure (or timeout) in any of the
+    # steps that follow.
+    - name: Save OpenSSL cache
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ github.workspace }}/osslcache
+        key: ${{ steps.config.outputs.cache-key }}
+      if: steps.ossl-cache.outputs.cache-hit != 'true'
+
+    - name: Set CFLAGS/LDFLAGS
+      run: |
+        echo "OPENSSL_DIR=${OSSL_PATH}" >> $GITHUB_ENV
+        echo "CFLAGS=${CFLAGS} -Werror=implicit-function-declaration" >> $GITHUB_ENV
+        echo "RUSTFLAGS=-Clink-arg=-Wl,-rpath=${OSSL_PATH}/lib -Clink-arg=-Wl,-rpath=${OSSL_PATH}/lib64" >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/build-openssl/action.yml
+++ b/.github/actions/build-openssl/action.yml
@@ -1,12 +1,5 @@
 name: Build custom OpenSSL
-description: |
-  Builds OpenSSL/LibreSSL/BoringSSL/AWS-LC from source, caching the
-  installed tree, and exports the environment variables needed to build
-  cryptography against it (OPENSSL_DIR, CFLAGS, RUSTFLAGS).
-
-  The cache is restored and saved with explicit steps rather than
-  actions/cache's post-job save, so a build is written to the cache as
-  soon as it finishes instead of at the end of the job.
+description: Builds OpenSSL/LibreSSL/BoringSSL/AWS-LC from source, with caching, and exports the environment variables needed to build cryptography against it
 
 inputs:
   type:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,40 +96,13 @@ jobs:
         timeout-minutes: 2
         uses: ./.github/actions/fetch-vectors
         if: matrix.PYTHON.NOXSESSION != 'flake' && matrix.PYTHON.NOXSESSION != 'docs' && matrix.PYTHON.NOXSESSION != 'rust'
-      - name: Compute config hash and set config vars
-        run: |
-          DEFAULT_CONFIG_FLAGS="shared no-ssl2 no-ssl3"
-          CONFIG_FLAGS="$DEFAULT_CONFIG_FLAGS $CONFIG_FLAGS"
-          OPENSSL_HASH=$(echo "${{ matrix.PYTHON.OPENSSL.TYPE }}-${{ matrix.PYTHON.OPENSSL.VERSION }}-$CONFIG_FLAGS" | sha1sum | sed 's/ .*$//')
-          echo "CONFIG_FLAGS=${CONFIG_FLAGS}" >> $GITHUB_ENV
-          echo "OPENSSL_HASH=${OPENSSL_HASH}" >> $GITHUB_ENV
-          echo "OSSL_INFO=${{ matrix.PYTHON.OPENSSL.TYPE }}-${{ matrix.PYTHON.OPENSSL.VERSION }}-${CONFIG_FLAGS}" >> $GITHUB_ENV
-          echo "OSSL_PATH=${{ github.workspace }}/osslcache/${{ matrix.PYTHON.OPENSSL.TYPE }}-${{ matrix.PYTHON.OPENSSL.VERSION }}-${OPENSSL_HASH}" >> $GITHUB_ENV
-        env:
-          CONFIG_FLAGS: ${{ matrix.PYTHON.OPENSSL.CONFIG_FLAGS }}
-        if: matrix.PYTHON.OPENSSL
-      - name: Load OpenSSL cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: ossl-cache
-        timeout-minutes: 2
-        with:
-          path: ${{ github.workspace }}/osslcache
-          # When altering the openssl build process you may need to increment
-          # the value on the end of this cache key so that you can prevent it
-          # from fetching the cache and skipping the build step.
-          key: "${{ matrix.PYTHON.OPENSSL.TYPE }}-${{ matrix.PYTHON.OPENSSL.VERSION }}-${{ env.OPENSSL_HASH }}-${{ hashFiles('.github/bin/build_openssl.sh') }}-0"
-        if: matrix.PYTHON.OPENSSL
       - name: Build custom OpenSSL/LibreSSL
-        run: .github/bin/build_openssl.sh
-        env:
-          TYPE: ${{ matrix.PYTHON.OPENSSL.TYPE }}
-          VERSION: ${{ matrix.PYTHON.OPENSSL.VERSION }}
-        if: matrix.PYTHON.OPENSSL && steps.ossl-cache.outputs.cache-hit != 'true'
-      - name: Set CFLAGS/LDFLAGS
-        run: |
-          echo "OPENSSL_DIR=${OSSL_PATH}" >> $GITHUB_ENV
-          echo "CFLAGS=${CFLAGS} -Werror=implicit-function-declaration" >> $GITHUB_ENV
-          echo "RUSTFLAGS=-Clink-arg=-Wl,-rpath=${OSSL_PATH}/lib -Clink-arg=-Wl,-rpath=${OSSL_PATH}/lib64" >> $GITHUB_ENV
+        id: openssl
+        uses: ./.github/actions/build-openssl
+        with:
+          type: ${{ matrix.PYTHON.OPENSSL.TYPE }}
+          version: ${{ matrix.PYTHON.OPENSSL.VERSION }}
+          config-flags: ${{ matrix.PYTHON.OPENSSL.CONFIG_FLAGS }}
         if: matrix.PYTHON.OPENSSL
       - name: Cache rust and pip
         uses: ./.github/actions/cache
@@ -139,7 +112,7 @@ jobs:
           # setup-python step because the latter doesn't distinguish
           # different Python versions of PyPy that share the same PyPy
           # version number.
-          key: "${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.PYTHON.NOXSESSION }}-${{ env.OPENSSL_HASH }}-0"
+          key: "${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.PYTHON.NOXSESSION }}-${{ steps.openssl.outputs.hash }}-0"
       # This must run after the cache action: rust-cache prunes binaries
       # that already existed in ~/.cargo/bin before it ran, so installing
       # bindgen first means it never gets cached. When the cache is warm,


### PR DESCRIPTION
The `linux` job's four OpenSSL steps (config hash, cache, `build_openssl.sh`, `CFLAGS`/`RUSTFLAGS` exports) move into a new `.github/actions/build-openssl` composite action. It takes `type`/`version`/`config-flags` and exposes the config hash as an output, which the rust/pip cache key now reads instead of the `OPENSSL_HASH` env var.

The cache also switches from `actions/cache` to explicit `actions/cache/restore` + `actions/cache/save`, with the save running immediately after the build instead of in a post-job step. A build now reaches the cache as soon as it finishes, so a failure or the 15-minute job timeout in a later step (nox install, tests) no longer means rebuilding OpenSSL on the next run.

Cache keys are unchanged, so existing entries are still hits — the hash computation produces the same digest as before (verified locally: `openssl` + `4.0.1` + `no-legacy` → `9d20c05…`, same as the inline version).

One behavior change: the cache steps lose their `timeout-minutes: 2`, since composite-action steps don't support that key. The job's `timeout-minutes: 15` still applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_016EoZRhEKeErJj1DA83MvxT)_