### PR TITLE
Add ty type checking alongside mypy

### DIFF
--- a/ci-constraints-requirements.txt
+++ b/ci-constraints-requirements.txt
@@ -248,6 +248,8 @@ tomli==2.4.1 ; python_full_version <= '3.11'
     #   nox
     #   pytest
     #   sphinx
+ty==0.0.69
+    # via cryptography (pyproject.toml:dev)
 typing-extensions==4.16.0
     # via
     #   cryptography (pyproject.toml)

--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -24,6 +24,22 @@ running ``ruff`` against it. If you've installed the development requirements
 this will automatically use our configuration. You can also run the ``nox``
 job with ``nox -e flake``.
 
+We type check with both ``mypy`` and ``ty``. The two use different suppression
+comments, so a line that needs suppressing in both must carry both, with the
+``mypy`` one first (``mypy`` only recognizes ``# type: ignore`` when it is the
+first comment on the line):
+
+.. code-block:: python
+
+    key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
+
+``ty`` does not understand ``mypy``'s error codes (see `ty#3127`_) and ignores
+a ``# type: ignore[...]`` comment that has any codes in brackets, so a
+``mypy``-only suppression needs nothing extra. A bare ``# type: ignore``, on
+the other hand, is honored by both, and needs no ``ty`` comment.
+
+Don't add a ``# ty: ignore`` that isn't needed: ``ty`` reports unused ones.
+
 `Write comments as complete sentences.`_
 
 Class names which contains acronyms or initialisms should always be
@@ -148,3 +164,4 @@ So, specifically:
 .. _`syntax`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists
 .. _`Studies have shown`: https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/
 .. _`our mailing list`: https://mail.python.org/mailman/listinfo/cryptography-dev
+.. _`ty#3127`: https://github.com/astral-sh/ty/issues/3127

--- a/noxfile.py
+++ b/noxfile.py
@@ -54,6 +54,26 @@ def load_pyproject_toml() -> dict:
         return tomllib.load(f)
 
 
+def run_ty(session: nox.Session) -> None:
+    # ty rejects every `pytest.skip("...")` under pytest 8, the newest pytest
+    # supporting 3.9 (https://github.com/astral-sh/ty/issues/2797).
+    if sys.version_info < (3, 10):
+        session.log("Skipping ty: needs pytest 9, which needs Python 3.10+")
+        return
+
+    session.run(
+        "ty",
+        "check",
+        # ty targets `project.requires-python`, not the running interpreter.
+        f"--python-version={sys.version_info[0]}.{sys.version_info[1]}",
+        "src/cryptography/",
+        "vectors/cryptography_vectors/",
+        "tests/",
+        "release.py",
+        "noxfile.py",
+    )
+
+
 @nox.session
 @nox.session(name="tests-ssh")
 @nox.session(name="tests-randomorder")
@@ -232,6 +252,7 @@ def flake(session: nox.Session) -> None:
         "release.py",
         "noxfile.py",
     )
+    run_ty(session)
     session.run("check-sdist", "--no-isolation")
 
 
@@ -323,14 +344,8 @@ def local(session: nox.Session):
         external=True,
     )
 
-    session.run(
-        "mypy",
-        "src/cryptography/",
-        "vectors/cryptography_vectors/",
-        "tests/",
-        "release.py",
-        "noxfile.py",
-    )
+    # `local` runs ty instead of mypy; `flake` runs both.
+    run_ty(session)
 
     session.run(
         "maturin",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ sdist = ["build >=1.0.0"]
 pep8test = [
     "ruff >=0.11.11",
     "mypy >=1.14",
+    "ty >=0.0.69",
     "check-sdist",
     "click >=8.0.1",
 ]
@@ -158,6 +159,21 @@ warn_unused_ignores = true
 warn_unused_configs = true
 strict_equality = true
 strict_bytes = true
+
+# ty does not understand mypy's error codes, so a line both checkers flag
+# carries a `# type: ignore[...]` followed by a `# ty: ignore[...]`. If ty
+# grows support for mypy's names (https://github.com/astral-sh/ty/issues/3127)
+# the `ty:` halves can be dropped.
+[tool.ty.rules]
+# In `sys.version_info`-gated code one branch is always unreachable, and ty
+# reports the blanket ignore there as unused while mypy stays quiet. Whichever
+# version we check, one arm of such a pair gets flagged. mypy's
+# `warn_unused_ignores` already covers `# type: ignore` comments, so turn this
+# off. `unused-ignore-comment` (for `# ty: ignore`) stays enabled, since mypy
+# can't check those.
+# Tracked upstream as https://github.com/astral-sh/ty/issues/2681; this can be
+# re-enabled once ty stops reporting suppressions in unreachable code.
+unused-type-ignore-comment = "ignore"
 
 [[tool.mypy.overrides]]
 module = ["pretend"]

--- a/src/cryptography/hazmat/bindings/openssl/binding.py
+++ b/src/cryptography/hazmat/bindings/openssl/binding.py
@@ -36,7 +36,7 @@ def build_conditional_library(
     conditional_names: Mapping[str, Callable[[], list[str]]],
 ) -> typing.Any:
     conditional_lib = types.ModuleType("lib")
-    conditional_lib._original_lib = lib  # type: ignore[attr-defined]
+    conditional_lib._original_lib = lib  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     excluded_names = set()
     for condition, names_cb in conditional_names.items():
         if not getattr(lib, condition):

--- a/src/cryptography/x509/extensions.py
+++ b/src/cryptography/x509/extensions.py
@@ -2510,7 +2510,7 @@ class UnrecognizedExtension(ExtensionType):
         self._value = value
 
     @property
-    def oid(self) -> ObjectIdentifier:  # type: ignore[override]
+    def oid(self) -> ObjectIdentifier:  # type: ignore[override]  # ty: ignore[invalid-attribute-override]
         return self._oid
 
     @property

--- a/tests/hazmat/asn1/test_api.py
+++ b/tests/hazmat/asn1/test_api.py
@@ -225,7 +225,7 @@ class TestSequenceAPI:
         with pytest.raises(
             TypeError, match="got an unexpected keyword argument 'bar'"
         ):
-            Example(bar=3)  # type: ignore[call-arg]
+            Example(bar=3)  # type: ignore[call-arg]  # ty: ignore[missing-argument, unknown-argument]
 
     def test_fail_init_missing_field_name(self) -> None:
         @asn1.sequence
@@ -239,7 +239,7 @@ class TestSequenceAPI:
         )
 
         with pytest.raises(TypeError, match=expected_err):
-            Example()  # type: ignore[call-arg]
+            Example()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
 
     def test_fail_positional_field_initialization(self) -> None:
         @asn1.sequence
@@ -475,7 +475,7 @@ class TestSequenceAPI:
             class Example:
                 foo: typing.Union[
                     Annotated[
-                        asn1.Variant[int, str],
+                        asn1.Variant[int, str],  # ty: ignore[invalid-type-arguments]
                         asn1.Implicit(0),
                     ],
                     Annotated[
@@ -542,7 +542,7 @@ class TestSetAPI:
         with pytest.raises(
             TypeError, match="got an unexpected keyword argument 'bar'"
         ):
-            Example(bar=3)  # type: ignore[call-arg]
+            Example(bar=3)  # type: ignore[call-arg]  # ty: ignore[missing-argument, unknown-argument]
 
     def test_fail_init_missing_field_name(self) -> None:
         @asn1.set
@@ -556,7 +556,7 @@ class TestSetAPI:
         )
 
         with pytest.raises(TypeError, match=expected_err):
-            Example()  # type: ignore[call-arg]
+            Example()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
 
     def test_fail_positional_field_initialization(self) -> None:
         @asn1.set

--- a/tests/hazmat/primitives/test_dh.py
+++ b/tests/hazmat/primitives/test_dh.py
@@ -506,7 +506,7 @@ class TestDH:
         assert key1 != object()
 
         with pytest.raises(TypeError):
-            key1 < key2  # type: ignore[operator]
+            key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
     def test_public_key_copy(self):
         key_bytes = load_vectors_from_file(

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -397,7 +397,7 @@ class TestDSA:
         assert key1 != key3
         assert key1 != object()
         with pytest.raises(TypeError):
-            key1 < key2  # type: ignore[operator]
+            key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
     def test_public_key_copy(self):
         key_bytes = load_vectors_from_file(

--- a/tests/hazmat/primitives/test_ec.py
+++ b/tests/hazmat/primitives/test_ec.py
@@ -763,7 +763,7 @@ class TestECEquality:
         assert key1 != key3
         assert key1 != object()
         with pytest.raises(TypeError):
-            key1 < key2  # type: ignore[operator]
+            key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
     def test_public_key_copy(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())

--- a/tests/hazmat/primitives/test_ed25519.py
+++ b/tests/hazmat/primitives/test_ed25519.py
@@ -286,7 +286,7 @@ def test_public_key_equality():
     assert key1 != object()
 
     with pytest.raises(TypeError):
-        key1 < key2  # type: ignore[operator]
+        key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
 
 def test_public_key_copy():

--- a/tests/hazmat/primitives/test_ed448.py
+++ b/tests/hazmat/primitives/test_ed448.py
@@ -303,7 +303,7 @@ def test_public_key_equality():
     assert key1 != object()
 
     with pytest.raises(TypeError):
-        key1 < key2  # type: ignore[operator]
+        key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/test_hkdf.py
+++ b/tests/hazmat/primitives/test_hkdf.py
@@ -117,7 +117,7 @@ class TestHKDF:
         # This was DeprecatedIn47 but we can't raise a warning
         # because the scapy tests are fragile butterflies
         hkdf = HKDF(hashes.SHA256(), 32, salt=b"0", info=None)
-        prk = hkdf._extract(b"0")  # type:ignore[attr-defined]
+        prk = hkdf._extract(b"0")  # type:ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         assert len(prk) == 32
 
     def test_buffer_protocol(self):

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -2817,7 +2817,7 @@ class TestRSAPEMPublicKeySerialization:
         assert key1 != key3
         assert key1 != object()
         with pytest.raises(TypeError):
-            key1 < key2  # type: ignore[operator]
+            key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
     def test_public_key_copy(self, rsa_key_2048: rsa.RSAPrivateKey):
         key1 = rsa_key_2048.public_key()

--- a/tests/hazmat/primitives/test_x25519.py
+++ b/tests/hazmat/primitives/test_x25519.py
@@ -366,7 +366,7 @@ def test_public_key_equality():
     assert key1 != key3
     assert key1 != object()
     with pytest.raises(TypeError):
-        key1 < key2  # type: ignore[operator]
+        key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/test_x448.py
+++ b/tests/hazmat/primitives/test_x448.py
@@ -291,7 +291,7 @@ def test_public_key_equality():
     assert key1 != key3
     assert key1 != object()
     with pytest.raises(TypeError):
-        key1 < key2  # type: ignore[operator]
+        key1 < key2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/utils.py
+++ b/tests/hazmat/primitives/utils.py
@@ -290,7 +290,7 @@ def aead_exception_test(cipher_factory, mode_factory):
     with pytest.raises(AlreadyUpdated):
         decryptor.authenticate_additional_data(b"b" * 16)
     with pytest.raises(AttributeError):
-        decryptor.tag  # type: ignore[attr-defined]
+        decryptor.tag  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
 
 def generate_aead_tag_exception_test(cipher_factory, mode_factory):

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -316,7 +316,7 @@ class TestCertificateRevocationList:
             x509.load_der_x509_crl,
         )
         with pytest.raises(TypeError):
-            crl1 < crl1  # type: ignore[operator]
+            crl1 < crl1  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
     def test_update_dates(self):
         crl = _load_cert(
@@ -1585,7 +1585,7 @@ class TestRSACertificate:
             x509.load_pem_x509_certificate,
         )
         with pytest.raises(TypeError, match="'>' not supported"):
-            cert > cert2  # type: ignore[operator]
+            cert > cert2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
     def test_hash(self):
         cert1 = _load_cert(
@@ -2385,7 +2385,7 @@ class TestRSACertificateRequest:
             x509.load_pem_x509_csr,
         )
         with pytest.raises(TypeError, match="'>' not supported"):
-            csr > csr2  # type: ignore[operator]
+            csr > csr2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
     def test_hash(self):
         request1 = _load_cert(
@@ -4921,7 +4921,7 @@ class TestCertificateBuilder:
         )
 
         with pytest.raises(TypeError):
-            builder.sign(None, None)  # type:ignore[arg-type]
+            builder.sign(None, None)  # type:ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     def test_build_unsigned_cert(self, rsa_key_2048: rsa.RSAPrivateKey):
         subject_private_key = rsa_key_2048
@@ -6697,7 +6697,7 @@ class TestObjectIdentifier:
         oid1 = x509.ObjectIdentifier("2.999.1")
         oid2 = x509.ObjectIdentifier("2.999.2")
         with pytest.raises(TypeError):
-            oid1 < oid2  # type: ignore[operator]
+            oid1 < oid2  # type: ignore[operator]  # ty: ignore[unsupported-operator]
 
     def test_repr(self):
         oid = x509.ObjectIdentifier("2.5.4.3")


### PR DESCRIPTION
This PR adds ty side-by-side mypy for typechecking.

ty and mypy use incompatible suppression comments: ty ignores any `# type: ignore[...]` that carries error codes in brackets, and mypy only recognizes `# type: ignore` when it is the first comment on a line. Lines that both checkers flag now carry a mypy comment followed by a ty one, which each tool parses as its own. A bare `# type: ignore` is honored by both, so the sites that already use one are left alone.

Add ty to the pep8test dependency group and run it in the `flake` and `local` nox sessions. ty resolves its target version from `project.requires-python` rather than the interpreter it runs on, so pass `--python-version` to keep it in step with mypy; otherwise the two disagree about which `sys.version_info` branch is reachable, and ty demands `tomli` even on interpreters where the fallback import is dead.

Disable ty's `unused-type-ignore-comment`. One arm of a `sys.version_info` pair is unreachable at any given version, and ty reports the blanket ignore mypy needs there as unused. mypy's `warn_unused_ignores` already covers those comments. `unused-ignore-comment` (for `# ty: ignore`) stays on, since mypy cannot check those.


Claude-Session: https://claude.ai/code/session_01FfdhCmHmddyxdZACBwjaeg