### PR TITLE
Give pyo3-build-config a stable interpreter path in CI

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -19,7 +19,7 @@ runs:
         KEY: "${{ inputs.key }}"
     - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
       with:
-        key: ${{ steps.normalized-key.outputs.key }}-5
+        key: ${{ steps.normalized-key.outputs.key }}-6
     # maturin writes the pyo3 config file to target/maturin/, and pyo3-ffi's
     # build script registers cargo:rerun-if-changed on it. rust-cache's
     # cleanup deletes target/maturin/ before saving, so the file was

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,14 +82,20 @@ def tests(session: nox.Session) -> None:
 
     install_spec = f".[{','.join(extras)}]"
     install(session, "-e", "./vectors")
+    # Build with this session's interpreter, not an isolated build env: its
+    # random temp path ends up in PYO3_PYTHON for non-abi3 builds, and
+    # pyo3-build-config reruns when that changes, defeating the cargo cache.
+    pyproject_data = load_pyproject_toml()
+    install(session, *pyproject_data["build-system"]["requires"])
     if session.name == "tests-rust-debug":
         install(
             session,
+            "--no-build-isolation",
             "--config-settings-package=cryptography:build-args=--profile=dev",
             install_spec,
         )
     else:
-        install(session, install_spec)
+        install(session, "--no-build-isolation", install_spec)
 
     install(
         session,
@@ -247,6 +253,10 @@ def rust(session: nox.Session) -> None:
         {
             "RUSTFLAGS": f"-Cinstrument-coverage  {rustflags}",
             "LLVM_PROFILE_FILE": str(prof_location / "cov-%p.profraw"),
+            # Without this pyo3-build-config finds the interpreter through
+            # VIRTUAL_ENV and reruns whenever the venv's pyvenv.cfg is
+            # newer, i.e. on every CI run, defeating the cargo cache.
+            "PYO3_PYTHON": str(pathlib.Path(session.bin) / f"python{BIN_EXT}"),
         }
     )
 


### PR DESCRIPTION
Split out of #15568.

Two things made cargo rerun pyo3-ffi's build script, and so recompile pyo3-ffi and pyo3, on every CI run despite a warm cache. Both were confirmed with `CARGO_LOG=cargo::core::compiler::fingerprint=info` on the experiment branch.

- **`rust` session** (14 jobs per run): pyo3-build-config finds the interpreter through `VIRTUAL_ENV` and registers `rerun-if-changed` on the venv's `pyvenv.cfg`, which nox recreates on every run (`stale: changed .../pyvenv.cfg`). Setting `PYO3_PYTHON` skips that lookup, and the path is stable across runs.
- **Free-threaded `tests` jobs** (3.14t and 3.15t on Linux, macOS and Windows): those are non-abi3 builds, so maturin passes the build interpreter to pyo3-build-config as `PYO3_PYTHON`, and with uv's build isolation that interpreter lives in a randomly named temp dir (`EnvVarChanged { name: "PYO3_PYTHON", old_value: ".../builds-v0/.tmp2W0eFt/bin/python", new_value: ".../builds-v0/.tmpqfq2lv/bin/python" }`). Installing the build-system requirements into the session and building with `--no-build-isolation` uses the session's own interpreter instead. The abi3 jobs never consult the interpreter, so this doesn't change anything for them.

The cache key suffix is bumped so the recorded fingerprints refresh; the first run is cold, the warm one is what shows the effect. On the experiment branch the warm run had zero non-workspace crate recompiles on every checked job.

Timing comparison to follow as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM)_