### PR TITLE
Upgrade mypy to 2.3.0 on Python 3.10+

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -102,7 +102,7 @@ markupsafe==3.0.3
     # via jinja2
 mypy==1.19.1 ; python_full_version < '3.10'
     # via cryptography (pyproject.toml:dev)
-mypy==2.1.0 ; python_full_version >= '3.10'
+mypy==2.3.0 ; python_full_version >= '3.10'
     # via cryptography (pyproject.toml:dev)
 mypy-extensions==1.1.0
     # via mypy

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -249,14 +249,16 @@ class TestSequenceAPI:
         # The kw-only init is only enforced in Python >= 3.10, which is
         # when the parameter `kw_only` for `dataclasses.datalass` was
         # added.
+        # Bare `type: ignore` because mypy <2.3 reports this as `misc` and
+        # mypy >=2.3 reports it as `call-arg`.
         if sys.version_info < (3, 10):
-            assert Example(5).foo == 5  # type: ignore[misc]
+            assert Example(5).foo == 5  # type: ignore
         else:
             with pytest.raises(
                 TypeError,
                 match="takes 1 positional argument but 2 were given",
             ):
-                Example(5)  # type: ignore[misc]
+                Example(5)  # type: ignore
 
     def test_fail_malformed_root_type(self) -> None:
         @asn1.sequence
@@ -564,14 +566,16 @@ class TestSetAPI:
         # The kw-only init is only enforced in Python >= 3.10, which is
         # when the parameter `kw_only` for `dataclasses.datalass` was
         # added.
+        # Bare `type: ignore` because mypy <2.3 reports this as `misc` and
+        # mypy >=2.3 reports it as `call-arg`.
         if sys.version_info < (3, 10):
-            assert Example(5).foo == 5  # type: ignore[misc]
+            assert Example(5).foo == 5  # type: ignore
         else:
             with pytest.raises(
                 TypeError,
                 match="takes 1 positional argument but 2 were given",
             ):
-                Example(5)  # type: ignore[misc]
+                Example(5)  # type: ignore
 
     def test_fail_malformed_root_type(self) -> None:
         @asn1.set

--- a/tests/hazmat/primitives/test_kbkdf.py
+++ b/tests/hazmat/primitives/test_kbkdf.py
@@ -347,7 +347,9 @@ class TestKBKDFHMAC:
                 b"context",
                 None,
                 backend,
-                0,  # type: ignore[misc]
+                # Bare `type: ignore` because mypy <2.3 reports this as
+                # `misc` and mypy >=2.3 reports it as `call-arg`.
+                0,  # type: ignore
             )
 
     def test_invalid_break_location(self):
@@ -771,7 +773,9 @@ class TestKBKDFCMAC:
                 b"context",
                 None,
                 backend,
-                0,  # type: ignore[misc]
+                # Bare `type: ignore` because mypy <2.3 reports this as
+                # `misc` and mypy >=2.3 reports it as `call-arg`.
+                0,  # type: ignore
             )
 
     def test_invalid_break_location(self):


### PR DESCRIPTION
mypy 2.3 changed the error code for "Too many positional arguments" from [misc] to [call-arg]. Since the Python 3.9 flake job stays on mypy 1.19 (mypy 2.x requires Python 3.10+), no single error code works for both, so use a bare `type: ignore` at those call sites.


Claude-Session: https://claude.ai/code/session_01RAxXsKkjKM9hT6CrMdDcpk