### PR TITLE
Silence new nightly clippy clone_on_copy lint

### DIFF
--- a/src/rust/src/serialization.rs
+++ b/src/rust/src/serialization.rs
@@ -2,6 +2,10 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+// The `from_py_object` option on `pyo3::pyclass` generates a `clone` call,
+// which clippy flags for the `Copy` types in this module.
+#![allow(clippy::clone_on_copy)]
+
 use pyo3::types::PyAnyMethods;
 
 use crate::types;

--- a/src/rust/src/serialization.rs
+++ b/src/rust/src/serialization.rs
@@ -4,6 +4,7 @@
 
 // The `from_py_object` option on `pyo3::pyclass` generates a `clone` call,
 // which clippy flags for the `Copy` types in this module.
+// https://github.com/PyO3/pyo3/issues/6308
 #![allow(clippy::clone_on_copy)]
 
 use pyo3::types::PyAnyMethods;


### PR DESCRIPTION
Recent Rust nightly (1.99.0-nightly, `1a98b1e13` 2026-08-07) started reporting `clippy::clone_on_copy` for the `clone` call that `pyo3::pyclass`'s `from_py_object` option generates. That fails the `linux (3.14, rust,tests, nightly)` job with `-D warnings`, e.g. on #15416:

```
error: using `clone` on type `Encoding` which implements the `Copy` trait
  --> src/rust/src/serialization.rs:13:5
   |
13 |     from_py_object,
   |     ^^^^^^^^^^^^^^ help: try removing the `clone` call: `from_py_object`
```

All four affected pyclasses are `Copy` enums in `serialization.rs` (`Encoding`, `PrivateFormat`, `PublicFormat`, `ParameterFormat`), so this allows the lint for that module. Stable clippy (1.94 and the 1.83.0 MSRV job) doesn't fire, so this looks like a change in how nightly clippy suppresses lints from external macros.

An item-level `#[allow]` on each enum does *not* work: the offending code is a sibling impl block emitted by the macro, which carries no attributes of its own, so the lint level has to come from the enclosing module.

```rust
impl<'a, 'py> ::pyo3::FromPyObject<'a, 'py> for Encoding where Self: ::std::clone::Clone {
    type Error = ::pyo3::pyclass::PyClassGuardError<'a, 'py>;
    fn extract(obj: ::pyo3::Borrowed<'a, 'py, ::pyo3::PyAny>) -> ::std::result::Result<Self, <Self as ::pyo3::FromPyObject<'a, 'py>>::Error> {
        ::std::result::Result::Ok(::std::clone::Clone::clone(&*obj.extract::<::pyo3::PyClassGuard<'_, Encoding>>()?))
    }
}
```

Verified locally with `nox -e rust` under both nightly and stable: `cargo fmt --check` and `cargo clippy --all -- -D warnings` are clean and the Rust tests pass on both. (The session's final coverage step fails locally only because `llvm-tools` isn't installed in this container.)

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbYhmwr3z7r3znpg14n2k)_