### PR TITLE
Deprecate DSA

### DIFF
--- a/.github/downstream.d/certbot-josepy.sh
+++ b/.github/downstream.d/certbot-josepy.sh
@@ -10,7 +10,9 @@ case "${1}" in
         ;;
     run)
         cd josepy
-        pytest tests
+        # josepy's tests load a DSA key, which now emits a deprecation
+        # warning.
+        pytest -W "ignore:DSA is deprecated:cryptography.utils.CryptographyDeprecationWarning" tests
         ;;
     *)
         exit 1

--- a/.github/downstream.d/certbot.sh
+++ b/.github/downstream.d/certbot.sh
@@ -14,7 +14,9 @@ case "${1}" in
         # to errors. We can probably remove this when acme gets split into
         # its own repo
         pytest -Wignore certbot
-        pytest acme
+        # pyOpenSSL references cryptography's DSA types at import time,
+        # which now emits a deprecation warning.
+        pytest -W "ignore:DSA is deprecated:cryptography.utils.CryptographyDeprecationWarning" acme
         ;;
     *)
         exit 1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Deprecated DSA. Everything DSA is deprecated, including the types in
+  ``cryptography.hazmat.primitives.asymmetric.dsa`` and loading DSA keys with
+  the key loading APIs (including from X.509 certificates and certificate
+  signing requests). Users should migrate to a more modern signature
+  algorithm.
+
 .. _v50-0-1:
 
 50.0.1 - 2026-08-25

--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -8,8 +8,7 @@ DSA
 .. deprecated:: 51.0.0
     DSA is deprecated and support will be removed in a future release. Users
     should migrate to a more modern signature algorithm such as
-    :doc:`EdDSA using curve25519</hazmat/primitives/asymmetric/ed25519>` or
-    :doc:`ECDSA</hazmat/primitives/asymmetric/ec>`.
+    :doc:`ML-DSA</hazmat/primitives/asymmetric/mldsa>`.
 
 .. note::
 

--- a/docs/hazmat/primitives/asymmetric/dsa.rst
+++ b/docs/hazmat/primitives/asymmetric/dsa.rst
@@ -5,6 +5,12 @@ DSA
 
 .. module:: cryptography.hazmat.primitives.asymmetric.dsa
 
+.. deprecated:: 51.0.0
+    DSA is deprecated and support will be removed in a future release. Users
+    should migrate to a more modern signature algorithm such as
+    :doc:`EdDSA using curve25519</hazmat/primitives/asymmetric/ed25519>` or
+    :doc:`ECDSA</hazmat/primitives/asymmetric/ec>`.
+
 .. note::
 
     DSA is a **legacy algorithm** and should generally be avoided in favor of

--- a/src/cryptography/hazmat/primitives/asymmetric/dsa.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dsa.py
@@ -7,10 +7,16 @@ from __future__ import annotations
 import abc
 import typing
 
+from cryptography import utils
 from cryptography.hazmat.bindings._rust import openssl as rust_openssl
 from cryptography.hazmat.primitives import _serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
 from cryptography.utils import Buffer
+
+_DSA_DEPRECATION_MSG = (
+    "DSA is deprecated and support will be removed in a future release. "
+    "Use a more modern signature algorithm."
+)
 
 
 class DSAParameters(metaclass=abc.ABCMeta):
@@ -175,5 +181,107 @@ def generate_parameters(
 def generate_private_key(
     key_size: int, backend: typing.Any = None
 ) -> DSAPrivateKey:
-    parameters = generate_parameters(key_size)
+    parameters = _generate_parameters(key_size)
     return parameters.generate_private_key()
+
+
+# Aliases that do not emit the deprecation warning on attribute access, for
+# internal use (e.g. the unions in
+# cryptography.hazmat.primitives.asymmetric.types, which are evaluated at
+# import time, and isinstance checks in the serialization and X.509 code).
+# `utils.deprecated` replaces the public names in this module's namespace, so
+# `generate_private_key` must go through the alias too.
+_generate_parameters = generate_parameters
+_DSAPublicKey = DSAPublicKey
+_DSAPrivateKey = DSAPrivateKey
+_DSAPrivateNumbers = DSAPrivateNumbers
+_DSAPublicNumbers = DSAPublicNumbers
+_DSAParameterNumbers = DSAParameterNumbers
+
+utils.deprecated(
+    generate_parameters,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="generate_parameters",
+)
+
+utils.deprecated(
+    generate_private_key,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="generate_private_key",
+)
+
+utils.deprecated(
+    DSAPrivateNumbers,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAPrivateNumbers",
+)
+
+utils.deprecated(
+    DSAPublicNumbers,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAPublicNumbers",
+)
+
+utils.deprecated(
+    DSAParameterNumbers,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAParameterNumbers",
+)
+
+utils.deprecated(
+    DSAParameters,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAParameters",
+)
+
+utils.deprecated(
+    DSAParameters,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAParametersWithNumbers",
+)
+
+utils.deprecated(
+    DSAPrivateKey,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAPrivateKey",
+)
+
+utils.deprecated(
+    DSAPrivateKey,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAPrivateKeyWithSerialization",
+)
+
+utils.deprecated(
+    DSAPublicKey,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAPublicKey",
+)
+
+utils.deprecated(
+    DSAPublicKey,
+    __name__,
+    _DSA_DEPRECATION_MSG,
+    utils.DeprecatedIn51,
+    name="DSAPublicKeyWithSerialization",
+)

--- a/src/cryptography/hazmat/primitives/asymmetric/types.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/types.py
@@ -19,11 +19,11 @@ from cryptography.hazmat.primitives.asymmetric import (
     x25519,
 )
 
-# Every asymmetric key type. These use the private DH aliases so that
-# importing this module doesn't trigger the FFDH deprecation warning.
+# Every asymmetric key type. These use the private DH and DSA aliases so that
+# importing this module doesn't trigger the FFDH or DSA deprecation warnings.
 PublicKeyTypes = typing.Union[
     dh._DHPublicKey,
-    dsa.DSAPublicKey,
+    dsa._DSAPublicKey,
     rsa.RSAPublicKey,
     ec.EllipticCurvePublicKey,
     ed25519.Ed25519PublicKey,
@@ -47,7 +47,7 @@ PrivateKeyTypes = typing.Union[
     mlkem.MLKEM768PrivateKey,
     mlkem.MLKEM1024PrivateKey,
     rsa.RSAPrivateKey,
-    dsa.DSAPrivateKey,
+    dsa._DSAPrivateKey,
     ec.EllipticCurvePrivateKey,
     x25519.X25519PrivateKey,
     x448.X448PrivateKey,
@@ -58,7 +58,7 @@ CertificateIssuerPrivateKeyTypes = typing.Union[
     ed25519.Ed25519PrivateKey,
     ed448.Ed448PrivateKey,
     rsa.RSAPrivateKey,
-    dsa.DSAPrivateKey,
+    dsa._DSAPrivateKey,
     ec.EllipticCurvePrivateKey,
     mldsa.MLDSA44PrivateKey,
     mldsa.MLDSA65PrivateKey,
@@ -67,7 +67,7 @@ CertificateIssuerPrivateKeyTypes = typing.Union[
 # Just the key types we allow to be used for x509 signing. This mirrors
 # the certificate private key types
 CertificateIssuerPublicKeyTypes = typing.Union[
-    dsa.DSAPublicKey,
+    dsa._DSAPublicKey,
     rsa.RSAPublicKey,
     ec.EllipticCurvePublicKey,
     ed25519.Ed25519PublicKey,
@@ -79,7 +79,7 @@ CertificateIssuerPublicKeyTypes = typing.Union[
 # This type removes DHPublicKey. x448/x25519/mlkem can be a public key
 # but cannot be used in signing so they are allowed here.
 CertificatePublicKeyTypes = typing.Union[
-    dsa.DSAPublicKey,
+    dsa._DSAPublicKey,
     rsa.RSAPublicKey,
     ec.EllipticCurvePublicKey,
     ed25519.Ed25519PublicKey,

--- a/src/cryptography/hazmat/primitives/serialization/pkcs12.py
+++ b/src/cryptography/hazmat/primitives/serialization/pkcs12.py
@@ -33,7 +33,7 @@ __all__ = [
 
 PKCS12PrivateKeyTypes = typing.Union[
     rsa.RSAPrivateKey,
-    dsa.DSAPrivateKey,
+    dsa._DSAPrivateKey,
     ec.EllipticCurvePrivateKey,
     ed25519.Ed25519PrivateKey,
     ed448.Ed448PrivateKey,
@@ -54,7 +54,7 @@ class PKCS12KeyAndCertificates:
             key,
             (
                 rsa.RSAPrivateKey,
-                dsa.DSAPrivateKey,
+                dsa._DSAPrivateKey,
                 ec.EllipticCurvePrivateKey,
                 ed25519.Ed25519PrivateKey,
                 ed448.Ed448PrivateKey,
@@ -149,7 +149,7 @@ def serialize_key_and_certificates(
         key,
         (
             rsa.RSAPrivateKey,
-            dsa.DSAPrivateKey,
+            dsa._DSAPrivateKey,
             ec.EllipticCurvePrivateKey,
             ed25519.Ed25519PrivateKey,
             ed448.Ed448PrivateKey,

--- a/src/cryptography/hazmat/primitives/serialization/ssh.py
+++ b/src/cryptography/hazmat/primitives/serialization/ssh.py
@@ -142,7 +142,7 @@ def _get_ssh_key_type(key: SSHPrivateKeyTypes | SSHPublicKeyTypes) -> bytes:
         key_type = _ecdsa_key_type(key)
     elif isinstance(key, (rsa.RSAPrivateKey, rsa.RSAPublicKey)):
         key_type = _SSH_RSA
-    elif isinstance(key, (dsa.DSAPrivateKey, dsa.DSAPublicKey)):
+    elif isinstance(key, (dsa._DSAPrivateKey, dsa._DSAPublicKey)):
         key_type = _SSH_DSA
     elif isinstance(
         key, (ed25519.Ed25519PrivateKey, ed25519.Ed25519PublicKey)
@@ -388,8 +388,8 @@ class _SSHFormatDSA:
     ) -> tuple[dsa.DSAPublicKey, memoryview]:
         """Make DSA public key from data."""
         (p, q, g, y), data = self.get_public(data)
-        parameter_numbers = dsa.DSAParameterNumbers(p, q, g)
-        public_numbers = dsa.DSAPublicNumbers(y, parameter_numbers)
+        parameter_numbers = dsa._DSAParameterNumbers(p, q, g)
+        public_numbers = dsa._DSAPublicNumbers(y, parameter_numbers)
         self._validate(public_numbers)
         public_key = public_numbers.public_key()
         return public_key, data
@@ -403,10 +403,10 @@ class _SSHFormatDSA:
 
         if (p, q, g, y) != pubfields:
             raise ValueError("Corrupt data: dsa field mismatch")
-        parameter_numbers = dsa.DSAParameterNumbers(p, q, g)
-        public_numbers = dsa.DSAPublicNumbers(y, parameter_numbers)
+        parameter_numbers = dsa._DSAParameterNumbers(p, q, g)
+        public_numbers = dsa._DSAPublicNumbers(y, parameter_numbers)
         self._validate(public_numbers)
-        private_numbers = dsa.DSAPrivateNumbers(x, public_numbers)
+        private_numbers = dsa._DSAPrivateNumbers(x, public_numbers)
         private_key = private_numbers.private_key()
         return private_key, data
 
@@ -664,7 +664,7 @@ def _lookup_kformat(key_type: utils.Buffer):
 SSHPrivateKeyTypes = typing.Union[
     ec.EllipticCurvePrivateKey,
     rsa.RSAPrivateKey,
-    dsa.DSAPrivateKey,
+    dsa._DSAPrivateKey,
     ed25519.Ed25519PrivateKey,
 ]
 
@@ -780,7 +780,7 @@ def load_ssh_private_key(
     if edata != _PADDING[: len(edata)]:
         raise ValueError("Corrupt data: invalid padding")
 
-    if isinstance(private_key, dsa.DSAPrivateKey):
+    if isinstance(private_key, dsa._DSAPrivateKey):
         warnings.warn(
             "SSH DSA keys are deprecated and will be removed in a future "
             "release.",
@@ -798,7 +798,7 @@ def _serialize_ssh_private_key(
 ) -> bytes:
     """Serialize private key with OpenSSH custom encoding."""
     utils._check_bytes("password", password)
-    if isinstance(private_key, dsa.DSAPrivateKey):
+    if isinstance(private_key, dsa._DSAPrivateKey):
         warnings.warn(
             "SSH DSA key support is deprecated and will be "
             "removed in a future release",
@@ -871,7 +871,7 @@ def _serialize_ssh_private_key(
 SSHPublicKeyTypes = typing.Union[
     ec.EllipticCurvePublicKey,
     rsa.RSAPublicKey,
-    dsa.DSAPublicKey,
+    dsa._DSAPublicKey,
     ed25519.Ed25519PublicKey,
 ]
 
@@ -1182,7 +1182,7 @@ def load_ssh_public_key(
     else:
         public_key = cert_or_key
 
-    if isinstance(public_key, dsa.DSAPublicKey):
+    if isinstance(public_key, dsa._DSAPublicKey):
         warnings.warn(
             "SSH DSA keys are deprecated and will be removed in a future "
             "release.",
@@ -1194,7 +1194,7 @@ def load_ssh_public_key(
 
 def serialize_ssh_public_key(public_key: SSHPublicKeyTypes) -> bytes:
     """One-line public key format for OpenSSH"""
-    if isinstance(public_key, dsa.DSAPublicKey):
+    if isinstance(public_key, dsa._DSAPublicKey):
         warnings.warn(
             "SSH DSA key support is deprecated and will be "
             "removed in a future release",

--- a/src/cryptography/utils.py
+++ b/src/cryptography/utils.py
@@ -28,6 +28,7 @@ DeprecatedIn42 = CryptographyDeprecationWarning
 DeprecatedIn43 = CryptographyDeprecationWarning
 DeprecatedIn47 = CryptographyDeprecationWarning
 DeprecatedIn50 = CryptographyDeprecationWarning
+DeprecatedIn51 = CryptographyDeprecationWarning
 
 
 # If you're wondering why we don't use `Buffer`, it's because `Buffer` would

--- a/src/cryptography/x509/base.py
+++ b/src/cryptography/x509/base.py
@@ -365,7 +365,7 @@ class CertificateBuilder:
         if not isinstance(
             key,
             (
-                dsa.DSAPublicKey,
+                dsa._DSAPublicKey,
                 rsa.RSAPublicKey,
                 ec.EllipticCurvePublicKey,
                 ed25519.Ed25519PublicKey,

--- a/src/rust/src/backend/dsa.rs
+++ b/src/rust/src/backend/dsa.rs
@@ -7,7 +7,13 @@ use pyo3::types::PyAnyMethods;
 use crate::backend::utils;
 use crate::buf::CffiBuf;
 use crate::error::{CryptographyError, CryptographyResult};
-use crate::{error, exceptions};
+use crate::{error, exceptions, types};
+
+fn warn_dsa_deprecated(py: pyo3::Python<'_>) -> pyo3::PyResult<()> {
+    let warning_cls = types::DEPRECATED_IN_51.get(py)?;
+    let message = c"DSA is deprecated and support will be removed in a future release. Use a more modern signature algorithm.";
+    pyo3::PyErr::warn(py, &warning_cls, message, 1)
+}
 
 #[pyo3::pyclass(
     frozen,
@@ -37,19 +43,23 @@ struct DsaParameters {
 }
 
 pub(crate) fn private_key_from_pkey(
+    py: pyo3::Python<'_>,
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
-) -> DsaPrivateKey {
-    DsaPrivateKey {
+) -> CryptographyResult<DsaPrivateKey> {
+    warn_dsa_deprecated(py)?;
+    Ok(DsaPrivateKey {
         pkey: pkey.to_owned(),
-    }
+    })
 }
 
 pub(crate) fn public_key_from_pkey(
+    py: pyo3::Python<'_>,
     pkey: &openssl::pkey::PKeyRef<openssl::pkey::Public>,
-) -> DsaPublicKey {
-    DsaPublicKey {
+) -> CryptographyResult<DsaPublicKey> {
+    warn_dsa_deprecated(py)?;
+    Ok(DsaPublicKey {
         pkey: pkey.to_owned(),
-    }
+    })
 }
 
 #[pyo3::pyfunction]

--- a/src/rust/src/backend/keys.rs
+++ b/src/rust/src/backend/keys.rs
@@ -165,7 +165,7 @@ fn private_key_from_pkey<'p>(
         openssl::pkey::Id::ED448 => Ok(crate::backend::ed448::private_key_from_pkey(pkey)
             .into_pyobject(py)?
             .into_any()),
-        openssl::pkey::Id::DSA => Ok(crate::backend::dsa::private_key_from_pkey(pkey)
+        openssl::pkey::Id::DSA => Ok(crate::backend::dsa::private_key_from_pkey(py, pkey)?
             .into_pyobject(py)?
             .into_any()),
         openssl::pkey::Id::DH => Ok(crate::backend::dh::private_key_from_pkey(py, pkey)?
@@ -363,7 +363,7 @@ fn public_key_from_pkey<'p>(
             .into_pyobject(py)?
             .into_any()),
 
-        openssl::pkey::Id::DSA => Ok(crate::backend::dsa::public_key_from_pkey(pkey)
+        openssl::pkey::Id::DSA => Ok(crate::backend::dsa::public_key_from_pkey(py, pkey)?
             .into_pyobject(py)?
             .into_any()),
         openssl::pkey::Id::DH => Ok(crate::backend::dh::public_key_from_pkey(py, pkey)?

--- a/src/rust/src/types.rs
+++ b/src/rust/src/types.rs
@@ -48,6 +48,8 @@ pub static DEPRECATED_IN_43: LazyPyImport =
     LazyPyImport::new("cryptography.utils", &["DeprecatedIn43"]);
 pub static DEPRECATED_IN_50: LazyPyImport =
     LazyPyImport::new("cryptography.utils", &["DeprecatedIn50"]);
+pub static DEPRECATED_IN_51: LazyPyImport =
+    LazyPyImport::new("cryptography.utils", &["DeprecatedIn51"]);
 
 pub static KEY_SERIALIZATION_ENCRYPTION_BUILDER: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives._serialization",
@@ -477,13 +479,15 @@ pub static MLDSA87_PUBLIC_KEY: LazyPyImport = LazyPyImport::new(
     &["MLDSA87PublicKey"],
 );
 
+// These use the private aliases so that looking them up doesn't emit the
+// DSA deprecation warning.
 pub static DSA_PRIVATE_KEY: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.asymmetric.dsa",
-    &["DSAPrivateKey"],
+    &["_DSAPrivateKey"],
 );
 pub static DSA_PUBLIC_KEY: LazyPyImport = LazyPyImport::new(
     "cryptography.hazmat.primitives.asymmetric.dsa",
-    &["DSAPublicKey"],
+    &["_DSAPublicKey"],
 );
 
 #[cfg(not(Py_3_11))]

--- a/tests/hazmat/primitives/fixtures_dsa.py
+++ b/tests/hazmat/primitives/fixtures_dsa.py
@@ -3,11 +3,18 @@
 # for complete details.
 
 
-from cryptography.hazmat.primitives.asymmetric.dsa import (
-    DSAParameterNumbers,
-    DSAPrivateNumbers,
-    DSAPublicNumbers,
-)
+import warnings
+
+from cryptography import utils
+from cryptography.hazmat.primitives.asymmetric import dsa
+
+# This module is imported at test collection time; suppress the DSA
+# deprecation warning so it doesn't appear in the warning summary.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", utils.DeprecatedIn51)
+    DSAParameterNumbers = dsa.DSAParameterNumbers
+    DSAPrivateNumbers = dsa.DSAPrivateNumbers
+    DSAPublicNumbers = dsa.DSAPublicNumbers
 
 DSA_KEY_1024 = DSAPrivateNumbers(
     public_numbers=DSAPublicNumbers(

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -29,6 +29,14 @@ from ...utils import (
 from .fixtures_dsa import DSA_KEY_1024, DSA_KEY_2048, DSA_KEY_3072
 from .utils import skip_fips_traditional_openssl
 
+# Accessing any attribute of the dsa module and loading any DSA key emits the
+# DSA deprecation warning. Ignore it module-wide rather than wrapping every
+# call site.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:DSA is deprecated"
+    ":cryptography.utils.CryptographyDeprecationWarning"
+)
+
 _ALGORITHMS_DICT: dict[str, hashes.HashAlgorithm] = {
     "SHA1": hashes.SHA1(),
     "SHA224": hashes.SHA224(),
@@ -55,6 +63,55 @@ def _skip_if_dsa_not_supported(
 def test_skip_if_dsa_not_supported(backend):
     with pytest.raises(pytest.skip.Exception):
         _skip_if_dsa_not_supported(backend, DummyHashAlgorithm(), 1, 1, 1)
+
+
+@pytest.mark.supported(
+    only_if=lambda backend: backend.dsa_supported(),
+    skip_message="Does not support DSA.",
+)
+class TestDSADeprecation:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "generate_parameters",
+            "generate_private_key",
+            "DSAParameterNumbers",
+            "DSAPublicNumbers",
+            "DSAPrivateNumbers",
+            "DSAParameters",
+            "DSAParametersWithNumbers",
+            "DSAPrivateKey",
+            "DSAPrivateKeyWithSerialization",
+            "DSAPublicKey",
+            "DSAPublicKeyWithSerialization",
+        ],
+    )
+    def test_module_attribute_deprecated(self, name):
+        with pytest.warns(utils.DeprecatedIn51):
+            getattr(dsa, name)
+
+    def test_load_private_key_deprecated(self):
+        key = DSA_KEY_2048.private_key()
+        data = key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+        with pytest.warns(utils.DeprecatedIn51):
+            loaded = serialization.load_pem_private_key(data, None)
+            assert isinstance(loaded, dsa.DSAPrivateKey)
+        assert loaded.private_numbers() == key.private_numbers()
+
+    def test_load_public_key_deprecated(self):
+        key = DSA_KEY_2048.private_key().public_key()
+        data = key.public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        with pytest.warns(utils.DeprecatedIn51):
+            loaded = serialization.load_der_public_key(data)
+            assert isinstance(loaded, dsa.DSAPublicKey)
+        assert loaded == key
 
 
 @pytest.mark.supported(

--- a/tests/hazmat/primitives/test_dsa.py
+++ b/tests/hazmat/primitives/test_dsa.py
@@ -69,55 +69,6 @@ def test_skip_if_dsa_not_supported(backend):
     only_if=lambda backend: backend.dsa_supported(),
     skip_message="Does not support DSA.",
 )
-class TestDSADeprecation:
-    @pytest.mark.parametrize(
-        "name",
-        [
-            "generate_parameters",
-            "generate_private_key",
-            "DSAParameterNumbers",
-            "DSAPublicNumbers",
-            "DSAPrivateNumbers",
-            "DSAParameters",
-            "DSAParametersWithNumbers",
-            "DSAPrivateKey",
-            "DSAPrivateKeyWithSerialization",
-            "DSAPublicKey",
-            "DSAPublicKeyWithSerialization",
-        ],
-    )
-    def test_module_attribute_deprecated(self, name):
-        with pytest.warns(utils.DeprecatedIn51):
-            getattr(dsa, name)
-
-    def test_load_private_key_deprecated(self):
-        key = DSA_KEY_2048.private_key()
-        data = key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        )
-        with pytest.warns(utils.DeprecatedIn51):
-            loaded = serialization.load_pem_private_key(data, None)
-            assert isinstance(loaded, dsa.DSAPrivateKey)
-        assert loaded.private_numbers() == key.private_numbers()
-
-    def test_load_public_key_deprecated(self):
-        key = DSA_KEY_2048.private_key().public_key()
-        data = key.public_bytes(
-            serialization.Encoding.DER,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        with pytest.warns(utils.DeprecatedIn51):
-            loaded = serialization.load_der_public_key(data)
-            assert isinstance(loaded, dsa.DSAPublicKey)
-        assert loaded == key
-
-
-@pytest.mark.supported(
-    only_if=lambda backend: backend.dsa_supported(),
-    skip_message="Does not support DSA.",
-)
 class TestDSA:
     def test_generate_dsa_parameters(self):
         parameters = dsa.generate_parameters(2048)

--- a/tests/hazmat/primitives/test_pkcs12.py
+++ b/tests/hazmat/primitives/test_pkcs12.py
@@ -6,11 +6,12 @@
 import contextlib
 import os
 import typing
+import warnings
 from datetime import datetime, timezone
 
 import pytest
 
-from cryptography import x509
+from cryptography import utils, x509
 from cryptography.hazmat.decrepit.ciphers.algorithms import RC2
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import (
@@ -39,6 +40,21 @@ from cryptography.hazmat.primitives.serialization.pkcs12 import (
 
 from ...doubles import DummyKeySerializationEncryption
 from ...utils import load_vectors_from_file
+
+# Accessing attributes of the dsa module emits the DSA deprecation warning;
+# these are evaluated at collection time, so suppress it there. Loading the
+# DSA key back out of the PKCS#12 blob also warns, hence the mark.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", utils.DeprecatedIn51)
+    _DSA_KEY_TYPE_PARAM = pytest.param(
+        dsa.generate_private_key,
+        dsa.DSAPrivateKey,
+        [1024],
+        marks=pytest.mark.filterwarnings(
+            "ignore:DSA is deprecated"
+            ":cryptography.utils.CryptographyDeprecationWarning"
+        ),
+    )
 
 
 def _skip_curve_unsupported(backend, curve):
@@ -313,7 +329,7 @@ class TestPKCS12Creation:
                 [],
             ),
             (rsa.generate_private_key, rsa.RSAPrivateKey, [65537, 1024]),
-            (dsa.generate_private_key, dsa.DSAPrivateKey, [1024]),
+            _DSA_KEY_TYPE_PARAM,
         ]
         + [
             pytest.param(

--- a/tests/hazmat/primitives/test_serialization.py
+++ b/tests/hazmat/primitives/test_serialization.py
@@ -162,13 +162,14 @@ class TestDERSerialization:
         ],
     )
     def test_load_der_dsa_private_key(self, key_path, password):
-        key = load_vectors_from_file(
-            os.path.join("asymmetric", *key_path),
-            lambda derfile: load_der_private_key(derfile.read(), password),
-            mode="rb",
-        )
-        assert key
-        assert isinstance(key, dsa.DSAPrivateKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            key = load_vectors_from_file(
+                os.path.join("asymmetric", *key_path),
+                lambda derfile: load_der_private_key(derfile.read(), password),
+                mode="rb",
+            )
+            assert key
+            assert isinstance(key, dsa.DSAPrivateKey)
         _check_dsa_private_numbers(key.private_numbers())
 
     @pytest.mark.parametrize(
@@ -393,13 +394,14 @@ class TestDERSerialization:
         ],
     )
     def test_load_der_dsa_public_key(self, key_file):
-        key = load_vectors_from_file(
-            key_file,
-            lambda derfile: load_der_public_key(derfile.read()),
-            mode="rb",
-        )
-        assert key
-        assert isinstance(key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            key = load_vectors_from_file(
+                key_file,
+                lambda derfile: load_der_public_key(derfile.read()),
+                mode="rb",
+            )
+            assert key
+            assert isinstance(key, dsa.DSAPublicKey)
 
     def test_load_ec_public_key(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
@@ -691,14 +693,15 @@ class TestPEMSerialization:
     )
     def test_load_dsa_private_key(self, key_path, password, backend):
         _skip_fips_format(key_path, password, backend)
-        key = load_vectors_from_file(
-            os.path.join("asymmetric", *key_path),
-            lambda pemfile: load_pem_private_key(
-                pemfile.read().encode(), password, backend
-            ),
-        )
-        assert key
-        assert isinstance(key, dsa.DSAPrivateKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            key = load_vectors_from_file(
+                os.path.join("asymmetric", *key_path),
+                lambda pemfile: load_pem_private_key(
+                    pemfile.read().encode(), password, backend
+                ),
+            )
+            assert key
+            assert isinstance(key, dsa.DSAPrivateKey)
         _check_dsa_private_numbers(key.private_numbers())
 
     @pytest.mark.parametrize(
@@ -789,12 +792,13 @@ class TestPEMSerialization:
         ],
     )
     def test_load_pem_dsa_public_key(self, key_file):
-        key = load_vectors_from_file(
-            key_file,
-            lambda pemfile: load_pem_public_key(pemfile.read().encode()),
-        )
-        assert key
-        assert isinstance(key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            key = load_vectors_from_file(
+                key_file,
+                lambda pemfile: load_pem_public_key(pemfile.read().encode()),
+            )
+            assert key
+            assert isinstance(key, dsa.DSAPublicKey)
 
     def test_load_ec_public_key(self, backend):
         _skip_curve_unsupported(backend, ec.SECP256R1())
@@ -1218,17 +1222,18 @@ class TestPEMSerialization:
         skip_message="Does not support DSA.",
     )
     def test_load_pem_dsa_private_key(self):
-        key = load_vectors_from_file(
-            os.path.join("asymmetric", "PKCS8", "unenc-dsa-pkcs8.pem"),
-            lambda pemfile: load_pem_private_key(
-                pemfile.read().encode(), None
-            ),
-        )
-        assert key
-        assert isinstance(key, dsa.DSAPrivateKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            key = load_vectors_from_file(
+                os.path.join("asymmetric", "PKCS8", "unenc-dsa-pkcs8.pem"),
+                lambda pemfile: load_pem_private_key(
+                    pemfile.read().encode(), None
+                ),
+            )
+            assert key
+            assert isinstance(key, dsa.DSAPrivateKey)
 
-        params = key.parameters()
-        assert isinstance(params, dsa.DSAParameters)
+            params = key.parameters()
+            assert isinstance(params, dsa.DSAParameters)
 
         num = key.private_numbers()
         pub = num.public_numbers

--- a/tests/hazmat/primitives/test_ssh.py
+++ b/tests/hazmat/primitives/test_ssh.py
@@ -750,12 +750,13 @@ class TestOpenSSHSerialization:
         ],
     )
     def test_dsa_private_key_sizes(self, key_path, supported):
-        key = load_vectors_from_file(
-            os.path.join("asymmetric", *key_path),
-            lambda pemfile: load_pem_private_key(pemfile.read(), None),
-            mode="rb",
-        )
-        assert isinstance(key, dsa.DSAPrivateKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            key = load_vectors_from_file(
+                os.path.join("asymmetric", *key_path),
+                lambda pemfile: load_pem_private_key(pemfile.read(), None),
+                mode="rb",
+            )
+            assert isinstance(key, dsa.DSAPrivateKey)
         if supported:
             with pytest.warns(utils.DeprecatedIn40):
                 res = key.private_bytes(
@@ -970,7 +971,8 @@ class TestDSSSSHSerialization:
             key = load_ssh_public_key(ssh_key)
 
         assert key is not None
-        assert isinstance(key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            assert isinstance(key, dsa.DSAPublicKey)
 
         numbers = key.public_numbers()
 
@@ -999,10 +1001,11 @@ class TestDSSSSHSerialization:
             "b656",
             16,
         )
-        expected = dsa.DSAPublicNumbers(
-            expected_y,
-            dsa.DSAParameterNumbers(expected_p, expected_q, expected_g),
-        )
+        with pytest.warns(utils.DeprecatedIn51):
+            expected = dsa.DSAPublicNumbers(
+                expected_y,
+                dsa.DSAParameterNumbers(expected_p, expected_q, expected_g),
+            )
 
         assert numbers == expected
 

--- a/tests/wycheproof/test_dsa.py
+++ b/tests/wycheproof/test_dsa.py
@@ -6,6 +6,7 @@ import binascii
 
 import pytest
 
+from cryptography import utils
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import dsa
@@ -30,10 +31,11 @@ _DIGESTS = {
     "dsa_3072_256_sha256_test.json",
 )
 def test_dsa_signature(backend, wycheproof):
-    key = serialization.load_der_public_key(
-        binascii.unhexlify(wycheproof.testgroup["publicKeyDer"]), backend
-    )
-    assert isinstance(key, dsa.DSAPublicKey)
+    with pytest.warns(utils.DeprecatedIn51):
+        key = serialization.load_der_public_key(
+            binascii.unhexlify(wycheproof.testgroup["publicKeyDer"]), backend
+        )
+        assert isinstance(key, dsa.DSAPublicKey)
     digest = _DIGESTS[wycheproof.testgroup["sha"]]
 
     if wycheproof.valid or (

--- a/tests/x509/test_x509.py
+++ b/tests/x509/test_x509.py
@@ -3624,8 +3624,9 @@ class TestCertificateBuilder:
 
         assert cert.version is x509.Version.v3
         assert cert.signature_algorithm_oid == hashalg_oid
-        public_key = cert.public_key()
-        assert isinstance(public_key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            public_key = cert.public_key()
+            assert isinstance(public_key, dsa.DSAPublicKey)
         assert cert.public_key_algorithm_oid == PublicKeyAlgorithmOID.DSA
         _check_cert_times(
             cert,
@@ -5422,8 +5423,9 @@ class TestCertificateSigningRequestBuilder:
         )
 
         assert isinstance(request.signature_hash_algorithm, hashes.SHA256)
-        public_key = request.public_key()
-        assert isinstance(public_key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            public_key = request.public_key()
+            assert isinstance(public_key, dsa.DSAPublicKey)
         subject = request.subject
         assert isinstance(subject, x509.Name)
         assert list(subject) == [
@@ -5902,8 +5904,9 @@ class TestDSACertificate:
             x509.load_pem_x509_certificate,
         )
         assert isinstance(cert.signature_hash_algorithm, hashes.SHA1)
-        public_key = cert.public_key()
-        assert isinstance(public_key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            public_key = cert.public_key()
+            assert isinstance(public_key, dsa.DSAPublicKey)
         assert cert.signature_algorithm_parameters is None
         num = public_key.public_numbers()
         assert num.y == int(
@@ -6022,8 +6025,9 @@ class TestDSACertificate:
             b"0b2142f86300c0603551d13040530030101ff"
         )
         assert cert.signature_hash_algorithm is not None
-        public_key = cert.public_key()
-        assert isinstance(public_key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            public_key = cert.public_key()
+            assert isinstance(public_key, dsa.DSAPublicKey)
         public_key.verify(
             cert.signature,
             cert.tbs_certificate_bytes,
@@ -6036,7 +6040,8 @@ class TestDSACertificate:
         ca, cert = _generate_ca_and_leaf(
             issuer_private_key, subject_private_key
         )
-        cert.verify_directly_issued_by(ca)
+        with pytest.warns(utils.DeprecatedIn51):
+            cert.verify_directly_issued_by(ca)
 
     def test_verify_directly_issued_by_dsa_bad_sig(self):
         issuer_private_key = DSA_KEY_3072.private_key()
@@ -6046,7 +6051,8 @@ class TestDSACertificate:
         )
         cert_bad_sig = _break_cert_sig(cert)
         with pytest.raises(InvalidSignature):
-            cert_bad_sig.verify_directly_issued_by(ca)
+            with pytest.warns(utils.DeprecatedIn51):
+                cert_bad_sig.verify_directly_issued_by(ca)
 
 
 @pytest.mark.supported(
@@ -6074,8 +6080,9 @@ class TestDSACertificateRequest:
     def test_load_dsa_request(self, path, loader_func):
         request = _load_cert(path, loader_func)
         assert isinstance(request.signature_hash_algorithm, hashes.SHA1)
-        public_key = request.public_key()
-        assert isinstance(public_key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            public_key = request.public_key()
+            assert isinstance(public_key, dsa.DSAPublicKey)
         subject = request.subject
         assert isinstance(subject, x509.Name)
         assert list(subject) == [
@@ -6121,8 +6128,9 @@ class TestDSACertificateRequest:
             b"fa140342bc4a3bba16bd0681c8a6a2dbbb7efe6ce2b8463b170ba000"
         )
         assert request.signature_hash_algorithm is not None
-        public_key = request.public_key()
-        assert isinstance(public_key, dsa.DSAPublicKey)
+        with pytest.warns(utils.DeprecatedIn51):
+            public_key = request.public_key()
+            assert isinstance(public_key, dsa.DSAPublicKey)
         public_key.verify(
             request.signature,
             request.tbs_certrequest_bytes,

--- a/tests/x509/test_x509_ext.py
+++ b/tests/x509/test_x509_ext.py
@@ -11,7 +11,7 @@ import typing
 
 import pytest
 
-from cryptography import x509
+from cryptography import utils, x509
 from cryptography.hazmat._oid import _OID_NAMES
 from cryptography.hazmat.bindings._rust import x509 as rust_x509
 from cryptography.hazmat.primitives import hashes
@@ -1747,7 +1747,9 @@ class TestSubjectKeyIdentifierExtension:
         ext = cert.extensions.get_extension_for_oid(
             ExtensionOID.SUBJECT_KEY_IDENTIFIER
         )
-        ski = x509.SubjectKeyIdentifier.from_public_key(cert.public_key())
+        with pytest.warns(utils.DeprecatedIn51):
+            public_key = cert.public_key()
+        ski = x509.SubjectKeyIdentifier.from_public_key(public_key)
         assert ext.value == ski
 
     def test_invalid_bit_string_padding_from_public_key(self):


### PR DESCRIPTION
Deprecates DSA (not ECDSA), following the FFDH deprecation precedent.

**Behavior**

- Accessing any public name in `cryptography.hazmat.primitives.asymmetric.dsa` (`generate_parameters`, `generate_private_key`, the `DSA*Numbers` classes, `DSAParameters`, `DSAPrivateKey`, `DSAPublicKey`, and the `*With*` aliases) emits a `DeprecatedIn51` warning via `utils.deprecated`.
- Loading a DSA key through the key loading APIs emits the same warning from the Rust side (`private_key_from_pkey` / `public_key_from_pkey` in `backend/dsa.rs`). This covers PEM/DER key loading, PKCS#12, and `public_key()` on X.509 certificates and CSRs.
- Loading DSA keys via the OpenSSH loaders keeps emitting only the existing SSH DSA deprecation warning, rather than a second one.

**Internal plumbing**

- Added `DeprecatedIn51` and the matching `DEPRECATED_IN_51` lazy import.
- Added private, non-warning aliases (`_DSAPublicKey`, `_DSAPrivateKey`, `_DSA*Numbers`, `_generate_parameters`) and switched internal users to them: the asymmetric type unions, `ssh.py`, `pkcs12.py`, `CertificateBuilder.public_key`, and the Rust `DSA_PRIVATE_KEY` / `DSA_PUBLIC_KEY` type lookups used by X.509 signing. Without the last one, signing with e.g. an Ed25519 key would have tripped the DSA warning during the `isinstance` chain.

**Docs / changelog**

- `.. deprecated:: 51.0.0` note on the DSA docs page pointing at ML-DSA, and a CHANGELOG entry under 51.0.0.

**Tests**

- `test_dsa.py` ignores the warning module-wide (as `test_dh.py` does).
- The DSA call sites in the serialization, X.509, SSH, PKCS#12, and Wycheproof tests assert the warning with `pytest.warns(utils.DeprecatedIn51)`; collection-time uses in `fixtures_dsa.py` and `test_pkcs12.py` suppress it.

**Downstream CI**

- certbot's `acme` suite and josepy promote warnings to errors and hit the new warning (pyOpenSSL references the DSA types at import time; josepy deliberately loads a DSA key), so those two downstream scripts now ignore this one warning, matching the existing `-Wignore` in `certbot.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YR2uV1PCas9ov5jz1KphM