### PR TITLE
Build BoringSSL and AWS-LC with optimization in CI

### DIFF
--- a/.github/bin/build_openssl.sh
+++ b/.github/bin/build_openssl.sh
@@ -55,7 +55,10 @@ elif [[ "${TYPE}" == "boringssl" ]]; then
   git clone https://boringssl.googlesource.com/boringssl
   pushd boringssl
   git checkout "${VERSION}"
-  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # Without a build type CMake passes no optimization flags at all.
+  # RelWithAsserts is Release with asserts kept, which is what BoringSSL's
+  # own CI uses.
+  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithAsserts -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH}/bin"
@@ -65,7 +68,8 @@ elif [[ "${TYPE}" == "aws-lc" ]]; then
   git clone https://github.com/aws/aws-lc.git
   pushd aws-lc
   git checkout "${VERSION}"
-  cmake -GNinja -B build -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  # See the BoringSSL build above for the build type.
+  cmake -GNinja -B build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithAsserts -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH:?}/bin"

--- a/.github/bin/build_openssl.sh
+++ b/.github/bin/build_openssl.sh
@@ -55,9 +55,6 @@ elif [[ "${TYPE}" == "boringssl" ]]; then
   git clone https://boringssl.googlesource.com/boringssl
   pushd boringssl
   git checkout "${VERSION}"
-  # Without a build type CMake passes no optimization flags at all.
-  # RelWithAsserts is Release with asserts kept, which is what BoringSSL's
-  # own CI uses.
   cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithAsserts -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
@@ -68,7 +65,6 @@ elif [[ "${TYPE}" == "aws-lc" ]]; then
   git clone https://github.com/aws/aws-lc.git
   pushd aws-lc
   git checkout "${VERSION}"
-  # See the BoringSSL build above for the build type.
   cmake -GNinja -B build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithAsserts -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need


### PR DESCRIPTION
Split out of #15568.

Neither project sets a default `CMAKE_BUILD_TYPE`, and the CI build didn't pass one, so CMake passed no optimization flags at all: the libraries under test were compiled at -O0 (checked by inspecting the generated `build.ninja`). `RelWithAsserts` is Release without `NDEBUG`, i.e. -O3 with asserts kept, and is what BoringSSL's own CI uses.

This changes what's under test (an optimized library rather than an unoptimized one), so it's its own PR.

Local build times on 4 cores, both with the test suites already disabled by #15569:

| Library | -O0 | RelWithAsserts |
|---|---|---|
| BoringSSL | 48s | 65s |
| AWS-LC | 15s | 29s |

The library builds are cached, so that cost is paid once per bump; the pytest run against them is paid on every run. Timing comparison to follow as a comment once the warm run is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM)_