### PR TITLE
Only pre-key one cipher context for direction-independent AEADs

### DIFF
--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -87,8 +87,15 @@ impl std::ops::Deref for AeadCipher {
 pub(crate) struct EvpCipherAead {
     cipher: AeadCipher,
     key: pyo3::Py<pyo3::PyAny>,
-    base_encryption_ctx: openssl::cipher_ctx::CipherCtx,
-    base_decryption_ctx: openssl::cipher_ctx::CipherCtx,
+    // A context with the cipher and key set, but no per-operation state.
+    // Each operation copies it and then sets the direction and nonce on the
+    // copy, so the key schedule is computed only once at construction time.
+    base_ctx: openssl::cipher_ctx::CipherCtx,
+    // Most AEADs only use the forward block cipher, so a context keyed for
+    // encryption can be switched to decryption. OCB, however, chooses its
+    // hardware stream routine at key-setup time based on the direction, so
+    // it needs a separate pre-keyed decryption context.
+    base_decryption_ctx: Option<openssl::cipher_ctx::CipherCtx>,
     tag_len: usize,
     tag_first: bool,
     is_ccm: bool,
@@ -102,23 +109,28 @@ impl EvpCipherAead {
         tag_len: usize,
         tag_first: bool,
         is_ccm: bool,
+        key_schedule_per_direction: bool,
     ) -> CryptographyResult<EvpCipherAead> {
-        let mut base_encryption_ctx = openssl::cipher_ctx::CipherCtx::new()?;
-        let mut base_decryption_ctx = openssl::cipher_ctx::CipherCtx::new()?;
+        let mut base_ctx = openssl::cipher_ctx::CipherCtx::new()?;
+        let mut base_decryption_ctx = None;
         // CCM requires the IV and tag lengths to be set before the key, so
-        // contexts can't be pre-keyed. The base contexts are left
+        // the context can't be pre-keyed. The base context is left
         // uninitialized and every operation initializes a context from
         // scratch.
         if !is_ccm {
             let key_buf = key.extract::<CffiBuf<'_>>(py)?;
-            base_encryption_ctx.encrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
-            base_decryption_ctx.decrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
+            base_ctx.encrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
+            if key_schedule_per_direction {
+                let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
+                ctx.decrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
+                base_decryption_ctx = Some(ctx);
+            }
         }
 
         Ok(EvpCipherAead {
             cipher,
             key,
-            base_encryption_ctx,
+            base_ctx,
             base_decryption_ctx,
             tag_len,
             tag_first,
@@ -208,9 +220,9 @@ impl EvpCipherAead {
         check_length(plaintext)?;
 
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
-        if self.is_ccm || ctx.copy(&self.base_encryption_ctx).is_err() {
+        if self.is_ccm || ctx.copy(&self.base_ctx).is_err() {
             // Copying the pre-keyed context isn't possible: either this is
-            // CCM (whose base contexts are uninitialized), or this OpenSSL
+            // CCM (whose base context is uninitialized), or this OpenSSL
             // doesn't support copying AEAD contexts (providers prior to
             // OpenSSL 3.2). Initialize a new context from scratch.
             ctx = openssl::cipher_ctx::CipherCtx::new()?;
@@ -279,9 +291,10 @@ impl EvpCipherAead {
         }
 
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
-        if self.is_ccm || ctx.copy(&self.base_decryption_ctx).is_err() {
+        let base_ctx = self.base_decryption_ctx.as_ref().unwrap_or(&self.base_ctx);
+        if self.is_ccm || ctx.copy(base_ctx).is_err() {
             // Copying the pre-keyed context isn't possible: either this is
-            // CCM (whose base contexts are uninitialized), or this OpenSSL
+            // CCM (whose base context is uninitialized), or this OpenSSL
             // doesn't support copying AEAD contexts (providers prior to
             // OpenSSL 3.2). Initialize a new context from scratch.
             ctx = openssl::cipher_ctx::CipherCtx::new()?;
@@ -303,6 +316,9 @@ impl EvpCipherAead {
                 ctx.set_iv_length(nonce.len())?;
             }
 
+            // If the copied context was keyed for encryption,
+            // re-initializing with no cipher or key switches it to
+            // decryption while retaining the key schedule.
             ctx.decrypt_init(None, None, nonce)?;
             ctx.set_tag(tag)?;
         }
@@ -437,6 +453,7 @@ impl ChaCha20Poly1305 {
                         AeadCipher::Static(openssl::cipher::Cipher::chacha20_poly1305()),
                         key,
                         16,
+                        false,
                         false,
                         false,
                     )?,
@@ -610,7 +627,7 @@ impl AesGcm {
         };
 
         Ok(AesGcm {
-            ctx: EvpCipherAead::new(py, AeadCipher::Static(cipher), key, 16, false, false)?,
+            ctx: EvpCipherAead::new(py, AeadCipher::Static(cipher), key, 16, false, false, false)?,
         })
     }
 
@@ -819,6 +836,7 @@ impl AesCcm {
                         tag_length,
                         false,
                         true,
+                        false,
                     )?,
                     tag_length
                 })
@@ -1041,6 +1059,7 @@ impl AesSiv {
                         16,
                         true,
                         false,
+                        false,
                     )?,
                 })
             } else {
@@ -1238,6 +1257,8 @@ impl AesOcb3 {
                         16,
                         false,
                         false,
+                        // OCB's key setup is direction-specific.
+                        true,
                     )?,
                 })
             }
@@ -1460,6 +1481,7 @@ impl AesGcmSiv {
                         AeadCipher::Fetched(cipher),
                         key,
                         16,
+                        false,
                         false,
                         false,
                     )?,

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -84,18 +84,52 @@ impl std::ops::Deref for AeadCipher {
     }
 }
 
+/// Describes how a cipher's key schedule relates to the direction of
+/// operation. This determines how many contexts we pre-key at construction
+/// time.
+#[derive(Clone, Copy)]
+pub(crate) enum KeySchedule {
+    /// Key setup doesn't depend on direction (the cipher only uses the
+    /// forward block cipher, or sets up both at once). A single keyed
+    /// context serves both directions.
+    DirectionIndependent,
+    /// Key setup depends on direction. OpenSSL's OCB chooses its hardware
+    /// stream routine at key-setup time based on it, so a context keyed for
+    /// one direction cannot be used for the other.
+    PerDirection,
+}
+
+/// Pre-keyed contexts with the cipher and key set, but no per-operation
+/// state. Each operation copies the appropriate one and then sets the
+/// direction and nonce on the copy, so the key schedule is computed only once
+/// at construction time.
+enum BaseCtxs {
+    /// CCM requires the IV and tag lengths to be set before the key, so its
+    /// contexts can't be pre-keyed. Every operation initializes a context
+    /// from scratch.
+    None,
+    Shared(openssl::cipher_ctx::CipherCtx),
+    PerDirection {
+        encrypt: openssl::cipher_ctx::CipherCtx,
+        decrypt: openssl::cipher_ctx::CipherCtx,
+    },
+}
+
+impl BaseCtxs {
+    fn get(&self, encrypt: bool) -> Option<&openssl::cipher_ctx::CipherCtx> {
+        match self {
+            BaseCtxs::None => None,
+            BaseCtxs::Shared(ctx) => Some(ctx),
+            BaseCtxs::PerDirection { encrypt: ctx, .. } if encrypt => Some(ctx),
+            BaseCtxs::PerDirection { decrypt: ctx, .. } => Some(ctx),
+        }
+    }
+}
+
 pub(crate) struct EvpCipherAead {
     cipher: AeadCipher,
     key: pyo3::Py<pyo3::PyAny>,
-    // A context with the cipher and key set, but no per-operation state.
-    // Each operation copies it and then sets the direction and nonce on the
-    // copy, so the key schedule is computed only once at construction time.
-    base_ctx: openssl::cipher_ctx::CipherCtx,
-    // Most AEADs only use the forward block cipher, so a context keyed for
-    // encryption can be switched to decryption. OCB, however, chooses its
-    // hardware stream routine at key-setup time based on the direction, so
-    // it needs a separate pre-keyed decryption context.
-    base_decryption_ctx: Option<openssl::cipher_ctx::CipherCtx>,
+    base_ctxs: BaseCtxs,
     tag_len: usize,
     tag_first: bool,
     is_ccm: bool,
@@ -109,29 +143,34 @@ impl EvpCipherAead {
         tag_len: usize,
         tag_first: bool,
         is_ccm: bool,
-        key_schedule_per_direction: bool,
+        key_schedule: KeySchedule,
     ) -> CryptographyResult<EvpCipherAead> {
-        let mut base_ctx = openssl::cipher_ctx::CipherCtx::new()?;
-        let mut base_decryption_ctx = None;
-        // CCM requires the IV and tag lengths to be set before the key, so
-        // the context can't be pre-keyed. The base context is left
-        // uninitialized and every operation initializes a context from
-        // scratch.
-        if !is_ccm {
+        let base_ctxs = if is_ccm {
+            BaseCtxs::None
+        } else {
             let key_buf = key.extract::<CffiBuf<'_>>(py)?;
-            base_ctx.encrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
-            if key_schedule_per_direction {
-                let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
-                ctx.decrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
-                base_decryption_ctx = Some(ctx);
+            match key_schedule {
+                KeySchedule::DirectionIndependent => {
+                    // The direction chosen here is arbitrary; each
+                    // operation sets its own on the copy.
+                    let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
+                    ctx.encrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
+                    BaseCtxs::Shared(ctx)
+                }
+                KeySchedule::PerDirection => {
+                    let mut encrypt = openssl::cipher_ctx::CipherCtx::new()?;
+                    encrypt.encrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
+                    let mut decrypt = openssl::cipher_ctx::CipherCtx::new()?;
+                    decrypt.decrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
+                    BaseCtxs::PerDirection { encrypt, decrypt }
+                }
             }
-        }
+        };
 
         Ok(EvpCipherAead {
             cipher,
             key,
-            base_ctx,
-            base_decryption_ctx,
+            base_ctxs,
             tag_len,
             tag_first,
             is_ccm,
@@ -220,11 +259,15 @@ impl EvpCipherAead {
         check_length(plaintext)?;
 
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
-        if self.is_ccm || ctx.copy(&self.base_ctx).is_err() {
-            // Copying the pre-keyed context isn't possible: either this is
-            // CCM (whose base context is uninitialized), or this OpenSSL
-            // doesn't support copying AEAD contexts (providers prior to
-            // OpenSSL 3.2). Initialize a new context from scratch.
+        let copied = match self.base_ctxs.get(true) {
+            Some(base) => ctx.copy(base).is_ok(),
+            None => false,
+        };
+        if !copied {
+            // Copying a pre-keyed context isn't possible: either this is
+            // CCM (which has none), or this OpenSSL doesn't support copying
+            // AEAD contexts (providers prior to OpenSSL 3.2). Initialize a
+            // new context from scratch.
             ctx = openssl::cipher_ctx::CipherCtx::new()?;
             let key_buf = self.key.extract::<CffiBuf<'_>>(py)?;
             if self.is_ccm {
@@ -291,12 +334,15 @@ impl EvpCipherAead {
         }
 
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
-        let base_ctx = self.base_decryption_ctx.as_ref().unwrap_or(&self.base_ctx);
-        if self.is_ccm || ctx.copy(base_ctx).is_err() {
-            // Copying the pre-keyed context isn't possible: either this is
-            // CCM (whose base context is uninitialized), or this OpenSSL
-            // doesn't support copying AEAD contexts (providers prior to
-            // OpenSSL 3.2). Initialize a new context from scratch.
+        let copied = match self.base_ctxs.get(false) {
+            Some(base) => ctx.copy(base).is_ok(),
+            None => false,
+        };
+        if !copied {
+            // Copying a pre-keyed context isn't possible: either this is
+            // CCM (which has none), or this OpenSSL doesn't support copying
+            // AEAD contexts (providers prior to OpenSSL 3.2). Initialize a
+            // new context from scratch.
             ctx = openssl::cipher_ctx::CipherCtx::new()?;
             let key_buf = self.key.extract::<CffiBuf<'_>>(py)?;
             if self.is_ccm {
@@ -316,9 +362,9 @@ impl EvpCipherAead {
                 ctx.set_iv_length(nonce.len())?;
             }
 
-            // If the copied context was keyed for encryption,
-            // re-initializing with no cipher or key switches it to
-            // decryption while retaining the key schedule.
+            // Re-initializing with no cipher or key sets the direction
+            // (the copied context may have been keyed for encryption) and
+            // nonce while retaining the key schedule.
             ctx.decrypt_init(None, None, nonce)?;
             ctx.set_tag(tag)?;
         }
@@ -455,7 +501,7 @@ impl ChaCha20Poly1305 {
                         16,
                         false,
                         false,
-                        false,
+                        KeySchedule::DirectionIndependent,
                     )?,
                 })
             }
@@ -627,7 +673,15 @@ impl AesGcm {
         };
 
         Ok(AesGcm {
-            ctx: EvpCipherAead::new(py, AeadCipher::Static(cipher), key, 16, false, false, false)?,
+            ctx: EvpCipherAead::new(
+                py,
+                AeadCipher::Static(cipher),
+                key,
+                16,
+                false,
+                false,
+                KeySchedule::DirectionIndependent,
+            )?,
         })
     }
 
@@ -836,7 +890,7 @@ impl AesCcm {
                         tag_length,
                         false,
                         true,
-                        false,
+                        KeySchedule::DirectionIndependent,
                     )?,
                     tag_length
                 })
@@ -1059,7 +1113,7 @@ impl AesSiv {
                         16,
                         true,
                         false,
-                        false,
+                        KeySchedule::DirectionIndependent,
                     )?,
                 })
             } else {
@@ -1257,8 +1311,7 @@ impl AesOcb3 {
                         16,
                         false,
                         false,
-                        // OCB's key setup is direction-specific.
-                        true,
+                        KeySchedule::PerDirection,
                     )?,
                 })
             }
@@ -1483,7 +1536,7 @@ impl AesGcmSiv {
                         16,
                         false,
                         false,
-                        false,
+                        KeySchedule::DirectionIndependent,
                     )?,
                 })
             }

--- a/src/rust/src/backend/aead.rs
+++ b/src/rust/src/backend/aead.rs
@@ -87,7 +87,6 @@ impl std::ops::Deref for AeadCipher {
 /// Describes how a cipher's key schedule relates to the direction of
 /// operation. This determines how many contexts we pre-key at construction
 /// time.
-#[derive(Clone, Copy)]
 pub(crate) enum KeySchedule {
     /// Key setup doesn't depend on direction (the cipher only uses the
     /// forward block cipher, or sets up both at once). A single keyed
@@ -95,7 +94,13 @@ pub(crate) enum KeySchedule {
     DirectionIndependent,
     /// Key setup depends on direction. OpenSSL's OCB chooses its hardware
     /// stream routine at key-setup time based on it, so a context keyed for
-    /// one direction cannot be used for the other.
+    /// one direction cannot be used for the other. (OCB is the only user,
+    /// and it's unsupported on the other backends.)
+    #[cfg(not(any(
+        CRYPTOGRAPHY_IS_LIBRESSL,
+        CRYPTOGRAPHY_IS_BORINGSSL,
+        CRYPTOGRAPHY_IS_AWSLC
+    )))]
     PerDirection,
 }
 
@@ -109,6 +114,11 @@ enum BaseCtxs {
     /// from scratch.
     None,
     Shared(openssl::cipher_ctx::CipherCtx),
+    #[cfg(not(any(
+        CRYPTOGRAPHY_IS_LIBRESSL,
+        CRYPTOGRAPHY_IS_BORINGSSL,
+        CRYPTOGRAPHY_IS_AWSLC
+    )))]
     PerDirection {
         encrypt: openssl::cipher_ctx::CipherCtx,
         decrypt: openssl::cipher_ctx::CipherCtx,
@@ -116,12 +126,29 @@ enum BaseCtxs {
 }
 
 impl BaseCtxs {
-    fn get(&self, encrypt: bool) -> Option<&openssl::cipher_ctx::CipherCtx> {
+    fn for_encryption(&self) -> Option<&openssl::cipher_ctx::CipherCtx> {
         match self {
             BaseCtxs::None => None,
             BaseCtxs::Shared(ctx) => Some(ctx),
-            BaseCtxs::PerDirection { encrypt: ctx, .. } if encrypt => Some(ctx),
-            BaseCtxs::PerDirection { decrypt: ctx, .. } => Some(ctx),
+            #[cfg(not(any(
+                CRYPTOGRAPHY_IS_LIBRESSL,
+                CRYPTOGRAPHY_IS_BORINGSSL,
+                CRYPTOGRAPHY_IS_AWSLC
+            )))]
+            BaseCtxs::PerDirection { encrypt, .. } => Some(encrypt),
+        }
+    }
+
+    fn for_decryption(&self) -> Option<&openssl::cipher_ctx::CipherCtx> {
+        match self {
+            BaseCtxs::None => None,
+            BaseCtxs::Shared(ctx) => Some(ctx),
+            #[cfg(not(any(
+                CRYPTOGRAPHY_IS_LIBRESSL,
+                CRYPTOGRAPHY_IS_BORINGSSL,
+                CRYPTOGRAPHY_IS_AWSLC
+            )))]
+            BaseCtxs::PerDirection { decrypt, .. } => Some(decrypt),
         }
     }
 }
@@ -157,6 +184,11 @@ impl EvpCipherAead {
                     ctx.encrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
                     BaseCtxs::Shared(ctx)
                 }
+                #[cfg(not(any(
+                    CRYPTOGRAPHY_IS_LIBRESSL,
+                    CRYPTOGRAPHY_IS_BORINGSSL,
+                    CRYPTOGRAPHY_IS_AWSLC
+                )))]
                 KeySchedule::PerDirection => {
                     let mut encrypt = openssl::cipher_ctx::CipherCtx::new()?;
                     encrypt.encrypt_init(Some(&cipher), Some(key_buf.as_bytes()), None)?;
@@ -259,7 +291,7 @@ impl EvpCipherAead {
         check_length(plaintext)?;
 
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
-        let copied = match self.base_ctxs.get(true) {
+        let copied = match self.base_ctxs.for_encryption() {
             Some(base) => ctx.copy(base).is_ok(),
             None => false,
         };
@@ -334,7 +366,7 @@ impl EvpCipherAead {
         }
 
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()?;
-        let copied = match self.base_ctxs.get(false) {
+        let copied = match self.base_ctxs.for_decryption() {
             Some(base) => ctx.copy(base).is_ok(),
             None => false,
         };


### PR DESCRIPTION
Previously every `EvpCipherAead` pre-keyed two `CipherCtx`s at construction, one for encryption and one for decryption. For most of our AEADs (GCM, ChaCha20-Poly1305, SIV, GCM-SIV) the key schedule doesn't depend on direction, so a single keyed context serves both: each operation already copies the base context and re-initializes the copy with no cipher or key to set the nonce, and that same call sets the direction.

OCB is the exception. OpenSSL selects its hardware stream routine (encrypt vs decrypt) at key-setup time based on the direction flag, so a context keyed for one direction produces wrong output for the other. It keeps a pre-keyed context per direction.

This is modeled with an explicit `KeySchedule` enum (`DirectionIndependent` / `PerDirection`) passed to the constructor, and the pre-keyed contexts are stored as none (CCM), a single shared context, or an encrypt/decrypt pair.

Construction gets cheaper by one context allocation and one key schedule; the per-operation path is unchanged. Measured on OpenSSL 3.5.1:

| Constructor | before | after |
|---|---|---|
| AESGCM | ~1.10 µs | ~0.68 µs |
| ChaCha20Poly1305 | ~1.05 µs | ~0.67 µs |
| AESOCB3 | ~1.32 µs | ~1.32 µs |

The encrypt/decrypt benchmarks in `tests/bench/test_aead.py` are flat within noise.

Tested with `nox -e local` against OpenSSL 3.0.13, and the AEAD tests against an OpenSSL 3.5.1 build (where AEAD context copying is supported, so the copy path is actually exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMHEsFraACZfyKod2vniDh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMHEsFraACZfyKod2vniDh)_