### PR TITLE
Use uv-managed Python for the remaining workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,13 +43,12 @@ jobs:
         uses: ./cryptography-base/.github/actions/fetch-vectors
 
       - name: Setup python
-        id: setup-python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
+          version-file: cryptography-pr/ci-constraints-requirements.txt
           python-version: "3.11"
+          enable-cache: false
 
-      - name: Install uv
-        run: pip install -c ./cryptography-pr/ci-constraints-requirements.txt uv
       - name: Create virtualenv (base)
         run: |
           uv venv .venv-base
@@ -67,4 +66,4 @@ jobs:
         run: .venv-pr/bin/pytest --benchmark-enable --benchmark-only ./cryptography-pr/tests/bench/ --benchmark-json=bench-pr.json --x509-limbo-root=x509-limbo/
 
       - name: Compare results
-        run: python ./cryptography-pr/.github/bin/compare_benchmarks.py bench-base.json bench-pr.json | tee -a $GITHUB_STEP_SUMMARY
+        run: .venv-pr/bin/python ./cryptography-pr/.github/bin/compare_benchmarks.py bench-base.json bench-pr.json | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -25,17 +25,18 @@ jobs:
           persist-credentials: false
       - name: Setup python
         id: setup-python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
-          python-version: 3.11
+          version-file: ci-constraints-requirements.txt
+          python-version: "3.11"
+          activate-environment: true
+          cache-dependency-glob: ci-constraints-requirements.txt
       - name: Cache rust and pip
         uses: ./.github/actions/cache
         timeout-minutes: 2
         with:
-          # This creates the same key as the docs job (as long as they have the same
-          # python version)
-          key: 3.11-${{ steps.setup-python.outputs.python-version }}
-      - run: python -m pip install -c ci-constraints-requirements.txt 'nox[uv]'
+          key: ${{ steps.setup-python.outputs.python-runtime-id }}
+      - run: uv pip install -c ci-constraints-requirements.txt 'nox[uv]'
       - name: Build nox environment
         run: |
             nox -v --install-only -s docs-linkcheck

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -42,19 +42,17 @@ jobs:
           echo "PYPI_URL=https://test.pypi.org/legacy/" >> $GITHUB_ENV
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testpypi'
 
-      - name: Setup python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: '3.14'
-        timeout-minutes: 3
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: ci-constraints-requirements.txt
           sparse-checkout-cone-mode: false
           persist-credentials: false
-
-      - run: python -m pip install -c ci-constraints-requirements.txt 'uv'
+      - name: Setup uv
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
+        with:
+          version-file: ci-constraints-requirements.txt
+          enable-cache: false
+        timeout-minutes: 3
 
       - uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
         with:


### PR DESCRIPTION
Follow-up to #15572 and #15621. `benchmark.yml`, `linkcheck.yml` and `pypi-publish.yml` were the last users of `actions/setup-python`; after this there are none. All three get uv from `astral-sh/setup-uv` with the version pinned by `ci-constraints-requirements.txt`.

- **benchmark**: setup-uv with Python 3.11 replaces setup-python plus the pip install of uv. The comparison script runs on the PR venv's interpreter instead of whatever `python` is on PATH, since nothing puts a specific one there any more.
- **linkcheck**: mirrors the `ci.yml` linux job (activated venv, nox via `uv pip install`, cache keyed on `python-runtime-id`). The comment saying its cache key matched the docs job's is dropped: docs runs on 3.12 with an OpenSSL component in its key, and rust-cache adds the job id regardless, so they haven't shared a cache for a while.
- **pypi-publish**: it only needed Python to pip-install uv for `uv publish`, so it now installs uv directly after the sparse checkout and sets up no interpreter at all. This one can't be exercised on a PR (it runs on wheel-builder completion or manual dispatch); the publish step itself is untouched.

benchmark and linkcheck both trigger on changes to their own file, so they run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116sWJmeCaubZF2aMbR4kfc

---
_Generated by [Claude Code](https://claude.ai/code/session_0116sWJmeCaubZF2aMbR4kfc)_