### PR TITLE
Don't build the test suites of the OpenSSL forks we compile in CI

### DIFF
--- a/.github/bin/build_openssl.sh
+++ b/.github/bin/build_openssl.sh
@@ -17,8 +17,7 @@ if [[ "${TYPE}" == "openssl" ]]; then
   # linker doesn't load the system one.
   sed -i "s/^SHLIB_VERSION=.*/SHLIB_VERSION=100/" VERSION.dat
 
-  # CONFIG_FLAGS is a global coming from a previous step. no-tests skips
-  # building the test programs, which are never run here.
+  # CONFIG_FLAGS is a global coming from a previous step
   ./config ${CONFIG_FLAGS} no-tests -fPIC --prefix="${OSSL_PATH}"
 
   make depend

--- a/.github/bin/build_openssl.sh
+++ b/.github/bin/build_openssl.sh
@@ -17,8 +17,9 @@ if [[ "${TYPE}" == "openssl" ]]; then
   # linker doesn't load the system one.
   sed -i "s/^SHLIB_VERSION=.*/SHLIB_VERSION=100/" VERSION.dat
 
-  # CONFIG_FLAGS is a global coming from a previous step
-  ./config ${CONFIG_FLAGS} -fPIC --prefix="${OSSL_PATH}"
+  # CONFIG_FLAGS is a global coming from a previous step. no-tests skips
+  # building the test programs, which are never run here.
+  ./config ${CONFIG_FLAGS} no-tests -fPIC --prefix="${OSSL_PATH}"
 
   make depend
   make -j"$(nproc)"
@@ -44,7 +45,7 @@ elif [[ "${TYPE}" == "libressl" ]]; then
   curl -LO "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${VERSION}.tar.gz"
   tar zxf "libressl-${VERSION}.tar.gz"
   pushd "libressl-${VERSION}"
-  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DLIBRESSL_TESTS=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries, libtls, and docs we don't need. can't skip install/compile sadly
   rm -rf "${OSSL_PATH}/bin"
@@ -55,7 +56,9 @@ elif [[ "${TYPE}" == "boringssl" ]]; then
   git clone https://boringssl.googlesource.com/boringssl
   pushd boringssl
   git checkout "${VERSION}"
-  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # install depends on all, which includes the (large) test suite unless
+  # BUILD_TESTING is off.
+  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH}/bin"
@@ -65,7 +68,9 @@ elif [[ "${TYPE}" == "aws-lc" ]]; then
   git clone https://github.com/aws/aws-lc.git
   pushd aws-lc
   git checkout "${VERSION}"
-  cmake -GNinja -B build -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # install depends on all, which includes the (large) test suite unless
+  # BUILD_TESTING is off.
+  cmake -GNinja -B build -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH:?}/bin"

--- a/.github/bin/build_openssl.sh
+++ b/.github/bin/build_openssl.sh
@@ -55,8 +55,6 @@ elif [[ "${TYPE}" == "boringssl" ]]; then
   git clone https://boringssl.googlesource.com/boringssl
   pushd boringssl
   git checkout "${VERSION}"
-  # install depends on all, which includes the (large) test suite unless
-  # BUILD_TESTING is off.
   cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
@@ -67,8 +65,6 @@ elif [[ "${TYPE}" == "aws-lc" ]]; then
   git clone https://github.com/aws/aws-lc.git
   pushd aws-lc
   git checkout "${VERSION}"
-  # install depends on all, which includes the (large) test suite unless
-  # BUILD_TESTING is off.
   cmake -GNinja -B build -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need


### PR DESCRIPTION
Split out of #15568.

`ninja install` depends on `all`, which includes the test suites of BoringSSL, AWS-LC and LibreSSL unless they're turned off (`BUILD_TESTING` / `LIBRESSL_TESTS`), and OpenSSL's default target builds its test programs unless configured with `no-tests`. None of them are ever run in CI.

Build times measured for the from-source builds:

| Library | Before | After |
|---|---|---|
| BoringSSL, local 4 cores | 141s | 48s |
| AWS-LC, local 4 cores | 87s | 15s* |
| BoringSSL, CI | 179–187s | 98–115s* |
| AWS-LC, CI | 154–162s | 81–82s* |
| OpenSSL master, CI | 228s | 156s* |

\* measured on #15568 with a superset of this change (that branch also skips the AWS-LC `bssl` tool and OpenSSL's man pages), so the numbers here should be close but not identical.

The script hash is part of the OpenSSL cache key, so every cached library build is rebuilt once after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM)_