### PR TITLE
Fix nightly cargo unused_dependencies warning in cryptography-cffi

### DIFF
--- a/src/rust/cryptography-cffi/src/lib.rs
+++ b/src/rust/cryptography-cffi/src/lib.rs
@@ -4,12 +4,9 @@
 
 #![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
 
-// This crate never calls into `openssl-sys` directly, but it must depend on
-// it: Cargo only exposes a `links` crate's build metadata (here
-// `DEP_OPENSSL_INCLUDE`, which `build.rs` uses to compile the CFFI-generated
-// C code against the right OpenSSL headers) to its immediate dependents. This
-// `use` marks the dependency as intentional so `cargo::unused_dependencies`
-// doesn't flag it.
+// Not called directly, but `build.rs` needs `DEP_OPENSSL_INCLUDE`, which
+// Cargo only exposes to immediate dependents of `openssl-sys`. This `use`
+// keeps `cargo::unused_dependencies` from flagging it.
 use openssl_sys as _;
 
 #[cfg(python_implementation = "PyPy")]

--- a/src/rust/cryptography-cffi/src/lib.rs
+++ b/src/rust/cryptography-cffi/src/lib.rs
@@ -4,6 +4,14 @@
 
 #![deny(rust_2018_idioms, clippy::undocumented_unsafe_blocks)]
 
+// This crate never calls into `openssl-sys` directly, but it must depend on
+// it: Cargo only exposes a `links` crate's build metadata (here
+// `DEP_OPENSSL_INCLUDE`, which `build.rs` uses to compile the CFFI-generated
+// C code against the right OpenSSL headers) to its immediate dependents. This
+// `use` marks the dependency as intentional so `cargo::unused_dependencies`
+// doesn't flag it.
+use openssl_sys as _;
+
 #[cfg(python_implementation = "PyPy")]
 extern "C" {
     fn Cryptography_make_openssl_module() -> std::os::raw::c_int;


### PR DESCRIPTION
The latest nightly (1.100, which stabilizes `[lints.cargo]`) emits:

```
warning: unused dependency `openssl-sys`
  --> src/rust/cryptography-cffi/Cargo.toml:12:1
   = note: `cargo::unused_dependencies` is set to `warn` by default
```

The dependency is required: `cryptography-cffi`'s `build.rs` reads `DEP_OPENSSL_INCLUDE` to compile the CFFI-generated C code against the right OpenSSL headers, and Cargo only exports a `links` crate's metadata to its immediate dependents. Dropping the dependency leaves that variable unset, so the build would only work when OpenSSL headers happen to be on the system include path.

This marks the dependency as intentional with `use openssl_sys as _;`, the usual idiom for link/metadata-only dependencies. Nightly and stable clippy are clean with `-D warnings`, and `nox -e rust` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdrEHfbwEfRs5CR4328Mbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdrEHfbwEfRs5CR4328Mbk)_