### PR TITLE
Note why we don't reject all-zeros X/Ed 25519/448 keys

### DIFF
--- a/src/rust/src/backend/ed25519.rs
+++ b/src/rust/src/backend/ed25519.rs
@@ -40,6 +40,8 @@ pub(crate) fn public_key_from_pkey(
     }
 }
 
+// We don't reject all-zeros keys -- there's no threat model in which accepting
+// them is a risk.
 #[pyo3::pyfunction]
 fn from_private_bytes(data: CffiBuf<'_>) -> pyo3::PyResult<Ed25519PrivateKey> {
     let pkey = openssl::pkey::PKey::private_key_from_raw_bytes(

--- a/src/rust/src/backend/ed448.rs
+++ b/src/rust/src/backend/ed448.rs
@@ -40,6 +40,8 @@ pub(crate) fn public_key_from_pkey(
     }
 }
 
+// We don't reject all-zeros keys -- there's no threat model in which accepting
+// them is a risk.
 #[pyo3::pyfunction]
 fn from_private_bytes(data: CffiBuf<'_>) -> pyo3::PyResult<Ed448PrivateKey> {
     let pkey =

--- a/src/rust/src/backend/x25519.rs
+++ b/src/rust/src/backend/x25519.rs
@@ -39,6 +39,8 @@ pub(crate) fn public_key_from_pkey(
     }
 }
 
+// We don't reject all-zeros keys -- there's no threat model in which accepting
+// them is a risk.
 #[pyo3::pyfunction]
 fn from_private_bytes(data: CffiBuf<'_>) -> pyo3::PyResult<X25519PrivateKey> {
     let pkey =

--- a/src/rust/src/backend/x448.rs
+++ b/src/rust/src/backend/x448.rs
@@ -39,6 +39,8 @@ pub(crate) fn public_key_from_pkey(
     }
 }
 
+// We don't reject all-zeros keys -- there's no threat model in which accepting
+// them is a risk.
 #[pyo3::pyfunction]
 fn from_private_bytes(data: CffiBuf<'_>) -> pyo3::PyResult<X448PrivateKey> {
     let pkey =


### PR DESCRIPTION
Adds a short comment above `from_private_bytes` in the X25519, X448, Ed25519, and Ed448 backend modules recording that we deliberately don't reject all-zeros keys, since there's no threat model in which accepting them is a risk.

Comment-only change; no behavior difference.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtyEzx8vFtPnRLrf5TJzsw)_