### PR TITLE
Key the cargo cache on the OpenSSL build it was compiled against

### DIFF
--- a/.github/actions/build-openssl/action.yml
+++ b/.github/actions/build-openssl/action.yml
@@ -17,6 +17,9 @@ outputs:
   hash:
     description: "Hash of the build inputs, for use in other cache keys"
     value: ${{ steps.config.outputs.hash }}
+  cache-key:
+    description: "The key the build is cached under. Cache keys for things compiled against this build should include it, see the linux job in ci.yml"
+    value: ${{ steps.config.outputs.cache-key }}
 
 runs:
   using: "composite"

--- a/.github/actions/build-openssl/action.yml
+++ b/.github/actions/build-openssl/action.yml
@@ -18,7 +18,7 @@ outputs:
     description: "Hash of the build inputs, for use in other cache keys"
     value: ${{ steps.config.outputs.hash }}
   cache-key:
-    description: "The key the build is cached under. Cache keys for things compiled against this build should include it, see the linux job in ci.yml"
+    description: "The key the build is cached under"
     value: ${{ steps.config.outputs.cache-key }}
 
 runs:

--- a/.github/actions/fetch-openssl/action.yml
+++ b/.github/actions/fetch-openssl/action.yml
@@ -20,7 +20,7 @@ inputs:
 
 outputs:
   artifact-id:
-    description: "The id of the downloaded artifact, for use in cache keys"
+    description: "The id of the downloaded artifact"
     value: ${{ fromJSON(steps.download.outputs.artifacts)[0].id }}
 
 runs:

--- a/.github/actions/fetch-openssl/action.yml
+++ b/.github/actions/fetch-openssl/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: "The directory to extract the artifact to"
     required: true
 
+outputs:
+  artifact-id:
+    description: "The id of the downloaded artifact, for use in cache keys"
+    value: ${{ fromJSON(steps.download.outputs.artifacts)[0].id }}
+
 runs:
   using: "composite"
 

--- a/.github/actions/windows-tests/action.yml
+++ b/.github/actions/windows-tests/action.yml
@@ -34,8 +34,7 @@ runs:
     - run: rustup component add llvm-tools-preview
       shell: bash
       if: ${{ inputs.noxsession != 'tests-nocoverage' }}
-    # This runs before the cache step because the artifact id is part of
-    # the cache key, see the macos job in ci.yml for why.
+    # Before the cache step: the artifact id is part of its key.
     - name: Download OpenSSL
       id: openssl
       uses: ./.github/actions/fetch-openssl

--- a/.github/actions/windows-tests/action.yml
+++ b/.github/actions/windows-tests/action.yml
@@ -34,14 +34,10 @@ runs:
     - run: rustup component add llvm-tools-preview
       shell: bash
       if: ${{ inputs.noxsession != 'tests-nocoverage' }}
-    - name: Cache rust and pip
-      uses: ./.github/actions/cache
-      with:
-        key: ${{ inputs.noxsession }}-${{ inputs.arch }}-${{ steps.setup-python.outputs.python-version }}
-    - run: python -m pip install -c ci-constraints-requirements.txt "nox[uv]" "tomli; python_version < '3.11'"
-      shell: bash
-
+    # This runs before the cache step because the artifact id is part of
+    # the cache key, see the macos job in ci.yml for why.
     - name: Download OpenSSL
+      id: openssl
       uses: ./.github/actions/fetch-openssl
       with:
         workflow: build-windows-openssl.yml
@@ -52,6 +48,12 @@ runs:
           echo "OPENSSL_DIR=C:/openssl-${OPENSSL_NAME}" >> $GITHUB_ENV
       env:
         OPENSSL_NAME: ${{ inputs.openssl-name }}
+      shell: bash
+    - name: Cache rust and pip
+      uses: ./.github/actions/cache
+      with:
+        key: ${{ inputs.noxsession }}-${{ inputs.arch }}-${{ steps.setup-python.outputs.python-version }}-${{ steps.openssl.outputs.artifact-id }}
+    - run: python -m pip install -c ci-constraints-requirements.txt "nox[uv]" "tomli; python_version < '3.11'"
       shell: bash
 
     - name: Clone test vectors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,13 @@ jobs:
           # setup-python step because the latter doesn't distinguish
           # different Python versions of PyPy that share the same PyPy
           # version number.
-          key: "${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.PYTHON.NOXSESSION }}-${{ steps.openssl.outputs.hash }}-0"
+          #
+          # The OpenSSL cache key (not just the config hash) is included
+          # because openssl-sys registers rerun-if-changed on the include
+          # directory: a cargo cache saved against an older build of the
+          # same configuration sees "newer" headers on every run and
+          # recompiles openssl-sys, openssl, and everything above them.
+          key: "${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.PYTHON.NOXSESSION }}-${{ steps.openssl.outputs.cache-key }}-0"
       # This must run after the cache action: rust-cache prunes binaries
       # that already existed in ~/.cargo/bin before it ran, so installing
       # bindgen first means it never gets cached. When the cache is warm,
@@ -283,17 +289,32 @@ jobs:
           cache: pip
           cache-dependency-path: ci-constraints-requirements.txt
         timeout-minutes: 3
+      # This runs before the cache step because the artifact id is part
+      # of the cache key, see below.
+      - name: Download OpenSSL
+        id: openssl
+        uses: ./.github/actions/fetch-openssl
+        with:
+          workflow: build-macos-openssl.yml
+          name: openssl-macos-arm64
+          path: "../openssl-macos-arm64/"
       # Keyed on the resolved interpreter version (like the linux and
       # windows jobs), not just the matrix name: the alpha that a -dev
       # entry resolves to moves over time, and a cached maturin/pyo3
       # config built by an older alpha gets rewritten by maturin on every
       # run, which re-dirties pyo3-ffi and recompiles it, pyo3, and every
       # crate above them despite a warm cache.
+      #
+      # Also keyed on the OpenSSL artifact: openssl-sys registers
+      # rerun-if-changed on the include directory, whose mtimes are pinned
+      # to the artifact's creation time. A cache saved before the artifact
+      # was rebuilt would otherwise see "newer" headers on every run and
+      # recompile openssl-sys, openssl, and everything above them.
       - name: Cache rust and pip
         uses: ./.github/actions/cache
         timeout-minutes: 2
         with:
-          key: ${{ matrix.PYTHON.NOXSESSION }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}
+          key: ${{ matrix.PYTHON.NOXSESSION }}-${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ steps.openssl.outputs.artifact-id }}
       - run: rustup component add llvm-tools-preview
 
       - run: python -m pip install -c ci-constraints-requirements.txt 'nox[uv]' 'tomli; python_version < "3.11"'
@@ -302,12 +323,6 @@ jobs:
         timeout-minutes: 2
         uses: ./.github/actions/fetch-vectors
 
-      - name: Download OpenSSL
-        uses: ./.github/actions/fetch-openssl
-        with:
-          workflow: build-macos-openssl.yml
-          name: openssl-macos-arm64
-          path: "../openssl-macos-arm64/"
       - name: Build nox environment
         run: |
           OPENSSL_DIR=$(readlink -f ../openssl-macos-arm64/) \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,9 @@ jobs:
           # different Python versions of PyPy that share the same PyPy
           # version number.
           #
-          # The OpenSSL cache key (not just the config hash) is included
-          # because openssl-sys registers rerun-if-changed on the include
-          # directory: a cargo cache saved against an older build of the
-          # same configuration sees "newer" headers on every run and
-          # recompiles openssl-sys, openssl, and everything above them.
+          # openssl-sys reruns its build script when the include directory
+          # is newer than the cached fingerprint, so the key names the
+          # specific OpenSSL build, not just its configuration.
           key: "${{ matrix.PYTHON.VERSION }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.PYTHON.NOXSESSION }}-${{ steps.openssl.outputs.cache-key }}-0"
       # This must run after the cache action: rust-cache prunes binaries
       # that already existed in ~/.cargo/bin before it ran, so installing
@@ -289,8 +287,7 @@ jobs:
           cache: pip
           cache-dependency-path: ci-constraints-requirements.txt
         timeout-minutes: 3
-      # This runs before the cache step because the artifact id is part
-      # of the cache key, see below.
+      # Before the cache step: the artifact id is part of its key.
       - name: Download OpenSSL
         id: openssl
         uses: ./.github/actions/fetch-openssl
@@ -305,11 +302,9 @@ jobs:
       # run, which re-dirties pyo3-ffi and recompiles it, pyo3, and every
       # crate above them despite a warm cache.
       #
-      # Also keyed on the OpenSSL artifact: openssl-sys registers
-      # rerun-if-changed on the include directory, whose mtimes are pinned
-      # to the artifact's creation time. A cache saved before the artifact
-      # was rebuilt would otherwise see "newer" headers on every run and
-      # recompile openssl-sys, openssl, and everything above them.
+      # Also keyed on the OpenSSL artifact: its header mtimes are its
+      # creation time, and a cargo cache older than the artifact would
+      # otherwise recompile openssl-sys and everything above it every run.
       - name: Cache rust and pip
         uses: ./.github/actions/cache
         timeout-minutes: 2


### PR DESCRIPTION
Split out of #15568.

openssl-sys registers `cargo:rerun-if-changed` on the OpenSSL include directory, and cargo evaluates that by mtime. The cargo cache was keyed on the OpenSSL *configuration* but not on the specific *build*, so a cargo cache saved before the library was rebuilt sees "newer" headers on every run and recompiles openssl-sys, openssl, and everything above them, until the next Cargo.lock or rustc change happens to rotate the key.

- **macOS / Windows**: the pyca/infra artifact's mtimes are pinned to its creation time. On main today every macOS job recompiles openssl-sys, openssl (and, for unrelated reasons handled separately, pyo3-ffi and pyo3) because the artifact is newer than the cargo cache. The artifact id becomes part of the cache key, which means downloading before the cache step. The `fetch-openssl` action gains an `artifact-id` output.
- **Linux**: the OpenSSL cache key includes the build script hash, the cargo cache key only included the config hash. After #15569 every from-source library was rebuilt with fresh mtimes against an unchanged cargo cache, so the same recompile is now happening on every linux job with a custom OpenSSL. The cargo cache key now uses the OpenSSL cache key.

No cache-key suffix bump is needed: the keys change by construction.

Timing comparison to follow as a comment once the warm run is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM)_