### PR TITLE
Skip building the parts of the OpenSSL forks we delete anyway

### DIFF
--- a/.github/bin/build_openssl.sh
+++ b/.github/bin/build_openssl.sh
@@ -21,7 +21,7 @@ if [[ "${TYPE}" == "openssl" ]]; then
   ./config ${CONFIG_FLAGS} no-tests -fPIC --prefix="${OSSL_PATH}"
 
   make depend
-  make -j"$(nproc)"
+  make -j"$(nproc)" build_sw
   # avoid installing the docs (for performance)
   # https://github.com/openssl/openssl/issues/6685#issuecomment-403838728
   make install_sw install_ssldirs
@@ -44,7 +44,7 @@ elif [[ "${TYPE}" == "libressl" ]]; then
   curl -LO "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${VERSION}.tar.gz"
   tar zxf "libressl-${VERSION}.tar.gz"
   pushd "libressl-${VERSION}"
-  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DLIBRESSL_TESTS=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  cmake -GNinja -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=OFF -DLIBRESSL_APPS=OFF -DLIBRESSL_TESTS=OFF -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries, libtls, and docs we don't need. can't skip install/compile sadly
   rm -rf "${OSSL_PATH}/bin"
@@ -65,7 +65,7 @@ elif [[ "${TYPE}" == "aws-lc" ]]; then
   git clone https://github.com/aws/aws-lc.git
   pushd aws-lc
   git checkout "${VERSION}"
-  cmake -GNinja -B build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithAsserts -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
+  cmake -GNinja -B build -DBUILD_TESTING=OFF -DBUILD_TOOL=OFF -DCMAKE_BUILD_TYPE=RelWithAsserts -DCMAKE_INSTALL_PREFIX="${OSSL_PATH}"
   ninja -C build install
   # delete binaries we don't need
   rm -rf "${OSSL_PATH:?}/bin"


### PR DESCRIPTION
Split out of #15568, the last of the build-script changes.

OpenSSL's default `make` target also generates the man pages (`build_sw` doesn't; `install_sw` was already skipping their installation), LibreSSL builds its apps and AWS-LC its `bssl` tool. The script deletes `bin/` and `share/` from the install right afterwards.

Paid once per bump since the builds are cached. Timing comparison to follow as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZZQDQuPPD8T7jaAsCSHtM)_