### PR TITLE
Point the ECDH performance citation at the paper's landing page

### DIFF
--- a/docs/hazmat/primitives/asymmetric/ec.rst
+++ b/docs/hazmat/primitives/asymmetric/ec.rst
@@ -772,7 +772,7 @@ Elliptic Curve Object Identifiers
 .. _`800-56A`: https://csrc.nist.gov/pubs/sp/800/56/a/r3/final
 .. _`some concern`: https://crypto.stackexchange.com/questions/10263/should-we-trust-the-nist-recommended-ecc-parameters
 .. _`less than 224 bits`: https://www.cosic.esat.kuleuven.be/ecrypt/ecrypt2/documents/D.SPA.20.pdf
-.. _`elliptic curve diffie-hellman is faster than diffie-hellman`: https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1100&context=cseconfwork
+.. _`elliptic curve diffie-hellman is faster than diffie-hellman`: https://digitalcommons.unl.edu/cseconfwork/105/
 .. _`minimize the number of security concerns for elliptic-curve cryptography`: https://cr.yp.to/ecdh/curve25519-20060209.pdf
 .. _`SafeCurves`: https://safecurves.cr.yp.to/
 .. _`ECDSA`: https://en.wikipedia.org/wiki/ECDSA


### PR DESCRIPTION
The scheduled linkcheck has failed on main for the last four weekly runs (most recently 34544896952) on one link: the PDF endpoint `https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1100&context=cseconfwork`, cited from `docs/hazmat/primitives/asymmetric/ec.rst`, returns 403 to every client, browser user agents included.

This points the citation at the paper's landing page, `https://digitalcommons.unl.edu/cseconfwork/105/`, which serves fine. It's the same paper ("The Performance of Elliptic Curve Based Group Diffie-Hellman Protocols for Secure Group Communication over Ad Hoc Networks"); the landing page's `citation_pdf_url` is the article=1100 URL.

Verified with `nox -e docs-linkcheck` locally: the new link reports `ok`, and nothing else reports broken. (Two mail.python.org links hit a 5s read timeout from my sandbox's network; the run on main reached them fine.) The linkcheck workflow doesn't trigger on `.rst` changes, so it won't run on this PR; the next scheduled run on main will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116sWJmeCaubZF2aMbR4kfc

---
_Generated by [Claude Code](https://claude.ai/code/session_0116sWJmeCaubZF2aMbR4kfc)_