### PR TITLE
Raise InvalidTag on AEAD finalize failure regardless of error queue

### DIFF
--- a/src/rust/src/backend/ciphers.rs
+++ b/src/rust/src/backend/ciphers.rs
@@ -233,12 +233,16 @@ impl CipherContext {
         py: pyo3::Python<'p>,
     ) -> CryptographyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
         let mut out_buf = vec![0; self.ctx.block_size()];
-        let n = self.ctx.cipher_final(&mut out_buf).or_else(|e| {
-            if e.errors().is_empty()
-                && self
-                    .py_mode
-                    .bind(py)
-                    .is_instance(&types::MODE_WITH_AUTHENTICATION_TAG.get(py)?)?
+        let n = self.ctx.cipher_final(&mut out_buf).or_else(|_| {
+            // For authenticated modes, the only way finalize can fail is a
+            // tag mismatch. Older OpenSSL versions (and BoringSSL, AWS-LC,
+            // and LibreSSL) leave the error queue empty in that case, while
+            // OpenSSL >= 4.1 pushes PROV_R_BAD_DECRYPT, so we can't key on
+            // the error queue.
+            if self
+                .py_mode
+                .bind(py)
+                .is_instance(&types::MODE_WITH_AUTHENTICATION_TAG.get(py)?)?
             {
                 return Err(CryptographyError::from(exceptions::InvalidTag::new_err(())));
             }


### PR DESCRIPTION
Fixes the OpenSSL master failures in #15594.

OpenSSL f7d2d2acef (openssl/openssl#32587, "AEADs: add an error to the queue on tag mismatch") now raises `PROV_R_BAD_DECRYPT` when an AEAD tag check fails in `EVP_DecryptFinal_ex`. `CipherContext::finalize` only mapped a failure to `InvalidTag` when the error queue was empty, so on OpenSSL master a bad GCM tag surfaced as `ValueError: The length of the provided data is not a multiple of the block length.` in `test_aes_gcm.py`, `test_sm4.py`, and the Wycheproof AES-GCM tests.

For modes with an authentication tag, treat any finalize failure as `InvalidTag`. Older OpenSSL, BoringSSL, AWS-LC, and LibreSSL still leave the queue empty on tag mismatch, so nothing changes there. The one-shot AEAD classes in `aead.rs` already map all decrypt failures unconditionally, which is why `test_aead.py` was unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg4jjDRiLcBQrdEFsL3fCD
