### PR TITLE
Add X509_V_FLAG_EXTENDED_CRL_SUPPORT binding

### DIFF
--- a/src/_cffi_src/openssl/x509_vfy.py
+++ b/src/_cffi_src/openssl/x509_vfy.py
@@ -101,6 +101,7 @@ static const long X509_V_FLAG_EXPLICIT_POLICY;
 static const long X509_V_FLAG_INHIBIT_MAP;
 static const long X509_V_FLAG_CHECK_SS_SIGNATURE;
 static const long X509_V_FLAG_PARTIAL_CHAIN;
+static const long X509_V_FLAG_EXTENDED_CRL_SUPPORT;
 
 static const long X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT;
 static const long X509_CHECK_FLAG_NO_WILDCARDS;


### PR DESCRIPTION
Expose the OpenSSL verification-parameter flag `X509_V_FLAG_EXTENDED_CRL_SUPPORT` in the _cffi_src OpenSSL bindings, alongside the existing `X509_V_FLAG_CRL_CHECK{,_ALL}` constants. This flag enables OpenSSL's extended CRL features during path validation.

The flag has existed in OpenSSL since the 0.9.9/1.0.0 development cycle (openssl/openssl@9d84d4e, 2008), so excluding the version guard.