### PR TITLE
CI performance experiment: bindgen cache, library build flags, cargo cache fixes

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -19,7 +19,7 @@ runs:
         KEY: "${{ inputs.key }}"
     - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
-        key: ${{ steps.normalized-key.outputs.key }}-5
+        key: ${{ steps.normalized-key.outputs.key }}-6
     # maturin writes the pyo3 config file to target/maturin/, and pyo3-ffi's
     # build script registers cargo:rerun-if-changed on it. rust-cache's
     # cleanup deletes target/maturin/ before saving, so the file was
@@ -30,7 +30,7 @@ runs:
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: target/maturin
-        key: "maturin-pyo3-config-${{ steps.normalized-key.outputs.key }}-0"
+        key: "maturin-pyo3-config-${{ steps.normalized-key.outputs.key }}-1"
     # Cargo's rerun-if-changed check compares the config file's mtime
     # against the .fingerprint timestamps from rust-cache. The two caches
     # can be saved on different runs, so pin the config to a fixed old

--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -19,7 +19,7 @@ runs:
         KEY: "${{ inputs.key }}"
     - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
-        key: ${{ steps.normalized-key.outputs.key }}-6
+        key: ${{ steps.normalized-key.outputs.key }}-7
     # maturin writes the pyo3 config file to target/maturin/, and pyo3-ffi's
     # build script registers cargo:rerun-if-changed on it. rust-cache's
     # cleanup deletes target/maturin/ before saving, so the file was

--- a/.github/actions/fetch-openssl/action.yml
+++ b/.github/actions/fetch-openssl/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: "The directory to extract the artifact to"
     required: true
 
+outputs:
+  artifact-id:
+    description: "The id of the downloaded artifact, for use in cache keys"
+    value: ${{ fromJSON(steps.download.outputs.artifacts)[0].id }}
+
 runs:
   using: "composite"
 

--- a/.github/actions/windows-tests/action.yml
+++ b/.github/actions/windows-tests/action.yml
@@ -63,6 +63,8 @@ runs:
       run: nox -v --install-only
       env:
         NOXSESSION: ${{ inputs.noxsession }}
+        # TEMPORARY, see the linux job in ci.yml.
+        CARGO_LOG: cargo::core::compiler::fingerprint=info
       shell: bash
     - name: Tests
       run: nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo

--- a/.github/actions/windows-tests/action.yml
+++ b/.github/actions/windows-tests/action.yml
@@ -34,14 +34,10 @@ runs:
     - run: rustup component add llvm-tools-preview
       shell: bash
       if: ${{ inputs.noxsession != 'tests-nocoverage' }}
-    - name: Cache rust and pip
-      uses: ./.github/actions/cache
-      with:
-        key: ${{ inputs.noxsession }}-${{ inputs.arch }}-${{ steps.setup-python.outputs.python-version }}
-    - run: python -m pip install -c ci-constraints-requirements.txt "nox[uv]" "tomli; python_version < '3.11'"
-      shell: bash
-
+    # This runs before the cache step because the artifact id is part of
+    # the cache key, see the macos job in ci.yml for why.
     - name: Download OpenSSL
+      id: openssl
       uses: ./.github/actions/fetch-openssl
       with:
         workflow: build-windows-openssl.yml
@@ -52,6 +48,12 @@ runs:
           echo "OPENSSL_DIR=C:/openssl-${OPENSSL_NAME}" >> $GITHUB_ENV
       env:
         OPENSSL_NAME: ${{ inputs.openssl-name }}
+      shell: bash
+    - name: Cache rust and pip
+      uses: ./.github/actions/cache
+      with:
+        key: ${{ inputs.noxsession }}-${{ inputs.arch }}-${{ steps.setup-python.outputs.python-version }}-${{ steps.openssl.outputs.artifact-id }}
+    - run: python -m pip install -c ci-constraints-requirements.txt "nox[uv]" "tomli; python_version < '3.11'"
       shell: bash
 
     - name: Clone test vectors

--- a/.github/bin/build_openssl.sh
+++ b/.github/bin/build_openssl.sh
@@ -17,11 +17,13 @@ if [[ "${TYPE}" == "openssl" ]]; then
   # linker doesn't load the system one.
   sed -i "s/^SHLIB_VERSION=.*/SHLIB_VERSION=100/" VERSION.dat
 
-  # CONFIG_FLAGS is a global coming from a previous step
-  ./config ${CONFIG_FLAGS} -fPIC --prefix="${OSSL_PATH}"
+  # CONFIG_FLAGS is a global coming from a previous step. no-tests skips
+  # building the test programs and build_sw (rather than the default all
+  # target) skips generating the man pages; neither is installed.
+  ./config ${CONFIG_FLAGS} no-tests -fPIC --prefix="${OSSL_PATH}"
 
   make depend
-  make -j"$(nproc)"
+  make -j"$(nproc)" build_sw
   # avoid installing the docs (for performance)
   # https://github.com/openssl/openssl/issues/6685#issuecomment-403838728
   make install_sw install_ssldirs
@@ -44,7 +46,9 @@ elif [[ "${TYPE}" == "libressl" ]]; then
   curl -LO "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${VERSION}.tar.gz"
   tar zxf "libressl-${VERSION}.tar.gz"
   pushd "libressl-${VERSION}"
-  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # The tests and apps aren't built: the openssl binary would be deleted
+  # below anyway, and the tests depend on it.
+  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DLIBRESSL_APPS=OFF -DLIBRESSL_TESTS=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries, libtls, and docs we don't need. can't skip install/compile sadly
   rm -rf "${OSSL_PATH}/bin"
@@ -55,7 +59,9 @@ elif [[ "${TYPE}" == "boringssl" ]]; then
   git clone https://boringssl.googlesource.com/boringssl
   pushd boringssl
   git checkout "${VERSION}"
-  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # install depends on all, which includes the (large) test suite unless
+  # BUILD_TESTING is off.
+  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH}/bin"
@@ -65,7 +71,9 @@ elif [[ "${TYPE}" == "aws-lc" ]]; then
   git clone https://github.com/aws/aws-lc.git
   pushd aws-lc
   git checkout "${VERSION}"
-  cmake -GNinja -B build -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # install depends on all, which includes the (large) test suite and the
+  # bssl tool unless they're turned off.
+  cmake -GNinja -B build -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH:?}/bin"

--- a/.github/bin/build_openssl.sh
+++ b/.github/bin/build_openssl.sh
@@ -60,8 +60,10 @@ elif [[ "${TYPE}" == "boringssl" ]]; then
   pushd boringssl
   git checkout "${VERSION}"
   # install depends on all, which includes the (large) test suite unless
-  # BUILD_TESTING is off.
-  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # BUILD_TESTING is off. Without a build type CMake passes no
+  # optimization flags at all; RelWithAsserts is Release with asserts
+  # kept, which is what BoringSSL's own CI uses.
+  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithAsserts -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH}/bin"
@@ -72,8 +74,9 @@ elif [[ "${TYPE}" == "aws-lc" ]]; then
   pushd aws-lc
   git checkout "${VERSION}"
   # install depends on all, which includes the (large) test suite and the
-  # bssl tool unless they're turned off.
-  cmake -GNinja -B build -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # bssl tool unless they're turned off. See the BoringSSL build above
+  # for the build type.
+  cmake -GNinja -B build -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=RelWithAsserts -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH:?}/bin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
           - {VERSION: "3.14", NOXSESSION: "tests", RUST: "1.87", OPENSSL: {TYPE: "openssl", VERSION: "4.0.2"}}
           - {VERSION: "3.14", NOXSESSION: "tests", RUST: "1.87", NOXARGS: "--enable-fips=1", OPENSSL: {TYPE: "openssl", CONFIG_FLAGS: "enable-fips", VERSION: "3.6.4"}}
     timeout-minutes: 15
+    env:
+      # bindgen-cli is only needed by the BoringSSL and AWS-LC jobs. The
+      # version is part of its cache key, so bump it here to pick up a new
+      # release.
+      BINDGEN_CLI_VERSION: "0.72.1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 3
@@ -113,12 +118,21 @@ jobs:
           # different Python versions of PyPy that share the same PyPy
           # version number.
           key: "${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.PYTHON.NOXSESSION }}-${{ steps.openssl.outputs.hash }}-0"
+      # bindgen gets its own cache, keyed only on its version and the
+      # runner platform. The rust cache above is keyed on the OpenSSL
+      # build hash, so every BoringSSL/AWS-LC bump used to start from a
+      # cold cargo cache and spend ~50s compiling bindgen from source.
       # This must run after the cache action: rust-cache prunes binaries
-      # that already existed in ~/.cargo/bin before it ran, so installing
-      # bindgen first means it never gets cached. When the cache is warm,
-      # cargo sees the binary is already installed and skips the build.
-      - run: rustup run stable cargo install bindgen-cli
+      # that already existed in ~/.cargo/bin before it ran.
+      - name: Cache bindgen-cli
+        id: bindgen-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/bindgen
+          key: bindgen-cli-${{ env.BINDGEN_CLI_VERSION }}-${{ runner.os }}-${{ runner.arch }}
         if: matrix.PYTHON.OPENSSL.TYPE == 'boringssl' || matrix.PYTHON.OPENSSL.TYPE == 'aws-lc'
+      - run: rustup run stable cargo install bindgen-cli --version "${BINDGEN_CLI_VERSION}"
+        if: (matrix.PYTHON.OPENSSL.TYPE == 'boringssl' || matrix.PYTHON.OPENSSL.TYPE == 'aws-lc') && steps.bindgen-cache.outputs.cache-hit != 'true'
 
       - run: python -m pip install -c ci-constraints-requirements.txt 'nox[uv]' 'tomli; python_version < "3.11"'
       - name: Create nox environment
@@ -283,17 +297,32 @@ jobs:
           cache: pip
           cache-dependency-path: ci-constraints-requirements.txt
         timeout-minutes: 3
+      # This runs before the cache step because the artifact id is part
+      # of the cache key, see below.
+      - name: Download OpenSSL
+        id: openssl
+        uses: ./.github/actions/fetch-openssl
+        with:
+          workflow: build-macos-openssl.yml
+          name: openssl-macos-arm64
+          path: "../openssl-macos-arm64/"
       # Keyed on the resolved interpreter version (like the linux and
       # windows jobs), not just the matrix name: the alpha that a -dev
       # entry resolves to moves over time, and a cached maturin/pyo3
       # config built by an older alpha gets rewritten by maturin on every
       # run, which re-dirties pyo3-ffi and recompiles it, pyo3, and every
       # crate above them despite a warm cache.
+      #
+      # Also keyed on the OpenSSL artifact: openssl-sys registers
+      # rerun-if-changed on the include directory, whose mtimes are pinned
+      # to the artifact's creation time. A cache saved before the artifact
+      # was rebuilt would otherwise see "newer" headers on every run and
+      # recompile openssl-sys, openssl, and everything above them.
       - name: Cache rust and pip
         uses: ./.github/actions/cache
         timeout-minutes: 2
         with:
-          key: ${{ matrix.PYTHON.NOXSESSION }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}
+          key: ${{ matrix.PYTHON.NOXSESSION }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ steps.openssl.outputs.artifact-id }}
       - run: rustup component add llvm-tools-preview
 
       - run: python -m pip install -c ci-constraints-requirements.txt 'nox[uv]' 'tomli; python_version < "3.11"'
@@ -302,12 +331,6 @@ jobs:
         timeout-minutes: 2
         uses: ./.github/actions/fetch-vectors
 
-      - name: Download OpenSSL
-        uses: ./.github/actions/fetch-openssl
-        with:
-          workflow: build-macos-openssl.yml
-          name: openssl-macos-arm64
-          path: "../openssl-macos-arm64/"
       - name: Build nox environment
         run: |
           OPENSSL_DIR=$(readlink -f ../openssl-macos-arm64/) \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: 0
+  # TEMPORARY, for the CI performance experiment: log why cargo considers
+  # a crate dirty, so warm-cache runs show any remaining unexpected
+  # recompiles. Remove before merging.
+  CARGO_LOG: cargo::core::compiler::fingerprint=info
   # Enable uv's debug output everywhere, minus its per-file cache/index
   # log lines. All directives must stay scoped to uv targets (no bare
   # level like `debug`) so other Rust binaries that read RUST_LOG are

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: 0
-  # TEMPORARY, for the CI performance experiment: log why cargo considers
-  # a crate dirty, so warm-cache runs show any remaining unexpected
-  # recompiles. Remove before merging.
-  CARGO_LOG: cargo::core::compiler::fingerprint=info
   # Enable uv's debug output everywhere, minus its per-file cache/index
   # log lines. All directives must stay scoped to uv targets (no bare
   # level like `debug`) so other Rust binaries that read RUST_LOG are
@@ -146,6 +142,10 @@ jobs:
           NOXSESSION: ${{ matrix.PYTHON.NOXSESSION }}
           # Needed until https://github.com/PyO3/pyo3/issues/5093
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
+          # TEMPORARY, for the CI performance experiment: log why cargo
+          # considers a crate dirty. Only on the build step: the rust
+          # session parses cargo's JSON output and this would break it.
+          CARGO_LOG: cargo::core::compiler::fingerprint=info
       - name: Tests
         run: |
             nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo ${{ matrix.PYTHON.NOXARGS }}
@@ -344,6 +344,8 @@ jobs:
         env:
           NOXSESSION: ${{ matrix.PYTHON.NOXSESSION }}
           MACOSX_DEPLOYMENT_TARGET: "11.0"
+          # TEMPORARY, see the linux job.
+          CARGO_LOG: cargo::core::compiler::fingerprint=info
       - name: Tests
         run: nox --no-install --  --color=yes --wycheproof-root=wycheproof --x509-limbo-root=x509-limbo
         env:

--- a/noxfile.py
+++ b/noxfile.py
@@ -247,6 +247,13 @@ def rust(session: nox.Session) -> None:
         {
             "RUSTFLAGS": f"-Cinstrument-coverage  {rustflags}",
             "LLVM_PROFILE_FILE": str(prof_location / "cov-%p.profraw"),
+            # When pyo3-build-config locates the interpreter through
+            # VIRTUAL_ENV it registers cargo:rerun-if-changed on the venv's
+            # pyvenv.cfg. CI recreates this venv on every run, so the fresh
+            # mtime made cargo rerun pyo3-ffi's build script and recompile
+            # pyo3-ffi and pyo3 despite a warm cache. Naming the interpreter
+            # explicitly skips that lookup; this path is stable across runs.
+            "PYO3_PYTHON": str(pathlib.Path(session.bin) / f"python{BIN_EXT}"),
         }
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,14 +82,24 @@ def tests(session: nox.Session) -> None:
 
     install_spec = f".[{','.join(extras)}]"
     install(session, "-e", "./vectors")
+    # Build cryptography with this session's interpreter rather than in an
+    # isolated build environment. The build environment lives in a
+    # temporary directory with a fresh random name, and for non-abi3
+    # builds (free-threaded interpreters) maturin passes that interpreter
+    # to pyo3-build-config as PYO3_PYTHON, which registers
+    # rerun-if-env-changed on it: every CI run recompiled pyo3-ffi and
+    # pyo3 despite a warm cache. The session venv's path is stable.
+    pyproject_data = load_pyproject_toml()
+    install(session, *pyproject_data["build-system"]["requires"])
     if session.name == "tests-rust-debug":
         install(
             session,
+            "--no-build-isolation",
             "--config-settings-package=cryptography:build-args=--profile=dev",
             install_spec,
         )
     else:
-        install(session, install_spec)
+        install(session, "--no-build-isolation", install_spec)
 
     install(
         session,


### PR DESCRIPTION
Draft, opened to get CI timings for a set of CI speedups. Three commits, meant to be judged separately:

1. **Speed up CI: cache bindgen, skip library tests, fix two cargo cache misses**
   - bindgen-cli gets its own cache keyed on its version. The rust cache is keyed on the OpenSSL build hash, so every BoringSSL/AWS-LC bump started from a cold cargo cache and spent ~50s compiling bindgen from source on four jobs.
   - The from-source BoringSSL, AWS-LC, OpenSSL and LibreSSL builds no longer build their test suites (nor docs for OpenSSL, nor apps for LibreSSL). Measured locally on 4 cores, BoringSSL goes from 141s to 48s.
   - The `rust` nox session sets `PYO3_PYTHON`. nox recreates the venv on every CI run and pyo3-build-config registers `rerun-if-changed` on `$VIRTUAL_ENV/pyvenv.cfg`, so cargo recompiled pyo3-ffi and pyo3 in every rust session despite a warm cache. Reproduced locally with `CARGO_LOG=cargo::core::compiler::fingerprint=info` (`stale: changed .../pyvenv.cfg`).
   - The macOS and Windows cargo cache keys include the id of the downloaded OpenSSL artifact. The include directory's mtimes are pinned to the artifact's creation time, so a cache saved before the artifact was rebuilt saw newer headers on every run and recompiled openssl-sys, openssl and everything above them (visible in every current macOS run).
   - Cache key suffixes are bumped so this starts from fresh caches. The first run here is cold; the second run is the one that shows the warm-cache behaviour.

2. **Build BoringSSL and AWS-LC with optimization in CI**
   Neither project sets a default `CMAKE_BUILD_TYPE` and the CI build didn't pass one, so the libraries under test were compiled with no optimization flags at all. `RelWithAsserts` is `-O3` with asserts kept, which is what BoringSSL's own CI uses. This changes what's under test, so it's a separate commit; the pytest run against these libraries is currently 2-3x slower than against OpenSSL.

3. **TEMPORARY: log cargo fingerprint decisions in CI**
   Diagnostic only, to be dropped before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM)_